### PR TITLE
[dvsim] Fix dvsim to produce better coverage reports

### DIFF
--- a/ci/scripts/check-generated.sh
+++ b/ci/scripts/check-generated.sh
@@ -73,6 +73,8 @@ gen_hw_and_check_clean "Register headers" regs             || bad=1
 # causing this check to fail.
 gen_hw_and_check_clean "top and cmdgen"   top_and_cmdgen   || bad=1
 
+gen_hw_and_check_clean "top_sim_cfgs"     dvgen   || bad=1
+
 gen_and_check_clean \
     "secded primitive code" \
     util/design/secded_gen.py --no_fpv || bad=1

--- a/ci/scripts/check-sim-cfgs.py
+++ b/ci/scripts/check-sim-cfgs.py
@@ -127,7 +127,7 @@ def check_sim_cfg_files(grouped: dict) -> bool:
         for file, fields in sim_cfgs_files:
             dir_path = Path(directory)
             if dir_path == SEARCH_ROOT / "hw" / "dv":
-                expected = "top_sim_cfgs.hjson"
+                expected = "all_sim_cfgs.hjson"
                 if file != expected:
                     mismatches.append(f"Filename {directory}/{file}"
                                       f" should be named {expected}")

--- a/hw/Makefile
+++ b/hw/Makefile
@@ -89,6 +89,9 @@ $(ips_reg): %_reg:
 
 top_and_cmdgen: top cmdgen
 
-all: top cmdgen regs
+dvgen:
+	${PRJ_DIR}/util/gen_ip_collection.py --flow sim_dv --tops top_earlgrey top_darjeeling
+
+all: top cmdgen regs dvgen
 
 .PHONY: all

--- a/hw/data/common_project_cfg.hjson
+++ b/hw/data/common_project_cfg.hjson
@@ -2,11 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  project:          opentitan
-  repo_server:      "github.com/lowrisc/opentitan"
-  book:             opentitan.org/book
-  doc_server:       docs.opentitan.org
-  results_server:   reports.opentitan.org
+  project:          pavona
+  repo_server:      "github.com/pavona/pavona-staging"
+  book:             pavona.org/book
+  doc_server:       docs.pavona.org
+  results_server:   reports.pavona.org
 
   // Default directory structure for the output
   scratch_base_path:  "{scratch_root}/{branch}"
@@ -14,8 +14,7 @@
 
   // Common data structure
   build_pass_patterns: []
-  // TODO: Add back FuseSoC fail pattern after
-  // https://github.com/lowRISC/opentitan/issues/7348 is resolved.
+  // TODO: Add back FuseSoC fail pattern
   build_fail_patterns: []
 
   exports: [

--- a/hw/dv/all_sim_cfgs.hjson
+++ b/hw/dv/all_sim_cfgs.hjson
@@ -1,4 +1,3 @@
-// Copyright lowRISC contributors (OpenTitan project).
 // Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
@@ -11,16 +10,16 @@
 
 {
   // This is a cfg hjson group for DV simulations. It includes ALL individual DV simulation
-  // cfgs of the IPs and the full chip used in top_darjeeling. This enables the common
+  // cfgs across all IPs and tops in the project. This enables the common
   // regression sets to be run in one shot.
-  name: top_darjeeling_batch
+  name: all_tops_batch
 
   import_cfgs: [// Project wide common cfg file
                 "{proj_root}/hw/data/common_project_cfg.hjson"]
 
   flow: sim
 
-  rel_path: "hw/top_darjeeling/dv/summary"
+  rel_path: "hw/dv/summary"
 
   // Need to override the default output directory
   overrides: [
@@ -78,6 +77,20 @@
              "{proj_root}/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson",
              "{proj_root}/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson",
              "{proj_root}/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson",
+             // top_earlgrey autogen IPs.
+             "{proj_root}/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/pwm/dv/pwm_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
+             // top_earlgrey chip.
+             "{proj_root}/hw/top_earlgrey/dv/chip_sim_cfg.hjson",
              // top_darjeeling autogen IPs.
              "{proj_root}/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson",

--- a/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
+++ b/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
@@ -1,11 +1,19 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
+
+//
+// ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
+// PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
+// util/gen_ip_collection.py --flow sim_dv
+//                --tops top_earlgrey top_darjeeling
+
 {
   // This is a cfg hjson group for DV simulations. It includes ALL individual DV simulation
   // cfgs of the IPs and the full chip used in top_earlgrey. This enables the common
   // regression sets to be run in one shot.
-  name: top_earlgrey_batch_sim
+  name: top_earlgrey_batch
 
   import_cfgs: [// Project wide common cfg file
                 "{proj_root}/hw/data/common_project_cfg.hjson"]
@@ -14,57 +22,75 @@
 
   rel_path: "hw/top_earlgrey/dv/summary"
 
-  // Maintain alphabetical order below.
+  // Need to override the default output directory
+  overrides: [
+    {
+        name: scratch_path
+        value: "{scratch_base_path}/{name}-{flow}"
+    }
+  ]
+
   use_cfgs: [
              // Unit tests for UVCs.
              "{proj_root}/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson",
              // IPs.
              "{proj_root}/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson",
-             "{proj_root}/hw/ip/aes/dv/aes_unmasked_sim_cfg.hjson",
              "{proj_root}/hw/ip/aes/dv/aes_masked_sim_cfg.hjson",
+             "{proj_root}/hw/ip/aes/dv/aes_unmasked_sim_cfg.hjson",
              "{proj_root}/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson",
              "{proj_root}/hw/ip/csrng/dv/csrng_sim_cfg.hjson",
+             "{proj_root}/hw/ip/dma/dv/dma_sim_cfg.hjson",
              "{proj_root}/hw/ip/edn/dv/edn_edn0_sim_cfg.hjson",
              "{proj_root}/hw/ip/edn/dv/edn_edn1_sim_cfg.hjson",
+             "{proj_root}/hw/ip/entropy_src/dv/entropy_src_rng16bits_sim_cfg.hjson",
              "{proj_root}/hw/ip/entropy_src/dv/entropy_src_rng4bits_sim_cfg.hjson",
              "{proj_root}/hw/ip/hmac/dv/hmac_sim_cfg.hjson",
              "{proj_root}/hw/ip/i2c/dv/i2c_sim_cfg.hjson",
              "{proj_root}/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson",
+             "{proj_root}/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson",
              "{proj_root}/hw/ip/kmac/dv/kmac_masked_sim_cfg.hjson",
              "{proj_root}/hw/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson",
+             "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_disabled_sim_cfg.hjson",
+             "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_enabled_sim_cfg.hjson",
              "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_volatile_unlock_disabled_sim_cfg.hjson",
              "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_volatile_unlock_enabled_sim_cfg.hjson",
-             "{proj_root}/hw/ip/acc/dv/uvm/acc_standard_sim_cfg.hjson",
+             "{proj_root}/hw/ip/mbx/dv/mbx_sim_cfg.hjson",
              "{proj_root}/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson",
-             "{proj_root}/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson",
-             "{proj_root}/hw/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson",
-             "{proj_root}/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson",
-             "{proj_root}/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson",
-             "{proj_root}/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson",
              "{proj_root}/hw/ip/rom_ctrl/dv/rom_ctrl_32kB_sim_cfg.hjson",
              "{proj_root}/hw/ip/rom_ctrl/dv/rom_ctrl_64kB_sim_cfg.hjson",
+             "{proj_root}/hw/ip/rv_dm/dv/rv_dm_use_dmi_interface_sim_cfg.hjson",
              "{proj_root}/hw/ip/rv_dm/dv/rv_dm_use_jtag_interface_sim_cfg.hjson",
              "{proj_root}/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson",
-             "{proj_root}/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson",
+             "{proj_root}/hw/ip/soc_dbg_ctrl/dv/soc_dbg_ctrl_sim_cfg.hjson",
              "{proj_root}/hw/ip/spi_device/dv/spi_device_1r1w_sim_cfg.hjson",
              "{proj_root}/hw/ip/spi_device/dv/spi_device_2p_sim_cfg.hjson",
+             "{proj_root}/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson",
+             "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_exec_64kB_sim_cfg.hjson",
              "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson",
              "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_ret_sim_cfg.hjson",
              "{proj_root}/hw/ip/sysrst_ctrl/dv/sysrst_ctrl_sim_cfg.hjson",
              "{proj_root}/hw/ip/uart/dv/uart_sim_cfg.hjson",
              "{proj_root}/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson",
-             // Top level IPs.
-             "{proj_root}/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim_cfg.hjson",
+             "{proj_root}/hw/ip/acc/dv/uvm/acc_pqc_sim_cfg.hjson",
+             "{proj_root}/hw/ip/acc/dv/uvm/acc_standard_sim_cfg.hjson",
+             "{proj_root}/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson",
+             "{proj_root}/hw/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson",
+             "{proj_root}/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson",
+             "{proj_root}/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson",
+             "{proj_root}/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson",
+             // top_earlgrey autogen IPs.
              "{proj_root}/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip_autogen/pwm/dv/pwm_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson",
-             "{proj_root}/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
-             // Top level.
-             "{proj_root}/hw/top_earlgrey/dv/chip_sim_cfg.hjson"]
+             // top_earlgrey chip.
+             "{proj_root}/hw/top_earlgrey/dv/chip_sim_cfg.hjson",
+            ]
 }

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -145,8 +145,7 @@ class FlowCfg():
         self._expand()
 
         # Construct the path variables after variable expansion.
-        self.results_dir = (Path(self.scratch_base_path) / "reports" /
-                            self.rel_path / "latest")
+        self.results_dir = (Path(self.scratch_path) / "reports" / "latest")
         self.results_page = (self.results_dir / self.results_html_name)
 
         tmp_path = (self.results_server + "/" + self.rel_path +
@@ -423,8 +422,7 @@ class FlowCfg():
             log.info("[scratch_path]: [%s] [%s]", item.name, item.scratch_path)
             item.write_results(self.results_html_name, item.results_md,
                                json_str)
-            log.log(VERBOSE, "[report]: [%s] [%s/report.html]", item.name,
-                    item.results_dir)
+            log.info("[report]: [%s] [%s/report.html]", item.name, item.results_dir)
             self.errors_seen |= item.errors_seen
 
         if self.is_primary_cfg:

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -421,21 +421,22 @@ class FlowCfg():
             log.info("[results]: [%s]:\n%s\n", item.name, result)
             log.info("[scratch_path]: [%s] [%s]", item.name, item.scratch_path)
             item.write_results(self.results_html_name, item.results_md,
-                               json_str)
-            log.info("[report]: [%s] [%s/report.html]", item.name, item.results_dir)
+                               json_str, is_primary_cfg=False)
+            log.info("[report]: [%s] [%s/report.html]\n\n", item.name, item.results_dir)
             self.errors_seen |= item.errors_seen
 
         if self.is_primary_cfg:
             self.gen_results_summary()
             self.write_results(self.results_html_name,
-                               self.results_summary_md)
+                               self.results_summary_md, is_primary_cfg=True)
+            log.info("[report]: [%s] [%s/report.html]", self.name, self.results_dir)
 
     def gen_results_summary(self):
         '''Public facing API to generate summary results for each IP/cfg file
         '''
         return
 
-    def write_results(self, html_filename, text_md, json_str=None):
+    def write_results(self, html_filename, text_md, json_str=None, is_primary_cfg=False):
         """Write results to files.
 
         This function converts text_md to HTML and writes the result to a file
@@ -452,7 +453,7 @@ class FlowCfg():
         # Write results to the report area.
         with open(self.results_dir / html_filename, "w") as f:
             f.write(
-                md_results_to_html(self.results_title, self.css_file, text_md))
+                md_results_to_html(self.results_title, self.css_file, text_md, is_primary_cfg))
 
         if json_str is not None:
             filename = Path(html_filename).with_suffix('.json')

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -838,8 +838,8 @@ class SimCfg(FlowCfg):
 
                 # self.rel_path gives us the path to the directory
                 # containing the sim_cfg file...
-                testplan = "https://{}/{}".format(
-                    self.book,
+                testplan = "https://{}/tree/main/{}".format(
+                    self.repo_server,
                     Path(self.rel_path).parent / 'data' / f"{self.name}_testplan.html"
                 )
 

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -840,7 +840,7 @@ class SimCfg(FlowCfg):
                 # containing the sim_cfg file...
                 testplan = "https://{}/tree/main/{}".format(
                     self.repo_server,
-                    Path(self.rel_path).parent / 'data' / f"{self.name}_testplan.html"
+                    Path(self.rel_path).parent / 'data' / f"{self.name}_testplan.hjson"
                 )
 
             results_str += f"### [Testplan]({testplan})\n"
@@ -879,7 +879,7 @@ class SimCfg(FlowCfg):
                         if self.args.publish:
                             cov_report_page_path = "cov_report"
                         else:
-                            cov_report_page_path = self.cov_report_dir
+                            cov_report_page_path = "../../cov_report"
                         cov_report_page_path += "/" + self.cov_report_page
                         results_str += "({})\n\n".format(cov_report_page_path)
                     results_str += self.cov_report_deploy.cov_results

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -875,18 +875,20 @@ class SimCfg(FlowCfg):
                     results_str += "\n## Coverage Results\n"
                     # Link the dashboard page using "cov_report_page" value.
                     if hasattr(self, "cov_report_page"):
-                        results_str += "\n### [Coverage Dashboard]"
-                        if self.args.publish:
-                            cov_report_page_path = "cov_report"
-                        else:
-                            cov_report_page_path = "../../cov_report"
-                        cov_report_page_path += "/" + self.cov_report_page
-                        results_str += "({})\n\n".format(cov_report_page_path)
+                        results_str += "\n### Coverage Dashboard\n\n"
+                        # TODO: modify to include differentiation between public and private
+                        # dashboard usage.
+                        # if self.args.publish:
+                        #     cov_report_page_path = "cov_report"
+                        # else:
+                        #     cov_report_page_path = "../../cov_report"
+                        # cov_report_page_path += "/" + self.cov_report_page
+                        # results_str += "({})\n\n".format(cov_report_page_path)
                     results_str += self.cov_report_deploy.cov_results
                     self.results_summary[
-                        "Coverage"] = self.cov_report_deploy.cov_total
+                        "Overall Coverage"] = self.cov_report_deploy.cov_total
                 else:
-                    self.results_summary["Coverage"] = "--"
+                    self.results_summary["Overall Coverage"] = "--"
 
         if results.buckets:
             self.errors_seen = True
@@ -911,28 +913,33 @@ class SimCfg(FlowCfg):
         lines += [f"### Branch: {self.branch}"]
 
         table = []
-        header = []
+        rows = []
+        DEFAULT_VALUE = "-- %"
         for cfg in self.cfgs:
-            row = cfg.results_summary
+            cov_scores = cfg.cov_report_deploy.cov_results_dict
+            cov_scores = {f"{key.capitalize()} Coverage": val for key, val in cov_scores.items()}
+            row = cfg.results_summary | cov_scores
             if row:
                 # convert name entry to relative link
-                row = cfg.results_summary
                 row["Name"] = cfg._get_results_page_link(
                     self.results_dir,
                     row["Name"])
+                rows.append(row)
 
-                # If header is set, ensure its the same for all cfgs.
-                if header:
-                    assert header == cfg.results_summary.keys()
-                else:
-                    header = cfg.results_summary.keys()
-                table.append(row.values())
+        if rows:
+            all_keys = list(dict.fromkeys(key for row in rows for key in row))
+            # Move the "Overall Coverage" key to the end
+            all_keys.remove("Overall Coverage")
+            all_keys.append("Overall Coverage")
+
+            for row in rows:
+                normalized = {key: row.get(key, DEFAULT_VALUE) for key in all_keys}
+                table.append(list(normalized.values()))
 
         if table:
-            assert header
-            colalign = ("center", ) * len(header)
+            colalign = ("center", ) * len(all_keys)
             table_txt = tabulate(table,
-                                 headers=header,
+                                 headers=all_keys,
                                  tablefmt="pipe",
                                  colalign=colalign)
             lines += ["", table_txt, ""]
@@ -941,7 +948,7 @@ class SimCfg(FlowCfg):
             lines += ["\nNo results to display.\n"]
 
         self.results_summary_md = "\n".join(lines)
-        print(self.results_summary_md)
+        print(str(self.results_summary_md))
         return self.results_summary_md
 
     def _publish_results(self, results_server: ResultsServer):

--- a/util/dvsim/style.css
+++ b/util/dvsim/style.css
@@ -123,3 +123,24 @@
   color: #000000;
   background-color: #57EF57;
 }
+
+/* Header column group colors for batch coverage */
+.results table.col-12 thead tr th:nth-child(1) {
+    background-color: #3D1067 !important;
+}
+
+.results table.col-12 thead tr th:nth-child(n+2):nth-child(-n+3) {
+    background-color: #5C2D91 !important;
+}
+
+.results table.col-12 thead tr th:nth-child(4) {
+    background-color: #3D1067 !important;
+}
+
+.results table.col-12 thead tr th:nth-child(n+5):nth-child(-n+12) {
+    background-color: #5C2D91 !important;
+}
+
+.results table.col-12 thead tr th:nth-child(13) {
+    background-color: #3D1067 !important;
+}

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -16,6 +16,7 @@ import time
 from collections import OrderedDict
 from datetime import datetime
 from pathlib import Path
+from bs4 import BeautifulSoup
 
 import hjson
 import mistletoe
@@ -346,7 +347,7 @@ def find_and_substitute_wildcards(sub_dict,
     return sub_dict
 
 
-def md_results_to_html(title, css_file, md_text):
+def md_results_to_html(title, css_file, md_text, is_primary_cfg=False):
     '''Convert results in md format to html. Add a little bit of styling.
     '''
     html_text = "<!DOCTYPE html>\n"
@@ -366,6 +367,8 @@ def md_results_to_html(title, css_file, md_text):
     html_text = transform(html_text,
                           external_styles=css_file,
                           cssutils_logging_level=log.ERROR)
+    if is_primary_cfg:
+        html_text = html_styling_batch_coverage(html_text)
     return html_text
 
 
@@ -515,6 +518,34 @@ def htmc_color_pc_cells(text):
         for item in subst_list:
             text = text.replace(item, subst_list[item])
     return text
+
+
+def html_styling_batch_coverage(html_text):
+    """
+    Introduce formatting fixes for fitting the batch coverage page and
+    tag tables with a class based on their column count for CSS styling
+    when making a batch coverage report.
+    """
+    # Fix table centering: replace whatever margin was inlined with explicit auto margins
+    html_text = re.sub(
+        r'(<table[^>]*style="[^"]*?)margin:[^;]+;',
+        r'\1margin-left:auto; margin-right:auto;',
+        html_text
+    )
+    # Break out of the constrained .results div and center on full viewport
+    html_text = html_text.replace(
+        "<table",
+        "<div style=\"width:100vw; position:relative; left:50%;"
+        " transform:translateX(-50%); overflow-x:auto;\"><table"
+    )
+    html_text = html_text.replace(
+        "</table>",
+        "</table></div>"
+    )
+    soup = BeautifulSoup(html_text, "html.parser")
+    table = soup.select_one("table")
+    table["class"] = table.get("class", []) + ["col-12"]
+    return str(soup)
 
 
 def print_msg_list(msg_list_title, msg_list, max_msg_count=-1):

--- a/util/gen_ip_collection.py
+++ b/util/gen_ip_collection.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""
+gen_ip_collection.py
+Collects IP and top-level sim cfg files and generates batch hjson files.
+Usage:
+    ./gen_ip_collection.py --flow sim_dv --tops top_earlgrey top_darjeeling
+"""
+import argparse
+import glob
+import os
+from pathlib import Path
+
+SEARCH_ROOT = Path(__file__).resolve().parents[1]
+LOWRISC_COPYRIGHT_LINE = "// Copyright lowRISC contributors (OpenTitan project)."
+ZERORISC_COPYRIGHT_LINE = "// Copyright zeroRISC Inc."
+LICENSE_LINES = """\
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0"""
+
+COPYRIGHT_HEADER_SOLO = f"{ZERORISC_COPYRIGHT_LINE}\n{LICENSE_LINES}"
+COPYRIGHT_HEADER_JOINT = (
+    f"{LOWRISC_COPYRIGHT_LINE}\n{ZERORISC_COPYRIGHT_LINE}\n{LICENSE_LINES}"
+)
+WARNHDR = """//
+// ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
+// PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
+"""
+
+
+def get_copyright_header(path, flow, tops):
+    """Return the appropriate copyright header for this file."""
+    tops_str = ' '.join(tops)
+    GENCMD = (f"// util/gen_ip_collection.py --flow {flow}\n"
+              f"//                --tops {tops_str}\n")
+    if os.path.exists(path):
+        try:
+            with open(path) as f:
+                first_line = f.readline().strip()
+            if first_line == LOWRISC_COPYRIGHT_LINE:
+                return f"{COPYRIGHT_HEADER_JOINT}\n\n{WARNHDR}{GENCMD}"
+        except OSError as e:
+            print(f"Warning: could not read {path}: {e}")
+    return f"{COPYRIGHT_HEADER_SOLO}\n\n{WARNHDR}{GENCMD}"
+
+
+# =============================
+#   Specific to sim_dv flow
+# =============================
+
+def collect_sim_dv(tops):
+    """
+    Collect all sim_cfg hjson files into two buckets:
+      - ip_cfgs:  shared across all tops (hw/ip/... and hw/dv/...)
+      - top_cfgs: dict keyed by topname, each containing top-specific cfgs
+    """
+    ip_cfgs = []
+    top_cfgs = {top: [] for top in tops}
+
+    def skip(sim_name):
+        return "base" in sim_name
+
+    # ---- IP bucket ----
+    # Pattern 1: hw/ip/{ip_name}/dv/{sim_cfg}
+    # Pattern 2: hw/ip/{ip_name}/dv/uvm/{sim_cfg}
+    # Pattern 3: hw/ip/prim/dv/{prim_variant}/{sim_cfg}
+    # Pattern 4: hw/dv/sv/{ip_name}/dv/{sim_cfg}
+    for cfg in (
+        sorted(glob.glob("hw/ip/*/dv/*_sim_cfg.hjson"))
+        + sorted(glob.glob("hw/ip/*/dv/uvm/*_sim_cfg.hjson"))
+        + sorted(glob.glob("hw/ip/prim/dv/*/*_sim_cfg.hjson"))
+        + sorted(glob.glob("hw/dv/sv/*/*/*_sim_cfg.hjson"))
+    ):
+        sim_name = Path(cfg).stem.replace("_sim_cfg", "")
+        if skip(sim_name):
+            continue
+        ip_cfgs.append(cfg)
+
+    # ---- Top-specific bucket ----
+    for top in tops:
+        # Pattern 5: hw/{top}/ip_autogen/{ip_name}/dv/{sim_cfg}
+        # Pattern 6: hw/{top}/ip_autogen/{ip_name}/dv/{subdir}/{sim_cfg}
+        # Pattern 7: hw/{top}/ip/{xbar_name}/dv/autogen/{sim_cfg}
+        # Pattern 8: hw/{top}/dv/{sim_cfg} (chip-level)
+        for cfg in (
+            sorted(glob.glob(f"hw/{top}/ip_autogen/*/dv/*_sim_cfg.hjson"))
+            + sorted(glob.glob(f"hw/{top}/ip_autogen/*/dv/*/*_sim_cfg.hjson"))
+            + sorted(glob.glob(f"hw/{top}/ip/*/dv/autogen/*_sim_cfg.hjson"))
+            + sorted(glob.glob(f"hw/{top}/dv/*_sim_cfg.hjson"))
+        ):
+            sim_name = Path(cfg).stem.replace("_sim_cfg", "")
+            if skip(sim_name):
+                continue
+            top_cfgs[top].append(cfg)
+
+    return ip_cfgs, top_cfgs
+
+
+def format_use_cfgs(cfgs, indent=13):
+    """Format a list of cfg paths as hjson use_cfgs entries."""
+    pad = " " * indent
+    lines = [f'{pad}"{{proj_root}}/{cfg}",' for cfg in cfgs]
+    return "\n".join(lines)
+
+
+def generate_hjson(ip_cfgs, top_cfgs, tops, copyright_header, top_specific=False):
+    """Generate hjson for a batch sim_cfgs"""
+    sections = []
+
+    tl_agent_cfgs = [c for c in ip_cfgs if "hw/dv/sv/" in c]
+    pure_ip_cfgs = [c for c in ip_cfgs if "hw/ip/" in c]
+
+    if tl_agent_cfgs:
+        sections.append(
+            "             // Unit tests for UVCs.\n" +
+            format_use_cfgs(tl_agent_cfgs)
+        )
+    if pure_ip_cfgs:
+        sections.append(
+            "             // IPs.\n" +
+            format_use_cfgs(pure_ip_cfgs)
+        )
+
+    for top in tops:
+        cfgs = top_cfgs[top]
+        autogen_cfgs = [c for c in cfgs if f"hw/{top}/ip_autogen/" in c
+                        or f"hw/{top}/ip/" in c]
+        chip_cfgs = [c for c in cfgs if f"hw/{top}/dv/" in c]
+
+        if autogen_cfgs:
+            sections.append(
+                f"             // {top} autogen IPs.\n" +
+                format_use_cfgs(autogen_cfgs)
+            )
+        if chip_cfgs:
+            sections.append(
+                f"             // {top} chip.\n" +
+                format_use_cfgs(chip_cfgs)
+            )
+
+    use_cfgs_body = "\n".join(sections)
+
+    if not top_specific:
+        batchname_desc = "across all IPs and tops in the project"
+        batchname = "all_tops"
+        rel_path = "hw/dv/summary"
+    else:
+        batchname_desc = f"of the IPs and the full chip used in {top}"
+        batchname = tops[0]
+        rel_path = f"hw/{tops[0]}/dv/summary"
+
+    return f"""{copyright_header}
+{{
+  // This is a cfg hjson group for DV simulations. It includes ALL individual DV simulation
+  // cfgs {batchname_desc}. This enables the common
+  // regression sets to be run in one shot.
+  name: {batchname}_batch
+
+  import_cfgs: [// Project wide common cfg file
+                "{{proj_root}}/hw/data/common_project_cfg.hjson"]
+
+  flow: sim
+
+  rel_path: "{rel_path}"
+
+  // Need to override the default output directory
+  overrides: [
+    {{
+        name: scratch_path
+        value: "{{scratch_base_path}}/{{name}}-{{flow}}"
+    }}
+  ]
+
+  use_cfgs: [
+{use_cfgs_body}
+            ]
+}}
+"""
+
+
+def write_file(path, content, dry_run):
+    if dry_run:
+        print(f"\n{'=' * 60}")
+        print(f"Would write: {path}")
+        print('=' * 60)
+        print(content)
+    else:
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w") as f:
+                f.write(content)
+            print(f"Written: {path}")
+        except OSError as e:
+            print("Failed to create output directory {}: \n{}."
+                  .format(os.path.dirname(path), e))
+
+
+def run_sim_dv(tops, dry_run, flow):
+    print("Collecting sim_dv sim_cfg files...")
+    ip_cfgs, top_cfgs = collect_sim_dv(tops)
+    print(f"  Found {len(ip_cfgs)} shared IP cfgs")
+    for top, cfgs in top_cfgs.items():
+        print(f"  Found {len(cfgs)} cfgs for {top}")
+
+    # Per-top hjson files
+    for top in tops:
+        out_path = f"hw/{top}/dv/{top}_sim_cfgs.hjson"
+        copyright_header = get_copyright_header(out_path, flow, top_cfgs)
+        content = generate_hjson(ip_cfgs, top_cfgs, [top], copyright_header, True)
+        write_file(out_path, content, dry_run)
+
+    # Global hjson file
+    out_path = "hw/dv/all_sim_cfgs.hjson"
+    copyright_header = get_copyright_header(out_path, flow, top_cfgs)
+    content = generate_hjson(ip_cfgs, top_cfgs, tops, copyright_header)
+    write_file(out_path, content, dry_run)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate repo-wide IP collection files.",
+    )
+    parser.add_argument(
+        "--flow",
+        required=True,
+        choices=["sim_dv"],
+        help="Flow type to collect for. Currently supported: sim_dv",
+    )
+    parser.add_argument(
+        "--tops",
+        required=True,
+        nargs="+",
+        metavar="TOP",
+        help="One or more tops to collect for (e.g. --tops top_earlgrey top_darjeeling)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be generated without writing files",
+    )
+    return parser.parse_args()
+
+
+def main():
+    try:
+        os.chdir(SEARCH_ROOT)
+    except OSError as e:
+        print(f"Failed to change to directory {SEARCH_ROOT}: \n{e}")
+    args = parse_args()
+    if args.flow == "sim_dv":
+        run_sim_dv(args.tops, args.dry_run, args.flow)
+    else:
+        print(f"Unknown flow: {args.flow}")
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR includes 3 commits. One by one, they do the following:
- Change the `scratch` directory structure to include the run reports in `*-sim-*/reports/{timestamp or latest}/report.html` as opposed to the previous structure, where it would mimic the directory structure of the repository (e.g. for an IP in `hw/ip`, the report would be in `hw/ip/{ipname}/report.html`.
- Change absolute links to coverage reports in run reports to relative links. Also change links to test plans from `html` links to a book to links to the repository `hjson` files (to be changed later, note issue #34).
- Allow coverage summary numbers (e.g. group, code, line, etc.) to show up in `*_batch_sim_cfgs.hjson` run reports for each IP included, as well as some neater formatting for the HTML. Remove coverage reports link from run reports.

This commit is building on top of #51.