### PR TITLE
[ac_range_check, doc] Update documentation for ac_range_check

### DIFF
--- a/hw/ip_templates/ac_range_check/README.md
+++ b/hw/ip_templates/ac_range_check/README.md
@@ -2,7 +2,7 @@
 
 The System on Chip (SoC) must implement differentiated security access controls for shared memory regions located outside of the Root of Trust (RoT).
 To facilitate access to these memory regions, a dedicated TL-UL port is provided, connecting to the Control Network (CTN) fabric.
-This document outlines the requirements for a framework, referred to as Access Control Range Check (AC Range Check).
+This document outlines the requirements of a framework, referred to as Access Control Range Check (AC Range Check).
 In the proposed architecture, the AC Range Check mechanism intercepts the outgoing TL-UL bus, ensuring that only valid and authorized addresses are accessed.
 Adding the AC Range Check on the TL-UL bus will likely introduce a flop stage to meet the timings, which will cause a cycle of delay for bus initiators to receive their response.
 
@@ -12,11 +12,11 @@ Adding the AC Range Check on the TL-UL bus will likely introduce a flop stage to
 
 AC Range checks on the memory bus shares similarities with an I/O Peripheral Memory Protection (IOPMP) in that both mechanisms control access to memory regions, ensuring that only authorized transactions pass through.
 Like an IOPMP, AC ranges define specific address spaces and enforce permissions, preventing unauthorized access.
-However, AC range checks offer a simpler implementation and verification process.
+However, AC Range checks offer a simpler implementation and verification process.
 
 ## Parameterizable Range Registers
 
-The AC range check IP shall support a configurable number of range registers, allowing a flexible and granular security configuration.
+The AC Range Check IP shall support a configurable number of range registers, allowing a flexible and granular security configuration.
 The number of range registers shall be parameterizable at design time for every instance of the IP to accommodate different use cases and system requirements, providing scalability based on system size and complexity.
 A typical configuration would be between 16 and 32 ranges, but the design should not be limited to those bounds.
 
@@ -46,7 +46,7 @@ The matching process includes:
 * **Address Match:** The request's address is checked against the ranges defined by the enabled range registers (top-of-range matching).
 * **Permission Check:** For each matching range, the permissions associated with that range (READ, WRITE) are checked against the type of access requested.
 * **RACL Check:** For each matching range, the RACL policy associated with that range (read_perm, write_perm) is checked against the source role of the access requested.
-RACL is specified in Integrated OpenTitan: Register Access Control (RACL).
+RACL is specified in [Register Access Control (RACL)](../racl_ctrl/README.md).
 
 ## Access Policy
 
@@ -55,7 +55,7 @@ The following policy governs the handling of access requests based on the outcom
 * **Allowed Access:** If an incoming request matches an enabled range and the corresponding permission allows the requested operation (READ or WRITE), the request is granted, and the transaction proceeds normally.
 * **Denied Access:** If the request does not match any range or matches a range but the configured permission denied the requested operation, the TL-UL response shall return an error, i.e., setting `d_error = 1` when acknowledging the request.
 Further, the request is denied as follows:
-  * **Write Requests** Denied write requests shall be dropped, meaning no write operation is performed.
+  * **Write Requests:** Denied write requests shall be dropped, meaning no write operation is performed.
   * **Read/Execute Requests:** Denied read/execute requests shall return a zero value as a response.
 
 Range register 0 may be used as a configurable default policy to match the whole address space.
@@ -92,21 +92,22 @@ Upon the **first denied request**, the system shall record the following informa
 
 * **Range Index:** Identifies the specific range responsible for denying the request. If the access is denied because no range matches, it is logged in a dedicated status bit.
 * **Access Type:** Indicates whether the request was a READ, WRITE, or EXECUTE operation.
-* **RACL role:** Indicates the RACL role of th request and an indicator if a RACL read or write check caused the denial.
+* **RACL role:** Indicates the RACL role of the request and an indicator if a RACL read or write check caused the denial.
 * **Access Address:** Logs the exact address that the request attempted to access.
 
 ### Single Event Logging
 
 * This logging mechanism is triggered only for the first denied access after a reset or after the log has been cleared, ensuring that only the initial violation is captured for diagnostics.
-* Subsequent denied requests will not overwrite the log, preserving the information of the first event until manually cleared by the RoT.
-The log is cleared automatically when the interrupt is acknowledged or manually by writing a configuration bit.
+* Subsequent denied requests will not overwrite the log, preserving the information of the first event until it is cleared by setting the `log_clear` bit in the [LOG_CONFIG](./doc/registers.md#log_config) CSR.
+* The log is cleared automatically when the interrupt is acknowledged or manually by writing a configuration bit.
+* The log is only performed for ranges where logging is enabled.
 
 ## Enable/Disable Control and Lock Mechanism
 
 Each range register shall include both an enable/disable control bit and a lock mechanism.
 The following controls apply:
 
-* **Enable/Disable** Control: Each range register can be enabled or disabled individually.
+* **Enable/Disable Control:** Each range register can be enabled or disabled individually.
 Disabled range registers shall not participate in the matching process and shall have no effect on access control decisions.
 * **Lock Mechanism:** Once a range register is configured, a lock can be asserted to prevent further modification of the range's configuration.
 When the lock is active, the base, mask/limit, and permission settings of the range register are immutable and cannot be altered until the system is reset.

--- a/hw/ip_templates/ac_range_check/README.md
+++ b/hw/ip_templates/ac_range_check/README.md
@@ -114,11 +114,10 @@ When the lock is active, the base, mask/limit, and permission settings of the ra
 
 ## Bypass Mode
 
-The system shall support a bypass mode controlled via a bypass_wire signal.
-The bypass_signal shall be driven by a 8-bit encoded multi-bit encoded signal in the ROT-controlled register space.
-A single bypass_signal shall manage access override for all source AC range registers within the system.
+The system shall support a bypass mode controlled via the `range_check_overwrite_i` 8-bit multi-bit encoded signal controlled by the RoT.
+A single `range_check_overwrite_i` shall manage access override for all source AC Range registers within the system.
 
-When the bypass_wire is asserted, the range register logic shall allow access for all transactions, overriding any existing configuration settings.
-This includes ignoring permission restrictions such as READ, WRITE, or  EXECUTE and RACL checks, ensuring all transactions are permitted while bypass mode is active.
+When `range_check_overwrite_i` is asserted, the range register logic shall allow access for all transactions, overriding any existing configuration settings.
+This includes ignoring permission restrictions such as READ, WRITE, and EXECUTE, as well as RACL checks; ensuring all transactions are permitted while bypass mode is active.
 
 The bypass mode may be used during early silicon bring-up or debugging phases, where reducing the security due to disabled range filters is acceptable.

--- a/hw/ip_templates/ac_range_check/data/ac_range_check.hjson.tpl
+++ b/hw/ip_templates/ac_range_check/data/ac_range_check.hjson.tpl
@@ -15,7 +15,16 @@ import math
   cip_id:             "41",
   design_spec:        "../doc"
   dv_doc:             "../doc/dv"
-  version:            "1.0.0"
+  revisions:          [
+      {
+        // TODO: The checklist should be updated.
+        version: "1.0.0",
+        life_stage: "L2",
+        design_stage: "D1",
+        verification_stage: "V1",
+        dif_stage: "S1"
+      }
+  ]
 
   clocking: [{clock: "clk_i", reset: "rst_ni", primary: true}]
   bus_interfaces: [

--- a/hw/ip_templates/ac_range_check/doc/checklist.md
+++ b/hw/ip_templates/ac_range_check/doc/checklist.md
@@ -133,7 +133,7 @@ Review        | Signoff date            | Not Started |
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
 Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [AC_RANGE_CHECK DV document](../dv/README.md)
-Documentation | [TESTPLAN_COMPLETED][]                | Ongoing     | See issue [#27791](https://github.com/lowRISC/opentitan/issues/27791) [AC_RANGE_CHECK Testplan](../dv/README.md#testplan)
+Documentation | [TESTPLAN_COMPLETED][]                | Ongoing     | [AC_RANGE_CHECK Testplan](../dv/README.md#testplan)
 Testbench     | [TB_TOP_CREATED][]                    | Done        |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |
@@ -150,7 +150,7 @@ Regression    | [FPV_REGRESSION_SETUP][]              | N/A         |
 Coverage      | [SIM_COVERAGE_MODEL_ADDED][]          | Done        |
 Code Quality  | [TB_LINT_SETUP][]                     | Ongoing     | Not properly set yet, command fails
 Integration   | [PRE_VERIFIED_SUB_MODULES_V1][]       | N/A         |
-Review        | [DESIGN_SPEC_REVIEWED][]              | Ongoing     | See issue [#27792](https://github.com/lowRISC/opentitan/issues/27792)
+Review        | [DESIGN_SPEC_REVIEWED][]              | Ongoing     |
 Review        | [TESTPLAN_REVIEWED][]                 | Not Started | TODO with relevant stakeholders
 Review        | [STD_TEST_CATEGORIES_PLANNED][]       | Not Started | Exception (?)
 Review        | [V2_CHECKLIST_SCOPED][]               | Done        |
@@ -183,7 +183,7 @@ Review        | [V2_CHECKLIST_SCOPED][]               | Done        |
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
 Documentation | [DESIGN_DELTAS_CAPTURED_V2][]           | Not Started |
-Documentation | [DV_DOC_COMPLETED][]                    | Ongoing     | See issue #27793
+Documentation | [DV_DOC_COMPLETED][]                    | Ongoing     |
 Testbench     | [FUNCTIONAL_COVERAGE_IMPLEMENTED][]     | Not Started |
 Testbench     | [ALL_INTERFACES_EXERCISED][]            | Not Started |
 Testbench     | [ALL_ASSERTION_CHECKS_ADDED][]          | Not Started |

--- a/hw/ip_templates/ac_range_check/doc/theory_of_operation.md
+++ b/hw/ip_templates/ac_range_check/doc/theory_of_operation.md
@@ -1,6 +1,6 @@
 # Theory of Operation
 
-The following pseudo-code illustrates the range check logic, incorporating range priorities and access control rules.
+The following pseudo-code illustrates the Access Control Range Check logic, incorporating range priorities and access control rules.
 The default system behavior is to deny access unless explicitly allowed by the range configuration.
 The incoming address is compared against each enabled range register, and access control decisions are made based on matching and permissions.
 The priority order (a lower range slot has a higher priority) of the ranges ensures that higher-priority ranges override lower-priority ones when a conflict occurs (i.e., if more than one range matches the incoming request).
@@ -19,7 +19,7 @@ def range_check_access(address, access_type):
       # If address matches within this range, check permissions
       if range_match:
         if access_type == EXECUTE and range[i].execute and access_role in range[i].read_perm:
-	  access_granted == True
+	        access_granted == True
         else if access_type == READ and range[i].read and access_role in range[i].read_perm:
           access_granted = True
         else if access_type == WRITE and range[i].write and access_role in range[i].write_perm:
@@ -34,4 +34,35 @@ def range_check_access(address, access_type):
     return ACCESS_GRANTED
   else:
     return ACCESS_DENIED
+```
+
+Additionally, we perform the deny count and the logging mechanism as follows:
+
+```
+def range_check_logging(range_idx, access_decision, address, access_type, log_clear):
+  if access_decision == ACCESS_DENIED and not log_clear:        # Check for every denied access
+    if deny_count == 0 and range[range_idx].log_denied_access:  # If first deny, log its info
+      deny_count += 1
+      first_denied_access_log = { range_idx,
+                                  range[range_idx].ctn_uid,
+                                  range[range_idx].racl_role,
+                                  (access_type in {READ, EXECUTE}) and access_role in range[range_idx].read_perm,
+                                  (access_type == WRITE) and access_role in range[range_idx].write_perm,
+                                  !range_match,
+                                  (access_type == EXECUTE),
+                                  (access_type == WRITE),
+                                  (access_type == READ),
+                                  deny_count,
+                                  address
+                                }
+    else if range[range_idx].log_denied_access:                 # Else, only increase the count
+      deny_count += 1
+
+    if deny_count >= deny_count_threshold:                      # If the count reaches the
+      return DENY_COUNT_ERROR                                   # threshold, raise an error
+
+  # If told to clear the log, reset the counter
+  else if log_clear:
+    deny_count = 0
+    first_denied_access_log = {}
 ```

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/README.md
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/README.md
@@ -2,7 +2,7 @@
 
 The System on Chip (SoC) must implement differentiated security access controls for shared memory regions located outside of the Root of Trust (RoT).
 To facilitate access to these memory regions, a dedicated TL-UL port is provided, connecting to the Control Network (CTN) fabric.
-This document outlines the requirements for a framework, referred to as Access Control Range Check (AC Range Check).
+This document outlines the requirements of a framework, referred to as Access Control Range Check (AC Range Check).
 In the proposed architecture, the AC Range Check mechanism intercepts the outgoing TL-UL bus, ensuring that only valid and authorized addresses are accessed.
 Adding the AC Range Check on the TL-UL bus will likely introduce a flop stage to meet the timings, which will cause a cycle of delay for bus initiators to receive their response.
 
@@ -12,11 +12,11 @@ Adding the AC Range Check on the TL-UL bus will likely introduce a flop stage to
 
 AC Range checks on the memory bus shares similarities with an I/O Peripheral Memory Protection (IOPMP) in that both mechanisms control access to memory regions, ensuring that only authorized transactions pass through.
 Like an IOPMP, AC ranges define specific address spaces and enforce permissions, preventing unauthorized access.
-However, AC range checks offer a simpler implementation and verification process.
+However, AC Range checks offer a simpler implementation and verification process.
 
 ## Parameterizable Range Registers
 
-The AC range check IP shall support a configurable number of range registers, allowing a flexible and granular security configuration.
+The AC Range Check IP shall support a configurable number of range registers, allowing a flexible and granular security configuration.
 The number of range registers shall be parameterizable at design time for every instance of the IP to accommodate different use cases and system requirements, providing scalability based on system size and complexity.
 A typical configuration would be between 16 and 32 ranges, but the design should not be limited to those bounds.
 
@@ -46,7 +46,7 @@ The matching process includes:
 * **Address Match:** The request's address is checked against the ranges defined by the enabled range registers (top-of-range matching).
 * **Permission Check:** For each matching range, the permissions associated with that range (READ, WRITE) are checked against the type of access requested.
 * **RACL Check:** For each matching range, the RACL policy associated with that range (read_perm, write_perm) is checked against the source role of the access requested.
-RACL is specified in Integrated OpenTitan: Register Access Control (RACL).
+RACL is specified in [Register Access Control (RACL)](../racl_ctrl/README.md).
 
 ## Access Policy
 
@@ -55,7 +55,7 @@ The following policy governs the handling of access requests based on the outcom
 * **Allowed Access:** If an incoming request matches an enabled range and the corresponding permission allows the requested operation (READ or WRITE), the request is granted, and the transaction proceeds normally.
 * **Denied Access:** If the request does not match any range or matches a range but the configured permission denied the requested operation, the TL-UL response shall return an error, i.e., setting `d_error = 1` when acknowledging the request.
 Further, the request is denied as follows:
-  * **Write Requests** Denied write requests shall be dropped, meaning no write operation is performed.
+  * **Write Requests:** Denied write requests shall be dropped, meaning no write operation is performed.
   * **Read/Execute Requests:** Denied read/execute requests shall return a zero value as a response.
 
 Range register 0 may be used as a configurable default policy to match the whole address space.
@@ -92,21 +92,22 @@ Upon the **first denied request**, the system shall record the following informa
 
 * **Range Index:** Identifies the specific range responsible for denying the request. If the access is denied because no range matches, it is logged in a dedicated status bit.
 * **Access Type:** Indicates whether the request was a READ, WRITE, or EXECUTE operation.
-* **RACL role:** Indicates the RACL role of th request and an indicator if a RACL read or write check caused the denial.
+* **RACL role:** Indicates the RACL role of the request and an indicator if a RACL read or write check caused the denial.
 * **Access Address:** Logs the exact address that the request attempted to access.
 
 ### Single Event Logging
 
 * This logging mechanism is triggered only for the first denied access after a reset or after the log has been cleared, ensuring that only the initial violation is captured for diagnostics.
-* Subsequent denied requests will not overwrite the log, preserving the information of the first event until manually cleared by the RoT.
-The log is cleared automatically when the interrupt is acknowledged or manually by writing a configuration bit.
+* Subsequent denied requests will not overwrite the log, preserving the information of the first event until it is cleared by setting the `log_clear` bit in the [LOG_CONFIG](./doc/registers.md#log_config) CSR.
+* The log is cleared automatically when the interrupt is acknowledged or manually by writing a configuration bit.
+* The log is only performed for ranges where logging is enabled.
 
 ## Enable/Disable Control and Lock Mechanism
 
 Each range register shall include both an enable/disable control bit and a lock mechanism.
 The following controls apply:
 
-* **Enable/Disable** Control: Each range register can be enabled or disabled individually.
+* **Enable/Disable Control:** Each range register can be enabled or disabled individually.
 Disabled range registers shall not participate in the matching process and shall have no effect on access control decisions.
 * **Lock Mechanism:** Once a range register is configured, a lock can be asserted to prevent further modification of the range's configuration.
 When the lock is active, the base, mask/limit, and permission settings of the range register are immutable and cannot be altered until the system is reset.

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/README.md
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/README.md
@@ -114,11 +114,10 @@ When the lock is active, the base, mask/limit, and permission settings of the ra
 
 ## Bypass Mode
 
-The system shall support a bypass mode controlled via a bypass_wire signal.
-The bypass_signal shall be driven by a 8-bit encoded multi-bit encoded signal in the ROT-controlled register space.
-A single bypass_signal shall manage access override for all source AC range registers within the system.
+The system shall support a bypass mode controlled via the `range_check_overwrite_i` 8-bit multi-bit encoded signal controlled by the RoT.
+A single `range_check_overwrite_i` shall manage access override for all source AC Range registers within the system.
 
-When the bypass_wire is asserted, the range register logic shall allow access for all transactions, overriding any existing configuration settings.
-This includes ignoring permission restrictions such as READ, WRITE, or  EXECUTE and RACL checks, ensuring all transactions are permitted while bypass mode is active.
+When `range_check_overwrite_i` is asserted, the range register logic shall allow access for all transactions, overriding any existing configuration settings.
+This includes ignoring permission restrictions such as READ, WRITE, and EXECUTE, as well as RACL checks; ensuring all transactions are permitted while bypass mode is active.
 
 The bypass mode may be used during early silicon bring-up or debugging phases, where reducing the security due to disabled range filters is acceptable.

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/data/ac_range_check.hjson
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/data/ac_range_check.hjson
@@ -12,7 +12,16 @@
   cip_id:             "41",
   design_spec:        "../doc"
   dv_doc:             "../doc/dv"
-  version:            "1.0.0"
+  revisions:          [
+      {
+        // TODO: The checklist should be updated.
+        version: "1.0.0",
+        life_stage: "L2",
+        design_stage: "D1",
+        verification_stage: "V1",
+        dif_stage: "S1"
+      }
+  ]
 
   clocking: [{clock: "clk_i", reset: "rst_ni", primary: true}]
   bus_interfaces: [

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/doc/checklist.md
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/doc/checklist.md
@@ -133,7 +133,7 @@ Review        | Signoff date            | Not Started |
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
 Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [AC_RANGE_CHECK DV document](../dv/README.md)
-Documentation | [TESTPLAN_COMPLETED][]                | Ongoing     | See issue [#27791](https://github.com/lowRISC/opentitan/issues/27791) [AC_RANGE_CHECK Testplan](../dv/README.md#testplan)
+Documentation | [TESTPLAN_COMPLETED][]                | Ongoing     | [AC_RANGE_CHECK Testplan](../dv/README.md#testplan)
 Testbench     | [TB_TOP_CREATED][]                    | Done        |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |
@@ -150,7 +150,7 @@ Regression    | [FPV_REGRESSION_SETUP][]              | N/A         |
 Coverage      | [SIM_COVERAGE_MODEL_ADDED][]          | Done        |
 Code Quality  | [TB_LINT_SETUP][]                     | Ongoing     | Not properly set yet, command fails
 Integration   | [PRE_VERIFIED_SUB_MODULES_V1][]       | N/A         |
-Review        | [DESIGN_SPEC_REVIEWED][]              | Ongoing     | See issue [#27792](https://github.com/lowRISC/opentitan/issues/27792)
+Review        | [DESIGN_SPEC_REVIEWED][]              | Ongoing     |
 Review        | [TESTPLAN_REVIEWED][]                 | Not Started | TODO with relevant stakeholders
 Review        | [STD_TEST_CATEGORIES_PLANNED][]       | Not Started | Exception (?)
 Review        | [V2_CHECKLIST_SCOPED][]               | Done        |
@@ -183,7 +183,7 @@ Review        | [V2_CHECKLIST_SCOPED][]               | Done        |
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
 Documentation | [DESIGN_DELTAS_CAPTURED_V2][]           | Not Started |
-Documentation | [DV_DOC_COMPLETED][]                    | Ongoing     | See issue #27793
+Documentation | [DV_DOC_COMPLETED][]                    | Ongoing     |
 Testbench     | [FUNCTIONAL_COVERAGE_IMPLEMENTED][]     | Not Started |
 Testbench     | [ALL_INTERFACES_EXERCISED][]            | Not Started |
 Testbench     | [ALL_ASSERTION_CHECKS_ADDED][]          | Not Started |

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/doc/theory_of_operation.md
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/doc/theory_of_operation.md
@@ -1,6 +1,6 @@
 # Theory of Operation
 
-The following pseudo-code illustrates the range check logic, incorporating range priorities and access control rules.
+The following pseudo-code illustrates the Access Control Range Check logic, incorporating range priorities and access control rules.
 The default system behavior is to deny access unless explicitly allowed by the range configuration.
 The incoming address is compared against each enabled range register, and access control decisions are made based on matching and permissions.
 The priority order (a lower range slot has a higher priority) of the ranges ensures that higher-priority ranges override lower-priority ones when a conflict occurs (i.e., if more than one range matches the incoming request).
@@ -19,7 +19,7 @@ def range_check_access(address, access_type):
       # If address matches within this range, check permissions
       if range_match:
         if access_type == EXECUTE and range[i].execute and access_role in range[i].read_perm:
-	  access_granted == True
+	        access_granted == True
         else if access_type == READ and range[i].read and access_role in range[i].read_perm:
           access_granted = True
         else if access_type == WRITE and range[i].write and access_role in range[i].write_perm:
@@ -34,4 +34,35 @@ def range_check_access(address, access_type):
     return ACCESS_GRANTED
   else:
     return ACCESS_DENIED
+```
+
+Additionally, we perform the deny count and the logging mechanism as follows:
+
+```
+def range_check_logging(range_idx, access_decision, address, access_type, log_clear):
+  if access_decision == ACCESS_DENIED and not log_clear:        # Check for every denied access
+    if deny_count == 0 and range[range_idx].log_denied_access:  # If first deny, log its info
+      deny_count += 1
+      first_denied_access_log = { range_idx,
+                                  range[range_idx].ctn_uid,
+                                  range[range_idx].racl_role,
+                                  (access_type in {READ, EXECUTE}) and access_role in range[range_idx].read_perm,
+                                  (access_type == WRITE) and access_role in range[range_idx].write_perm,
+                                  !range_match,
+                                  (access_type == EXECUTE),
+                                  (access_type == WRITE),
+                                  (access_type == READ),
+                                  deny_count,
+                                  address
+                                }
+    else if range[range_idx].log_denied_access:                 # Else, only increase the count
+      deny_count += 1
+
+    if deny_count >= deny_count_threshold:                      # If the count reaches the
+      return DENY_COUNT_ERROR                                   # threshold, raise an error
+
+  # If told to clear the log, reset the counter
+  else if log_clear:
+    deny_count = 0
+    first_denied_access_log = {}
 ```


### PR DESCRIPTION
This PR includes three commits:

- One for scrubbing mentions from `ac_range_check` documentation and updating the documentation slightly (for clarity's sake).
- One for clarifying the Bypass Mode, which seemed unclear in the original version.
- One for including the revisions section in the `ac_range_check.hjson` file.
