### PR TITLE
[aon_timer,V2S] Set verification stage as V2S

### DIFF
--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -22,7 +22,7 @@
   version:            "2.0.0",
   life_stage:         "L1",
   design_stage:       "D3",
-  verification_stage: "V3",
+  verification_stage: "V2S",
   dif_stage:          "S2",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},


### PR DESCRIPTION
V3 requires 100% coverage, and aon_timer is not there yet, so V2S is the right verification stage.

Fixes #15