### PR TITLE
[topgen] Support external TL-UL connections

### DIFF
--- a/util/tlgen/README.md
+++ b/util/tlgen/README.md
@@ -122,6 +122,7 @@ inst_type | optional | string | Instance type
 xbar | optional | python Bool | If true, the node is connected to another Xbar
 addr_range | optional | list of group | List of addr_range group
 stub | optional | python Bool | Real node or stub.  Stubs only occupy address ranges
+external | optional | python Bool | If true, the port does not have a module within the top
 
 
 ### Address configurations

--- a/util/tlgen/validate.py
+++ b/util/tlgen/validate.py
@@ -75,7 +75,8 @@ Crossbar node description. It can be host, device, or internal nodes.
         'inst_type': ['s', 'Instance type'],
         'xbar': ['pb', 'If true, the node is connected to another Xbar'],
         'addr_range': ['lg', addrs],
-        'stub': ['pb', 'Real node or stub.  Stubs only occupy address ranges']
+        'stub': ['pb', 'Real node or stub.  Stubs only occupy address ranges'],
+        'external': ['pb', 'If true, the port does not have a module within the top']
     },
     'added': {}
 }

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1095,6 +1095,11 @@ def create_generic_ip_blocks(topcfg: ConfigT, alias_cfgs: Dict[str, ConfigT],
     invalid_attr_instances = []
     for instance in topcfg["module"]:
         ip_type = instance["type"]
+        if instance.get("external"):
+            ip_attrs[ip_type] = IpAttrs(ip_block=None,
+                                        hjson_path=None,
+                                        top_only=True,
+                                        instances=[instance])
         if "attr" not in instance:
             handle_instance(top_only=False)
         elif lib.is_top_reggen(instance):

--- a/util/topgen/intermodule.py
+++ b/util/topgen/intermodule.py
@@ -180,6 +180,8 @@ def autoconnect_xbar(topcfg: OrderedDict, name_to_block: Dict[str, IpBlock],
         # If not, this is a memory that will just have a dictionary of inter
         # signals.
         block = name_to_block[port_mod['type']]
+        if name_to_module[port_base].get('external'):
+            sig_name = "tl"
         try:
             sig_name = block.bus_interfaces.find_port_name(
                 is_host, port_iname)
@@ -673,6 +675,11 @@ def find_otherside_modules(topcfg: OrderedDict, m,
     if special_result is not None:
         return [('top', special_result[0], special_result[1])]
 
+    for (prefix, sig), (dst_m, dst_s) in special_inst_names.items():
+        if s.startswith(sig) and m.startswith(prefix) and not s.endswith("soc"):
+            print(s, m)
+            return [('top', dst_m, dst_s)]
+
     signame = "{}.{}".format(m, s)
     for req, rsps in topcfg["inter_module"]["connect"].items():
         if req.startswith(signame):
@@ -695,6 +702,21 @@ def find_otherside_modules(topcfg: OrderedDict, m,
 
 
 def check_intermodule(topcfg: Dict, prefix: str) -> int:
+    name_to_module = {}
+    for mod in topcfg['module']:
+        assert mod['name'] not in name_to_module
+        if lib.is_inst(mod):
+            name_to_module[mod['name']] = mod
+        if mod.get("external"):
+            signal = {'name': 'tl',
+                      'struct': 'tl',
+                      'package': 'tlul_pkg',
+                      'type': 'req_rsp',
+                      'act': 'rsp',
+                      'width': '1',
+                      'inst_name': mod['name']}
+            topcfg['inter_signal']['signals'].append(signal)
+
     if "inter_module" not in topcfg:
         return 0
 

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -526,6 +526,8 @@ def get_pad_list(padstr: str) -> List[Dict[str, Union[str, int]]]:
 def idx_of_last_module_with_params(top: ConfigT) -> int:
     last = -1
     for idx, module in enumerate(top["module"]):
+        if module.get('external'):
+            continue
         if len(module["param_list"]):
             last = idx
     return last
@@ -725,21 +727,31 @@ def get_base_and_size(name_to_block: IpBlocksT, inst: ConfigT,
                       ifname: Optional[str]) -> Tuple[int, int]:
 
     block = name_to_block.get(inst['type'])
-    assert block, f"No module named {inst['type']} (coming from instance {inst['name']})"
-    # If inst is the instantiation of some block, find the register block
-    # that corresponds to ifname
-    if rb := block.reg_blocks.get(ifname):
-        bytes_used = 1 << rb.get_addr_width()
-    elif mem := inst["memory"].get(ifname):
-        bytes_used = int(mem["size"], 0)
+    if block is None:
+        if inst.get("external"):
+            if "external_size" in inst.keys():
+                bytes_used = deepcopy(int(inst["external_size"]))
+                base_addrs = deepcopy(inst['base_addrs'][ifname])
+            else:
+                raise ValueError('Missing external_size key in module '
+                                 '{}'.format(inst['name']))
+        else:
+            assert False, f"No module named {inst['type']} (coming from instance {inst['name']})"
     else:
-        raise RuntimeError(
-            'Cannot connect to non-existent {} device interface '
-            'on {!r} (an instance of the {!r} block).'.format(
-                'default' if ifname is None else repr(ifname),
-                inst['name'], block.name))
+        # If inst is the instantiation of some block, find the register block
+        # that corresponds to ifname
+        if rb := block.reg_blocks.get(ifname):
+            bytes_used = 1 << rb.get_addr_width()
+        elif mem := inst["memory"].get(ifname):
+            bytes_used = int(mem["size"], 0)
+        else:
+            raise RuntimeError(
+                'Cannot connect to non-existent {} device interface '
+                'on {!r} (an instance of the {!r} block).'.format(
+                    'default' if ifname is None else repr(ifname),
+                    inst['name'], block.name))
 
-    base_addrs = deepcopy(inst['base_addrs'][ifname])
+        base_addrs = deepcopy(inst['base_addrs'][ifname])
 
     for (asid, base_addr) in base_addrs.items():
         if isinstance(base_addr, str):
@@ -979,14 +991,9 @@ class TopGen:
         '''
         device_region = defaultdict(dict)
         for inst in self.top['module']:
-            block = self._name_to_block[inst['type']]
-            for if_name in block.reg_blocks.keys():
-                full_if = (inst['name'], if_name)
-                full_if_name = Name.from_snake_case(full_if[0])
-                if if_name is not None:
-                    full_if_name += Name.from_snake_case(if_name)
-
-                name = full_if_name
+            if inst.get("external"):
+                if_name = None
+                full_if_name = (inst['name'], if_name)
                 base, size = get_base_and_size(self._name_to_block, inst,
                                                if_name)
                 if addr_space not in base:
@@ -995,6 +1002,23 @@ class TopGen:
                 region = MemoryRegion(self._top_name, name, addr_space,
                                       base[addr_space], size)
                 device_region[inst['name']].update({if_name: region})
+            else:
+                block = self._name_to_block[inst['type']]
+                for if_name in block.reg_blocks.keys():
+                    full_if = (inst['name'], if_name)
+                    full_if_name = Name.from_snake_case(full_if[0])
+                    if if_name is not None:
+                        full_if_name += Name.from_snake_case(if_name)
+
+                    name = full_if_name
+                    base, size = get_base_and_size(self._name_to_block, inst,
+                                                   if_name)
+                    if addr_space not in base:
+                        continue
+
+                    region = MemoryRegion(self._top_name, name, addr_space,
+                                          base[addr_space], size)
+                    device_region[inst['name']].update({if_name: region})
 
         self.device_regions[addr_space] = device_region
 

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -81,6 +81,7 @@ def elaborate_instance(instance, block: IpBlock):
 
     mod_name = instance["name"]
     cc_mod_name = lib.Name.from_snake_case(mod_name).as_camel_case()
+    is_external = instance.get("external") is not None
 
     # Check to see if all declared parameters exist
     param_decl_accounting = [decl for decl in instance["param_decl"].keys()]
@@ -99,119 +100,120 @@ def elaborate_instance(instance, block: IpBlock):
         if mem not in instance["memory"]:
             raise ValueError(f"Module instance {mod_name} does not describe memory {mem}")
 
-    # param_list
-    new_params = []
-    for param in block.params.by_name.values():
-        if isinstance(param, LocalParam):
-            # Remove local parameters.
-            continue
-
-        new_param = param.as_dict()
-
-        param_expose = param.expose if isinstance(param, Parameter) else False
-
-        # Check for security-relevant parameters that are not exposed,
-        # adding a top-level name.
-        if param.name.lower().startswith("sec") and not param_expose:
-            log.warning(f"{mod_name} has security-critical parameter "
-                        f"{param.name} not exposed to top")
-
-        # Move special prefixes to the beginning of the parameter name.
-        param_prefixes = ["Sec", "RndCnst", "MemSize"]
-        name_top = cc_mod_name + param.name
-        for prefix in param_prefixes:
-            if not param.name.startswith(prefix):
+    if not is_external:
+        # param_list
+        new_params = []
+        for param in block.params.by_name.values():
+            if isinstance(param, LocalParam):
+                # Remove local parameters.
                 continue
-            else:
-                if param.name == prefix:
-                    raise ValueError(f'Module instance {mod_name} has a '
-                                     f'parameter {param.name} that is equal '
-                                     f'to prefix {prefix}.')
 
-                if re.match(prefix + '[A-Z].+$', param.name):
-                    name_top = (prefix + cc_mod_name +
-                                param.name[len(prefix):])
-                break
+            new_param = param.as_dict()
 
-        new_param['name_top'] = name_top
+            param_expose = param.expose if isinstance(param, Parameter) else False
 
-        # Generate random bits or permutation, if needed
-        if isinstance(param, RandParameter):
-            if param.randtype == "data":
-                new_default = _get_random_data_hex_literal(param.randcount)
-                # Effective width of the random vector
-                randwidth = param.randcount
-            elif param.randtype == "perm":
-                new_default = _get_random_perm_hex_literal(param.randcount)
-                # Effective width of the random vector
-                randwidth = param.randcount * ceil(log2(param.randcount))
-            else:
-                assert param.randtype == "extdata"
-                # Default value is provided externally at a later point or has already been filled
-                # in. If this is already the case, we don't need to fill in a blank value to be
-                # filled in later.
-                fill_default = None
-                for p in instance.get("param_list", []):
-                    if p["name"] == param.name and p["default"] is not None:
-                        fill_default = p["default"]
-                        break
-                randwidth = param.randcount
-                new_default = None
-                if fill_default:
-                    new_default = fill_default
+            # Check for security-relevant parameters that are not exposed,
+            # adding a top-level name.
+            if param.name.lower().startswith("sec") and not param_expose:
+                log.warning(f"{mod_name} has security-critical parameter "
+                            f"{param.name} not exposed to top")
 
-            new_param['default'] = new_default
-            new_param['randwidth'] = randwidth
+            # Move special prefixes to the beginning of the parameter name.
+            param_prefixes = ["Sec", "RndCnst", "MemSize"]
+            name_top = cc_mod_name + param.name
+            for prefix in param_prefixes:
+                if not param.name.startswith(prefix):
+                    continue
+                else:
+                    if param.name == prefix:
+                        raise ValueError(f'Module instance {mod_name} has a '
+                                         f'parameter {param.name} that is equal '
+                                         f'to prefix {prefix}.')
 
-        elif isinstance(param, MemSizeParameter):
-            key = param.name[7:].lower()
-            # Set the parameter to the specified memory size.
-            if key in instance["memory"]:
-                new_default = int(instance["memory"][key]["size"], 0)
+                    if re.match(prefix + '[A-Z].+$', param.name):
+                        name_top = (prefix + cc_mod_name +
+                                    param.name[len(prefix):])
+                    break
+
+            new_param['name_top'] = name_top
+
+            # Generate random bits or permutation, if needed
+            if isinstance(param, RandParameter):
+                if param.randtype == 'data':
+                    new_default = _get_random_data_hex_literal(param.randcount)
+                    # Effective width of the random vector
+                    randwidth = param.randcount
+                elif param.randtype == "perm":
+                    new_default = _get_random_perm_hex_literal(param.randcount)
+                    # Effective width of the random vector
+                    randwidth = param.randcount * ceil(log2(param.randcount))
+                else:
+                    assert param.randtype == "extdata"
+                    # Default value is provided externally at a later point or has already been filled
+                    # in. If this is already the case, we don't need to fill in a blank value to be
+                    # filled in later.
+                    fill_default = None
+                    for p in instance.get("param_list", []):
+                        if p["name"] == param.name and p["default"] is not None:
+                            fill_default = p["default"]
+                            break
+                    randwidth = param.randcount
+                    new_default = None
+                    if fill_default:
+                        new_default = fill_default
+
                 new_param['default'] = new_default
-            else:
-                log.error("Missing memory configuration for "
-                          f"memory {key} in instance {instance['name']}")
+                new_param['randwidth'] = randwidth
 
-        # if this exposed parameter is listed in the `param_decl` dict,
-        # override its default value.
-        elif param.name in instance["param_decl"].keys():
-            new_param['default'] = instance["param_decl"][param.name]
-            # remove the parameter from the accounting dict
-            param_decl_accounting.remove(param.name)
+            elif isinstance(param, MemSizeParameter):
+                key = param.name[7:].lower()
+                # Set the parameter to the specified memory size.
+                if key in instance["memory"]:
+                    new_default = int(instance["memory"][key]["size"], 0)
+                    new_param['default'] = new_default
+                else:
+                    log.error("Missing memory configuration for "
+                              f"memory {key} in instance {instance['name']}")
 
-        new_params.append(new_param)
+            # if this exposed parameter is listed in the `param_decl` dict,
+            # override its default value.
+            elif param.name in instance["param_decl"].keys():
+                new_param['default'] = instance["param_decl"][param.name]
+                # remove the parameter from the accounting dict
+                param_decl_accounting.remove(param.name)
 
-    instance["param_list"] = new_params
+            new_params.append(new_param)
 
-    # for each module declaration, check to see that the parameter actually
-    # exists and can be set
-    for decl in param_decl_accounting:
-        log.error("{} is not a valid parameter of {} that can be "
-                  "set from top level".format(decl, block.name))
+        instance["param_list"] = new_params
 
-    # These objects get added-to in place by code in intermodule.py, so we have
-    # to convert and copy them here.
-    instance["inter_signal_list"] = [s.as_dict() for s in block.inter_signals]
+        # for each module declaration, check to see that the parameter actually
+        # exists and can be set
+        for decl in param_decl_accounting:
+            log.error("{} is not a valid parameter of {} that can be "
+                      "set from top level".format(decl, block.name))
 
-    # If we have width-parametrized intersignal, we need to update the intersignal param name
-    # the the instance mangled param name
-    for s in instance["inter_signal_list"]:
-        if isinstance(s['width'], Parameter):
-            for p in instance["param_list"]:
-                if p['name'] == s['width'].name:
-                    # When mangling the name, we first need to deep copy the
-                    # param. Parameters in signals have a reference to a
-                    # parameter. If we have multiple instances of the same IP,
-                    # then their signals would reference the same single
-                    # parameter. If we would mangle that directly, we all
-                    # signals of all IPs would reference to that single mangled
-                    # parameter. Since parameters are instance dependent, that
-                    # would fail. Therefore, copy the parameter first to have
-                    # a unique parameter for that particular signal and
-                    # instance, which is safe to mangle.
-                    s['width'] = deepcopy(s['width'])
-                    s['width'].name_top = p['name_top']
+        # These objects get added-to in place by code in intermodule.py, so we have
+        # to convert and copy them here.
+        instance["inter_signal_list"] = [s.as_dict() for s in block.inter_signals]
+
+        # If we have width-parametrized intersignal, we need to update the intersignal param name
+        # the the instance mangled param name
+        for s in instance["inter_signal_list"]:
+            if isinstance(s['width'], Parameter):
+                for p in instance["param_list"]:
+                    if p['name'] == s['width'].name:
+                        # When mangling the name, we first need to deep copy the
+                        # param. Parameters in signals have a reference to a
+                        # parameter. If we have multiple instances of the same IP,
+                        # then their signals would reference the same single
+                        # parameter. If we would mangle that directly, we all
+                        # signals of all IPs would reference to that single mangled
+                        # parameter. Since parameters are instance dependent, that
+                        # would fail. Therefore, copy the parameter first to have
+                        # a unique parameter for that particular signal and
+                        # instance, which is safe to mangle.
+                        s['width'] = deepcopy(s['width'])
+                        s['width'].name_top = p['name_top']
 
     # An instance must either have a 'base_addr' address or a 'base_addrs'
     # address, but can't have both.
@@ -224,14 +226,14 @@ def elaborate_instance(instance, block: IpBlock):
         else:
             # If the instance has a base_addr field, make sure that the block
             # has just one device interface.
-            if len(block.reg_blocks) != 1:
+            if not is_external and len(block.reg_blocks) != 1:
                 raise ValueError('Instance {!r} has a base_addr field but it '
                                  'instantiates the block {!r}, which has {} '
                                  'device interfaces.'.format(
                                      instance['name'], block.name,
                                      len(block.reg_blocks)))
             else:
-                if_name = next(iter(block.reg_blocks))
+                if_name = next(iter(block.reg_blocks)) if not is_external else None
                 base_addrs = {if_name: instance['base_addr']}
 
         # Fill in a bogus base address (we don't have proper error handling, so
@@ -249,8 +251,11 @@ def elaborate_instance(instance, block: IpBlock):
         # it's got the same set of keys as the name of the interfaces in the
         # block.
         inst_if_names = set(base_addrs.keys())
-        block_if_names = set(block.reg_blocks.keys()) | set(block.memories.keys())
-        if block_if_names != inst_if_names:
+        if is_external:
+            block_if_names = {None}
+        else:
+            block_if_names = set(block.reg_blocks.keys()) | set(block.memories.keys())
+        if not is_external and block_if_names != inst_if_names:
             log.error('Instance {!r} has a base_addrs field with keys {} '
                       'but the block it instantiates ({!r}) has device '
                       'interfaces {}.'.format(instance['name'], inst_if_names,
@@ -843,6 +848,9 @@ def amend_resets(top: ConfigT,
     # Generate exported reset list
     exported_rsts = OrderedDict()
     for module in top["module"]:
+        if module.get("external"):
+            continue
+
         block = name_to_block.get(module['type'])
         if block is None and allow_missing_blocks:
             continue
@@ -926,6 +934,8 @@ def create_alert_lpgs(top: ConfigT, name_to_block: IpBlocksT):
     assert isinstance(top['clocks'], Clocks)
     clock_groups = top['clocks'].make_clock_to_group()
     for module in top["module"]:
+        if module.get("external"):
+            continue
         # the alert senders are attached to the primary clock of this block,
         # so let's start by getting that primary clock port of an IP (we need
         # that to look up the clock connection at the top-level).
@@ -1035,6 +1045,9 @@ def get_interrupt_modules(top: ConfigT,
 
     modules = []
     for module in top["module"]:
+        if module.get("external"):
+            continue
+
         block = name_to_block.get(module["type"])
         if block is None and allow_missing_blocks:
             continue
@@ -1067,6 +1080,9 @@ def get_outgoing_interrupt_modules(top: ConfigT,
 
     modules = defaultdict(list)
     for module in top["module"]:
+        if module.get("external"):
+            continue
+
         block = name_to_block.get(module["type"])
         if block is None and allow_missing_blocks:
             continue
@@ -1162,6 +1178,9 @@ def get_alert_modules(top: ConfigT,
 
     modules = []
     for module in top['module']:
+        if module.get("external"):
+            continue
+
         block = name_to_block.get(module['type'])
         if block is None and allow_missing_blocks:
             continue
@@ -1296,6 +1315,9 @@ def get_outgoing_alert_modules(top: ConfigT,
 
     modules = defaultdict(list)
     for module in top['module']:
+        if module.get("external"):
+            continue
+
         block = name_to_block.get(module['type'])
         if block is None and allow_missing_blocks:
             continue
@@ -1374,6 +1396,9 @@ def amend_wkup(topcfg: ConfigT,
     # create list of wakeup signals
     wakeups = []
     for m in topcfg["module"]:
+        if m.get("external"):
+            continue
+
         block = name_to_block.get(m['type'])
         if block is None and allow_missing_blocks:
             continue
@@ -1411,6 +1436,9 @@ def amend_reset_request(topcfg: ConfigT,
     # create list of reset signals
     reset_signals = []
     for m in topcfg["module"]:
+        if m.get("external"):
+            continue
+
         log.info("Adding reset requests from module %s" % m["name"])
         block = name_to_block.get(m['type'])
         if block is None and allow_missing_blocks:

--- a/util/topgen/templates/tb__xbar_connect.sv.tpl
+++ b/util/topgen/templates/tb__xbar_connect.sv.tpl
@@ -99,6 +99,7 @@ initial begin
 `ifndef GATE_LEVEL
 % for xbar in top["xbar"]:
   % for node in xbar["nodes"]:
+    % if not node.get("external"): 
 <%
 clk = 'clk_' + clk_src[node["clock"]]
 esc_name = node['name'].replace('.', '__')
@@ -112,6 +113,7 @@ sig_name = inst_sig_list[0][2]
     `DRIVE_CHIP_TL_EXT_DEVICE_IF(${esc_name}, ${inst_name}, ${sig_name})
     % elif node["type"] == "device" and not node["xbar"]:
     `DRIVE_CHIP_TL_DEVICE_IF(${esc_name}, ${inst_name}, ${sig_name})
+    % endif
     % endif
   % endfor
 % endfor

--- a/util/topgen/templates/toplevel_interrupts.tpl
+++ b/util/topgen/templates/toplevel_interrupts.tpl
@@ -27,7 +27,7 @@
 <%
   block = name_to_block[m['type']]
 %>\
-    % if not lib.is_inst(m) or "outgoing_interrupt" in m:
+    % if not lib.is_inst(m) or "outgoing_interrupt" in m or m.get('external'):
 <% continue %>
     % endif
     % for intr in block.interrupts:

--- a/util/topgen/templates/toplevel_rnd_cnst_pkg.sv.tpl
+++ b/util/topgen/templates/toplevel_rnd_cnst_pkg.sv.tpl
@@ -35,6 +35,9 @@ ${gencmd}
 package top_${top["name"]}_rnd_cnst_pkg;
 
 % for m in top["module"]:
+% if m.get('external'):
+<% continue %>
+% endif
   % for p in filter(lambda p: p.get("randtype") in ["data", "perm", "extdata"], m["param_list"]):
     % if loop.first:
   ////////////////////////////////////////////

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -305,7 +305,14 @@ module_optional = {
     'plic': ['s', 'Interrupt controller managing this module\'s interrupts'],
     'targets': ['l', 'Optional list of targets for this PLIC'],
     'alert_handler': ['s', 'Alert handler managing this module\'s alerts'],
-    "otp_map": ["g", "OTP Map information for OTP Ctrl"]
+    "otp_map": ["g", "OTP Map information for OTP Ctrl"],
+    'external': ['s', 'Optional key indicating whether the corresponding '
+                 'module is external to the current top and is not to be '
+                 'instantiated within it'
+    ],
+    'external_size': ['s', 'int byte sizes for each of the addresses of '
+                      'the peripheral'
+    ]
 }
 
 module_added = {
@@ -930,6 +937,9 @@ def check_clocks_resets(top: ConfigT, ip_name_to_block: IpBlocksT,
 
     # Check clock/reset port connection for all IPs
     for ipcfg in top['module']:
+        if ipcfg.get("external"):
+            continue
+
         ipcfg_name = ipcfg['type']
         log.info("Checking clock/resets for %s" % ipcfg_name)
         error += validate_reset(ipcfg, ip_name_to_block[ipcfg_name],


### PR DESCRIPTION
Introduced some attributes that allow for an external TL-UL port to be added to a particular top.

For a `host` port, it requires defining the external device as a module in the top configuration file; include the device in the address space for the top and include the following additional fields:
- `external`, indicating that it is a external device
- `external_size`, indicating the byte size of the address space of the device

For a `device` port, adding the node in the corresponding `xbar` with the `external` field will generate the corresponding port connection.