### PR TITLE
[dvsim,dv] Include --publish flag and weekly regression

### DIFF
--- a/ci/scripts/check-generated.sh
+++ b/ci/scripts/check-generated.sh
@@ -73,6 +73,8 @@ gen_hw_and_check_clean "Register headers" regs             || bad=1
 # causing this check to fail.
 gen_hw_and_check_clean "top and cmdgen"   top_and_cmdgen   || bad=1
 
+gen_hw_and_check_clean "top_sim_cfgs"     dvgen   || bad=1
+
 gen_and_check_clean \
     "secded primitive code" \
     util/design/secded_gen.py --no_fpv || bad=1

--- a/ci/scripts/check-sim-cfgs.py
+++ b/ci/scripts/check-sim-cfgs.py
@@ -127,7 +127,7 @@ def check_sim_cfg_files(grouped: dict) -> bool:
         for file, fields in sim_cfgs_files:
             dir_path = Path(directory)
             if dir_path == SEARCH_ROOT / "hw" / "dv":
-                expected = "top_sim_cfgs.hjson"
+                expected = "all_sim_cfgs.hjson"
                 if file != expected:
                     mismatches.append(f"Filename {directory}/{file}"
                                       f" should be named {expected}")

--- a/doc/contributing/ci/faq.md
+++ b/doc/contributing/ci/faq.md
@@ -25,8 +25,8 @@ This allows contributors to rely on a stable development base for testing new ch
 Upon creating a Pull Request (PR) in GitHub against the `pavona` respository, continuous integration jobs will automatically trigger.
 You can check the status of the running CI jobs in the `Checks` tab after navigating to your Pull Request.
 
-We also run nightly regressions on main branches that trigger automatically and include tests that are not reasonable to run on every PR.
-You can view the result of the most recent nightly regression by navigating to the repository's `Actions` tab and clicking the `Nightly` workflow on the left pane.
+We also run nightly and weekly regressions on main branches that trigger automatically and include tests that are not reasonable to run on every PR.
+You can view the result of the most recent regression by navigating to the repository's `Actions` tab and clicking the `Nightly` or `Weekly` workflow on the left pane.
 
 ## Contributing Tests
 

--- a/doc/contributing/dv/methodology/README.md
+++ b/doc/contributing/dv/methodology/README.md
@@ -44,7 +44,7 @@ DV effort needs to be well documented to not only provide a detailed description
 The first is provided by the **testplan** document and the second, by the **DV document**.
 The [**project status**](../../../contributing/hw/development_stages.md#indicating-stages-and-making-transitions) document tracks to progression of the effort through the stages.
 
-In addition to these documents, a nightly **regression dashboard** tabulating the test and coverage results will provide ability to track progress towards completion of the verification stages.
+In addition to these documents, a nightly and a weekly **regression dashboard** tabulating the test and coverage results will provide ability to track progress towards completion of the verification stages.
 
 To effectively document all these pieces, there are some key tooling components which are also discussed briefly below.
 

--- a/hw/Makefile
+++ b/hw/Makefile
@@ -89,6 +89,9 @@ $(ips_reg): %_reg:
 
 top_and_cmdgen: top cmdgen
 
-all: top cmdgen regs
+dvgen:
+	${PRJ_DIR}/util/gen_ip_collection.py --flow sim_dv --tops top_earlgrey top_darjeeling
+
+all: top cmdgen regs dvgen
 
 .PHONY: all

--- a/hw/data/common_project_cfg.hjson
+++ b/hw/data/common_project_cfg.hjson
@@ -2,11 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  project:          opentitan
-  repo_server:      "github.com/lowrisc/opentitan"
-  book:             opentitan.org/book
-  doc_server:       docs.opentitan.org
-  results_server:   reports.opentitan.org
+  project:          pavona
+  repo_server:      "github.com/pavona/pavona-staging"
+  book:             pavona.org/book
+  doc_server:       docs.pavona.org
+  results_server:   reports.pavona.org
 
   // Default directory structure for the output
   scratch_base_path:  "{scratch_root}/{branch}"
@@ -14,8 +14,7 @@
 
   // Common data structure
   build_pass_patterns: []
-  // TODO: Add back FuseSoC fail pattern after
-  // https://github.com/lowRISC/opentitan/issues/7348 is resolved.
+  // TODO: Add back FuseSoC fail pattern
   build_fail_patterns: []
 
   exports: [

--- a/hw/dv/all_sim_cfgs.hjson
+++ b/hw/dv/all_sim_cfgs.hjson
@@ -1,4 +1,3 @@
-// Copyright lowRISC contributors (OpenTitan project).
 // Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
@@ -11,16 +10,16 @@
 
 {
   // This is a cfg hjson group for DV simulations. It includes ALL individual DV simulation
-  // cfgs of the IPs and the full chip used in top_darjeeling. This enables the common
+  // cfgs across all IPs and tops in the project. This enables the common
   // regression sets to be run in one shot.
-  name: top_darjeeling_batch
+  name: all_tops_batch
 
   import_cfgs: [// Project wide common cfg file
                 "{proj_root}/hw/data/common_project_cfg.hjson"]
 
   flow: sim
 
-  rel_path: "hw/top_darjeeling/dv/summary"
+  rel_path: "hw/dv/summary"
 
   // Need to override the default output directory
   overrides: [
@@ -78,6 +77,20 @@
              "{proj_root}/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson",
              "{proj_root}/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson",
              "{proj_root}/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson",
+             // top_earlgrey autogen IPs.
+             "{proj_root}/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/pwm/dv/pwm_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
+             // top_earlgrey chip.
+             "{proj_root}/hw/top_earlgrey/dv/chip_sim_cfg.hjson",
              // top_darjeeling autogen IPs.
              "{proj_root}/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson",

--- a/hw/dv/all_sim_cfgs.hjson
+++ b/hw/dv/all_sim_cfgs.hjson
@@ -90,7 +90,7 @@
              "{proj_root}/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
              // top_earlgrey chip.
-             "{proj_root}/hw/top_earlgrey/dv/chip_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/dv/chip_earlgrey_sim_cfg.hjson",
              // top_darjeeling autogen IPs.
              "{proj_root}/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson",
@@ -106,6 +106,6 @@
              "{proj_root}/hw/top_darjeeling/ip/xbar_mbx/dv/autogen/xbar_mbx_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
              // top_darjeeling chip.
-             "{proj_root}/hw/top_darjeeling/dv/chip_sim_cfg.hjson",
+             "{proj_root}/hw/top_darjeeling/dv/chip_darjeeling_sim_cfg.hjson",
             ]
 }

--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -109,8 +109,9 @@
   build_modes: []
 
   // Regressions are tests that can be grouped together and run in one shot
-  // By default, two regressions are made available - "all" and "nightly". Both
-  // run all available tests for the DUT. "nightly" enables coverage as well.
+  // By default, five regressions are made available - "smoke", "all", "all_once", "nightly"
+  // and "weekly". The last four run all available tests for the DUT, with different reseed values.
+  // For "weekly" and "nightly", coverage is enabled as well.
   // The 'tests' key is set to an empty list, which indicates "run everything".
   // Regressions can enable sim modes, which are a set of build_opts and run_opts
   // that are grouped together. These are appended to the build modes used by the
@@ -133,6 +134,11 @@
     }
     {
       name: nightly
+      reseed: 1
+      en_sim_modes: ["cov"]
+    }
+    {
+      name: weekly
       en_sim_modes: ["cov"]
     }
   ]

--- a/hw/dv/tools/dvsim/verilator.hjson
+++ b/hw/dv/tools/dvsim/verilator.hjson
@@ -38,6 +38,10 @@
     }
     {
       name: nightly
+      reseed: 1
+    }
+    {
+      name: weekly
     }
   ]
   // -- END --

--- a/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson
@@ -110,5 +110,12 @@
              "prim_lfsr_gal_test",
              "prim_lfsr_fib_test"]
     }
+    {
+      name: weekly
+      tests:["prim_lfsr_gal_smoke",
+             "prim_lfsr_fib_smoke",
+             "prim_lfsr_gal_test",
+             "prim_lfsr_fib_test"]
+    }
   ]
 }

--- a/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson
@@ -51,7 +51,7 @@
       tests: ["prim_prince_test"]
     }
     {
-      name: nightly
+      name: weekly
       // Run the same test as the "smoke" regression, just with a higher reseed value.
       // This higher reseed value is due to the rather large state space created by
       // the 128-bit key and 64-bit data values.

--- a/hw/ip/spi_device/pre_dv/spi_tpm_sim_cfg.hjson
+++ b/hw/ip/spi_device/pre_dv/spi_tpm_sim_cfg.hjson
@@ -33,5 +33,9 @@
       name: nightly
       tests: ["spi_tpm_smoke"]
     }
+    {
+      name: weekly
+      tests: ["spi_tpm_smoke"]
+    }
   ]
 }

--- a/hw/ip/spi_device/pre_dv/spid_jedec_sim_cfg.hjson
+++ b/hw/ip/spi_device/pre_dv/spid_jedec_sim_cfg.hjson
@@ -29,5 +29,9 @@
       name: nightly
       tests: ["spid_jedec_smoke"]
     }
+    {
+      name: weekly
+      tests: ["spid_jedec_smoke"]
+    }
   ]
 }

--- a/hw/ip/spi_device/pre_dv/spid_passthrough_sim_cfg.hjson
+++ b/hw/ip/spi_device/pre_dv/spid_passthrough_sim_cfg.hjson
@@ -68,5 +68,12 @@
         "spid_passthrough_addr4b"
       ]
     }
+    {
+      name: weekly
+      tests: [
+        "spid_passthrough_readbasic",
+        "spid_passthrough_addr4b"
+      ]
+    }
   ]
 }

--- a/hw/ip/spi_device/pre_dv/spid_readcmd_sim_cfg.hjson
+++ b/hw/ip/spi_device/pre_dv/spid_readcmd_sim_cfg.hjson
@@ -29,5 +29,9 @@
       name: nightly
       tests: ["spid_readcmd_smoke"]
     }
+    {
+      name: weekly
+      tests: ["spid_readcmd_smoke"]
+    }
   ]
 }

--- a/hw/ip/spi_device/pre_dv/spid_status_sim_cfg.hjson
+++ b/hw/ip/spi_device/pre_dv/spid_status_sim_cfg.hjson
@@ -33,5 +33,9 @@
       name: nightly
       tests: ["spid_status_smoke"]
     }
+    {
+      name: weekly
+      tests: ["spid_status_smoke"]
+    }
   ]
 }

--- a/hw/ip/spi_device/pre_dv/spid_upload_sim_cfg.hjson
+++ b/hw/ip/spi_device/pre_dv/spid_upload_sim_cfg.hjson
@@ -29,5 +29,9 @@
       name: nightly
       tests: ["spid_upload_smoke"]
     }
+    {
+      name: weekly
+      tests: ["spid_upload_smoke"]
+    }
   ]
 }

--- a/hw/top_darjeeling/dv/chip_darjeeling_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_darjeeling_sim_cfg.hjson
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   // Name of the sim cfg - typically same as the name of the DUT.
-  name: chip
+  name: chip_darjeeling
 
   // Top level dut name (sv module).
   dut: chip_darjeeling_asic

--- a/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
+++ b/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
@@ -93,6 +93,6 @@
              "{proj_root}/hw/top_darjeeling/ip/xbar_mbx/dv/autogen/xbar_mbx_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
              // top_darjeeling chip.
-             "{proj_root}/hw/top_darjeeling/dv/chip_sim_cfg.hjson",
+             "{proj_root}/hw/top_darjeeling/dv/chip_darjeeling_sim_cfg.hjson",
             ]
 }

--- a/hw/top_earlgrey/dv/chip_earlgrey_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_earlgrey_sim_cfg.hjson
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   // Name of the sim cfg - typically same as the name of the DUT.
-  name: chip
+  name: chip_earlgrey
 
   // Top level dut name (sv module).
   dut: chip_earlgrey_asic

--- a/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
+++ b/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
@@ -1,11 +1,19 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
+
+//
+// ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
+// PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
+// util/gen_ip_collection.py --flow sim_dv
+//                --tops top_earlgrey top_darjeeling
+
 {
   // This is a cfg hjson group for DV simulations. It includes ALL individual DV simulation
   // cfgs of the IPs and the full chip used in top_earlgrey. This enables the common
   // regression sets to be run in one shot.
-  name: top_earlgrey_batch_sim
+  name: top_earlgrey_batch
 
   import_cfgs: [// Project wide common cfg file
                 "{proj_root}/hw/data/common_project_cfg.hjson"]
@@ -14,57 +22,75 @@
 
   rel_path: "hw/top_earlgrey/dv/summary"
 
-  // Maintain alphabetical order below.
+  // Need to override the default output directory
+  overrides: [
+    {
+        name: scratch_path
+        value: "{scratch_base_path}/{name}-{flow}"
+    }
+  ]
+
   use_cfgs: [
              // Unit tests for UVCs.
              "{proj_root}/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson",
              // IPs.
              "{proj_root}/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson",
-             "{proj_root}/hw/ip/aes/dv/aes_unmasked_sim_cfg.hjson",
              "{proj_root}/hw/ip/aes/dv/aes_masked_sim_cfg.hjson",
+             "{proj_root}/hw/ip/aes/dv/aes_unmasked_sim_cfg.hjson",
              "{proj_root}/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson",
              "{proj_root}/hw/ip/csrng/dv/csrng_sim_cfg.hjson",
+             "{proj_root}/hw/ip/dma/dv/dma_sim_cfg.hjson",
              "{proj_root}/hw/ip/edn/dv/edn_edn0_sim_cfg.hjson",
              "{proj_root}/hw/ip/edn/dv/edn_edn1_sim_cfg.hjson",
+             "{proj_root}/hw/ip/entropy_src/dv/entropy_src_rng16bits_sim_cfg.hjson",
              "{proj_root}/hw/ip/entropy_src/dv/entropy_src_rng4bits_sim_cfg.hjson",
              "{proj_root}/hw/ip/hmac/dv/hmac_sim_cfg.hjson",
              "{proj_root}/hw/ip/i2c/dv/i2c_sim_cfg.hjson",
              "{proj_root}/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson",
+             "{proj_root}/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson",
              "{proj_root}/hw/ip/kmac/dv/kmac_masked_sim_cfg.hjson",
              "{proj_root}/hw/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson",
+             "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_disabled_sim_cfg.hjson",
+             "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_enabled_sim_cfg.hjson",
              "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_volatile_unlock_disabled_sim_cfg.hjson",
              "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_volatile_unlock_enabled_sim_cfg.hjson",
-             "{proj_root}/hw/ip/acc/dv/uvm/acc_standard_sim_cfg.hjson",
+             "{proj_root}/hw/ip/mbx/dv/mbx_sim_cfg.hjson",
              "{proj_root}/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson",
-             "{proj_root}/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson",
-             "{proj_root}/hw/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson",
-             "{proj_root}/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson",
-             "{proj_root}/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson",
-             "{proj_root}/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson",
              "{proj_root}/hw/ip/rom_ctrl/dv/rom_ctrl_32kB_sim_cfg.hjson",
              "{proj_root}/hw/ip/rom_ctrl/dv/rom_ctrl_64kB_sim_cfg.hjson",
+             "{proj_root}/hw/ip/rv_dm/dv/rv_dm_use_dmi_interface_sim_cfg.hjson",
              "{proj_root}/hw/ip/rv_dm/dv/rv_dm_use_jtag_interface_sim_cfg.hjson",
              "{proj_root}/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson",
-             "{proj_root}/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson",
+             "{proj_root}/hw/ip/soc_dbg_ctrl/dv/soc_dbg_ctrl_sim_cfg.hjson",
              "{proj_root}/hw/ip/spi_device/dv/spi_device_1r1w_sim_cfg.hjson",
              "{proj_root}/hw/ip/spi_device/dv/spi_device_2p_sim_cfg.hjson",
+             "{proj_root}/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson",
+             "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_exec_64kB_sim_cfg.hjson",
              "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson",
              "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_ret_sim_cfg.hjson",
              "{proj_root}/hw/ip/sysrst_ctrl/dv/sysrst_ctrl_sim_cfg.hjson",
              "{proj_root}/hw/ip/uart/dv/uart_sim_cfg.hjson",
              "{proj_root}/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson",
-             // Top level IPs.
-             "{proj_root}/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim_cfg.hjson",
+             "{proj_root}/hw/ip/acc/dv/uvm/acc_pqc_sim_cfg.hjson",
+             "{proj_root}/hw/ip/acc/dv/uvm/acc_standard_sim_cfg.hjson",
+             "{proj_root}/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson",
+             "{proj_root}/hw/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson",
+             "{proj_root}/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson",
+             "{proj_root}/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson",
+             "{proj_root}/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson",
+             // top_earlgrey autogen IPs.
              "{proj_root}/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip_autogen/pwm/dv/pwm_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson",
-             "{proj_root}/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
-             // Top level.
-             "{proj_root}/hw/top_earlgrey/dv/chip_sim_cfg.hjson"]
+             // top_earlgrey chip.
+             "{proj_root}/hw/top_earlgrey/dv/chip_sim_cfg.hjson",
+            ]
 }

--- a/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
+++ b/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
@@ -91,6 +91,6 @@
              "{proj_root}/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
              // top_earlgrey chip.
-             "{proj_root}/hw/top_earlgrey/dv/chip_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/dv/chip_earlgrey_sim_cfg.hjson",
             ]
 }

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -145,8 +145,7 @@ class FlowCfg():
         self._expand()
 
         # Construct the path variables after variable expansion.
-        self.results_dir = (Path(self.scratch_base_path) / "reports" /
-                            self.rel_path / "latest")
+        self.results_dir = (Path(self.scratch_path) / "reports" / "latest")
         self.results_page = (self.results_dir / self.results_html_name)
 
         tmp_path = (self.results_server + "/" + self.rel_path +
@@ -423,8 +422,7 @@ class FlowCfg():
             log.info("[scratch_path]: [%s] [%s]", item.name, item.scratch_path)
             item.write_results(self.results_html_name, item.results_md,
                                json_str)
-            log.log(VERBOSE, "[report]: [%s] [%s/report.html]", item.name,
-                    item.results_dir)
+            log.info("[report]: [%s] [%s/report.html]", item.name, item.results_dir)
             self.errors_seen |= item.errors_seen
 
         if self.is_primary_cfg:

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -421,21 +421,22 @@ class FlowCfg():
             log.info("[results]: [%s]:\n%s\n", item.name, result)
             log.info("[scratch_path]: [%s] [%s]", item.name, item.scratch_path)
             item.write_results(self.results_html_name, item.results_md,
-                               json_str)
-            log.info("[report]: [%s] [%s/report.html]", item.name, item.results_dir)
+                               json_str, is_primary_cfg=False)
+            log.info("[report]: [%s] [%s/report.html]\n\n", item.name, item.results_dir)
             self.errors_seen |= item.errors_seen
 
         if self.is_primary_cfg:
             self.gen_results_summary()
             self.write_results(self.results_html_name,
-                               self.results_summary_md)
+                               self.results_summary_md, is_primary_cfg=True)
+            log.info("[report]: [%s] [%s/report.html]", self.name, self.results_dir)
 
     def gen_results_summary(self):
         '''Public facing API to generate summary results for each IP/cfg file
         '''
         return
 
-    def write_results(self, html_filename, text_md, json_str=None):
+    def write_results(self, html_filename, text_md, json_str=None, is_primary_cfg=False):
         """Write results to files.
 
         This function converts text_md to HTML and writes the result to a file
@@ -452,7 +453,7 @@ class FlowCfg():
         # Write results to the report area.
         with open(self.results_dir / html_filename, "w") as f:
             f.write(
-                md_results_to_html(self.results_title, self.css_file, text_md))
+                md_results_to_html(self.results_title, self.css_file, text_md, is_primary_cfg))
 
         if json_str is not None:
             filename = Path(html_filename).with_suffix('.json')

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -2,17 +2,18 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-import json
 import logging as log
 import os
 import pprint
 import subprocess
 import sys
 from pathlib import Path
-from shutil import which
+import shutil
+import stat
+import tempfile
+from bs4 import BeautifulSoup
 
 import hjson
-from results_server import NoGCPError, ResultsServer
 from CfgJson import set_target_attribute
 from LauncherFactory import get_launcher_cls
 from Scheduler import Scheduler
@@ -468,157 +469,173 @@ class FlowCfg():
                                         relative_to)
         return "[%s](%s)" % (link_text, relative_link)
 
-    def _publish_results(self, results_server: ResultsServer):
-        '''Publish results to the opentitan web server.
+    def publish_results(self, repository: str, flow: str):
+        """Publish these results to a corresponding repository."""
+        log.info("Publishing results to %s", repository)
+        repo_dir = os.path.expanduser("./scratch/results_repo")
 
-        Results are uploaded to {results_server_page}. If the 'latest'
-        directory exists, then it is renamed to its 'timestamp' directory.
-        Links to the last 7 regression results are appended at the end if the
-        results page.
-        '''
-        # Timeformat for moving the dir
-        tf = "%Y.%m.%d_%H.%M.%S"
+        env = self._setup_ssh_env()
+        self.clone_or_pull(repository, repo_dir, env)
 
-        # Maximum number of links to add to previous results pages at the
-        # bottom of the page that we're generating.
-        max_old_page_links = 7
+        latest_batch_report = os.path.join(self.scratch_path, 'reports', 'latest', 'report.html')
+        # Destination directory should be
+        dest_batch_dir = os.path.join(repo_dir, f"{self.name}_{flow}",
+                                      f"{self.name}_{flow}_{self.timestamp}",
+                                      f"{self.name}", 'reports', 'latest')
+        os.makedirs(dest_batch_dir, exist_ok=True)
+        shutil.copy2(latest_batch_report, os.path.join(dest_batch_dir, 'report.html'))
+        log.info("Copied report for %s", self.name)
 
-        # We're going to try to put things in a directory called "latest". But
-        # there's probably something with that name already. If so, we want to
-        # move the thing that's there already to be at a path based on its
-        # creation time.
+        self._write_index_html(os.path.join(repo_dir, f"{self.name}_{flow}"),
+                               f"{self.name}_{flow}",
+                               f"{self.name}_{flow}_index",
+                               f"{self.name}_{flow}_{self.timestamp}",
+                               os.path.join(f"{self.name}_{flow}_{self.timestamp}",
+                                            self.name,
+                                            'reports', 'latest', 'report.html'))
 
-        # Try to get the creation time of any existing "latest/report.html"
-        latest_dir = '{}/latest'.format(self.rel_path)
-        latest_report_path = '{}/report.html'.format(latest_dir)
-        old_results_time = results_server.get_creation_time(latest_report_path)
+        self._write_index_html(repo_dir,
+                               "Reports",
+                               "index",
+                               f"{self.name}_{flow}",
+                               f"{self.name}_{flow}/{self.name}_{flow}_index.html")
 
-        if old_results_time is not None:
-            # If there is indeed a creation time, we will need to move the
-            # "latest" directory to a path based on that time.
-            old_results_ts = old_results_time.strftime(tf)
-            backup_dir = '{}/{}'.format(self.rel_path, old_results_ts)
-
-            results_server.mv(latest_dir, backup_dir)
-
-        # Do an ls in the results root dir to check what directories exist. If
-        # something goes wrong then continue, behaving as if there were none.
-        try:
-            existing_paths = results_server.ls(self.rel_path)
-        except subprocess.CalledProcessError:
-            log.error('Failed to list {} with gsutil. '
-                      'Acting as if there was nothing.'
-                      .format(self.rel_path))
-            existing_paths = []
-
-        # Do an ls in the results root dir to check what directories exist.
-        existing_basenames = []
-        for existing_path in existing_paths:
-            # Here, existing_path will start with "gs://" and should end in a
-            # time or with "latest" and then a trailing '/'. Split it to find
-            # that the directory basename. The rsplit() here will result in
-            # ["some_path", "basename_we_want", ""]. Grab the middle.
-            existing_parts = existing_path.rsplit('/', 2)
-            existing_basenames.append(existing_parts[1])
-
-        # We want to add pointers to existing directories with recent
-        # timestamps. Sort in reverse (time and lexicographic!) order, then
-        # take the top few results.
-        existing_basenames.sort(reverse=True)
-
-        history_txt = "\n## Past Results\n"
-        history_txt += "- [Latest](../latest/" + self.results_html_name + ")\n"
-        for existing_basename in existing_basenames[:max_old_page_links]:
-            relative_url = '../{}/{}'.format(existing_basename,
-                                             self.results_html_name)
-            history_txt += '- [{}]({})\n'.format(existing_basename,
-                                                 relative_url)
-
-        # Append the history to the results.
-        publish_results_md = self.publish_results_md or self.results_md
-        publish_results_md = publish_results_md + history_txt
-
-        # Export any results dictionary to json
-        suffixes = ['html']
-        json_str = None
-        if hasattr(self, 'results_dict'):
-            suffixes.append('json')
-            json_str = json.dumps(self.results_dict)
-
-        # Export our markdown page to HTML and dump the json to a local file.
-        # These are called publish.html and publish.json locally, but we'll
-        # rename them as part of the upload.
-        self.write_results("publish.html", publish_results_md, json_str)
-
-        html_name_no_suffix = self.results_html_name.split('.', 1)[0]
-        dst_no_suffix = '{}/latest/{}'.format(self.rel_path,
-                                              html_name_no_suffix)
-
-        # Now copy our local files over to the server
-        log.info("Publishing results to %s", self.results_server_url)
-        for suffix in suffixes:
-            src = "{}/publish.{}".format(self.results_dir, suffix)
-            dst = "{}.{}".format(dst_no_suffix, suffix)
-            results_server.upload(src, dst)
-
-    def publish_results(self):
-        """Publish these results to the opentitan web server."""
-        try:
-            server_handle = ResultsServer(self.results_server)
-        except NoGCPError:
-            # We failed to create a results server object at all, so we're not going to be able
-            # to publish any results right now.
-            log.error("Google Cloud SDK not installed. Cannot access the "
-                      "results server")
-            return
+        shutil.copy2(os.path.join(self.proj_root, 'util', 'dvsim', 'style.css'), repo_dir)
 
         for item in self.cfgs:
-            item._publish_results(server_handle)
+            latest_report = os.path.join(item.scratch_path, 'reports', 'latest', 'report.html')
+            if not os.path.exists(latest_report):
+                log.warning("No report found for %s at %s, skipping.", item.name, latest_report)
+                continue
+            dest_dir = os.path.join(repo_dir,
+                                    f"{self.name}_{flow}",
+                                    f"{self.name}_{flow}_{self.timestamp}",
+                                    os.path.basename(item.scratch_path),
+                                    'reports',
+                                    'latest')
+            os.makedirs(dest_dir, exist_ok=True)
+            shutil.copy2(latest_report, os.path.join(dest_dir, 'report.html'))
+            log.info("Copied report for %s", item.name)
 
-        if self.is_primary_cfg:
-            self.publish_results_summary(server_handle)
+        subprocess.run(["git", "-C", repo_dir, "add", "-A"], check=True, env=env)
+        subprocess.run(["git", "-C", repo_dir, "commit", "-m",
+                        f"[dashboard] Update {self.name} {self.flow} {self.timestamp}"],
+                       check=True, env=env)
+        subprocess.run(["git", "-C", repo_dir, "push"], check=True, env=env)
+        log.info("Results published successfully.")
 
-        # Trigger a rebuild of the site/docs which may pull new data from
-        # the published results.
-        self.rebuild_site()
+    def _setup_ssh_env(self) -> dict:
+        """Start an ssh-agent, add the key via askpass, and return the env dict."""
+        passphrase = os.environ.get("SSH_KEY_PASSPHRASE")
 
-    def publish_results_summary(self, results_server: ResultsServer):
-        '''Public facing API for publishing md format results to the opentitan
-        web server.
-        '''
-        # Publish the results page.
-        log.info("Publishing results summary to %s", self.results_server_url)
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.sh', delete=False) as f:
+            f.write(f'#!/bin/sh\necho "{passphrase}"\n')
+            askpass_script = f.name
+        os.chmod(askpass_script, stat.S_IRWXU)
 
-        latest_dir = '{}/latest'.format(self.rel_path)
-        latest_report_path = '{}/report.html'.format(latest_dir)
-        results_server.upload(self.results_page, latest_report_path)
+        env = os.environ.copy()
+        env["SSH_ASKPASS"] = askpass_script
+        env["SSH_ASKPASS_REQUIRE"] = "force"
+        env["DISPLAY"] = ""
+        env["GIT_SSH_COMMAND"] = "ssh -o StrictHostKeyChecking=no"
 
-    def rebuild_site(self):
-        '''Trigger a rebuild of the opentitan.org site using a Cloud Build trigger.
-
-        The Gcloud project which builds and deploys the site ("gold-hybrid-255131") uses
-        a cloudbuild yaml file (util/site/site-builder/cloudbuild-deploy-docs.yaml) to define
-        the rebuilding of the site.
-        A manually-triggered job ('site-builder-manual') has been created, which can be
-        triggered through an appropriately-authenticated Google Cloud SDK command. This
-        function calls that command.
-        '''
-        if which('gcloud') is None:
-            log.error("Google Cloud SDK not installed!"
-                      "Cannot access the Cloud Build API to trigger a site rebuild.")
-            return
-
-        project = 'gold-hybrid-255313'
-        trigger_name = 'site-builder-manual'
-        cmd = f"gcloud beta --project {project} builds triggers run {trigger_name}".split(' ')
         try:
-            cmd_output = subprocess.run(args=cmd,
-                                        shell=True,
-                                        stdout=subprocess.PIPE,
-                                        stderr=subprocess.STDOUT)
-            log.log(VERBOSE, cmd_output.stdout.decode("utf-8"))
-        except Exception as e:
-            log.error(f"{e}: Failed to trigger Cloud Build job to rebuild site:\n\"{cmd}\"")
+            agent = subprocess.run(["ssh-agent", "-s"], check=True, capture_output=True, text=True)
+            for line in agent.stdout.splitlines():
+                if "=" in line and ";" in line:
+                    key, _, rest = line.partition("=")
+                    env[key] = rest.split(";")[0]
+            subprocess.run(["ssh-add"], check=True, env=env, stdin=subprocess.DEVNULL)
+        finally:
+            os.unlink(askpass_script)
+
+        return env
+
+    def clone_or_pull(self, repository: str, local_path: str, env: dict):
+        """Clone the repo if it doesn't exist locally, otherwise pull latest."""
+        try:
+            if not os.path.exists(local_path):
+                subprocess.run(["git", "clone", repository, local_path], check=True, env=env)
+            else:
+                subprocess.run(["git", "-C", local_path, "pull"], check=True, env=env)
+        except FileNotFoundError:
+            log.error("git is not installed or not on PATH. Cannot publish results.")
+            raise
+        except subprocess.TimeoutExpired:
+            log.error("Timed out trying to reach repository: %s", repository)
+            raise
+        except subprocess.CalledProcessError as e:
+            log.error("Git operation failed for %s:\n%s",
+                      repository, e.stderr.decode().strip() if e.stderr else "")
+            raise
+
+    def _write_index_html(self, repo_dir: str, title: str, filename: str, version: str, link: str):
+        """Create or update an index html file with a versioned link, kept alphabetically."""
+        os.makedirs(repo_dir, exist_ok=True)
+        style_src = os.path.join(os.path.dirname(__file__), 'style.css')
+        shutil.copy2(style_src, repo_dir)
+        filepath = os.path.join(repo_dir, f"{filename}.html")
+        if not os.path.exists(filepath):
+            html = f"""<!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="utf-8"/>
+                    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+                    <title>{title}</title>
+                    <link href="style.css" rel="stylesheet"/>
+                </head>
+            <body style="background-color: #ffffff; margin: 0; padding: 0;">
+                <div class="results index-page">
+                    <h1>{title}</h1>
+                    <table>
+                        <thead>
+                        <tr><th>Version</th></tr>
+                        </thead>
+                        <tbody>
+                        </tbody>
+                    </table>
+                </div>
+            </body>
+            </html>"""
+            with open(filepath, 'w') as f:
+                f.write(html)
+
+        with open(filepath, 'r') as f:
+            soup = BeautifulSoup(f.read(), 'html.parser')
+
+        tbody = soup.find('tbody')
+
+        for tr in tbody.find_all('tr'):
+            a = tr.find('a')
+            if a and a.text == version:
+                if a['href'] == link:
+                    log.info("Version %s already exists in %s, skipping.", version, filepath)
+                    return
+                else:
+                    a['href'] = link
+                    with open(filepath, 'w') as f:
+                        f.write(str(soup))
+                    return
+
+        new_tr = soup.new_tag('tr')
+        new_td = soup.new_tag('td')
+        new_a = soup.new_tag('a', href=link)
+        new_a.string = version
+        new_td.append(new_a)
+        new_tr.append(new_td)
+
+        inserted = False
+        for tr in tbody.find_all('tr'):
+            a = tr.find('a')
+            if a and a.text > version:
+                tr.insert_before(new_tr)
+                inserted = True
+                break
+        if not inserted:
+            tbody.append(new_tr)
+
+        with open(filepath, 'w') as f:
+            f.write(str(soup))
 
     def has_errors(self):
         return self.errors_seen

--- a/util/dvsim/FormalCfg.py
+++ b/util/dvsim/FormalCfg.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import hjson
 from OneShotCfg import OneShotCfg
-from results_server import ResultsServer
 from tabulate import tabulate
 from utils import subst_wildcards
 
@@ -255,18 +254,3 @@ class FormalCfg(OneShotCfg):
         self.result_summary[self.name] = summary
 
         return self.results_md
-
-    def _publish_results(self, results_server: ResultsServer):
-        ''' our agreement with tool vendors allows us to publish the summary
-        results (as in gen_results_summary).
-
-        In default this method does nothing: detailed messages from each child
-        cfg will not be published.
-        If the publish_report argument is set to true, this method will only
-        publish a result summary of the child cfg.
-        '''
-        if self.publish_report:
-            self.publish_results_md = self.gen_results_summary()
-            super()._publish_results(results_server)
-        else:
-            return

--- a/util/dvsim/README.md
+++ b/util/dvsim/README.md
@@ -45,4 +45,4 @@ Note that you may have already done this if you followed the getting started ste
 
 ## Bugs
 
-Please see [link](https://github.com/zerorisc/wanta/issues) for a list of open bugs and feature requests.
+Please see [link](https://github.com/pavona/pavona/issues) for a list of open bugs and feature requests.

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -838,8 +838,8 @@ class SimCfg(FlowCfg):
 
                 # self.rel_path gives us the path to the directory
                 # containing the sim_cfg file...
-                testplan = "https://{}/{}".format(
-                    self.book,
+                testplan = "https://{}/tree/main/{}".format(
+                    self.repo_server,
                     Path(self.rel_path).parent / 'data' / f"{self.name}_testplan.html"
                 )
 

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -840,7 +840,7 @@ class SimCfg(FlowCfg):
                 # containing the sim_cfg file...
                 testplan = "https://{}/tree/main/{}".format(
                     self.repo_server,
-                    Path(self.rel_path).parent / 'data' / f"{self.name}_testplan.html"
+                    Path(self.rel_path).parent / 'data' / f"{self.name}_testplan.hjson"
                 )
 
             results_str += f"### [Testplan]({testplan})\n"
@@ -879,7 +879,7 @@ class SimCfg(FlowCfg):
                         if self.args.publish:
                             cov_report_page_path = "cov_report"
                         else:
-                            cov_report_page_path = self.cov_report_dir
+                            cov_report_page_path = "../../cov_report"
                         cov_report_page_path += "/" + self.cov_report_page
                         results_str += "({})\n\n".format(cov_report_page_path)
                     results_str += self.cov_report_deploy.cov_results

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -21,7 +21,6 @@ from Deploy import CompileSim, CovAnalyze, CovMerge, CovReport, CovUnr, RunTest
 from FlowCfg import FlowCfg
 from modes import BuildMode, Mode, RunMode, find_mode
 from Regression import Regression
-from results_server import ResultsServer
 from SimResults import SimResults
 from tabulate import tabulate
 from Test import Test
@@ -950,17 +949,3 @@ class SimCfg(FlowCfg):
         self.results_summary_md = "\n".join(lines)
         print(str(self.results_summary_md))
         return self.results_summary_md
-
-    def _publish_results(self, results_server: ResultsServer):
-        '''Publish coverage results to the opentitan web server.'''
-        super()._publish_results(results_server)
-
-        if self.cov_report_deploy is not None:
-            log.info("Publishing coverage results to https://{}/{}/latest"
-                     .format(self.results_server,
-                             self.rel_path))
-
-            latest_dir = '{}/latest'.format(self.rel_path)
-            results_server.upload(self.cov_report_dir,
-                                  latest_dir,
-                                  recursive=True)

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -875,18 +875,20 @@ class SimCfg(FlowCfg):
                     results_str += "\n## Coverage Results\n"
                     # Link the dashboard page using "cov_report_page" value.
                     if hasattr(self, "cov_report_page"):
-                        results_str += "\n### [Coverage Dashboard]"
-                        if self.args.publish:
-                            cov_report_page_path = "cov_report"
-                        else:
-                            cov_report_page_path = "../../cov_report"
-                        cov_report_page_path += "/" + self.cov_report_page
-                        results_str += "({})\n\n".format(cov_report_page_path)
+                        results_str += "\n### Coverage Dashboard\n\n"
+                        # TODO: modify to include differentiation between public and private
+                        # dashboard usage.
+                        # if self.args.publish:
+                        #     cov_report_page_path = "cov_report"
+                        # else:
+                        #     cov_report_page_path = "../../cov_report"
+                        # cov_report_page_path += "/" + self.cov_report_page
+                        # results_str += "({})\n\n".format(cov_report_page_path)
                     results_str += self.cov_report_deploy.cov_results
                     self.results_summary[
-                        "Coverage"] = self.cov_report_deploy.cov_total
+                        "Overall Coverage"] = self.cov_report_deploy.cov_total
                 else:
-                    self.results_summary["Coverage"] = "--"
+                    self.results_summary["Overall Coverage"] = "--"
 
         if results.buckets:
             self.errors_seen = True
@@ -911,28 +913,33 @@ class SimCfg(FlowCfg):
         lines += [f"### Branch: {self.branch}"]
 
         table = []
-        header = []
+        rows = []
+        DEFAULT_VALUE = "-- %"
         for cfg in self.cfgs:
-            row = cfg.results_summary
+            cov_scores = cfg.cov_report_deploy.cov_results_dict
+            cov_scores = {f"{key.capitalize()} Coverage": val for key, val in cov_scores.items()}
+            row = cfg.results_summary | cov_scores
             if row:
                 # convert name entry to relative link
-                row = cfg.results_summary
                 row["Name"] = cfg._get_results_page_link(
                     self.results_dir,
                     row["Name"])
+                rows.append(row)
 
-                # If header is set, ensure its the same for all cfgs.
-                if header:
-                    assert header == cfg.results_summary.keys()
-                else:
-                    header = cfg.results_summary.keys()
-                table.append(row.values())
+        if rows:
+            all_keys = list(dict.fromkeys(key for row in rows for key in row))
+            # Move the "Overall Coverage" key to the end
+            all_keys.remove("Overall Coverage")
+            all_keys.append("Overall Coverage")
+
+            for row in rows:
+                normalized = {key: row.get(key, DEFAULT_VALUE) for key in all_keys}
+                table.append(list(normalized.values()))
 
         if table:
-            assert header
-            colalign = ("center", ) * len(header)
+            colalign = ("center", ) * len(all_keys)
             table_txt = tabulate(table,
-                                 headers=header,
+                                 headers=all_keys,
                                  tablefmt="pipe",
                                  colalign=colalign)
             lines += ["", table_txt, ""]
@@ -941,7 +948,7 @@ class SimCfg(FlowCfg):
             lines += ["\nNo results to display.\n"]
 
         self.results_summary_md = "\n".join(lines)
-        print(self.results_summary_md)
+        print(str(self.results_summary_md))
         return self.results_summary_md
 
     def _publish_results(self, results_server: ResultsServer):

--- a/util/dvsim/doc/glossary.md
+++ b/util/dvsim/doc/glossary.md
@@ -12,6 +12,10 @@ In Pavona, the build stage broadly performs the following steps:
 
 ## Build configuration
 
+A build configuration refers to the specific set of options and settings used to compile and elaborate the DUT into a simulation executable or database.
+It is uniquely identified by its build mode, which determines the compile-time and elaboration-time options applied.
+Each unique build configuration is generated in its own directory to avoid conflicts with other configurations.
+
 ## Build modes
 
 A test or a subset of tests may require the DUT to be modified a certain way at compile time (typically via `+define+` preprocessor macros) or elaboration time (typically, modification of design parameter values).
@@ -92,6 +96,11 @@ In Pavona, this step is accomplished by [FuseSoC](https://fusesoc.readthedocs.io
 
 ## Random seed
 
+A random seed is an integer value used to initialize the pseudo-random number generator (PRNG) used during a simulation run.
+Since constrained-random verification relies on randomization to generate stimulus, the seed determines the sequence of random values generated during a simulation.
+Running the same test with the same seed will always produce the same sequence of random values, making it possible to reproduce a failing test.
+Different seeds will produce different random sequences, allowing the same test to exercise different scenarios.
+
 ## Regressions
 
 A regression is a group of tests that are labeled with a target name.
@@ -101,16 +110,34 @@ Please see [TBD]() for more details.
 DVSim provides these standard regression targets for all DUTs:
 - `smoke` (typically run in CI checks)
 - `nightly` (a full regression with a single seed and coverage enabled, that is run every night)
-- `weekly` (a full regression with coverage enabled, that is run every night)
+- `weekly` (a full regression with coverage enabled, that is run every weekend)
 - `v1` / `v2` / `v3` (DVSim automatically extracts tests that are tagged V1 / V2 / V3 and creates a regression target).
 - `all` (runs all tests with the preset reseeds, without coverage)
 - `all_once` (run all tests with only a single randomly chosen seed)
 
 ## Reseeds
 
+Reseeding refers to the number of times a test is run with a different random seed.
+Running a test multiple times with different seeds increases the probability of hitting corner cases and bugs.
+The reseed value for a test can be specified in the DUT configuration file or overridden on the command line via `--reseed`.
+
 ## Run
 
+"Run" refers to the invocation of a previously built simulation executable to execute a specific test.
+In Pavona, the run stage broadly performs the following steps:
+
+- Create the run `scratch` directory.
+- Execute any pre-run utility scripts, if provided.
+- Invoke the simulation executable with the required runtime options, including the UVM test name and the random seed.
+- Execute any post-run utility scripts, if provided.
+- Parse the simulation log to determine whether the test passed or failed.
+
 ## Run modes
+
+A run mode encapsulates a list of special runtime options that may be applied to a simulation run.
+These are typically runtime plusargs (e.g. `+myarg=value`) or tool-specific runtime flags that alter the behavior of the simulation without requiring a recompilation of the executable.
+A test specification may specify one or more run modes to be applied to it.
+Run modes may also be enabled on the command line.
 
 ## Sim modes
 

--- a/util/dvsim/doc/glossary.md
+++ b/util/dvsim/doc/glossary.md
@@ -100,7 +100,8 @@ Please see [TBD]() for more details.
 
 DVSim provides these standard regression targets for all DUTs:
 - `smoke` (typically run in CI checks)
-- `nightly` (a full regression with coverage enabled, that is run every night)
+- `nightly` (a full regression with a single seed and coverage enabled, that is run every night)
+- `weekly` (a full regression with coverage enabled, that is run every night)
 - `v1` / `v2` / `v3` (DVSim automatically extracts tests that are tagged V1 / V2 / V3 and creates a regression target).
 - `all` (runs all tests with the preset reseeds, without coverage)
 - `all_once` (run all tests with only a single randomly chosen seed)

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -626,8 +626,10 @@ def parse_args():
                             "at the end."))
 
     pubg.add_argument("--publish",
-                      action='store_true',
-                      help="Publish results to reports.opentitan.org.")
+                      metavar="REPO",
+                      help="Publish results to the given GitHub repository "
+                           "(e.g. git@github.com:org/repo.git). "
+                           "Requires the SSH_KEY_PASSPHRASE environment variable to be set.")
 
     dvg = parser.add_argument_group('Controlling DVSim itself')
 
@@ -770,6 +772,13 @@ def main():
         cfg.deploy_objects()
         sys.exit(0)
 
+    # Error out if it is a non-publishable config
+    if args.publish is not None:
+        if not args.cov or not cfg.is_primary_cfg:
+            log.fatal("--publish requires --cov to be enabled"
+                      " and for the config file to be a batch sim_cfg")
+            sys.exit(1)
+
     # Deploy the builds and runs
     if args.items:
         # Create deploy objects.
@@ -780,8 +789,8 @@ def main():
         cfg.gen_results(results)
 
         # Publish results
-        if args.publish:
-            cfg.publish_results()
+        if args.publish is not None:
+            cfg.publish_results(args.publish, args.items[0])
 
     else:
         log.error("Nothing to run!")

--- a/util/dvsim/style.css
+++ b/util/dvsim/style.css
@@ -123,3 +123,24 @@
   color: #000000;
   background-color: #57EF57;
 }
+
+/* Header column group colors for batch coverage */
+.results table.col-12 thead tr th:nth-child(1) {
+    background-color: #3D1067 !important;
+}
+
+.results table.col-12 thead tr th:nth-child(n+2):nth-child(-n+3) {
+    background-color: #5C2D91 !important;
+}
+
+.results table.col-12 thead tr th:nth-child(4) {
+    background-color: #3D1067 !important;
+}
+
+.results table.col-12 thead tr th:nth-child(n+5):nth-child(-n+12) {
+    background-color: #5C2D91 !important;
+}
+
+.results table.col-12 thead tr th:nth-child(13) {
+    background-color: #3D1067 !important;
+}

--- a/util/dvsim/style.css
+++ b/util/dvsim/style.css
@@ -1,4 +1,5 @@
 /* Copyright lowRISC contributors (OpenTitan project). */
+/* Copyright zeroRISC Inc. */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
@@ -130,7 +131,7 @@
 }
 
 .results table.col-12 thead tr th:nth-child(n+2):nth-child(-n+3) {
-    background-color: #5C2D91 !important;
+    background-color: #4A1A7A !important;
 }
 
 .results table.col-12 thead tr th:nth-child(4) {
@@ -138,9 +139,70 @@
 }
 
 .results table.col-12 thead tr th:nth-child(n+5):nth-child(-n+12) {
-    background-color: #5C2D91 !important;
+    background-color: #4A1A7A !important;
 }
 
 .results table.col-12 thead tr th:nth-child(13) {
     background-color: #3D1067 !important;
+}
+
+/* Published reports index page additions */
+.results.index-page {
+  border-radius: 8px;
+  margin: 40px auto;
+  padding: 32px 40px;
+  font-family: 'Segoe UI', Roboto, Helvetica, sans-serif;
+}
+
+.results.index-page td {
+  text-align: left;
+  padding-left: 16px;
+  border: none;
+}
+
+.results.index-page th {
+  text-align: left;
+  background-color: #3D1067 !important;
+  padding-left: 16px;
+  border: none;
+}
+
+.results.index-page::before {
+  height: 4px;
+  background: linear-gradient(90deg, #3D1067, #5C2D91);
+  border-radius: 4px 4px 0 0;
+  margin: -32px -40px 32px -40px;
+}
+
+.results.index-page h1 {
+  color: #000000;
+  letter-spacing: 0.01em;
+  font-weight: 600;
+  text-align: left;
+  font-size: 2.5rem;
+}
+
+.results.index-page tbody tr {
+  background: #FFFFFF;
+}
+
+.results.index-page tbody tr:nth-child(even) {
+  background: #FFFFFF;
+}
+
+.results.index-page td a {
+  font-weight: 500;
+  display: block;
+  padding: 4px 0;
+}
+
+.results.index-page td a:hover {
+  text-decoration: underline;
+}
+
+.results.index-page table {
+  width: 100%;
+  margin: 0;
+  border: none;
+  box-shadow: none;
 }

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -16,6 +16,7 @@ import time
 from collections import OrderedDict
 from datetime import datetime
 from pathlib import Path
+from bs4 import BeautifulSoup
 
 import hjson
 import mistletoe
@@ -346,7 +347,7 @@ def find_and_substitute_wildcards(sub_dict,
     return sub_dict
 
 
-def md_results_to_html(title, css_file, md_text):
+def md_results_to_html(title, css_file, md_text, is_primary_cfg=False):
     '''Convert results in md format to html. Add a little bit of styling.
     '''
     html_text = "<!DOCTYPE html>\n"
@@ -366,6 +367,8 @@ def md_results_to_html(title, css_file, md_text):
     html_text = transform(html_text,
                           external_styles=css_file,
                           cssutils_logging_level=log.ERROR)
+    if is_primary_cfg:
+        html_text = html_styling_batch_coverage(html_text)
     return html_text
 
 
@@ -515,6 +518,34 @@ def htmc_color_pc_cells(text):
         for item in subst_list:
             text = text.replace(item, subst_list[item])
     return text
+
+
+def html_styling_batch_coverage(html_text):
+    """
+    Introduce formatting fixes for fitting the batch coverage page and
+    tag tables with a class based on their column count for CSS styling
+    when making a batch coverage report.
+    """
+    # Fix table centering: replace whatever margin was inlined with explicit auto margins
+    html_text = re.sub(
+        r'(<table[^>]*style="[^"]*?)margin:[^;]+;',
+        r'\1margin-left:auto; margin-right:auto;',
+        html_text
+    )
+    # Break out of the constrained .results div and center on full viewport
+    html_text = html_text.replace(
+        "<table",
+        "<div style=\"width:100vw; position:relative; left:50%;"
+        " transform:translateX(-50%); overflow-x:auto;\"><table"
+    )
+    html_text = html_text.replace(
+        "</table>",
+        "</table></div>"
+    )
+    soup = BeautifulSoup(html_text, "html.parser")
+    table = soup.select_one("table")
+    table["class"] = table.get("class", []) + ["col-12"]
+    return str(soup)
 
 
 def print_msg_list(msg_list_title, msg_list, max_msg_count=-1):

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -536,7 +536,7 @@ def html_styling_batch_coverage(html_text):
     html_text = html_text.replace(
         "<table",
         "<div style=\"width:100vw; position:relative; left:50%;"
-        " transform:translateX(-50%); overflow-x:auto;\"><table"
+        "transform:translateX(-50%); overflow-x:auto;\"><table"
     )
     html_text = html_text.replace(
         "</table>",

--- a/util/gen_ip_collection.py
+++ b/util/gen_ip_collection.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""
+gen_ip_collection.py
+Collects IP and top-level sim cfg files and generates batch hjson files.
+Usage:
+    ./gen_ip_collection.py --flow sim_dv --tops top_earlgrey top_darjeeling
+"""
+import argparse
+import glob
+import os
+from pathlib import Path
+
+SEARCH_ROOT = Path(__file__).resolve().parents[1]
+LOWRISC_COPYRIGHT_LINE = "// Copyright lowRISC contributors (OpenTitan project)."
+ZERORISC_COPYRIGHT_LINE = "// Copyright zeroRISC Inc."
+LICENSE_LINES = """\
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0"""
+
+COPYRIGHT_HEADER_SOLO = f"{ZERORISC_COPYRIGHT_LINE}\n{LICENSE_LINES}"
+COPYRIGHT_HEADER_JOINT = (
+    f"{LOWRISC_COPYRIGHT_LINE}\n{ZERORISC_COPYRIGHT_LINE}\n{LICENSE_LINES}"
+)
+WARNHDR = """//
+// ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
+// PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
+"""
+
+
+def get_copyright_header(path, flow, tops):
+    """Return the appropriate copyright header for this file."""
+    tops_str = ' '.join(tops)
+    GENCMD = (f"// util/gen_ip_collection.py --flow {flow}\n"
+              f"//                --tops {tops_str}\n")
+    if os.path.exists(path):
+        try:
+            with open(path) as f:
+                first_line = f.readline().strip()
+            if first_line == LOWRISC_COPYRIGHT_LINE:
+                return f"{COPYRIGHT_HEADER_JOINT}\n\n{WARNHDR}{GENCMD}"
+        except OSError as e:
+            print(f"Warning: could not read {path}: {e}")
+    return f"{COPYRIGHT_HEADER_SOLO}\n\n{WARNHDR}{GENCMD}"
+
+
+# =============================
+#   Specific to sim_dv flow
+# =============================
+
+def collect_sim_dv(tops):
+    """
+    Collect all sim_cfg hjson files into two buckets:
+      - ip_cfgs:  shared across all tops (hw/ip/... and hw/dv/...)
+      - top_cfgs: dict keyed by topname, each containing top-specific cfgs
+    """
+    ip_cfgs = []
+    top_cfgs = {top: [] for top in tops}
+
+    def skip(sim_name):
+        return "base" in sim_name
+
+    # ---- IP bucket ----
+    # Pattern 1: hw/ip/{ip_name}/dv/{sim_cfg}
+    # Pattern 2: hw/ip/{ip_name}/dv/uvm/{sim_cfg}
+    # Pattern 3: hw/ip/prim/dv/{prim_variant}/{sim_cfg}
+    # Pattern 4: hw/dv/sv/{ip_name}/dv/{sim_cfg}
+    for cfg in (
+        sorted(glob.glob("hw/ip/*/dv/*_sim_cfg.hjson"))
+        + sorted(glob.glob("hw/ip/*/dv/uvm/*_sim_cfg.hjson"))
+        + sorted(glob.glob("hw/ip/prim/dv/*/*_sim_cfg.hjson"))
+        + sorted(glob.glob("hw/dv/sv/*/*/*_sim_cfg.hjson"))
+    ):
+        sim_name = Path(cfg).stem.replace("_sim_cfg", "")
+        if skip(sim_name):
+            continue
+        ip_cfgs.append(cfg)
+
+    # ---- Top-specific bucket ----
+    for top in tops:
+        # Pattern 5: hw/{top}/ip_autogen/{ip_name}/dv/{sim_cfg}
+        # Pattern 6: hw/{top}/ip_autogen/{ip_name}/dv/{subdir}/{sim_cfg}
+        # Pattern 7: hw/{top}/ip/{xbar_name}/dv/autogen/{sim_cfg}
+        # Pattern 8: hw/{top}/dv/{sim_cfg} (chip-level)
+        for cfg in (
+            sorted(glob.glob(f"hw/{top}/ip_autogen/*/dv/*_sim_cfg.hjson"))
+            + sorted(glob.glob(f"hw/{top}/ip_autogen/*/dv/*/*_sim_cfg.hjson"))
+            + sorted(glob.glob(f"hw/{top}/ip/*/dv/autogen/*_sim_cfg.hjson"))
+            + sorted(glob.glob(f"hw/{top}/dv/*_sim_cfg.hjson"))
+        ):
+            sim_name = Path(cfg).stem.replace("_sim_cfg", "")
+            if skip(sim_name):
+                continue
+            top_cfgs[top].append(cfg)
+
+    return ip_cfgs, top_cfgs
+
+
+def format_use_cfgs(cfgs, indent=13):
+    """Format a list of cfg paths as hjson use_cfgs entries."""
+    pad = " " * indent
+    lines = [f'{pad}"{{proj_root}}/{cfg}",' for cfg in cfgs]
+    return "\n".join(lines)
+
+
+def generate_hjson(ip_cfgs, top_cfgs, tops, copyright_header, top_specific=False):
+    """Generate hjson for a batch sim_cfgs"""
+    sections = []
+
+    tl_agent_cfgs = [c for c in ip_cfgs if "hw/dv/sv/" in c]
+    pure_ip_cfgs = [c for c in ip_cfgs if "hw/ip/" in c]
+
+    if tl_agent_cfgs:
+        sections.append(
+            "             // Unit tests for UVCs.\n" +
+            format_use_cfgs(tl_agent_cfgs)
+        )
+    if pure_ip_cfgs:
+        sections.append(
+            "             // IPs.\n" +
+            format_use_cfgs(pure_ip_cfgs)
+        )
+
+    for top in tops:
+        cfgs = top_cfgs[top]
+        autogen_cfgs = [c for c in cfgs if f"hw/{top}/ip_autogen/" in c
+                        or f"hw/{top}/ip/" in c]
+        chip_cfgs = [c for c in cfgs if f"hw/{top}/dv/" in c]
+
+        if autogen_cfgs:
+            sections.append(
+                f"             // {top} autogen IPs.\n" +
+                format_use_cfgs(autogen_cfgs)
+            )
+        if chip_cfgs:
+            sections.append(
+                f"             // {top} chip.\n" +
+                format_use_cfgs(chip_cfgs)
+            )
+
+    use_cfgs_body = "\n".join(sections)
+
+    if not top_specific:
+        batchname_desc = "across all IPs and tops in the project"
+        batchname = "all_tops"
+        rel_path = "hw/dv/summary"
+    else:
+        batchname_desc = f"of the IPs and the full chip used in {top}"
+        batchname = tops[0]
+        rel_path = f"hw/{tops[0]}/dv/summary"
+
+    return f"""{copyright_header}
+{{
+  // This is a cfg hjson group for DV simulations. It includes ALL individual DV simulation
+  // cfgs {batchname_desc}. This enables the common
+  // regression sets to be run in one shot.
+  name: {batchname}_batch
+
+  import_cfgs: [// Project wide common cfg file
+                "{{proj_root}}/hw/data/common_project_cfg.hjson"]
+
+  flow: sim
+
+  rel_path: "{rel_path}"
+
+  // Need to override the default output directory
+  overrides: [
+    {{
+        name: scratch_path
+        value: "{{scratch_base_path}}/{{name}}-{{flow}}"
+    }}
+  ]
+
+  use_cfgs: [
+{use_cfgs_body}
+            ]
+}}
+"""
+
+
+def write_file(path, content, dry_run):
+    if dry_run:
+        print(f"\n{'=' * 60}")
+        print(f"Would write: {path}")
+        print('=' * 60)
+        print(content)
+    else:
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w") as f:
+                f.write(content)
+            print(f"Written: {path}")
+        except OSError as e:
+            print("Failed to create output directory {}: \n{}."
+                  .format(os.path.dirname(path), e))
+
+
+def run_sim_dv(tops, dry_run, flow):
+    print("Collecting sim_dv sim_cfg files...")
+    ip_cfgs, top_cfgs = collect_sim_dv(tops)
+    print(f"  Found {len(ip_cfgs)} shared IP cfgs")
+    for top, cfgs in top_cfgs.items():
+        print(f"  Found {len(cfgs)} cfgs for {top}")
+
+    # Per-top hjson files
+    for top in tops:
+        out_path = f"hw/{top}/dv/{top}_sim_cfgs.hjson"
+        copyright_header = get_copyright_header(out_path, flow, top_cfgs)
+        content = generate_hjson(ip_cfgs, top_cfgs, [top], copyright_header, True)
+        write_file(out_path, content, dry_run)
+
+    # Global hjson file
+    out_path = "hw/dv/all_sim_cfgs.hjson"
+    copyright_header = get_copyright_header(out_path, flow, top_cfgs)
+    content = generate_hjson(ip_cfgs, top_cfgs, tops, copyright_header)
+    write_file(out_path, content, dry_run)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate repo-wide IP collection files.",
+    )
+    parser.add_argument(
+        "--flow",
+        required=True,
+        choices=["sim_dv"],
+        help="Flow type to collect for. Currently supported: sim_dv",
+    )
+    parser.add_argument(
+        "--tops",
+        required=True,
+        nargs="+",
+        metavar="TOP",
+        help="One or more tops to collect for (e.g. --tops top_earlgrey top_darjeeling)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be generated without writing files",
+    )
+    return parser.parse_args()
+
+
+def main():
+    try:
+        os.chdir(SEARCH_ROOT)
+    except OSError as e:
+        print(f"Failed to change to directory {SEARCH_ROOT}: \n{e}")
+    args = parse_args()
+    if args.flow == "sim_dv":
+        run_sim_dv(args.tops, args.dry_run, args.flow)
+    else:
+        print(f"Unknown flow: {args.flow}")
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Now the `--publish` flag requires an argument corresponding to a repository to which `dvsim` collects the reports and `git push`es to. Note that it currently requires a `$SSH_KEY_PASSPHRASE` environment variable to be defined with the passphrase to push to a private repository (this is to be improved later on).

In addition to this, it includes a `weekly` argument that automatically mimics the `-i all`. Now, `nightly` runs the `-i all_once` with `-cov` enabled.

This PR is to be merged after #50, #51, and #52.