### PR TITLE
[gitless] Make the repo usable without git refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,6 +359,11 @@ jobs:
     with:
       bitstream: chip_earlgrey_cw340
 
+  gitless-check:
+    name: Test using the repo from a git archive (no git history)
+    needs: quick_lint
+    uses: ./.github/workflows/gitless.yml
+
   sw_build_test:
     name: Build and test software (Earlgrey)
     runs-on:

--- a/.github/workflows/gitless.yml
+++ b/.github/workflows/gitless.yml
@@ -1,0 +1,37 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Gitless repo test
+on:
+  workflow_call:
+
+jobs:
+  gitless:
+    name: Run gitless check
+    runs-on:
+      group: pavona-large
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          fetch-depth: 0
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+      - name: Work from git repo archive
+        run: |
+          git archive --format=tar.gz -o "../gitless.tar.gz" HEAD
+          cd ..
+          mkdir gitless
+          tar -xzf gitless.tar.gz -C gitless --strip-components=1
+          cd gitless
+          export REPO_TOP=$(realpath .)
+      - name: Run gitless check
+        continue-on-error: true
+        run: ./ci/scripts/check-gitless.sh -e
+      - name: Output gitless log
+        run: |
+          log_output=$(cat gitless.log)  # will be empty if no errors
+          if [ -n "$log_output" ]; then
+            echo $log_output
+            exit 1
+          fi

--- a/bazelisk.sh
+++ b/bazelisk.sh
@@ -14,6 +14,7 @@ cd "$(dirname "$0")"
 
 : "${CURL_FLAGS:=--silent}"
 : "${REPO_TOP:=$(git rev-parse --show-toplevel)}"
+: "${REPO_TOP:=$(dirname $0)}"
 : "${BINDIR:=.bin}"
 : "${BAZEL_BIN:=$(which bazel 2>/dev/null)}"
 

--- a/ci/scripts/check-bazel-banned-rules.sh
+++ b/ci/scripts/check-bazel-banned-rules.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-REPO_TOP="$(git rev-parse --show-toplevel)"
+REPO_TOP="$(git rev-parse --show-toplevel)" || REPO_TOP="$(realpath $0/../../..)"
 cd "$REPO_TOP"
 
 if grep -r --include '*MODULE.bazel' git_override; then

--- a/ci/scripts/check-gitless.sh
+++ b/ci/scripts/check-gitless.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# run this from the git-less package of the repo after installing all repo requirements
+
+EXIT_ON_FAIL=false
+TOOL=
+while getopts "het:" OPTION; do
+  case $OPTION in
+    h)
+      echo "Usage: check-gitless.sh [-h] [-e] [-t TOOL]"
+      echo "Run a series of tests on the repo that should work, both in git-less "
+      echo "(from git archive) and git-ful (from git clone) packages."
+      echo ""
+      echo "  -h    Print this help message."
+      echo "  -e    Exit the script after the first failed test command."
+      echo "  -t    Tool for running dvsim; DV tests will be skipped if not"
+      echo "        passed in or invalid tool."
+      exit 0
+      ;;
+    e)
+      echo "Exiting on first fail."
+      set -e
+      EXIT_ON_FAIL=true
+      ;;
+    t)
+      TOOL=$OPTARG
+      ;;
+    *)
+      echo "Invalid option: $OPTION"
+      ;;
+    esac
+done
+
+
+export REPO_TOP=${REPO_TOP:-$(realpath "$(dirname "$0")/../..")}
+cd "$REPO_TOP" || exit 1
+rm -f ./gitless.log
+touch ./gitless.log
+
+
+run_cmds () {
+  cd "$REPO_TOP" || exit 1
+  for cmd in "$@"; do
+    running_log=$(mktemp)
+    echo RUNNING: "$cmd" > "$running_log"
+    echo "--------------------------------------" >> "$running_log"
+    echo -n "    \`$cmd\`: "
+
+    if $cmd 1>/dev/null 2>>"$running_log"; then
+      cd "$REPO_TOP" || exit 1
+      echo "PASSED."
+
+    else
+      cd "$REPO_TOP" || exit 1
+      echo "" >> "$running_log"  # extra spacing kludge
+      echo "" >> "$running_log"
+      cat "$running_log" >> ./gitless.log
+      echo "FAILED. Check $REPO_TOP/gitless.log for stderr."
+      if [ "$EXIT_ON_FAIL"  = true ]; then
+        exit 1
+      fi
+    fi
+
+    rm "$running_log"
+  done
+}
+
+
+echo "Running basic checks for gitless..."
+run_cmds 'make -C hw all'
+run_cmds \
+  './ci/scripts/sw-build-test.sh earlgrey //...' \
+  './ci/scripts/sw-build-test.sh darjeeling //...'
+
+if [ "$(which verilator)" ]; then
+  run_cmds './ci/scripts/run-verilator-tests.sh'  # verilator tests first as sanity check
+else
+  echo "    Verilator install not found; skipping verilator tests."
+fi
+
+echo "Running DV tests [requires dvsim capabilities]..."
+if [ "$TOOL" = "vcs" ] || [ "$TOOL" = "quest" ] || [ "$TOOL" = "xcelium" ] || [ "$TOOL" = "ascentlint" ] || [ "$TOOL" = "verixcdc" ] || [ "$TOOL" = "mrdc" ] || [ "$TOOL" = "veriblelint" ] || [ "$TOOL" = "verilator" ] || [ "$TOOL" = "dc" ]; then  # possible tools listed in util/dvsim/dvsim.py
+  run_cmds \
+    './util/dvsim/dvsim.py -t '"$TOOL"' --cov ./hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson' \
+    './util/dvsim/dvsim.py -t '"$TOOL"' --cov ./hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson'
+else
+  echo "    No valid tool passed in. Skipping dvsim tests."
+fi
+
+
+exit 0

--- a/ci/scripts/check-lock-files.sh
+++ b/ci/scripts/check-lock-files.sh
@@ -6,13 +6,25 @@
 
 set -e
 
-REPO_TOP="$(git rev-parse --show-toplevel)"
+REPO_TOP="$(git rev-parse --show-toplevel)" || REPO_TOP="$(realpath $0/../../..)"
 
 cd "$REPO_TOP"
 
 fail() {
   file="$1"
   command="$2"
+
+  # if not using git repo, this simply allows users to easily regenerate files
+  git rev-parse --is-inside-work-tree > /dev/null || {
+    echo "No way to compare files to previous version (not in git directory)."
+    echo "Regenerate ${file} with \`${command}\`? (y/N)"
+    read regen
+    if [ "$regen" = "y" ]; then
+      $command
+      exit 0
+    fi
+    exit 1
+  }
 
   echo "::error::${file} is not up to date"             >&2
   echo "Regenerate this lock file using \`${command}\`" >&2

--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -21,7 +21,7 @@ shift 2
 # the corresponding targets in the @bitstreams workspace.
 COMMIT="$(git rev-parse HEAD)" || COMMIT="default"
 readonly COMMIT
-readonly BIT_CACHE_DIR="${HOME}/.cache/opentitan-bitstreams/cache/${COMMIT}"
+readonly BIT_CACHE_DIR="${HOME}/.cache/pavona-bitstreams/cache/${COMMIT}"
 readonly BIT_SRC="${BIN_DIR}/bitstream-cache/bitstream-cache.tar.gz"
 mkdir -p "${BIT_CACHE_DIR}"
 tar xzf ${BIT_SRC} -C ${BIT_CACHE_DIR}

--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -19,7 +19,7 @@ shift 2
 
 # Copy bitstreams and related files into the cache directory so Bazel will have
 # the corresponding targets in the @bitstreams workspace.
-COMMIT="$(git rev-parse HEAD)"
+COMMIT="$(git rev-parse HEAD)" || COMMIT="default"
 readonly COMMIT
 readonly BIT_CACHE_DIR="${HOME}/.cache/opentitan-bitstreams/cache/${COMMIT}"
 readonly BIT_SRC="${BIN_DIR}/bitstream-cache/bitstream-cache.tar.gz"

--- a/ci/scripts/target-location.sh
+++ b/ci/scripts/target-location.sh
@@ -6,7 +6,7 @@
 # Use Bazel to query for the location of targets instead of searching
 
 set -e
-REPO_TOP=$(git rev-parse --show-toplevel)
+REPO_TOP=$(git rev-parse --show-toplevel) || REPO_TOP=$(realpath $0/../../..)
 readonly REPO_TOP
 
 verbose='false'

--- a/ci/scripts/validate_alert_classification.py
+++ b/ci/scripts/validate_alert_classification.py
@@ -18,9 +18,10 @@ import sys
 from typing import Any, Dict, Tuple
 import hjson
 import re
+from tempfile import TemporaryFile
 
 
-REGS_OUTPUT_FILE = "sw/host/opentitanlib/src/otp/alert_handler_regs.rs"
+REGS_OUTPUT_FILE = Path("sw/host/opentitanlib/src/otp/alert_handler_regs.rs")
 
 
 def find_item_in_cfg(cfg_data: Dict[str, Any], item_name: str) -> Dict[str, Any]:
@@ -133,10 +134,15 @@ def validate_digest_values(
     print("    Generating expected digest values using opentitantool...")
     alert_handler_regtool_file = alert_handler_file.parent / "alert_handler.hjson"
 
+    stashed_regs_output = TemporaryFile(mode="x+t")
+    if not REGS_OUTPUT_FILE.is_file():
+        REGS_OUTPUT_FILE.touch()
+
     try:
         print("    Generating alert handler registers...")
+        stashed_regs_output.write(REGS_OUTPUT_FILE.read_text())
         subprocess.run(
-            ["./util/regtool.py", alert_handler_regtool_file, "-R", "-o", REGS_OUTPUT_FILE],
+            ["./util/regtool.py", alert_handler_regtool_file, "-R", "-o", str(REGS_OUTPUT_FILE)],
             check=True,
             capture_output=True,
             text=True,
@@ -159,10 +165,12 @@ def validate_digest_values(
         opentitantool_output = result.stdout
 
     except subprocess.CalledProcessError as e:
-        print(f"Error: Failed to generate expected digest values: {e}")
+        print(f"Error: Failed to generate expected digest values: {e.stderr}")
         return False, {}
-    finally:
-        subprocess.run(["git", "checkout", "--", REGS_OUTPUT_FILE], capture_output=True)
+    finally:  # restore original register output regardless of error or no error
+        stashed_regs_output.seek(0)
+        REGS_OUTPUT_FILE.write_text(stashed_regs_output.read())
+        stashed_regs_output.close()
 
     expected_digests_hex = {}
     try:

--- a/doc/getting_started/gitless.md
+++ b/doc/getting_started/gitless.md
@@ -1,0 +1,60 @@
+# Git-less Repo Considerations
+
+There are two ways to install Pavona: the first is to run `git clone` and pull the repo straight from GitHub, and the second way is to use the available tarball package (which does not retain git collateral).
+Cloning the repo is the default method, as the repo utilizes some of the features of git to track changes, but the repo can still be used without being a git repo.
+
+There are a few different ways in which the repo tries to use git that should be considered if you are using the "gitless" version of the repo:
+* The repo may try to find its own top directory using git.
+* The repo may try to get the hash of the current git commit or diff in order to track new changes.
+* The repo may use git branch or commit details to create new (state-specific) directories.
+* The repo will use git commands to vendor in code from other git repos.
+
+If you are using the gitless tarball version of this repo, below are the ways the default repo behavior changes given that the repo is not a git repo.
+Note that there is nothing stopping you from uncompressing the tarball, installing the repo requirements, and running `git init` to make it a new git repository with fresh history.
+
+## Testing the gitless package
+
+In this repo, there is a bash script named `ci/scripts/check-gitless.sh`.
+Run this script to run a few preliminary tests to check if the repo is functioning properly.
+
+Use the option `-e` to have the script stop after finding the first failure.
+Use option `-t <dvsim_tool>` to also run some dvsim tests with a given tool.
+Using `-h` will print the script usage.
+
+This sanity check will output logs for any errors found along the way (as `gitless.log` in the repo root).
+
+## Using Bazel and bitstream caches
+
+This repository by default [relies on caching FPGA bitstreams](../contributing/fpga/ref_manual_fpga.md) to save time.
+Because the gitless repo is not tied to a commit along the main branch, the bitstream cache can only be instantiated locally.
+
+The script `rules/scripts/initialize_bitstream_cache.sh` can create a new bitstream cache by building the specified bitstream and initializing the correct files for the bitstream cache.
+Another workaround for bitstream cache requirements is simply using the flag `--define bitstream=skip` if a bitstream has already been built or `--define bitstream=vivado` to use Vivado to build a new bitstream for any targets that require one.
+
+## Finding the repo's top directory
+
+In the gitless repo, scripts that need to find the top directory will simply use relative paths instead of commands like `git rev-parse --show-toplevel`.
+This is the most minor and easily substituted switch between git and gitless, but it does imply that most scripts in the repo should not be moved around to different directories.
+
+## Tracking changes
+
+As git is a version control system, it is natural for the repo to track code changes with it.
+Using the gitless repo does not have the same capabilities.
+
+Many of the scripts in the `ci/scripts` directory use git in order to limit their linting/file checking scope.
+They cannot be used in the gitless package, as they will error out.
+These files include (under `ci/scripts`): [`python-lint.sh`](../../ci/scripts/python-lint.sh), [`include-guard.sh`](../../ci/scripts/include-guard.sh), [`clang-format.sh`](../../ci/scripts/clang-format.sh), [`rust-format.sh`](../../ci/scripts/rust-format.sh), [`whitespace.sh`](../../ci/scripts/whitespace.sh), [`check-licence-headers.sh`](../../ci/scripts/whitespace.sh), [`lint-commits.sh`](../../ci/scripts/lint-commits.sh).
+Other similarly constrained files include: [`util/lint_commits.py`](../../util/lint_commits.py), [`util/diff_generated_util_output.py`](../../util/diff_generated_util_output.py).
+
+A similar git functionality that simply cannot be replicated in the gitless release is git bisect, which traverses git history.
+As such, [`util/fpga/bitstream_bisect.py`](../../util/fpga/bitstream_bisect.py) is unviable in gitless.
+
+## Vendored code
+
+This repo also vendors in some software and hardware from other quality codebases.
+Git is used to patch vendored code and pull from repository remotes.
+Since git is one of the install requirements for this repo, and each source of the vendored code is a git repo itself, there should be no problems here.
+
+As the repo currently chooses to vendor, most of the functionality will still work for vendoring in code.
+However, patches may not be committed to the main Pavona repo unless it is a git repo.
+For more information, see the documentation on vendoring [hardware](../contributing/hw/vendor.md) and [software](../../third_party/README.md).

--- a/hw/ip/acc/dv/verilator/run-some.py
+++ b/hw/ip/acc/dv/verilator/run-some.py
@@ -36,7 +36,6 @@ def find_gen_binaries() -> str:
 def get_projdir() -> str:
     '''Return the path to the top of the project'''
     path = os.path.join(_SCRIPT_DIR, '../../../../..')
-    assert os.path.exists(os.path.join(path, '.git'))
     return os.path.normpath(path)
 
 

--- a/quality/license_check.py
+++ b/quality/license_check.py
@@ -286,18 +286,29 @@ def detect_comment_char(all_matchers, filename):
 
 
 def git_find_repo_toplevel():
-    git_output = subprocess.check_output(
-        ["git", "rev-parse", "--show-toplevel"]
-    )
-    return Path(git_output.decode().strip()).resolve()
+    try:
+        git_output = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"]
+        )
+        return Path(git_output.decode().strip()).resolve()
+    except subprocess.CalledProcessError:
+        logging.warning("unable to find repo top level with git; using relative path")
+        return Path(__file__).parents[1].resolve()
 
 
 def git_find_all_file_paths(top_level, search_paths):
-    git_output = subprocess.check_output(
-        ["git", "-C", str(top_level), "ls-files", "-z", "--", *search_paths]
-    )
-    for path in git_output.rstrip(b"\0").split(b"\0"):
-        yield Path(top_level, path.decode())
+    try:
+        git_output = subprocess.check_output(
+            ["git", "-C", str(top_level), "ls-files", "-z", "--", *search_paths]
+        )
+        for path in git_output.rstrip(b"\0").split(b"\0"):
+            yield Path(top_level, path.decode())
+    except subprocess.CalledProcessError:
+        logging.warning("unable to find all filepaths with git; using glob from repo top")
+        for sp in search_paths:
+            if (Path(top_level) / sp).is_dir():
+                sp = sp + "/**"  # recurse into directories
+            yield from (fp for fp in Path(top_level).glob(sp) if fp.is_file())
 
 
 class ResultsTracker(object):

--- a/rules/bitstreams.bzl
+++ b/rules/bitstreams.bzl
@@ -114,7 +114,7 @@ bitstreams_repo = repository_rule(
         ),
         "cache": attr.string(
             doc = "Location of bitstreams cache.",
-            default = "~/.cache/opentitan-bitstreams",
+            default = "~/.cache/pavona-bitstreams",
         ),
         "refresh_time": attr.int(
             doc = "How often to check for new bitstreams (seconds).",

--- a/rules/scripts/bitstreams_workspace.py
+++ b/rules/scripts/bitstreams_workspace.py
@@ -27,9 +27,9 @@ MANIFEST_SCHEMA_VERSION_MIN = 2
 MANIFEST_SCHEMA_VERSION_MAX = 3
 
 # Default location of the bitstreams cache.
-CACHE_DIR = '~/.cache/opentitan-bitstreams'
+CACHE_DIR = '~/.cache/pavona-bitstreams'
 # Default bucket URL.
-BUCKET_URL = 'https://storage.googleapis.com/expo-bitstreams/'
+BUCKET_URL = 'https://storage.googleapis.com/expo-bitstreams/'  # TODO: update remote cache
 # The xml document returned by the bucket is in this namespace.
 XMLNS = {'': 'http://doc.s3.amazonaws.com/2006-03-01'}
 # Manifest schema directory
@@ -60,7 +60,7 @@ parser.add_argument('--latest-update',
                     default='latest.txt',
                     help='Last time the cache was updated')
 parser.add_argument('--branch',
-                    default="master",
+                    default="master",  # TODO: update after switch to new repo
                     help='Upstream git branch to search for bitstreams.')
 parser.add_argument('--bucket-url', default=BUCKET_URL, help='GCP Bucket URL')
 parser.add_argument('--build-file',
@@ -593,6 +593,18 @@ def main(argv):
             repo = os.path.dirname(args.repo)
     else:
         repo = os.path.dirname(argv[0])
+
+    # Check if repo is initialized with git or not. If not, unable ot use remote cache.
+    try:
+        in_git_repo = subprocess.check_output(["git", "rev-parse", "--is-inside-work-tree"],
+                                              cwd=repo, encoding="utf-8")
+        assert in_git_repo == "true\n"
+    except (subprocess.CalledProcessError, AssertionError):
+        logging.warning("not inside of git worktree, only using local cache")
+        args.offline = True
+        if args.bitstream == "HEAD":
+            logging.warning("bitstream for 'HEAD' without git history always corresponds to latest")
+            desired_bitstream = "latest"
 
     cache = BitstreamCache(args.bucket_url, args.cache, args.latest_update,
                            args.offline)

--- a/rules/scripts/bitstreams_workspace_test.py
+++ b/rules/scripts/bitstreams_workspace_test.py
@@ -46,7 +46,7 @@ class TestBitstreamCache(unittest.TestCase):
                                           return_value=MOCKED_OS_WALK_RETURN)
 
         cache = BitstreamCache('/',
-                               '/tmp/cache/opentitan-bitstreams',
+                               '/tmp/cache/pavona-bitstreams',
                                'latest.txt',
                                offline=True)
         cache.InitRepository = unittest.mock.MagicMock(name='method')
@@ -99,7 +99,7 @@ class TestBitstreamCache(unittest.TestCase):
             return_value='2022-07-14T15:02:54.463801')
 
         cache = BitstreamCache('/',
-                               '/tmp/cache/opentitan-bitstreams',
+                               '/tmp/cache/pavona-bitstreams',
                                'latest.txt',
                                offline=True)
         manifest = {
@@ -183,7 +183,7 @@ class TestFetchAvailableBitstreams(unittest.TestCase):
     """
 
     def setUp(self):
-        self.cache = BitstreamCache('/', '/tmp/cache/opentitan-bitstreams',
+        self.cache = BitstreamCache('/', '/tmp/cache/pavona-bitstreams',
                                     'latest.txt')
         self.cache.InitRepository = unittest.mock.MagicMock(name='method')
 
@@ -192,7 +192,7 @@ class TestFetchAvailableBitstreams(unittest.TestCase):
 
         MOCKED_GET_RETURN = [
             b"""<ListBucketResult xmlns="http://doc.s3.amazonaws.com/2006-03-01">
-<Name>opentitan-bitstreams</Name>
+<Name>pavona-bitstreams</Name>
 <Prefix/>
 <Marker/>
 <IsTruncated>false</IsTruncated>
@@ -224,7 +224,7 @@ class TestFetchAvailableBitstreams(unittest.TestCase):
         """Test fetching the XML file with the list of available bitstreams."""
         MOCKED_GET_RETURN = [
             b"""<ListBucketResult xmlns="http://doc.s3.amazonaws.com/2006-03-01">
-<Name>opentitan-bitstreams</Name>
+<Name>pavona-bitstreams</Name>
 <Prefix/>
 <Marker/>
 <NextMarker>master/bitstream-1.tar.gz</NextMarker>
@@ -239,7 +239,7 @@ class TestFetchAvailableBitstreams(unittest.TestCase):
 </Contents>
 </ListBucketResult>""",
             b"""<ListBucketResult xmlns="http://doc.s3.amazonaws.com/2006-03-01">
-<Name>opentitan-bitstreams</Name>
+<Name>pavona-bitstreams</Name>
 <Prefix/>
 <Marker>master/bitstream-1.tar.gz</Marker>
 <IsTruncated>false</IsTruncated>

--- a/rules/scripts/initialize_bitstream_cache.sh
+++ b/rules/scripts/initialize_bitstream_cache.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+
+set -e
+
+usage () {
+  echo "usage: $0 [-l] [-c CACHE_DIR] [-r REF] [-t TOP] [-h] TARGET ..."
+  echo "  Build and add a bitstream to the cache."
+  echo ""
+  echo "  -l                            Mark this new bitstream cache entry as the latest; default 0 (false)."
+  echo "  -c CACHE_DIR                  Cache directory; defaults to ~/.cache/pavona-bitstreams."
+  echo "  -r REF                        Git ref to mark this as; defaults to current commit or 'default'."
+  echo "  -t TOP                        Top level system to build bitstream for; default is earlgrey."
+  echo "  TARGET                        FPGA bitstream target to build for new cache entry."
+  echo "  -h                            Print the command line usage for this script."
+}
+
+cd "$(dirname $0)"/../..
+
+: ${BAZEL_BITSTREAMS_CACHE:="$(realpath ~/.cache/pavona-bitstreams)"}
+mark_latest=0
+ref="$(git rev-parse HEAD)" || ref="default"
+tops=()
+while getopts "hlc:r:t:" OPTION; do
+  case $OPTION in
+    h)
+      usage
+      exit 0
+      ;;
+    l)
+      mark_latest=1
+      ;;
+    c)
+      export BAZEL_BITSTREAMS_CACHE="$OPTARG"
+      ;;
+    r)
+      ref="$OPTARG"
+      ;;
+    t)
+      tops+=("$OPTARG")
+      ;;
+    *)
+      echo "Invalid option: -$OPTION"
+      usage
+      exit 1
+      ;;
+    esac
+done
+if (( ${#tops[@]} == 0 )); then
+  tops=("earlgrey")
+fi
+shift $(($OPTIND - 1))
+targets=( "$@" )
+
+
+# generate requested bitstreams
+new_entry=$BAZEL_BITSTREAMS_CACHE/cache/$ref
+mkdir -p $new_entry
+for top in "${tops[@]}"; do
+  for t in "${targets[@]}"; do
+    $PWD/bazelisk.sh build //hw/bitstream/vivado:fpga_$t
+    $PWD/bazelisk.sh build //hw/bitstream/vivado:"$top"_"$t"_archive
+    bitstream_tar_archive=$($PWD/bazelisk.sh outquery //hw/bitstream/vivado:"$top"_"$t"_archive)
+    echo "Taking archive from" "$bitstream_tar_archive"
+    tar -xf $bitstream_tar_archive -C $BAZEL_BITSTREAMS_CACHE/cache/$ref/ --strip-components=4
+    mv -f $BAZEL_BITSTREAMS_CACHE/cache/$ref/manifest.json $BAZEL_BITSTREAMS_CACHE/cache/$ref/manifest_"$top"_"$t".json  # label this manifest file as top-specific
+  done
+done
+
+# create the manifest.json file to include all bitstream targets built
+tmpdir=$(mktemp -d)
+$PWD/bazelisk.sh build //util/py/scripts:bitstream_cache_create
+mapfile -t manifests < <(find $BAZEL_BITSTREAMS_CACHE/cache/$ref -name "manifest*.json")
+$PWD/bazelisk.sh run //util/py/scripts:bitstream_cache_create -- \
+  --schema $PWD/rules/scripts/bitstreams_manifest.schema.json \
+  --stamp-file $PWD/bazel-out/volatile-status.txt \
+  --out $tmpdir \
+  "${manifests[@]}"
+cp $tmpdir/manifest.json $BAZEL_BITSTREAMS_CACHE/cache/$ref/
+
+# if applicable, mark this cache entry as the latest
+if [ $mark_latest = 1 ]; then
+  echo "$ref" > $BAZEL_BITSTREAMS_CACHE/latest.txt
+fi

--- a/sw/host/provisioning/orchestrator/src/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/src/orchestrator.py
@@ -174,7 +174,7 @@ def main(args_in):
     # Generate commit hash of current provisioning run.
     commit_hash = subprocess.run(shlex.split("git rev-parse HEAD"),
                                  capture_output=True,
-                                 text=True).stdout.strip()
+                                 text=True).stdout.strip() or "default"
 
     # Run all provisioning flows.
     get_user_confirmation(sku_config, device_id, commit_hash, args)

--- a/util/design/gen-otp-mmap.py
+++ b/util/design/gen-otp-mmap.py
@@ -68,8 +68,8 @@ SEQ_TEMPLATES = [
 
 
 def check_in_repo_top():
-    dot_git_path = Path.cwd() / ".git"
-    if not dot_git_path.exists():
+    reltop = Path(__file__).parents[2].resolve()
+    if Path.cwd() != reltop:
         log.error('This utility must be run from repo_top')
         exit(1)
 

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -159,12 +159,14 @@ def get_proj_root():
                             stderr=subprocess.PIPE)
     proj_root = result.stdout.decode("utf-8").strip()
     if not proj_root:
-        log.error(
+        log.warning(
             "Attempted to find the root of this GitHub repository by running:\n"
             "{}\n"
             "But this command has failed:\n"
-            "{}".format(' '.join(cmd), result.stderr.decode("utf-8")))
-        sys.exit(1)
+            "{}\n"
+            "Getting root directory "
+            "from relative path.".format(' '.join(cmd), result.stderr.decode("utf-8")))
+        proj_root = str(Path(__file__).parents[2].resolve())
     return proj_root
 
 

--- a/util/fix_trailing_whitespace.py
+++ b/util/fix_trailing_whitespace.py
@@ -36,7 +36,10 @@ IGNORED_SUFFIXES = {
 def is_ignored(path):
     if path in IGNORED_PATHS:
         return True
-    return subprocess.run(['git', 'check-ignore', path]).returncode == 0
+    git_check = subprocess.run(['git', 'check-ignore', path]).returncode
+    if git_check == 128:  # fatal error (https://git-scm.com/docs/git-check-ignore#_exit_status)
+        print("`git check-ignore` failed; not referencing any gitignore files (nothing ignored)")
+    return git_check == 0
 
 
 def walk_tree(paths=[REPO_TOP]):

--- a/util/gen_stamped_tarball.py
+++ b/util/gen_stamped_tarball.py
@@ -20,8 +20,8 @@ def main(args):
 
     version = args.version
     build_date = datetime.datetime.now().strftime('%Y-%m-%d')
-    commit_hash = stamp["BUILD_SCM_REVISION_SHORT"].strip()
-    commit_status = stamp["BUILD_SCM_STATUS"].strip()
+    commit_hash = stamp.get("BUILD_SCM_REVISION_SHORT", "default").strip()
+    commit_status = stamp.get("BUILD_SCM_STATUS", "modified").strip()
 
     package_dir = f'{build_date}-v{version}-{commit_hash}'
     if commit_status != 'clean':

--- a/util/get_workspace_status.sh
+++ b/util/get_workspace_status.sh
@@ -22,10 +22,14 @@
 # More info about the difference between stable and volatile variables is
 # available in https://bazel.build/docs/user-manual#workspace-status-command.
 
+if ! [ "$(git rev-parse --is-inside-work-tree)" ]; then
+  exit 0  # if not in a git working tree just provide no information
+fi
+
 git_rev=$(git rev-parse HEAD)
 if [[ $? != 0 ]];
 then
-  exit 1
+  git_rev="default"
 fi
 echo "BUILD_SCM_REVISION ${git_rev}"
 echo "STABLE_BUILD_SCM_REVISION ${git_rev}"
@@ -33,14 +37,14 @@ echo "STABLE_BUILD_SCM_REVISION ${git_rev}"
 git_rev_short=$(git rev-parse --short=8 HEAD)
 if [[ $? != 0 ]];
 then
-  exit 1
+  git_rev_short="default"
 fi
 echo "BUILD_SCM_REVISION_SHORT ${git_rev_short}"
 
 git_version=$(git describe --always --tags)
 if [[ $? != 0 ]];
 then
-  exit 1
+  git_version="default"
 fi
 echo "BUILD_GIT_VERSION ${git_version}"
 

--- a/util/lintpy.py
+++ b/util/lintpy.py
@@ -2,7 +2,7 @@
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-"""Lint Python for lowRISC rules"""
+"""Lint Python"""
 
 import argparse
 import os
@@ -26,9 +26,12 @@ _KNOWN_TOOLS = {
 def show_and_exit(clitool: str, packages: List[str]) -> None:
     util_path = os.path.dirname(os.path.realpath(clitool))
     os.chdir(util_path)
-    ver = subprocess.check_output(
-        ["git", "describe", "--always", "--dirty", "--broken"],
-        universal_newlines=True).strip()
+    try:
+        ver = subprocess.check_output(
+            ["git", "describe", "--always", "--dirty", "--broken"],
+            universal_newlines=True).strip()
+    except subprocess.CalledProcessError:
+        ver = None
     if not ver:
         ver = 'not found (not in Git repository?)'
     sys.stderr.write(clitool + " Git version " + ver + '\n')
@@ -154,6 +157,14 @@ def install_commit_hook():
     os.symlink(rel_path, hook_path)
 
 
+def in_git_repo():
+    try:
+        subprocess.check_output(["git", "rev-parse", "--is-inside-work-tree"])
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
 def main():
     parser = argparse.ArgumentParser(
         description=__doc__,
@@ -199,6 +210,8 @@ def main():
     if args.hook:
         if args.file:
             raise RuntimeError('Cannot specify both --hook and a file list.')
+        if not in_git_repo():
+            raise RuntimeError("Must be within a git repo to install commit hooks.")
         install_commit_hook()
         return 0
 
@@ -206,8 +219,11 @@ def main():
         input_files = args.file
         if args.commit:
             raise RuntimeError('Cannot specify both --commit and a file list.')
-    else:
+    elif in_git_repo():
         input_files = get_files_from_git(running_hook or args.commit)
+    else:
+        input_files = None
+        print("Must specify a file list if not in git repo.")
 
     if not input_files:
         print('No input files. Exiting.')

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -6,6 +6,7 @@
 set -euo pipefail
 
 : "${REPO_TOP:=$(git rev-parse --show-toplevel)}"
+: "${REPO_TOP:=$(dirname $0/.. | xargs realpath)}"
 
 : "${BAZELISK:=${REPO_TOP}/bazelisk.sh}"
 : "${BAZEL_VERSION:=$(cat "${REPO_TOP}/.bazelversion")}"

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -143,7 +143,7 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
   # We don't need all bitstreams in the cache, we just need the latest one so
   # that the cache is "initialized" and "offline" mode will work correctly.
   mkdir -p ${BAZEL_AIRGAPPED_DIR}/${BAZEL_BITSTREAMS_CACHEDIR}
-  readonly SYSTEM_BITSTREAM_CACHE="${HOME}/.cache/opentitan-bitstreams"
+  readonly SYSTEM_BITSTREAM_CACHE="${HOME}/.cache/pavona-bitstreams"
   readonly SYSTEM_BITSTREAM_CACHEDIR="${SYSTEM_BITSTREAM_CACHE}/cache"
   readonly LATEST_BISTREAM_HASH_FILE="${SYSTEM_BITSTREAM_CACHE}/latest.txt"
   # The revision named in latest.txt is not necessarily on disk. Induce the

--- a/util/py/scripts/bitstream_cache_create.py
+++ b/util/py/scripts/bitstream_cache_create.py
@@ -59,7 +59,7 @@ def get_scm_revision(volatile_status_file: Path):
             tokens = line.strip().split(' ')
             if len(tokens) == 2 and tokens[0] == 'BUILD_SCM_REVISION':
                 return tokens[1]
-    raise Exception('Could not get BUILD_SCM_REVISION from {}.'.format(volatile_status_file))
+    return "default"
 
 
 def update_manifest_stamps(manifest: Dict, stamp: str):

--- a/util/sh/scripts/gen-python-requirements.sh
+++ b/util/sh/scripts/gen-python-requirements.sh
@@ -7,6 +7,7 @@ source util/sh/lib/banners.sh
 source util/sh/lib/strict.sh
 
 : "${REPO_TOP:=$(git rev-parse --show-toplevel)}"
+: "${REPO_TOP:=$(realpath $0/../../..)}"
 PYTHON_REQS_IN_FILE="$REPO_TOP/pyproject.toml"
 PYTHON_REQS_OUT_FILE="$REPO_TOP/python-requirements.txt"
 

--- a/util/vendor.py
+++ b/util/vendor.py
@@ -52,13 +52,17 @@ verbose = False
 
 def git_is_clean_workdir(git_workdir):
     """Check if the git working directory is clean (no unstaged or staged changes)"""
-    cmd = ['git', 'status', '--untracked-files=no', '--porcelain']
-    modified_files = subprocess.run(cmd,
-                                    cwd=str(git_workdir),
-                                    check=True,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE).stdout.strip()
-    return not modified_files
+    try:
+        cmd = ['git', 'status', '--untracked-files=no', '--porcelain']
+        modified_files = subprocess.run(cmd,
+                                        cwd=str(git_workdir),
+                                        check=True,
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.PIPE).stdout.strip()
+        return not modified_files
+    except subprocess.CalledProcessError:
+        log.warning(f"Unable to query `git status` for {git_workdir}; assuming not clean")
+        return False
 
 
 def github_qualify_references(log, repo_userorg, repo_name):
@@ -301,9 +305,13 @@ class Mapping1:
             basedir = basepath
         cmd = ['git', 'apply', '--directory', str(basedir), '-p1',
                str(patchfile)]
+        alt_cmd = ['patch', '-d', str(basedir), '-p1', str(patchfile)]
         if verbose:
             cmd += ['--verbose']
-        subprocess.run(cmd, check=True)
+        try:
+            subprocess.run(cmd, check=True)
+        except subprocess.CalledProcessError:
+            subprocess.run(alt_cmd, check=True)
 
     def import_from_upstream(self, upstream_path,
                              target_path, exclude_files, patch_dir):

--- a/util/verible-format.py
+++ b/util/verible-format.py
@@ -20,9 +20,12 @@ VERIBLE_ARGS = ["--formal_parameters_indentation=indent",
 
 
 def get_repo_top():
-    return subprocess.run(['git', 'rev-parse', '--show-toplevel'],
-                          check=True, universal_newlines=True,
-                          stdout=subprocess.PIPE).stdout.strip()
+    try:
+        return subprocess.run(['git', 'rev-parse', '--show-toplevel'],
+                              check=True, universal_newlines=True,
+                              stdout=subprocess.PIPE).stdout.strip()
+    except subprocess.CalledProcessError:
+        return os.path.realpath(__file__ + "/../..")
 
 
 def get_verible_executable_path():


### PR DESCRIPTION
This repo should be mostly usable even if taken from a [git archive](https://git-scm.com/docs/git-archive) and/or if ported into a version control system that is not git.

This means that anything that unnecessarily relies on git refs should be revised. Of course, not all the functionalities of this repo (such as checking diffs) can be used without git history in place, but a number of them can. It is important to note that git is currently listed as one of the repository installation requirements, so some things (like patching) should still work without the repository itself being a git repo.

This PR replaces unnecessary uses of calls to git (such as using `git rev-parse` to find the repo top or creating paths based on the current git branch name) with some appropriate default behavior whenever unable to use git.

It also creates a "sanity check" testing script to ensure that the "git-less" version of the repo should work about as well as the "git-ful" one: `ci/scripts/check-gitless.sh` should pass for both a cloned version of the repo and a version taken from a `git archive` tarball.