### PR TITLE
[nightly] Fix permissions, run only Monday through Thursday

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ name: Nightly
 on:
   workflow_dispatch:
   schedule:
-    - cron: "00 02 * * *"
+    - cron: "00 02 * * 1-4" # 2:00 am Monday thru Thursday
 
 permissions:
   contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,6 +18,9 @@ jobs:
   # Run On-demand Tests
   on-demand:
     name: Run On-demand Tests
+    permissions:
+      # Required by verible_lint job, even though it doesn't run
+      pull-requests: write
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 


### PR DESCRIPTION
GitHub requires the full ci.yml permission set even though the job doesn't run when run as part of the nightly.

Second, run the nightly jobs Mondays through Thursdays only, as the weekly kicks off Friday nights.