### PR TITLE
[dv,dvsim] Standardize generation of scratch directories

### DIFF
--- a/hw/ip_templates/ac_range_check/dv/ac_range_check_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/ac_range_check/dv/ac_range_check_sim_cfg.hjson.tpl
@@ -42,6 +42,14 @@
   uvm_test: ${module_instance_name}_base_test
   uvm_test_seq: ${module_instance_name}_base_vseq
 
+  // Need to override the default output directory
+  overrides: [
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
+  ]
+
   // List of test specifications.
   tests: [
     {

--- a/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/alert_handler/dv/alert_handler_sim_cfg.hjson.tpl
@@ -47,6 +47,10 @@
       name: cover_reg_top_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/top_earlgrey/ip_autogen/${module_instance_name}/dv/cov/${module_instance_name}_cover_reg_top.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
   // Add ALERT_HANDLER specific exclusion files.

--- a/hw/ip_templates/clkmgr/dv/clkmgr_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/clkmgr/dv/clkmgr_sim_cfg.hjson.tpl
@@ -54,6 +54,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/clkmgr_tgl_excl.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
   // Default UVM test and seq class name.
   uvm_test: clkmgr_base_test

--- a/hw/ip_templates/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson.tpl
@@ -39,6 +39,10 @@
       name: "timescale"
       value: "1ns/100ps"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
 // Add additional tops for simulation.

--- a/hw/ip_templates/gpio/dv/gpio_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/gpio/dv/gpio_sim_cfg.hjson.tpl
@@ -45,6 +45,14 @@
   uvm_test: ${module_instance_name}_base_test
   uvm_test_seq: ${module_instance_name}_base_vseq
 
+  // Need to override the default output directory
+  overrides: [
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
+  ]
+
   // Add GPIO specific exclusion files.
   vcs_cov_excl_files: ["{self_dir}/cov/gpio_cov_excl.el"]
 

--- a/hw/ip_templates/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson.tpl
@@ -69,6 +69,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/otp_ctrl_cover.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
   // Default UVM test and seq class name.

--- a/hw/ip_templates/pwm/dv/pwm_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/pwm/dv/pwm_sim_cfg.hjson.tpl
@@ -46,6 +46,10 @@
       name: default_xcelium_cov_cfg_file
       value: "{self_dir}/cov/cover.ccf"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
   // Default iterations for all tests - each test entry can override this.

--- a/hw/ip_templates/pwrmgr/dv/pwrmgr_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/pwrmgr/dv/pwrmgr_sim_cfg.hjson.tpl
@@ -40,6 +40,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/pwrmgr_tgl_excl.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
   // Add additional tops for simulation.

--- a/hw/ip_templates/racl_ctrl/dv/racl_ctrl_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/racl_ctrl/dv/racl_ctrl_sim_cfg.hjson.tpl
@@ -23,4 +23,12 @@
 
   // Import the underlying sim_cfg (not templated)
   import_cfgs: ["{proj_root}/hw/ip/racl_ctrl/dv/racl_ctrl_tests.hjson"]
+
+  // Need to override the default output directory
+  overrides: [
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
+  ]
 }

--- a/hw/ip_templates/rstmgr/dv/rstmgr_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/rstmgr/dv/rstmgr_sim_cfg.hjson.tpl
@@ -46,6 +46,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg+{proj_root}/hw/dv/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/rstmgr_cover.cfg+{self_dir}/cov/rstmgr_tgl_excl.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
   // Add additional tops for simulation.

--- a/hw/top_darjeeling/ip/xbar_dbg/dv/autogen/xbar_dbg_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip/xbar_dbg/dv/autogen/xbar_dbg_sim_cfg.hjson
@@ -24,6 +24,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/top_darjeeling/ip/{dut}/dv/autogen/xbar_cover.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
   // Import additional common sim cfg files.
   import_cfgs: [// xbar common sim cfg file

--- a/hw/top_darjeeling/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson
@@ -24,6 +24,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/top_darjeeling/ip/{dut}/dv/autogen/xbar_cover.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
   // Import additional common sim cfg files.
   import_cfgs: [// xbar common sim cfg file

--- a/hw/top_darjeeling/ip/xbar_mbx/dv/autogen/xbar_mbx_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip/xbar_mbx/dv/autogen/xbar_mbx_sim_cfg.hjson
@@ -24,6 +24,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/top_darjeeling/ip/{dut}/dv/autogen/xbar_cover.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
   // Import additional common sim cfg files.
   import_cfgs: [// xbar common sim cfg file

--- a/hw/top_darjeeling/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson
@@ -24,6 +24,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/top_darjeeling/ip/{dut}/dv/autogen/xbar_cover.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
   // Import additional common sim cfg files.
   import_cfgs: [// xbar common sim cfg file

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson
@@ -42,6 +42,14 @@
   uvm_test: ac_range_check_base_test
   uvm_test_seq: ac_range_check_base_vseq
 
+  // Need to override the default output directory
+  overrides: [
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
+  ]
+
   // List of test specifications.
   tests: [
     {

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -47,6 +47,10 @@
       name: cover_reg_top_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/top_earlgrey/ip_autogen/alert_handler/dv/cov/alert_handler_cover_reg_top.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
   // Add ALERT_HANDLER specific exclusion files.

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -54,6 +54,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/clkmgr_tgl_excl.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
   // Default UVM test and seq class name.
   uvm_test: clkmgr_base_test

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
@@ -45,6 +45,14 @@
   uvm_test: gpio_base_test
   uvm_test_seq: gpio_base_vseq
 
+  // Need to override the default output directory
+  overrides: [
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
+  ]
+
   // Add GPIO specific exclusion files.
   vcs_cov_excl_files: ["{self_dir}/cov/gpio_cov_excl.el"]
 

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -69,6 +69,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/otp_ctrl_cover.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
   // Default UVM test and seq class name.

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -40,6 +40,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/pwrmgr_tgl_excl.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
   // Add additional tops for simulation.

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/dv/racl_ctrl_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/dv/racl_ctrl_sim_cfg.hjson
@@ -23,4 +23,12 @@
 
   // Import the underlying sim_cfg (not templated)
   import_cfgs: ["{proj_root}/hw/ip/racl_ctrl/dv/racl_ctrl_tests.hjson"]
+
+  // Need to override the default output directory
+  overrides: [
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
+  ]
 }

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -46,6 +46,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg+{proj_root}/hw/dv/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/rstmgr_cover.cfg+{self_dir}/cov/rstmgr_tgl_excl.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
   // Add additional tops for simulation.

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson
@@ -24,6 +24,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/top_earlgrey/ip/{dut}/dv/autogen/xbar_cover.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
   // Import additional common sim cfg files.
   import_cfgs: [// xbar common sim cfg file

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson
@@ -24,6 +24,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/top_earlgrey/ip/{dut}/dv/autogen/xbar_cover.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
   // Import additional common sim cfg files.
   import_cfgs: [// xbar common sim cfg file

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -47,6 +47,10 @@
       name: cover_reg_top_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/top_earlgrey/ip_autogen/alert_handler/dv/cov/alert_handler_cover_reg_top.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
   // Add ALERT_HANDLER specific exclusion files.

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -54,6 +54,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/clkmgr_tgl_excl.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
   // Default UVM test and seq class name.
   uvm_test: clkmgr_base_test

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -39,6 +39,10 @@
       name: "timescale"
       value: "1ns/100ps"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
 // Add additional tops for simulation.

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
@@ -45,6 +45,14 @@
   uvm_test: gpio_base_test
   uvm_test_seq: gpio_base_vseq
 
+  // Need to override the default output directory
+  overrides: [
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
+  ]
+
   // Add GPIO specific exclusion files.
   vcs_cov_excl_files: ["{self_dir}/cov/gpio_cov_excl.el"]
 

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -69,6 +69,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/otp_ctrl_cover.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
   // Default UVM test and seq class name.

--- a/hw/top_earlgrey/ip_autogen/pwm/dv/pwm_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwm/dv/pwm_sim_cfg.hjson
@@ -46,6 +46,10 @@
       name: default_xcelium_cov_cfg_file
       value: "{self_dir}/cov/cover.ccf"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
   // Default iterations for all tests - each test entry can override this.

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -40,6 +40,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/pwrmgr_tgl_excl.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
   // Add additional tops for simulation.

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -46,6 +46,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg+{proj_root}/hw/dv/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/rstmgr_cover.cfg+{self_dir}/cov/rstmgr_tgl_excl.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
   // Add additional tops for simulation.

--- a/hw/top_englishbreakfast/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson
@@ -24,6 +24,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/top_englishbreakfast/ip/{dut}/dv/autogen/xbar_cover.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
   // Import additional common sim cfg files.
   import_cfgs: [// xbar common sim cfg file

--- a/hw/top_englishbreakfast/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson
@@ -24,6 +24,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/top_englishbreakfast/ip/{dut}/dv/autogen/xbar_cover.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
   // Import additional common sim cfg files.
   import_cfgs: [// xbar common sim cfg file

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -54,6 +54,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/clkmgr_tgl_excl.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
   // Default UVM test and seq class name.
   uvm_test: clkmgr_base_test

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -39,6 +39,10 @@
       name: "timescale"
       value: "1ns/100ps"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
 // Add additional tops for simulation.

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
@@ -45,6 +45,14 @@
   uvm_test: gpio_base_test
   uvm_test_seq: gpio_base_vseq
 
+  // Need to override the default output directory
+  overrides: [
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
+  ]
+
   // Add GPIO specific exclusion files.
   vcs_cov_excl_files: ["{self_dir}/cov/gpio_cov_excl.el"]
 

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -40,6 +40,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/pwrmgr_tgl_excl.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
   // Add additional tops for simulation.

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -46,6 +46,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg+{proj_root}/hw/dv/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/rstmgr_cover.cfg+{self_dir}/cov/rstmgr_tgl_excl.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
 
   // Add additional tops for simulation.

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -203,6 +203,9 @@ def _subst_wildcards(var, mdict, ignored, ignore_error, seen):
             raise ValueError('String to be expanded contains '
                              'unknown wildcard, {!r}.'.format(match.group(0)))
 
+        if name == "variant" and value == "":
+            value = "base"
+
         value = _stringify_wildcard_value(value)
 
         # Do any recursive expansion of value, adding name to seen (to avoid

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -194,6 +194,17 @@ def _subst_wildcards(var, mdict, ignored, ignore_error, seen):
         if value is None:
             value = os.environ.get(name)
 
+        if value is None and name == "topname":
+            self_dir = mdict.get("self_dir")
+            top_ip = re.match(r'.*?/hw/([^/]+)/ip_autogen(/.*)?', self_dir)
+            top_tlul = re.match(r'.*?/hw/([^/]+)/ip(/.*)?', self_dir)
+            if top_ip:
+                value = top_ip.group(1)
+            elif top_tlul:
+                value = top_tlul.group(1)
+            else:
+                value = "default"
+
         if value is None:
             # Ignore missing values if ignore_error is True.
             if ignore_error:

--- a/util/tlgen/xbar.sim_cfg.hjson.tpl
+++ b/util/tlgen/xbar.sim_cfg.hjson.tpl
@@ -24,6 +24,10 @@
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/${xbar.ip_path}/dv/autogen/xbar_cover.cfg"
     }
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{topname}-{flow}-{tool}"
+    }
   ]
   // Import additional common sim cfg files.
   import_cfgs: [// xbar common sim cfg file


### PR DESCRIPTION
This PR is composed of two commits:
- The first one makes it so that running `dvsim` in a `base_sim_cfg` generates a `_base` scratch subdirectory for consistency sake.
- The second allows for `dvsim` simulations generating separate directories for separate tops. For e.g. simulations of `clkmgr` for `hw/top_earlgrey` and `hw/top_darjeeling` would generate reports / logs on `clkmgr_top_earlgrey` and `clkmgr_top_darjeeling` respectively.