### PR TITLE
[top_darjeeling,dv] Stopped chip level tests with build issues from running with dvsim

### DIFF
--- a/hw/top_darjeeling/dv/chip_darjeeling_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_darjeeling_sim_cfg.hjson
@@ -468,14 +468,15 @@
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+bypass_alert_ready_to_end_check=1"]
     }
-    {
-      name: chip_sw_data_integrity_escalation
-      uvm_test_seq: chip_sw_data_integrity_vseq
-      sw_images: ["//sw/device/tests/sim_dv:data_integrity_escalation_reset_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+bypass_alert_ready_to_end_check=1"]
-      reseed: 6
-    }
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_data_integrity_escalation
+    //   uvm_test_seq: chip_sw_data_integrity_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:data_integrity_escalation_reset_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+bypass_alert_ready_to_end_check=1"]
+    //   reseed: 6
+    // }
     // TODO(#501): Re-evaluate or fix for new pinmux(less) configurations
     // {
     //   name: chip_sw_sleep_pin_mio_dio_val
@@ -485,96 +486,97 @@
     //   // Starting the chip in prod LC state frees up all MIOs for this test.
     //   run_opts: ["+use_otp_image=OtpTypeLcStProd"]
     // }
-    {
-      name: chip_sw_sleep_pin_wake
-      uvm_test_seq: chip_sw_sleep_pin_wake_vseq
-      sw_images: ["//sw/device/tests:sleep_pin_wake_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      // Starting the chip in prod LC state frees up all MIOs for this test.
-      run_opts: ["+use_otp_image=OtpTypeLcStProd"]
-    }
-    {
-      name: chip_sw_sleep_pin_retention
-      uvm_test_seq: chip_sw_sleep_pin_retention_vseq
-      sw_images: ["//sw/device/tests:sleep_pin_retention_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-    }
-    {
-      name: chip_sw_uart_tx_rx
-      uvm_test_seq: chip_sw_uart_tx_rx_vseq
-      sw_images: ["//sw/device/tests:uart_tx_rx_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+uart_idx=0"]
-      reseed: 5
-    }
-    {
-      name: chip_sw_uart_tx_rx_bootstrap
-      uvm_test_seq: chip_sw_uart_tx_rx_vseq
-      sw_images: ["//sw/device/tests:uart_tx_rx_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_spi_load_bootstrap=1", "+test_timeout_ns=80_000_000"]
-      run_timeout_mins: 240
-    }
-    {
-      name: chip_sw_inject_scramble_seed
-      uvm_test_seq: chip_sw_inject_scramble_seed_vseq
-      sw_images: ["//sw/device/tests/sim_dv:inject_scramble_seed:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+lc_at_prod=1", "+flash_program_latency=5", "+sw_test_timeout_ns=150_000_000"]
-      run_timeout_mins: 300
-    }
-    {
-      name: chip_sw_exit_test_unlocked_bootstrap
-      uvm_test_seq: chip_sw_exit_test_unlocked_bootstrap_vseq
-      sw_images: ["//sw/device/tests/sim_dv:exit_test_unlocked_bootstrap:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+flash_program_latency=5", "+sw_test_timeout_ns=150_000_000"]
-      run_timeout_mins: 220
-    }
-    {
-      name: chip_sw_uart_rand_baudrate
-      uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
-      sw_images: ["//sw/device/tests:uart_tx_rx_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=80_000_000"]
-      run_timeout_mins: 120
-      reseed: 20
-    }
-    {
-      name: chip_sw_uart_tx_rx_alt_clk_freq
-      uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
-      sw_images: ["//sw/device/tests:uart_tx_rx_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=80_000_000",
-                 "+chip_clock_source=ChipClockSourceExternal96Mhz"]
-      run_timeout_mins: 120
-      reseed: 5
-    }
-    {
-      name: chip_sw_i2c_host_tx_rx
-      uvm_test_seq: chip_sw_i2c_host_tx_rx_vseq
-      sw_images: ["//sw/device/tests/sim_dv:i2c_host_tx_rx_test:6:new_rules"]
-      run_opts: ["+i2c_idx=0"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-    }
-    {
-      name: chip_sw_i2c_device_tx_rx
-      uvm_test_seq: chip_sw_i2c_device_tx_rx_vseq
-      sw_images: ["//sw/device/tests/sim_dv:i2c_device_tx_rx_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-    }
-    {
-      name: chip_sw_spi_device_tpm
-      uvm_test_seq: chip_sw_spi_device_tpm_vseq
-      sw_images: ["//sw/device/tests:spi_device_tpm_tx_rx_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-    }
-    {
-      name: chip_sw_spi_host_tx_rx
-      uvm_test_seq: chip_sw_spi_host_tx_rx_vseq
-      sw_images: ["//sw/device/tests/sim_dv:spi_host_tx_rx_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-    }
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_sleep_pin_wake
+    //   uvm_test_seq: chip_sw_sleep_pin_wake_vseq
+    //   sw_images: ["//sw/device/tests:sleep_pin_wake_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   // Starting the chip in prod LC state frees up all MIOs for this test.
+    //   run_opts: ["+use_otp_image=OtpTypeLcStProd"]
+    // }
+    // {
+    //   name: chip_sw_sleep_pin_retention
+    //   uvm_test_seq: chip_sw_sleep_pin_retention_vseq
+    //   sw_images: ["//sw/device/tests:sleep_pin_retention_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    // }
+    // {
+    //   name: chip_sw_uart_tx_rx
+    //   uvm_test_seq: chip_sw_uart_tx_rx_vseq
+    //   sw_images: ["//sw/device/tests:uart_tx_rx_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+uart_idx=0"]
+    //   reseed: 5
+    // }
+    // {
+    //   name: chip_sw_uart_tx_rx_bootstrap
+    //   uvm_test_seq: chip_sw_uart_tx_rx_vseq
+    //   sw_images: ["//sw/device/tests:uart_tx_rx_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+use_spi_load_bootstrap=1", "+test_timeout_ns=80_000_000"]
+    //   run_timeout_mins: 240
+    // }
+    // {
+    //   name: chip_sw_inject_scramble_seed
+    //   uvm_test_seq: chip_sw_inject_scramble_seed_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:inject_scramble_seed:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+lc_at_prod=1", "+flash_program_latency=5", "+sw_test_timeout_ns=150_000_000"]
+    //   run_timeout_mins: 300
+    // }
+    // {
+    //   name: chip_sw_exit_test_unlocked_bootstrap
+    //   uvm_test_seq: chip_sw_exit_test_unlocked_bootstrap_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:exit_test_unlocked_bootstrap:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+flash_program_latency=5", "+sw_test_timeout_ns=150_000_000"]
+    //   run_timeout_mins: 220
+    // }
+    // {
+    //   name: chip_sw_uart_rand_baudrate
+    //   uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
+    //   sw_images: ["//sw/device/tests:uart_tx_rx_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+sw_test_timeout_ns=80_000_000"]
+    //   run_timeout_mins: 120
+    //   reseed: 20
+    // }
+    // {
+    //   name: chip_sw_uart_tx_rx_alt_clk_freq
+    //   uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
+    //   sw_images: ["//sw/device/tests:uart_tx_rx_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+sw_test_timeout_ns=80_000_000",
+    //              "+chip_clock_source=ChipClockSourceExternal96Mhz"]
+    //   run_timeout_mins: 120
+    //   reseed: 5
+    // }
+    // {
+    //   name: chip_sw_i2c_host_tx_rx
+    //   uvm_test_seq: chip_sw_i2c_host_tx_rx_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:i2c_host_tx_rx_test:6:new_rules"]
+    //   run_opts: ["+i2c_idx=0"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    // }
+    // {
+    //   name: chip_sw_i2c_device_tx_rx
+    //   uvm_test_seq: chip_sw_i2c_device_tx_rx_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:i2c_device_tx_rx_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    // }
+    // {
+    //   name: chip_sw_spi_device_tpm
+    //   uvm_test_seq: chip_sw_spi_device_tpm_vseq
+    //   sw_images: ["//sw/device/tests:spi_device_tpm_tx_rx_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    // }
+    // {
+    //   name: chip_sw_spi_host_tx_rx
+    //   uvm_test_seq: chip_sw_spi_host_tx_rx_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:spi_host_tx_rx_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    // }
     {
       name: chip_sw_spi_device_pass_through
       uvm_test_seq: chip_sw_spi_passthrough_vseq
@@ -605,52 +607,53 @@
       sw_images: ["//sw/device/tests:lc_ctrl_otp_hw_cfg_test:6:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
-    {
-      name: chip_sw_otp_ctrl_lc_signals_test_unlocked0
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_lc_signals_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"],
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_otp_ctrl_lc_signals_test_unlocked0
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_lc_signals_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"],
       // Use the image as basis, but clear provisioning state of the SECRET2 and SECRET3
       // partitions so that the test can make front-door accesses to those partitions.
-      run_opts: ["+use_otp_image=OtpTypeLcStTestUnlocked0", "+otp_clear_secret2=1",
-                 "+otp_clear_secret3=1"]
-    }
-    {
-      name: chip_sw_otp_ctrl_lc_signals_dev
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_lc_signals_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"],
+    //   run_opts: ["+use_otp_image=OtpTypeLcStTestUnlocked0", "+otp_clear_secret2=1",
+    //              "+otp_clear_secret3=1"]
+    // }
+    // {
+    //   name: chip_sw_otp_ctrl_lc_signals_dev
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_lc_signals_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"],
       // Use the image as basis, but clear provisioning state of the SECRET2 and SECRET3
       // partitions so that the test can make front-door accesses to those partitions.
-      run_opts: ["+use_otp_image=OtpTypeLcStDev", "+otp_clear_secret2=1", "+otp_clear_secret3=1",
-                 "+sw_test_timeout_ns=100_000_000"]
-    }
-    {
-      name: chip_sw_otp_ctrl_lc_signals_prod
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_lc_signals_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"],
+    //   run_opts: ["+use_otp_image=OtpTypeLcStDev", "+otp_clear_secret2=1", "+otp_clear_secret3=1",
+    //              "+sw_test_timeout_ns=100_000_000"]
+    // }
+    // {
+    //   name: chip_sw_otp_ctrl_lc_signals_prod
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_lc_signals_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"],
       // Use the image as basis, but clear provisioning state of the SECRET2 and SECRET3
       // partitions so that the test can make front-door accesses to those partitions.
-      run_opts: ["+use_otp_image=OtpTypeLcStProd", "+otp_clear_secret2=1", "+otp_clear_secret3=1",
-                 "+sw_test_timeout_ns=100_000_000"]
-    }
-    {
-      name: chip_sw_otp_ctrl_lc_signals_rma
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_lc_signals_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"],
+    //   run_opts: ["+use_otp_image=OtpTypeLcStProd", "+otp_clear_secret2=1", "+otp_clear_secret3=1",
+    //              "+sw_test_timeout_ns=100_000_000"]
+    // }
+    // {
+    //   name: chip_sw_otp_ctrl_lc_signals_rma
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_lc_signals_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"],
       // Use the image as basis, but clear provisioning state of the SECRET2 and SECRET3
       // partitions so that the test can make front-door accesses to those partitions.
-      run_opts: ["+use_otp_image=OtpTypeLcStRma", "+otp_clear_secret2=1", "+otp_clear_secret3=1",
-                 "+sw_test_timeout_ns=100_000_000"]
-    }
-    {
-      name: chip_sw_otp_ctrl_vendor_test_csr_access
-      uvm_test_seq: chip_sw_otp_ctrl_vendor_test_csr_access_vseq
-      sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_vendor_test_csr_access_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-    }
+    //   run_opts: ["+use_otp_image=OtpTypeLcStRma", "+otp_clear_secret2=1", "+otp_clear_secret3=1",
+    //              "+sw_test_timeout_ns=100_000_000"]
+    // }
+    // {
+    //   name: chip_sw_otp_ctrl_vendor_test_csr_access
+    //   uvm_test_seq: chip_sw_otp_ctrl_vendor_test_csr_access_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_vendor_test_csr_access_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    // }
     {
       name: chip_sw_otp_ctrl_escalation
       uvm_test_seq: chip_sw_otp_ctrl_escalation_vseq
@@ -677,14 +680,15 @@
       run_timeout_mins: 180
       reseed: 1
     }
-    {
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
       // Set higher reseed value to reach all kmac_data to lc_ctrl toggle coverage.
-      name: chip_sw_lc_ctrl_transition
-      uvm_test_seq: chip_sw_lc_ctrl_transition_vseq
-      sw_images: ["//sw/device/tests/sim_dv:lc_ctrl_transition_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      reseed: 15
-    }
+    //   name: chip_sw_lc_ctrl_transition
+    //   uvm_test_seq: chip_sw_lc_ctrl_transition_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:lc_ctrl_transition_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   reseed: 15
+    // }
 
     {
       name: chip_sw_lc_ctrl_rma_to_scrap
@@ -721,36 +725,37 @@
       run_opts: ["+bypass_alert_ready_to_end_check=1"]
       reseed: 3
     }
-    {
-      name: chip_sw_lc_walkthrough_dev
-      uvm_test_seq: chip_sw_lc_walkthrough_vseq
-      sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+flash_program_latency=5",
-                 "+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStDev",
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_lc_walkthrough_dev
+    //   uvm_test_seq: chip_sw_lc_walkthrough_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+flash_program_latency=5",
+    //              "+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStDev",
                  // The test takes long time because it will transit to RMA state
-                 "+sw_test_timeout_ns=200_000_000"]
-      run_timeout_mins: 240
-    }
-    {
-      name: chip_sw_lc_walkthrough_prod
-      uvm_test_seq: chip_sw_lc_walkthrough_vseq
-      sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+flash_program_latency=5",
-                 "+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStProd",
+    //              "+sw_test_timeout_ns=200_000_000"]
+    //   run_timeout_mins: 240
+    // }
+    // {
+    //   name: chip_sw_lc_walkthrough_prod
+    //   uvm_test_seq: chip_sw_lc_walkthrough_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+flash_program_latency=5",
+    //              "+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStProd",
                  // The test takes long time because it will transit to RMA state
-                 "+sw_test_timeout_ns=200_000_000"]
-      run_timeout_mins: 240
-    }
-    {
-      name: chip_sw_lc_walkthrough_prodend
-      uvm_test_seq: chip_sw_lc_walkthrough_vseq
-      sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+flash_program_latency=5",
-                 "+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStProdEnd"]
-    }
+    //              "+sw_test_timeout_ns=200_000_000"]
+    //   run_timeout_mins: 240
+    // }
+    // {
+    //   name: chip_sw_lc_walkthrough_prodend
+    //   uvm_test_seq: chip_sw_lc_walkthrough_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+flash_program_latency=5",
+    //              "+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStProdEnd"]
+    // }
     {
       name: chip_sw_lc_ctrl_volatile_raw_unlock
       uvm_test_seq: chip_sw_lc_volatile_raw_unlock_vseq
@@ -769,24 +774,25 @@
         "+chip_clock_source=ChipClockSourceExternal48Mhz"]
       run_timeout_mins: 120
     }
-    {
-      name: chip_sw_lc_walkthrough_rma
-      uvm_test_seq: chip_sw_lc_walkthrough_vseq
-      sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStRma",
-                 "+flash_program_latency=5",
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_lc_walkthrough_rma
+    //   uvm_test_seq: chip_sw_lc_walkthrough_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStRma",
+    //              "+flash_program_latency=5",
                  // The test takes long time because it will transit to RMA state
-                 "+sw_test_timeout_ns=200_000_000"]
-      run_timeout_mins: 240
-    }
-    {
-      name: chip_sw_lc_walkthrough_testunlocks
-      uvm_test_seq: chip_sw_lc_walkthrough_testunlocks_vseq
-      sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_testunlocks_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStTestUnlock7"]
-    }
+    //              "+sw_test_timeout_ns=200_000_000"]
+    //   run_timeout_mins: 240
+    // }
+    // {
+    //   name: chip_sw_lc_walkthrough_testunlocks
+    //   uvm_test_seq: chip_sw_lc_walkthrough_testunlocks_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_testunlocks_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStTestUnlock7"]
+    // }
     {
       name: chip_sw_rstmgr_sw_req
       uvm_test_seq: chip_sw_base_vseq
@@ -820,13 +826,15 @@
       sw_images: ["//sw/device/tests:rstmgr_smoketest:6:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
-    {
-      name: chip_sw_pwrmgr_main_power_glitch_reset
-      uvm_test_seq: chip_sw_main_power_glitch_vseq
-      sw_images: ["//sw/device/tests/sim_dv:pwrmgr_main_power_glitch_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+bypass_alert_ready_to_end_check=1"]
-    }
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_pwrmgr_main_power_glitch_reset
+    //   uvm_test_seq: chip_sw_main_power_glitch_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:pwrmgr_main_power_glitch_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+bypass_alert_ready_to_end_check=1"]
+    // }
+    // End of TODO(Pavona #43)
     // {
     //   name: chip_sw_pwrmgr_random_sleep_all_reset_reqs
     //   uvm_test_seq: chip_sw_random_sleep_all_reset_vseq
@@ -850,35 +858,36 @@
     //   en_run_modes: ["sw_test_mode_test_rom"]
     //   run_timeout_mins: 120
     // }
-    {
-      name: chip_sw_pwrmgr_sleep_power_glitch_reset
-      uvm_test_seq: chip_sw_main_power_glitch_vseq
-      sw_images: ["//sw/device/tests/sim_dv:pwrmgr_sleep_power_glitch_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+bypass_alert_ready_to_end_check=1"]
-    }
-    {
-      name: chip_sw_pwrmgr_deep_sleep_power_glitch_reset
-      uvm_test_seq: chip_sw_deep_power_glitch_vseq
-      sw_images: ["//sw/device/tests/sim_dv:pwrmgr_deep_sleep_power_glitch_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+bypass_alert_ready_to_end_check=1"]
-    }
-    {
-      name: chip_sw_pwrmgr_random_sleep_power_glitch_reset
-      uvm_test_seq: chip_sw_random_power_glitch_vseq
-      sw_images: ["//sw/device/tests/sim_dv:pwrmgr_random_sleep_power_glitch_reset_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+bypass_alert_ready_to_end_check=1",
-                 "+sw_test_timeout_ns=24_000_000"]
-      run_timeout_mins: 120
-    }
-    {
-      name: chip_sw_pwrmgr_sleep_disabled
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests:pwrmgr_sleep_disabled_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-    }
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_pwrmgr_sleep_power_glitch_reset
+    //   uvm_test_seq: chip_sw_main_power_glitch_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:pwrmgr_sleep_power_glitch_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+bypass_alert_ready_to_end_check=1"]
+    // }
+    // {
+    //   name: chip_sw_pwrmgr_deep_sleep_power_glitch_reset
+    //   uvm_test_seq: chip_sw_deep_power_glitch_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:pwrmgr_deep_sleep_power_glitch_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+bypass_alert_ready_to_end_check=1"]
+    // }
+    // {
+    //   name: chip_sw_pwrmgr_random_sleep_power_glitch_reset
+    //   uvm_test_seq: chip_sw_random_power_glitch_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:pwrmgr_random_sleep_power_glitch_reset_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+bypass_alert_ready_to_end_check=1",
+    //              "+sw_test_timeout_ns=24_000_000"]
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: chip_sw_pwrmgr_sleep_disabled
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["//sw/device/tests:pwrmgr_sleep_disabled_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    // }
     {
       name: chip_sw_rv_timer_irq
       uvm_test_seq: chip_sw_base_vseq
@@ -925,13 +934,14 @@
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=30_000_000"]
     }
-    {
-      name: chip_sw_pwrmgr_wdog_reset
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests:pwrmgr_wdog_reset_reqs_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=18_000_000"]
-    }
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_pwrmgr_wdog_reset
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["//sw/device/tests:pwrmgr_wdog_reset_reqs_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+sw_test_timeout_ns=18_000_000"]
+    // }
     {
       name: chip_sw_aon_timer_wdog_lc_escalate
       uvm_test_seq: chip_sw_base_vseq
@@ -1017,16 +1027,17 @@
       sw_images: ["//sw/device/tests/autogen/{top_chip}:alert_test:6:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
-    {
-      name: chip_sw_alert_handler_escalation
-      uvm_test_seq: chip_sw_alert_handler_escalation_vseq
-      sw_images: ["//sw/device/tests:alert_handler_escalation_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_alert_handler_escalation
+    //   uvm_test_seq: chip_sw_alert_handler_escalation_vseq
+    //   sw_images: ["//sw/device/tests:alert_handler_escalation_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
       // Disable scoreboard to avoid incorrect alert prediction from the alert_monitor. Due to the
       // cross-domain alert senders and receivers, the monitor from the chip level did not support
       // processing alerts accurately from both ends.
-      run_opts: ["+en_scb=0", "+bypass_alert_ready_to_end_check=1"]
-    }
+    //   run_opts: ["+en_scb=0", "+bypass_alert_ready_to_end_check=1"]
+    // }
     {
       name: chip_sw_alert_handler_ping_timeout
       uvm_test_seq: chip_sw_base_vseq
@@ -1037,20 +1048,21 @@
       // processing alerts accurately from both ends.
       run_opts: ["+en_scb=0", "+sw_test_timeout_ns=24000000"]
     }
-    {
-      name: chip_sw_alert_handler_reverse_ping_in_deep_sleep
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests:alert_handler_reverse_ping_in_deep_sleep_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_alert_handler_reverse_ping_in_deep_sleep
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["//sw/device/tests:alert_handler_reverse_ping_in_deep_sleep_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
       // Disable scoreboard to avoid incorrect alert prediction from the alert_monitor. Due to the
       // cross-domain alert senders and receivers, the monitor from the chip level did not support
       // processing alerts accurately from both ends.
       // This test takes long due to the compile time configured reverse timeout. See test plan for
       // more details.
-      run_opts: ["+en_scb=0", "+sw_test_timeout_ns=300_000_000"]
-      run_timeout_mins: 240
-    }
-     {
+    //   run_opts: ["+en_scb=0", "+sw_test_timeout_ns=300_000_000"]
+    //   run_timeout_mins: 240
+    // }
+    {
       name: chip_sw_alert_handler_lpg_sleep_mode_alerts
       uvm_test_seq: chip_sw_all_escalation_resets_vseq
       sw_images: ["//sw/device/tests:alert_handler_lpg_sleep_mode_alerts_test:6:new_rules"]
@@ -1063,40 +1075,41 @@
       run_timeout_mins: 240
       reseed: 90
     }
-    {
-      name: chip_sw_alert_handler_lpg_sleep_mode_pings
-      uvm_test_seq: chip_sw_alert_handler_shorten_ping_wait_cycle_vseq
-      sw_images: ["//sw/device/tests:alert_handler_lpg_sleep_mode_pings_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+en_scb=0", "+sw_test_timeout_ns=3000_000_000", "+bypass_alert_ready_to_end_check=1"]
-      run_timeout_mins: 240
-    }
-    {
-      name: chip_sw_alert_handler_lpg_clkoff
-      uvm_test_seq: chip_sw_alert_handler_lpg_clkoff_vseq
-      sw_images: ["//sw/device/tests:alert_handler_lpg_clkoff_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+en_scb=0", "+sw_test_timeout_ns=3000_000_000"]
-      run_timeout_mins: 240
-    }
-    {
-      name: chip_sw_alert_handler_lpg_reset_toggle
-      uvm_test_seq: chip_sw_alert_handler_shorten_ping_wait_cycle_vseq
-      sw_images: ["//sw/device/tests:alert_handler_lpg_reset_toggle_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+en_scb=0", "+sw_test_timeout_ns=3000_000_000"]
-      run_timeout_mins: 240
-    }
-    {
-      name: chip_sw_alert_handler_entropy
-      uvm_test_seq: chip_sw_alert_handler_entropy_vseq
-      sw_images: ["//sw/device/tests/sim_dv:alert_handler_entropy_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_alert_handler_lpg_sleep_mode_pings
+    //   uvm_test_seq: chip_sw_alert_handler_shorten_ping_wait_cycle_vseq
+    //   sw_images: ["//sw/device/tests:alert_handler_lpg_sleep_mode_pings_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+en_scb=0", "+sw_test_timeout_ns=3000_000_000", "+bypass_alert_ready_to_end_check=1"]
+    //   run_timeout_mins: 240
+    // }
+    // {
+    //   name: chip_sw_alert_handler_lpg_clkoff
+    //   uvm_test_seq: chip_sw_alert_handler_lpg_clkoff_vseq
+    //   sw_images: ["//sw/device/tests:alert_handler_lpg_clkoff_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+en_scb=0", "+sw_test_timeout_ns=3000_000_000"]
+    //   run_timeout_mins: 240
+    // }
+    // {
+    //   name: chip_sw_alert_handler_lpg_reset_toggle
+    //   uvm_test_seq: chip_sw_alert_handler_shorten_ping_wait_cycle_vseq
+    //   sw_images: ["//sw/device/tests:alert_handler_lpg_reset_toggle_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+en_scb=0", "+sw_test_timeout_ns=3000_000_000"]
+    //   run_timeout_mins: 240
+    // }
+    // {
+    //   name: chip_sw_alert_handler_entropy
+    //   uvm_test_seq: chip_sw_alert_handler_entropy_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:alert_handler_entropy_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
       // Disable scoreboard to avoid incorrect alert prediction from the alert_monitor. Due to the
       // cross-domain alert senders and receivers, the monitor from the chip level did not support
       // processing alerts accurately from both ends.
-      run_opts: ["+en_scb=0", "+bypass_alert_ready_to_end_check=1"]
-    }
+    //   run_opts: ["+en_scb=0", "+bypass_alert_ready_to_end_check=1"]
+    // }
     {
       name: chip_sw_aes_entropy
       uvm_test_seq: chip_sw_base_vseq
@@ -1120,13 +1133,14 @@
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=18_000_000"]
     }
-    {
-      name: chip_sw_csrng_fuse_en_sw_app_read_test
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests/sim_dv:csrng_fuse_en_sw_app_read:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=15_000_000"]
-    }
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_csrng_fuse_en_sw_app_read_test
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:csrng_fuse_en_sw_app_read:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+sw_test_timeout_ns=15_000_000"]
+    // }
     {
       name: chip_sw_entropy_src_csrng
       uvm_test_seq: chip_sw_base_vseq
@@ -1270,12 +1284,13 @@
       run_opts: ["+sw_test_timeout_ns=12_000_000", "+bypass_alert_ready_to_end_check=1",
                  "+en_jitter=1", "+en_scb_tl_err_chk=0"]
     }
-    {
-      name: chip_sw_sram_ctrl_execution_main
-      uvm_test_seq: chip_sw_sram_ctrl_execution_main_vseq
-      sw_images: ["//sw/device/tests/sim_dv:sram_ctrl_execution_main_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-    }
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_sram_ctrl_execution_main
+    //   uvm_test_seq: chip_sw_sram_ctrl_execution_main_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:sram_ctrl_execution_main_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    // }
 // Refactor test to remove flash dependency
 //    {
 //      name: chip_sw_sleep_sram_ret_contents
@@ -1373,24 +1388,26 @@
       sw_images: ["//sw/device/tests:clkmgr_off_acc_trans_test:6:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
-    {
-      name: chip_sw_clkmgr_reset_frequency
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["sw/device/tests:clkmgr_reset_frequency_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-    }
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_clkmgr_reset_frequency
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["sw/device/tests:clkmgr_reset_frequency_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    // }
     {
       name: chip_sw_clkmgr_jitter
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:clkmgr_jitter_test:6:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
-    {
-      name: chip_sw_clkmgr_sleep_frequency
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["sw/device/tests:clkmgr_sleep_frequency_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-    }
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_clkmgr_sleep_frequency
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["sw/device/tests:clkmgr_sleep_frequency_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    // }
     {
       name: chip_jtag_csr_rw
       uvm_test_seq: "chip_jtag_csr_rw_vseq"
@@ -1403,19 +1420,21 @@
       en_run_modes: ["stub_cpu_mode"]
       run_opts: ["+create_jtag_riscv_map=1"]
     }
-    {
-      name: chip_sw_ast_clk_outputs
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests:ast_clk_outs_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-    }
-    {
-      name: chip_sw_lc_ctrl_program_error
-      uvm_test_seq: chip_sw_lc_ctrl_program_error_vseq
-      sw_images: ["sw/device/tests/sim_dv:lc_ctrl_program_error:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+en_scb=0", "+bypass_alert_ready_to_end_check=1"]
-    }
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_ast_clk_outputs
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["//sw/device/tests:ast_clk_outs_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    // }
+    // {
+    //   name: chip_sw_lc_ctrl_program_error
+    //   uvm_test_seq: chip_sw_lc_ctrl_program_error_vseq
+    //   sw_images: ["sw/device/tests/sim_dv:lc_ctrl_program_error:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+en_scb=0", "+bypass_alert_ready_to_end_check=1"]
+    // }
+    // End of TODO(Pavona #43)
     // {
     //   name: chip_sw_pwrmgr_normal_sleep_all_wake_ups
     //   uvm_test_seq: "chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq"
@@ -1457,13 +1476,14 @@
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_jtag_dmi=1"]
     }
-    {
-      name: chip_sw_rv_dm_access_after_escalation_reset
-      uvm_test_seq: "chip_sw_rv_dm_access_after_escalation_reset_vseq"
-      sw_images: ["//sw/device/tests:alert_handler_escalation_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_jtag_dmi=1"]
-    }
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_rv_dm_access_after_escalation_reset
+    //   uvm_test_seq: "chip_sw_rv_dm_access_after_escalation_reset_vseq"
+    //   sw_images: ["//sw/device/tests:alert_handler_escalation_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+use_jtag_dmi=1"]
+    // }
     {
       name: chip_rv_dm_lc_disabled
       build_mode: "cover_reg_top"
@@ -1572,20 +1592,21 @@
 //      en_run_modes: ["sw_test_mode_test_rom"]
 //      run_opts: ["+sw_test_timeout_ns=200_000_000"]
 //    }
-    {
-      name: chip_sw_power_virus
-      uvm_test_seq: chip_sw_power_virus_vseq
-      sw_images: [
-        "//sw/device/tests:power_virus_systemtest:6:new_rules",
-        "//sw/device/tests:power_virus_systemtest_otp_img_rma:4",
-      ]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: [
-        "+sw_test_timeout_ns=200_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      run_timeout_mins: 300
-    }
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: chip_sw_power_virus
+    //   uvm_test_seq: chip_sw_power_virus_vseq
+    //   sw_images: [
+    //     "//sw/device/tests:power_virus_systemtest:6:new_rules",
+    //     "//sw/device/tests:power_virus_systemtest_otp_img_rma:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=200_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   run_timeout_mins: 300
+    // }
     {
       name: chip_sw_dma_inline_hashing
       uvm_test_seq: chip_sw_dma_spi_hw_handshake_vseq

--- a/hw/top_darjeeling/dv/chip_darjeeling_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_darjeeling_sim_cfg.hjson
@@ -601,12 +601,13 @@
       sw_images: ["//sw/device/tests:kmac_entropy_test:6:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
-    {
-      name: chip_sw_lc_ctrl_otp_hw_cfg
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests:lc_ctrl_otp_hw_cfg_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-    }
+    // TODO(Pavona #44): Needs sw_image Bazel target
+    // {
+    //   name: chip_sw_lc_ctrl_otp_hw_cfg
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["//sw/device/tests:lc_ctrl_otp_hw_cfg_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    // }
     // TODO(Pavona #43): Needs Darjeeling execution environment
     // {
     //   name: chip_sw_otp_ctrl_lc_signals_test_unlocked0
@@ -654,6 +655,7 @@
     //   sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_vendor_test_csr_access_test:6:new_rules"]
     //   en_run_modes: ["sw_test_mode_test_rom"]
     // }
+    // End of TODO(Pavona #43)
     {
       name: chip_sw_otp_ctrl_escalation
       uvm_test_seq: chip_sw_otp_ctrl_escalation_vseq
@@ -662,24 +664,26 @@
       run_opts: ["+bypass_alert_ready_to_end_check=1"]
       reseed: 1
     }
-    {
-      name: chip_sw_otp_ctrl_nvm_cnt
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests:otp_ctrl_nvm_cnt_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=100_000_000"]
-      run_timeout_mins: 180
-      reseed: 1
-    }
-    {
-      name: chip_sw_otp_ctrl_sw_parts
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests:otp_ctrl_sw_parts_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=100_000_000"]
-      run_timeout_mins: 180
-      reseed: 1
-    }
+    // TODO(Pavona #44): Needs sw_image Bazel target
+    // {
+    //   name: chip_sw_otp_ctrl_nvm_cnt
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["//sw/device/tests:otp_ctrl_nvm_cnt_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+sw_test_timeout_ns=100_000_000"]
+    //   run_timeout_mins: 180
+    //   reseed: 1
+    // }
+    // {
+    //   name: chip_sw_otp_ctrl_sw_parts
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["//sw/device/tests:otp_ctrl_sw_parts_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+sw_test_timeout_ns=100_000_000"]
+    //   run_timeout_mins: 180
+    //   reseed: 1
+    // }
+    // End of TODO(Pavona #43)
     // TODO(Pavona #43): Needs Darjeeling execution environment
     // {
       // Set higher reseed value to reach all kmac_data to lc_ctrl toggle coverage.
@@ -756,6 +760,7 @@
     //   run_opts: ["+flash_program_latency=5",
     //              "+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStProdEnd"]
     // }
+    // End of TODO(Pavona #43)
     {
       name: chip_sw_lc_ctrl_volatile_raw_unlock
       uvm_test_seq: chip_sw_lc_volatile_raw_unlock_vseq
@@ -793,6 +798,7 @@
     //   en_run_modes: ["sw_test_mode_test_rom"]
     //   run_opts: ["+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStTestUnlock7"]
     // }
+    // End of TODO(Pavona #43)
     {
       name: chip_sw_rstmgr_sw_req
       uvm_test_seq: chip_sw_base_vseq
@@ -888,6 +894,7 @@
     //   sw_images: ["//sw/device/tests:pwrmgr_sleep_disabled_test:6:new_rules"]
     //   en_run_modes: ["sw_test_mode_test_rom"]
     // }
+    // End of TODO(Pavona #43)
     {
       name: chip_sw_rv_timer_irq
       uvm_test_seq: chip_sw_base_vseq
@@ -1021,12 +1028,13 @@
       sw_images: ["//sw/device/tests:aes_masking_off_test:6:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
-    {
-      name: chip_sw_alert_test
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests/autogen/{top_chip}:alert_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-    }
+    // TODO(Pavona #44): Needs sw_image Bazel target
+    // {
+    //   name: chip_sw_alert_test
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["//sw/device/tests/autogen/{top_chip}:alert_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    // }
     // TODO(Pavona #43): Needs Darjeeling execution environment
     // {
     //   name: chip_sw_alert_handler_escalation
@@ -1062,19 +1070,20 @@
     //   run_opts: ["+en_scb=0", "+sw_test_timeout_ns=300_000_000"]
     //   run_timeout_mins: 240
     // }
-    {
-      name: chip_sw_alert_handler_lpg_sleep_mode_alerts
-      uvm_test_seq: chip_sw_all_escalation_resets_vseq
-      sw_images: ["//sw/device/tests:alert_handler_lpg_sleep_mode_alerts_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+en_scb=0",
-                 "+sw_test_timeout_ns=3000_000_000",
-                 "+bypass_alert_ready_to_end_check=1",
-                 "+avoid_inject_fatal_error_for_ips=sram_ctrl_main,lc_ctrl*state_regs",
-                 "+avoid_ferr_ips_append=otp_ctrl*u_otp_ctrl_dai,rv_core_ibex*sw_fatal_err"]
-      run_timeout_mins: 240
-      reseed: 90
-    }
+    // TODO(Pavona #44): Needs sw_image Bazel target
+    // {
+    //   name: chip_sw_alert_handler_lpg_sleep_mode_alerts
+    //   uvm_test_seq: chip_sw_all_escalation_resets_vseq
+    //   sw_images: ["//sw/device/tests:alert_handler_lpg_sleep_mode_alerts_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+en_scb=0",
+    //              "+sw_test_timeout_ns=3000_000_000",
+    //              "+bypass_alert_ready_to_end_check=1",
+    //              "+avoid_inject_fatal_error_for_ips=sram_ctrl_main,lc_ctrl*state_regs",
+    //              "+avoid_ferr_ips_append=otp_ctrl*u_otp_ctrl_dai,rv_core_ibex*sw_fatal_err"]
+    //   run_timeout_mins: 240
+    //   reseed: 90
+    // }
     // TODO(Pavona #43): Needs Darjeeling execution environment
     // {
     //   name: chip_sw_alert_handler_lpg_sleep_mode_pings
@@ -1110,6 +1119,7 @@
       // processing alerts accurately from both ends.
     //   run_opts: ["+en_scb=0", "+bypass_alert_ready_to_end_check=1"]
     // }
+    // End of TODO(Pavona #43)
     {
       name: chip_sw_aes_entropy
       uvm_test_seq: chip_sw_base_vseq
@@ -1276,14 +1286,15 @@
       run_opts: ["+sw_test_timeout_ns=12_000_000", "+en_scb_tl_err_chk=0",
                  "+bypass_alert_ready_to_end_check=1"]
     }
-    {
-      name: chip_sw_sram_ctrl_scrambled_access_jitter_en
-      uvm_test_seq: chip_sw_sram_ctrl_scrambled_access_vseq
-      sw_images: ["//sw/device/tests/sim_dv:sram_ctrl_scrambled_access_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=12_000_000", "+bypass_alert_ready_to_end_check=1",
-                 "+en_jitter=1", "+en_scb_tl_err_chk=0"]
-    }
+    // TODO(Pavona #44): Needs sw_image Bazel target
+    // {
+    //   name: chip_sw_sram_ctrl_scrambled_access_jitter_en
+    //   uvm_test_seq: chip_sw_sram_ctrl_scrambled_access_vseq
+    //   sw_images: ["//sw/device/tests/sim_dv:sram_ctrl_scrambled_access_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+sw_test_timeout_ns=12_000_000", "+bypass_alert_ready_to_end_check=1",
+    //              "+en_jitter=1", "+en_scb_tl_err_chk=0"]
+    // }
     // TODO(Pavona #43): Needs Darjeeling execution environment
     // {
     //   name: chip_sw_sram_ctrl_execution_main
@@ -1291,6 +1302,7 @@
     //   sw_images: ["//sw/device/tests/sim_dv:sram_ctrl_execution_main_test:6:new_rules"]
     //   en_run_modes: ["sw_test_mode_test_rom"]
     // }
+    // End of TODO(Pavona #43)
 // Refactor test to remove flash dependency
 //    {
 //      name: chip_sw_sleep_sram_ret_contents
@@ -1300,16 +1312,18 @@
 //      run_opts: ["+sw_test_timeout_ns=20_000_000", "+en_scb_tl_err_chk=0",
 //                 "+bypass_alert_ready_to_end_check=1"]
 //    }
-    {
-      name: chip_sw_coremark
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//third_party/coremark/{top_chip}:coremark_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+en_uart_logger=1",
-                 "+sw_test_timeout_ns=100_000_000"]
-      reseed: 1
-      run_timeout_mins: 180
-    }
+    // TODO(Pavona #44): Needs sw_image Bazel target
+    // {
+    //   name: chip_sw_coremark
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["//third_party/coremark/{top_chip}:coremark_test:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+en_uart_logger=1",
+    //              "+sw_test_timeout_ns=100_000_000"]
+    //   reseed: 1
+    //   run_timeout_mins: 180
+    // }
+    // End of TODO(Pavona #44)
     // {
     //   name: chip_sw_pwrmgr_b2b_sleep_reset_req
     //   uvm_test_seq: chip_sw_repeat_reset_wkup_vseq
@@ -1462,20 +1476,22 @@
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+en_scb_tl_err_chk=0", "+use_jtag_dmi=1"]
     }
-    {
-      name: chip_sw_rv_dm_ndm_reset_req_when_cpu_halted
-      uvm_test_seq: "chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq"
-      sw_images: ["//sw/device/tests:rv_dm_ndm_reset_req_when_cpu_halted:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_jtag_dmi=1"]
-    }
-    {
-      name: chip_sw_rv_dm_access_after_wakeup
-      uvm_test_seq: chip_sw_rv_dm_access_after_wakeup_vseq
-      sw_images: ["//sw/device/tests:rv_dm_access_after_wakeup:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_jtag_dmi=1"]
-    }
+    // TODO(Pavona #44): Needs sw_image Bazel target
+    // {
+    //   name: chip_sw_rv_dm_ndm_reset_req_when_cpu_halted
+    //   uvm_test_seq: "chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq"
+    //   sw_images: ["//sw/device/tests:rv_dm_ndm_reset_req_when_cpu_halted:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+use_jtag_dmi=1"]
+    // }
+    // {
+    //   name: chip_sw_rv_dm_access_after_wakeup
+    //   uvm_test_seq: chip_sw_rv_dm_access_after_wakeup_vseq
+    //   sw_images: ["//sw/device/tests:rv_dm_access_after_wakeup:6:new_rules"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+use_jtag_dmi=1"]
+    // }
+    // End of TODO(Pavona #44)
     // TODO(Pavona #43): Needs Darjeeling execution environment
     // {
     //   name: chip_sw_rv_dm_access_after_escalation_reset

--- a/hw/top_darjeeling/dv/chip_rom_tests.hjson
+++ b/hw/top_darjeeling/dv/chip_rom_tests.hjson
@@ -15,794 +15,793 @@
       en_run_modes: ["sw_test_mode_base_rom_with_fake_keys"]
       run_opts: ["+sw_test_timeout_ns=20000000"]
     }
-    {
-      name: rom_e2e_smoke
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_test_key_0"]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: ["+sw_test_timeout_ns=20000000"]
-    }
-    {
-      name: rom_e2e_shutdown_exception_c
-      uvm_test_seq: chip_sw_rom_e2e_shutdown_exception_c_vseq
-      sw_images: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_shutdown_exception_c:6:signed:fake_rsa_test_key_0"]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: ["+sw_test_timeout_ns=20000000"]
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_shutdown_output
-      uvm_test_seq: chip_sw_rom_e2e_shutdown_output_vseq
+    // TODO(Pavona #44): Needs sw_image Bazel target
+    // {
+    //   name: rom_e2e_smoke
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_test_key_0"]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: ["+sw_test_timeout_ns=20000000"]
+    // }
+    // {
+    //   name: rom_e2e_shutdown_exception_c
+    //   uvm_test_seq: chip_sw_rom_e2e_shutdown_exception_c_vseq
+    //   sw_images: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_shutdown_exception_c:6:signed:fake_rsa_test_key_0"]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: ["+sw_test_timeout_ns=20000000"]
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_shutdown_output
+    //   uvm_test_seq: chip_sw_rom_e2e_shutdown_output_vseq
       # Note: this is an unsigned test, as we are verifying a boot failure.
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_shutdown_output_test_unlocked0:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=20000000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_boot_policy_valid_a_good_b_good_test_unlocked0
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_shutdown_output_test_unlocked0:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=20000000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_boot_policy_valid_a_good_b_good_test_unlocked0
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_test_unlocked0:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=410_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 480
-    }
-    {
-      name: rom_e2e_boot_policy_valid_a_good_b_good_dev
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_test_unlocked0:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=410_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 480
+    // }
+    // {
+    //   name: rom_e2e_boot_policy_valid_a_good_b_good_dev
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_dev:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 180
-    }
-    {
-      name: rom_e2e_boot_policy_valid_a_good_b_good_prod
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_dev:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 180
+    // }
+    // {
+    //   name: rom_e2e_boot_policy_valid_a_good_b_good_prod
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 180
-    }
-    {
-      name: rom_e2e_boot_policy_valid_a_good_b_good_prod_end
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 180
+    // }
+    // {
+    //   name: rom_e2e_boot_policy_valid_a_good_b_good_prod_end
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod_end:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 180
-    }
-    {
-      name: rom_e2e_boot_policy_valid_a_good_b_good_rma
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod_end:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 180
+    // }
+    // {
+    //   name: rom_e2e_boot_policy_valid_a_good_b_good_rma
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_rma:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 180
-    }
-    {
-      name: rom_e2e_boot_policy_valid_a_good_b_bad_test_unlocked0
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_rma:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 180
+    // }
+    // {
+    //   name: rom_e2e_boot_policy_valid_a_good_b_bad_test_unlocked0
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_test_unlocked0:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=410_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 480
-    }
-    {
-      name: rom_e2e_boot_policy_valid_a_good_b_bad_dev
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_test_unlocked0:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=410_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 480
+    // }
+    // {
+    //   name: rom_e2e_boot_policy_valid_a_good_b_bad_dev
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_dev:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 180
-    }
-    {
-      name: rom_e2e_boot_policy_valid_a_good_b_bad_prod
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_dev:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 180
+    // }
+    // {
+    //   name: rom_e2e_boot_policy_valid_a_good_b_bad_prod
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 180
-    }
-    {
-      name: rom_e2e_boot_policy_valid_a_good_b_bad_prod_end
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 180
+    // }
+    // {
+    //   name: rom_e2e_boot_policy_valid_a_good_b_bad_prod_end
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod_end:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 180
-    }
-    {
-      name: rom_e2e_boot_policy_valid_a_good_b_bad_rma
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod_end:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 180
+    // }
+    // {
+    //   name: rom_e2e_boot_policy_valid_a_good_b_bad_rma
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_rma:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 180
-    }
-    {
-      name: rom_e2e_boot_policy_valid_a_bad_b_good_test_unlocked0
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_rma:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 180
+    // }
+    // {
+    //   name: rom_e2e_boot_policy_valid_a_bad_b_good_test_unlocked0
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_test_unlocked0:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=410_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 480
-    }
-    {
-      name: rom_e2e_boot_policy_valid_a_bad_b_good_dev
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_test_unlocked0:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=410_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 480
+    // }
+    // {
+    //   name: rom_e2e_boot_policy_valid_a_bad_b_good_dev
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_dev:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 180
-    }
-    {
-      name: rom_e2e_boot_policy_valid_a_bad_b_good_prod
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_dev:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 180
+    // }
+    // {
+    //   name: rom_e2e_boot_policy_valid_a_bad_b_good_prod
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 180
-    }
-    {
-      name: rom_e2e_boot_policy_valid_a_bad_b_good_prod_end
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 180
+    // }
+    // {
+    //   name: rom_e2e_boot_policy_valid_a_bad_b_good_prod_end
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod_end:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 180
-    }
-    {
-      name: rom_e2e_boot_policy_valid_a_bad_b_good_rma
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod_end:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 180
+    // }
+    // {
+    //   name: rom_e2e_boot_policy_valid_a_bad_b_good_rma
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_rma:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 180
-    }
-    {
-      name: rom_e2e_sigverify_always_a_bad_b_bad_test_unlocked0
-      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_test_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_rma:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 180
+    // }
+    // {
+    //   name: rom_e2e_sigverify_always_a_bad_b_bad_test_unlocked0
+    //   uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_test_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_test_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_test_unlocked0:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=600_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 600
-    }
-    {
-      name: rom_e2e_sigverify_always_a_bad_b_bad_dev
-      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_dev_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_test_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_test_unlocked0:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=600_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 600
+    // }
+    // {
+    //   name: rom_e2e_sigverify_always_a_bad_b_bad_dev
+    //   uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_dev_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_dev_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_dev:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_always_a_bad_b_bad_prod
-      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_dev_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_dev:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_sigverify_always_a_bad_b_bad_prod
+    //   uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_always_a_bad_b_bad_prod_end
-      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_sigverify_always_a_bad_b_bad_prod_end
+    //   uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     // TODO: Need to enable second slot image loading via index 7 in DV.
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod_end:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_sigverify_always_a_bad_b_bad_rma
+    //   uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
         // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod_end:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_always_a_bad_b_bad_rma
-      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        // TODO: Need to enable second slot image loading via index 7 in DV.
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_rma:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_always_a_bad_b_nothing_test_unlocked0
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_rma:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_sigverify_always_a_bad_b_nothing_test_unlocked0
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
-      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_test_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_test_unlocked0:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=410_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 480
-    }
-    {
-      name: rom_e2e_sigverify_always_a_bad_b_nothing_dev
+    //   uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_test_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_test_unlocked0:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=410_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 480
+    // }
+    // {
+    //   name: rom_e2e_sigverify_always_a_bad_b_nothing_dev
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
-      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_dev_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_dev:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_always_a_bad_b_nothing_prod
+    //   uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_dev_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_dev:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_sigverify_always_a_bad_b_nothing_prod
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
-      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_always_a_bad_b_nothing_prod_end
+    //   uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_sigverify_always_a_bad_b_nothing_prod_end
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
-      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod_end:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_always_a_bad_b_nothing_rma
+    //   uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod_end:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_sigverify_always_a_bad_b_nothing_rma
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
-      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_rma:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_always_a_nothing_b_bad_test_unlocked0
+    //   uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_rma:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_sigverify_always_a_nothing_b_bad_test_unlocked0
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
-      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:6:ot_flash_binary:signed:fake_rsa_test_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_test_unlocked0:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=410_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 480
-    }
-    {
-      name: rom_e2e_sigverify_always_a_nothing_b_bad_dev
+    //   uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:6:ot_flash_binary:signed:fake_rsa_test_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_test_unlocked0:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=410_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 480
+    // }
+    // {
+    //   name: rom_e2e_sigverify_always_a_nothing_b_bad_dev
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
-      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:6:ot_flash_binary:signed:fake_rsa_dev_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_dev:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_always_a_nothing_b_bad_prod
+    //   uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:6:ot_flash_binary:signed:fake_rsa_dev_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_dev:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_sigverify_always_a_nothing_b_bad_prod
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
-      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_always_a_nothing_b_bad_prod_end
+    //   uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_sigverify_always_a_nothing_b_bad_prod_end
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
-      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod_end:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_always_a_nothing_b_bad_rma
+    //   uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod_end:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_sigverify_always_a_nothing_b_bad_rma
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
-      uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_rma:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_asm_init_test_unlocked0
-      uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:signed:ot_flash_binary:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_e2e_bootstrap_entry_test_unlocked0:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+use_otp_image=OtpTypeCustom",
-        "+sw_test_timeout_ns=410_000_000",
-      ]
-      run_timeout_mins: 480
-    }
-    {
-      name: rom_e2e_asm_init_dev
-      uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:signed:ot_flash_binary:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_e2e_bootstrap_entry_dev:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+use_otp_image=OtpTypeCustom",
-        "+sw_test_timeout_ns=20000000",
-      ]
-      run_timeout_mins: 180
-    }
-    {
-      name: rom_e2e_asm_init_prod
-      uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:signed:ot_flash_binary:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_e2e_bootstrap_entry_prod:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+use_otp_image=OtpTypeCustom",
-        "+sw_test_timeout_ns=20000000",
-      ]
-      run_timeout_mins: 180
-    }
-    {
-      name: rom_e2e_asm_init_prod_end
-      uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:signed:ot_flash_binary:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_e2e_bootstrap_entry_prod_end:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+use_otp_image=OtpTypeCustom",
-        "+sw_test_timeout_ns=20000000",
-      ]
-      run_timeout_mins: 180
-    }
-    {
-      name: rom_e2e_asm_init_rma
-      uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:signed:ot_flash_binary:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_e2e_bootstrap_entry_rma:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+use_otp_image=OtpTypeCustom",
-        "+sw_test_timeout_ns=20000000",
-      ]
-      run_timeout_mins: 180
-    }
-    {
-      name: rom_e2e_jtag_debug_test_unlocked0
-      uvm_test_seq: chip_sw_rom_e2e_jtag_debug_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:img_test_unlocked0_exec_disabled:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+use_jtag_dmi=1",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_jtag_debug_dev
-      uvm_test_seq: chip_sw_rom_e2e_jtag_debug_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:img_dev_exec_disabled:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+use_jtag_dmi=1",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_jtag_debug_rma
-      uvm_test_seq: chip_sw_rom_e2e_jtag_debug_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:img_rma_exec_disabled:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+use_jtag_dmi=1",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_jtag_inject_test_unlocked0
-      uvm_test_seq: chip_sw_rom_e2e_jtag_inject_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:img_dev_exec_disabled:4",
-        "//sw/device/examples/sram_program:sram_program:5",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+use_jtag_dmi=1",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 200
-    }
-    {
-      name: rom_e2e_jtag_inject_dev
-      uvm_test_seq: chip_sw_rom_e2e_jtag_inject_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:img_dev_exec_disabled:4",
-        "//sw/device/examples/sram_program:sram_program:5",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+use_jtag_dmi=1",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 200
-    }
-    {
-      name: rom_e2e_jtag_inject_rma
-      uvm_test_seq: chip_sw_rom_e2e_jtag_inject_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:img_dev_exec_disabled:4",
-        "//sw/device/examples/sram_program:sram_program:5",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+use_jtag_dmi=1",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      reseed: 1
-      run_timeout_mins: 200
-    }
-    {
-      name: rom_e2e_static_critical
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_static_critical:6:signed:fake_rsa_test_key_0"]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: ["+sw_test_timeout_ns=20000000"]
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_keymgr_init_rom_ext_meas
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:rom_e2e_keymgr_init_test:6:signed:fake_rsa_test_key_0:ot_flash_binary",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_keymgr_rom_ext_meas:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=20_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_keymgr_init_rom_ext_no_meas
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:rom_e2e_keymgr_init_test:6:signed:fake_rsa_test_key_0:ot_flash_binary",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_keymgr_rom_ext_no_meas:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=20_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_keymgr_init_rom_ext_invalid_meas
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:rom_e2e_keymgr_init_test:6:signed:fake_rsa_test_key_0:ot_flash_binary",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_keymgr_rom_ext_invalid_meas:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=20_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      run_timeout_mins: 120
-    }
-
+    //   uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_rma:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=50_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_asm_init_test_unlocked0
+    //   uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:signed:ot_flash_binary:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_e2e_bootstrap_entry_test_unlocked0:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+use_otp_image=OtpTypeCustom",
+    //     "+sw_test_timeout_ns=410_000_000",
+    //   ]
+    //   run_timeout_mins: 480
+    // }
+    // {
+    //   name: rom_e2e_asm_init_dev
+    //   uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:signed:ot_flash_binary:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_e2e_bootstrap_entry_dev:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+use_otp_image=OtpTypeCustom",
+    //     "+sw_test_timeout_ns=20000000",
+    //   ]
+    //   run_timeout_mins: 180
+    // }
+    // {
+    //   name: rom_e2e_asm_init_prod
+    //   uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:signed:ot_flash_binary:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_e2e_bootstrap_entry_prod:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+use_otp_image=OtpTypeCustom",
+    //     "+sw_test_timeout_ns=20000000",
+    //   ]
+    //   run_timeout_mins: 180
+    // }
+    // {
+    //   name: rom_e2e_asm_init_prod_end
+    //   uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:signed:ot_flash_binary:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_e2e_bootstrap_entry_prod_end:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+use_otp_image=OtpTypeCustom",
+    //     "+sw_test_timeout_ns=20000000",
+    //   ]
+    //   run_timeout_mins: 180
+    // }
+    // {
+    //   name: rom_e2e_asm_init_rma
+    //   uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:signed:ot_flash_binary:fake_rsa_prod_key_0",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_e2e_bootstrap_entry_rma:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+use_otp_image=OtpTypeCustom",
+    //     "+sw_test_timeout_ns=20000000",
+    //   ]
+    //   run_timeout_mins: 180
+    // }
+    // {
+    //   name: rom_e2e_jtag_debug_test_unlocked0
+    //   uvm_test_seq: chip_sw_rom_e2e_jtag_debug_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:img_test_unlocked0_exec_disabled:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+use_jtag_dmi=1",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_jtag_debug_dev
+    //   uvm_test_seq: chip_sw_rom_e2e_jtag_debug_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:img_dev_exec_disabled:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+use_jtag_dmi=1",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_jtag_debug_rma
+    //   uvm_test_seq: chip_sw_rom_e2e_jtag_debug_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:img_rma_exec_disabled:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+use_jtag_dmi=1",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_jtag_inject_test_unlocked0
+    //   uvm_test_seq: chip_sw_rom_e2e_jtag_inject_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:img_dev_exec_disabled:4",
+    //     "//sw/device/examples/sram_program:sram_program:5",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+use_jtag_dmi=1",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 200
+    // }
+    // {
+    //   name: rom_e2e_jtag_inject_dev
+    //   uvm_test_seq: chip_sw_rom_e2e_jtag_inject_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:img_dev_exec_disabled:4",
+    //     "//sw/device/examples/sram_program:sram_program:5",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+use_jtag_dmi=1",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 200
+    // }
+    // {
+    //   name: rom_e2e_jtag_inject_rma
+    //   uvm_test_seq: chip_sw_rom_e2e_jtag_inject_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:img_dev_exec_disabled:4",
+    //     "//sw/device/examples/sram_program:sram_program:5",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+use_jtag_dmi=1",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   reseed: 1
+    //   run_timeout_mins: 200
+    // }
+    // {
+    //   name: rom_e2e_static_critical
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_static_critical:6:signed:fake_rsa_test_key_0"]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: ["+sw_test_timeout_ns=20000000"]
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_keymgr_init_rom_ext_meas
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:rom_e2e_keymgr_init_test:6:signed:fake_rsa_test_key_0:ot_flash_binary",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_keymgr_rom_ext_meas:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=20_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_keymgr_init_rom_ext_no_meas
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:rom_e2e_keymgr_init_test:6:signed:fake_rsa_test_key_0:ot_flash_binary",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_keymgr_rom_ext_no_meas:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=20_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   run_timeout_mins: 120
+    // }
+    // {
+    //   name: rom_e2e_keymgr_init_rom_ext_invalid_meas
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:rom_e2e_keymgr_init_test:6:signed:fake_rsa_test_key_0:ot_flash_binary",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_keymgr_rom_ext_invalid_meas:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=20_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   run_timeout_mins: 120
+    // }
     // Life cycle transitions with production ROM.
-    {
-      name: rom_volatile_raw_unlock
-      uvm_test_seq: chip_sw_lc_volatile_raw_unlock_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:signed:fake_rsa_test_key_0:ot_flash_binary",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=200_000_000",
-        "+use_otp_image=OtpTypeLcStRaw",
-        "+chip_clock_source=ChipClockSourceExternal48Mhz",
-        "+rom_prod_mode=1",
-      ]
-      run_timeout_mins: 480
-    }
-
-    {
-      name: rom_raw_unlock
-      uvm_test_seq: chip_sw_lc_raw_unlock_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:signed:fake_rsa_test_key_0:ot_flash_binary",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+do_creator_sw_cfg_ast_cfg=0",
-        "+sw_test_timeout_ns=200_000_000",
-        "+use_otp_image=OtpTypeLcStRaw",
-        "+chip_clock_source=ChipClockSourceExternal48Mhz",
-        "+rom_prod_mode=1",
-      ]
-      run_timeout_mins: 480
-    }
-
+    // {
+    //   name: rom_volatile_raw_unlock
+    //   uvm_test_seq: chip_sw_lc_volatile_raw_unlock_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:signed:fake_rsa_test_key_0:ot_flash_binary",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=200_000_000",
+    //     "+use_otp_image=OtpTypeLcStRaw",
+    //     "+chip_clock_source=ChipClockSourceExternal48Mhz",
+    //     "+rom_prod_mode=1",
+    //   ]
+    //   run_timeout_mins: 480
+    // }
+    // {
+    //   name: rom_raw_unlock
+    //   uvm_test_seq: chip_sw_lc_raw_unlock_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:6:signed:fake_rsa_test_key_0:ot_flash_binary",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: [
+    //     "+do_creator_sw_cfg_ast_cfg=0",
+    //     "+sw_test_timeout_ns=200_000_000",
+    //     "+use_otp_image=OtpTypeLcStRaw",
+    //     "+chip_clock_source=ChipClockSourceExternal48Mhz",
+    //     "+rom_prod_mode=1",
+    //   ]
+    //   run_timeout_mins: 480
+    // }
     // ROM self hash test.
     // TODO(moidx): Update to ROM e2e target not requiring sigverify_mod_exp dependency.
-    {
-      name: rom_e2e_self_hash
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/presigned_images:rom_e2e_self_hash:6:signed:ot_flash_binary"
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_rma_acc:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_real_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=200_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      run_timeout_mins: 480
-    }
+    // {
+    //   name: rom_e2e_self_hash
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e/presigned_images:rom_e2e_self_hash:6:signed:ot_flash_binary"
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_rma_acc:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_real_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=200_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   run_timeout_mins: 480
+    // }
+    // End of TODO(Pavona #44)
     // This test is commented out in the open-source, but can be uncommented by
     // back-end designers after they integrate the functional model of the ROM
     // macro into the netlist.
@@ -827,14 +826,15 @@
     // }
 
     // Signed chip-level tests to be run with ROM, instead of test ROM.
-    {
-      name: chip_sw_uart_smoketest_signed
-      uvm_test_seq: chip_sw_uart_smoke_vseq
-      sw_images: ["//sw/device/tests:uart_smoketest_signed:6:signed:fake_rsa_test_key_0"]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: ["+sw_test_timeout_ns=20000000"]
-      run_timeout_mins: 180
-    }
+    // TODO(Pavona #44): Needs sw_image Bazel target
+    // {
+    //   name: chip_sw_uart_smoketest_signed
+    //   uvm_test_seq: chip_sw_uart_smoke_vseq
+    //   sw_images: ["//sw/device/tests:uart_smoketest_signed:6:signed:fake_rsa_test_key_0"]
+    //   en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
+    //   run_opts: ["+sw_test_timeout_ns=20000000"]
+    //   run_timeout_mins: 180
+    // }
 
     // ROM func tests to be run with test ROM.
     // TODO(Pavona #43): Needs Darjeeling execution environment

--- a/hw/top_darjeeling/dv/chip_rom_tests.hjson
+++ b/hw/top_darjeeling/dv/chip_rom_tests.hjson
@@ -837,13 +837,14 @@
     }
 
     // ROM func tests to be run with test ROM.
-    {
-      name: rom_keymgr_functest
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/silicon_creator/lib/drivers:keymgr_functest:6"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=10_000_000"]
-    }
+    // TODO(Pavona #43): Needs Darjeeling execution environment
+    // {
+    //   name: rom_keymgr_functest
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: ["//sw/device/silicon_creator/lib/drivers:keymgr_functest:6"]
+    //   en_run_modes: ["sw_test_mode_test_rom"]
+    //   run_opts: ["+sw_test_timeout_ns=10_000_000"]
+    // }
   ]
 
   regressions: [


### PR DESCRIPTION
This PR comments out a large number of tests from `hw/top_darjeeling/dv/chip_sim_cfg.hjson` and `hw/top_darjeeling/dv/chip_rom_tests.hjson` due to build errors. The individual tests are tracked in #43 and #44 to be later fixed or outright removed.