### PR TITLE
[doc] Remove obsolete links

### DIFF
--- a/hw/dv/sv/cip_lib/README.md
+++ b/hw/dv/sv/cip_lib/README.md
@@ -418,7 +418,7 @@ CIP contains reusable security verification components, sequences and function c
 This section describes the details of them and the steps to enable them.
 
 ### Security Verification for bus integrity
-The countermeasure of bus integrity can be fully verified via importing [tl_access_tests](https://github.com/lowRISC/opentitan/blob/master/hw/dv/tools/dvsim/tests/tl_access_tests.hjson) and [tl_device_access_types_testplan](https://github.com/lowRISC/opentitan/blob/master/hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson).
+The countermeasure of bus integrity can be fully verified via importing [tl_access_tests](../../tools/dvsim/tests/tl_access_tests.hjson) and [tl_device_access_types_testplan](../../tools/dvsim/testplans/tl_device_access_types_testplan.hjson).
 The `tl_intg_err` test injects errors on control, data, or the ECC bits and verifies that the integrity error will trigger a fatal alert (provided via `cfg.tl_intg_alert_name`) and error status (provided via `cfg.tl_intg_alert_fields`) is set.
 Refer to section [cip_base_env_cfg](#cip_base_env_cfg) for more information on these 2 variables.
 The user may update these 2 variables as follows.
@@ -433,8 +433,8 @@ class ip_env_cfg extends cip_base_env_cfg #(.RAL_T(ip_reg_block));
 
 ### Security Verification for memory integrity
 The memory integrity countermeasure stores the data integrity in the memory rather than generating the integrity on-the-fly during a read.
-The [passthru_mem_intg_tests](https://github.com/lowRISC/opentitan/blob/master/hw/dv/tools/dvsim/tests/passthru_mem_intg_tests.hjson) can fully verify this countermeasure.
-The details of the test sequences are described in the [tl_device_access_types_testplan](https://github.com/lowRISC/opentitan/blob/master/hw/dv/tools/dvsim/testplans/passthru_mem_intg_testplan.hjson). Users need to override the task `inject_intg_fault_in_passthru_mem` to inject an integrity fault to the memory in the block common_vseq.
+The [passthru_mem_intg_tests](../../tools/dvsim/tests/passthru_mem_intg_tests.hjson) can fully verify this countermeasure.
+The details of the test sequences are described in the [tl_device_access_types_testplan](../../tools/dvsim/testplans/passthru_mem_intg_testplan.hjson). Users need to override the task `inject_intg_fault_in_passthru_mem` to inject an integrity fault to the memory in the block common_vseq.
 
 The following is an example from `sram_ctrl`, in which it flips up to `MAX_TL_ECC_ERRORS` bits of the data and generates a backdoor write to the memory.
 ```systemverilog
@@ -460,7 +460,7 @@ endclass
 ```
 
 ### Security Verification for shadow CSRs
-The countermeasure of shadow CSRs can be fully verified via importing [shadow_reg_errors_tests](https://github.com/lowRISC/opentitan/blob/master/hw/dv/tools/dvsim/tests/shadow_reg_errors_tests.hjson) and [shadow_reg_errors_testplan](https://github.com/lowRISC/opentitan/blob/master/hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson).
+The countermeasure of shadow CSRs can be fully verified via importing [shadow_reg_errors_tests](../../tools/dvsim/tests/shadow_reg_errors_tests.hjson) and [shadow_reg_errors_testplan](../../tools/dvsim/testplans/shadow_reg_errors_testplan.hjson).
 The details of the test sequences are described in the testplan. Users need to assign the status CSR fields to `cfg.shadow_update_err_status_fields` and `cfg.shadow_storage_err_status_fields` for update error and storage error respectively.
 ```systemverilog
 class ip_env_cfg extends cip_base_env_cfg #(.RAL_T(ip_reg_block));
@@ -472,15 +472,15 @@ class ip_env_cfg extends cip_base_env_cfg #(.RAL_T(ip_reg_block));
 ```
 
 ### Security Verification for REGWEN CSRs
-If the REGWEN CSR meets the following criteria, it can be fully verified by the common [csr_tests](https://github.com/lowRISC/opentitan/blob/master/hw/dv/tools/dvsim/tests/csr_tests.hjson).
+If the REGWEN CSR meets the following criteria, it can be fully verified by the common [csr_tests](../../tools/dvsim/tests/csr_tests.hjson).
  - The REGWEN CSR and its related lockable CSRs are HW read-only registers.
  - The related lockable CSRs are not WO type, otherwise the read value is always 0 and CSR tests can't really verify if the write value is taken or not.
  - No CSR exclusions have been added to the REGWEN CSR and its related lockable CSRs.
 If not, users need to write a test to verify it separately since cip_lib and dv_base_reg can't predict its value.
-For example, the [sram_ctrl_regwen_vseq](https://github.com/lowRISC/opentitan/blob/master/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_regwen_vseq.sv) has been added to verify `ctrl_regwen` and the lockable register `ctrl` since `ctrl` is a `WO` register and excluded in CSR tests.
+For example, the [sram_ctrl_regwen_vseq](../../../ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_regwen_vseq.sv) has been added to verify `ctrl_regwen` and the lockable register `ctrl` since `ctrl` is a `WO` register and excluded in CSR tests.
 
 Functional coverage for REGWEN CSRs and their related lockable CSRs is generated automatically in dv_base_reg.
-The details of functional coverage is described in [csr_testplan](https://github.com/lowRISC/opentitan/blob/master/hw/dv/tools/dvsim/testplans/csr_testplan.hjson).
+The details of functional coverage is described in [csr_testplan](../../tools/dvsim/testplans/csr_testplan.hjson).
 
 ### Security Verification for MUBI type CSRs
 A functional covergroup of MUBI type CSR is automatically created in the RAL model for each MUBI CSR, which ensures `True`, `False` and at least N of other values (N = width of the MUBI type) have been collected.
@@ -518,9 +518,9 @@ Note: The `sim_tops` in sim_cfg.hjson should be updated to include this bind fil
 A [security countermeasure verification framework](../../../../doc/contributing/dv/sec_cm_dv_framework/README.md) is implemented in cip_lib to verify common countermeasure primitives in a semi-automated way.
 
 #### Design Verification
-cip_lib imports [sec_cm_pkg](https://github.com/lowRISC/opentitan/tree/master/hw/dv/sv/sec_cm), which automatically locates all the common countermeasure primitives and binds an interface to each of them.
+cip_lib imports [sec_cm_pkg](../../sv/sec_cm), which automatically locates all the common countermeasure primitives and binds an interface to each of them.
 In the cib_base_vseq, it injects a fault to each of these primitives and verifies that the fault will lead to a fatal alert.
-The details of the sequences can be found in testplans - [sec_cm_count_testplan](https://github.com/lowRISC/opentitan/blob/master/hw/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson), [sec_cm_fsm_testplan](https://github.com/lowRISC/opentitan/blob/master/hw/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson) and [sec_cm_double_lfsr_testplan](https://github.com/lowRISC/opentitan/blob/master/hw/dv/tools/dvsim/testplans/sec_cm_double_lfsr_testplan.hjson).
+The details of the sequences can be found in testplans - [sec_cm_count_testplan](../../tools/dvsim/testplans/sec_cm_count_testplan.hjson), [sec_cm_fsm_testplan](../../tools/dvsim/testplans/sec_cm_fsm_testplan.hjson) and [sec_cm_double_lfsr_testplan](../../tools/dvsim/testplans/sec_cm_double_lfsr_testplan.hjson).
 If the block uses common security countermeasure primitives (prim_count, prim_sparse_fsm_flop, prim_double_lfsr), users can enable this sequence to fully verify them via following steps.
 
 1. Import the applicable sec_cm testplans.
@@ -528,7 +528,7 @@ If more checks or sequences are needed, add another testpoint in the block testp
 For example, when the fault is detected by countermeasure, some subsequent operations won’t be executed.
 Add a testpoint in the testplan to capture this sequence and the checks.
 
-2. Import [sec_cm_tests](https://github.com/lowRISC/opentitan/blob/master/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson) in sim_cfg.hjson file, as well as add applicable sec_cm bind files for `sim_tops`.
+2. Import [sec_cm_tests](../../tools/dvsim/tests/sec_cm_tests.hjson) in sim_cfg.hjson file, as well as add applicable sec_cm bind files for `sim_tops`.
 The `ip_sec_cm` test will be added and all common countermeasure primitives will be verified in this test.
 
 ```

--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -58,7 +58,7 @@
                "-CFLAGS --std=c99 -CFLAGS -fno-extended-identifiers",
                // C++17 standard is enforced for all sources, including the DPI-C constructs.
                // Refer to
-               // https://opentitan.org/book/doc/contributing/style_guides/c_cpp_coding_style.html#c-style-guide
+               // doc/contributing/style_guides/c_cpp_coding_style.md#c-style-guide
                "-CFLAGS --std=c++17",
                // Without this magic LDFLAGS argument below, we get compile time errors with
                // VCS on Google Linux machines that look like this:

--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -129,7 +129,6 @@
                // for each instance of the module. Hence, for each instance of the same module
                // $urandom() generates same random value.
                // Below switch generates different randomization values per instance of a module.
-               // Refer to https://github.com/lowRISC/opentitan/issues/27659 for more details.
                "-xlrm hier_inst_seed",
                // Disable the display of the SystemVerilog assert and cover statement summary
                // at the end of simulation. This summary is list of assertions that started but

--- a/hw/formal/README.md
+++ b/hw/formal/README.md
@@ -13,11 +13,11 @@ Here are two examples:
     <br />Every time <code>req</code> goes high, <code>ack</code> must be
     high exactly 2 clock cycles later.
 
-Above examples are using the <code>`ASSERT</code> macro defined in [prim_assert.sv](https://github.com/lowRISC/opentitan/blob/master/hw/ip/prim/rtl/prim_assert.sv),
+Above examples are using the <code>`ASSERT</code> macro defined in [prim_assert.sv](../ip/prim/rtl/prim_assert.sv),
 whose four arguments are assertion name, property, clock, and reset (active-high reset).
 
 Assertions are usually added by the designer in the RTL file.
-Assertions can also be added in a separate module, see for example [tlul_assert.sv](https://github.com/lowRISC/opentitan/blob/master/hw/ip/tlul/rtl/tlul_assert.sv) and its [documentation](../ip/tlul/doc/TlulProtocolChecker.md), which contains a generic protocol checker for the TileLink-UL standard.
+Assertions can also be added in a separate module, see for example [tlul_assert.sv](../ip/tlul/rtl/tlul_assert.sv) and its [documentation](../ip/tlul/doc/TlulProtocolChecker.md), which contains a generic protocol checker for the TileLink-UL standard.
 
 ## Types of Assertions
 There are two types of assertions:
@@ -35,7 +35,7 @@ end
 ```
 
 ## Useful Macros
-The file [prim_assert.sv](https://github.com/lowRISC/opentitan/blob/master/hw/ip/prim/rtl/prim_assert.sv) and [prim_assert_standard_macros.svh](https://github.com/lowRISC/opentitan/blob/master/hw/ip/prim/rtl/prim_assert_standard_macros.svh) define many useful shortcuts that you can use in your RTL code.
+The file [prim_assert.sv](../ip/prim/rtl/prim_assert.sv) and [prim_assert_standard_macros.svh](../ip/prim/rtl/prim_assert_standard_macros.svh) define many useful shortcuts that you can use in your RTL code.
 Some of them are detailed below:
 
 ### ASSERT(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST)
@@ -82,9 +82,9 @@ Assert that a concurrent property never happens.
 Assert that `signal` has a known value after reset, where "known" refers to a value that is not X.
 
 ### More Macros and Examples
-*   For more macros see file [prim_assert.sv](https://github.com/lowRISC/opentitan/blob/master/hw/ip/prim/rtl/prim_assert.sv) and [prim_assert_standard_macros.svh](https://github.com/lowRISC/opentitan/blob/master/hw/ip/prim/rtl/prim_assert_standard_macros.svh).
+*   For more macros see file [prim_assert.sv](../ip/prim/rtl/prim_assert.sv) and [prim_assert_standard_macros.svh](../ip/prim/rtl/prim_assert_standard_macros.svh).
 *   For more examples, search the repository for ASSERT by typing `grep -r ASSERT .`
-*   Also see [tlul_assert.sv](https://github.com/lowRISC/opentitan/blob/master/hw/ip/tlul/rtl/tlul_assert.sv) and its [documentation](../ip/tlul/doc/TlulProtocolChecker.md).
+*   Also see [tlul_assert.sv](../ip/tlul/rtl/tlul_assert.sv) and its [documentation](../ip/tlul/doc/TlulProtocolChecker.md).
 
 ## Useful SVA System Functions
 Below table lists useful SVA (SystemVerilog assertion) functions that can be used for assertion properties.
@@ -227,7 +227,7 @@ To ensure the symbolic variable performs the expected behaviors, two assumptions
 Coverpoints are used for properties and corner cases that the designer wants to make sure are being exercised by the testbench (e.g. FIFO-full checks).
 The code coverage tool then reports the coverage percentage of these coverpoints together with the other cover metrics (such as line coverage and branch coverage).
 
-The macro <code>`COVER(name, prop, clk, rst)</code> of [prim_assert.sv](https://github.com/lowRISC/opentitan/blob/master/hw/ip/prim/rtl/prim_assert.sv) can be used to add coverpoints to your design, where the cover property uses the same SVA syntax, operators, and system functions as the assert properties.
+The macro <code>`COVER(name, prop, clk, rst)</code> of [prim_assert.sv](../ip/prim/rtl/prim_assert.sv) can be used to add coverpoints to your design, where the cover property uses the same SVA syntax, operators, and system functions as the assert properties.
 
 ## Running FPV on DVSim
 

--- a/hw/ip/acc/doc/acc_intro.md
+++ b/hw/ip/acc/doc/acc_intro.md
@@ -279,7 +279,7 @@ Some notes to help explain the code above:
 - The first argument to `loopi` is the number of iterations, and the second is the number of instructions in the loop body
 - `.bss` marks data memory that is not initialized; the program would still work if we used `.data`, but the binary would be bigger because Ibex would store a bunch of placeholder zeroes
 
-To see all current ACC programs from the codebase, see the `sw/acc/` directory.
+To see all current ACC programs from the codebase, see the [`sw/acc/`](../../../../sw/acc) directory.
 The `crypto/` subdirectory contains code we use in production, while the `code-snippets` subdirectory contains small example programs.
 
 ## Performance
@@ -290,8 +290,8 @@ Look below for instructions on how to reproduce these benchmarks.
 | Operation | Cycles | Commit | Target | Constant time |
 |-----------|-------:|--------|:-------|---------------|
 | P256 scalar mult | 670089 | 5bcd7d | p256_scalar_mult_test | yes |
-| ECDSA-P256 sign | 704126 | 5bcd7d | p256_ecdsa_sign_test | yes |
-| ECDH-P256 verify | 420220 | 5bcd7d | p256_ecdsa_verify_test | no |
+| ECDSA-P256 sign | 704126 | 5bcd7d | run_p256_sign_test | yes |
+| ECDH-P256 verify | 420220 | 5bcd7d | run_p256_verify_test | no |
 | P384 scalar mult | 1632638 | 875b3a | p384_scalar_mult_test | yes |
 | ECDSA-P384 sign | 1697985 | 875b3a | p384_ecdsa_sign_test | yes |
 | ECDSA-P384 verify | 1075092 | 875b3a | p384_ecdsa_verify_test | no |
@@ -316,11 +316,11 @@ To reproduce these benchmarks yourself, checkout the specified commit, then run 
 
 #### Step 1: Build the tests.
 
-To build the tests with Bazel, run `bazel build //sw/acc/crypto/tests:<target_name>`, e.g. `bazel build //sw/acc/crypto/tests:p256_ecdsa_verify_test`.
-Then you'll need to find the `.elf` file that Bazel generates; for me this is e.g. `bazel-out/k8-fastbuild-ST-2cc462681f62/bin/sw/acc/crypto/tests/p256_ecdsa_verify_test.elf`.
+To build the tests with Bazel, run `bazel build //sw/acc/crypto/tests:<target_name>`, e.g. `bazel build //sw/acc/crypto/tests:run_p256_verify_test`.
+Then you'll need to find the `.elf` file that Bazel generates; for me this is e.g. `bazel-out/k8-fastbuild-ST-2cc462681f62/bin/sw/acc/crypto/tests/run_p256_verify_test.elf`.
 You can find the path for yours by running:
 ```
-bazel aquery 'outputs(".*.elf", //sw/acc/crypto/tests:p256_ecdsa_verify_test)' | grep 'Outputs'
+bazel aquery 'outputs(".*.elf", //sw/acc/crypto/tests:run_p256_verify_test)' | grep 'Outputs'
 ```
 
 Alternatively, you can build the tests manually with `acc_as.py` and `acc_ld.py`, as described in the [ACC development guide](developing_acc.md#build-acc-software).
@@ -333,7 +333,7 @@ See the [ACC development guide](developing_acc.md#run-the-python-simulator) for 
 
 ## SCA methodology
 
-Current code for side channel analysis (SCA) on ACC is in the `sw/device/sca` directory.
+Current code for side channel analysis (SCA) on ACC is in the [`sw/device/sca`](../../../../sw/device/sca) directory.
 The main focus of this code is analysis of power/EM side channels.
 For timing side channels, we use [static analysis scripts](#static-checks) instead.
 
@@ -365,7 +365,7 @@ A typical workflow when developing for ACC is to write both the program itself a
 If the tests fail, then the cycle-by-cycle printouts help to determine what went wrong.
 The simulator is also a good way to get accurate ACC cycle counts.
 
-You can see the current ACC simulator tests under `sw/acc/crypto/tests`.
+You can see the current ACC simulator tests under [`sw/acc/crypto/tests`](../../../../sw/acc/crypto/tests).
 
 ### Formal methods
 
@@ -378,14 +378,14 @@ Their ACC code is used in production silicon.
 There is no performance hit from the verified code, and since it is burned into hardware ROM it is essential that this code is correct.
 
 We are also pursuing other ongoing collaborations in formal methods, including adding ACC to the Jasmin compiler.
-In the meantime, we occasionally prove small and particularly tricky parts of programs against simplified ACC models in Coq, such as [here](https://github.com/lowRISC/opentitan/pull/19768).
+In the meantime, we occasionally prove small and particularly tricky parts of programs against simplified ACC models in Coq.
 
 ### Static checks
 
 Building on top of the ACC simulator, we also have Python tools that model ACC's control flow and statically:
-- [check](https://github.com/lowRISC/opentitan/blob/7528f848214589e837ce3b0dacac8385c458b772/hw/ip/otbn/util/check_const_time.py) if an ACC program or function is constant-time relative to secrets
-- [print](https://github.com/lowRISC/opentitan/blob/7528f848214589e837ce3b0dacac8385c458b772/hw/ip/otbn/util/analyze_information_flow.py) out the information-flow graph for ACC functions
-- [determine](https://github.com/lowRISC/opentitan/blob/7528f848214589e837ce3b0dacac8385c458b772/hw/ip/otbn/util/get_instruction_count_range.py) the minimum and maximum possible instruction count for a program
+- [check](../util/check_const_time.py) if an ACC program or function is constant-time relative to secrets
+- [print](../util/analyze_information_flow.py) out the information-flow graph for ACC functions
+- [determine](../util/get_instruction_count_range.py) the minimum and maximum possible instruction count for a program
 
 Some of these have Bazel build integration.
 For example, many ACC functions have a Bazel build target like this that runs the constant-time checker in CI:
@@ -394,7 +394,7 @@ acc_consttime_test(
     name = "p256_base_mult_consttime",
     subroutine = "p256_base_mult",
     deps = [
-        "//sw/acc/crypto:p256_ecdsa",
+        "//sw/acc/crypto:run_p256",
     ],
 )
 ```

--- a/hw/ip/hmac/doc/checklist.md
+++ b/hw/ip/hmac/doc/checklist.md
@@ -44,7 +44,7 @@ Documentation | [FEATURE_FROZEN][]        | Done        |
 RTL           | [FEATURE_COMPLETE][]      | Done        |
 RTL           | [PORT_FROZEN][]           | Done        | Interrupt port was revised.
 RTL           | [ARCHITECTURE_FROZEN][]   | Done        | Livestream was added
-RTL           | [REVIEW_TODO][]           | Done        | Removed irrelevant TODOs and create [#761][]
+RTL           | [REVIEW_TODO][]           | Done        | Removed irrelevant TODOs
 RTL           | [STYLE_X][]               | Done        |
 RTL           | [CDC_SYNCMACRO][]         | N/A         |
 Code Quality  | [LINT_PASS][]             | Done        |

--- a/hw/ip/lc_ctrl/doc/theory_of_operation.md
+++ b/hw/ip/lc_ctrl/doc/theory_of_operation.md
@@ -64,7 +64,7 @@ All 128bit lock and unlock tokens are passed through a cryptographic one way fun
 This mechanism is used to guard against reverse engineering and brute-forcing attempts.
 An attacker able to extract the hashed token values from the scrambled OTP partitions or from the netlist would first have to find a hash collision in order to perform a life cycle transition, since the values supplied to the life cycle controller must be valid hash pre-images.
 
-The employed one way function is a 128bit cSHAKE hash with the function name "" (empty string) and customization string "LC_CTRL", see also [kmac documentation](../../kmac/README.md) and AppCfgLcCtrl in [`kmac_pkg.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/ip/kmac/rtl/kmac_pkg.sv).
+The employed one way function is a 128bit cSHAKE hash with the function name "" (empty string) and customization string "LC_CTRL", see also [kmac documentation](../../kmac/README.md) and AppCfgLcCtrl in [`kmac_pkg.sv`](../../kmac/rtl/kmac_pkg.sv).
 
 ### Post Transition Handling
 
@@ -474,7 +474,7 @@ Note that these registers read back all-zero if the mutex is not claimed.
 
 #### Life Cycle TAP Controller
 
-The life cycle TAP controller is functionally very similar to the [RISC-V debug module](https://github.com/lowRISC/opentitan/blob/master/hw/ip/rv_dm/rtl/rv_dm.sv) for the Ibex processor and reuses the same debug transport module (DTM) and the associated debug module interface (DMI).
+The life cycle TAP controller is functionally very similar to the [RISC-V debug module](../../rv_dm/rtl/rv_dm.sv) for the Ibex processor and reuses the same debug transport module (DTM) and the associated debug module interface (DMI).
 The DTM and DMI are specified as part of the [RISC-V external debug specification, v0.13](https://github.com/riscv/riscv-debug-spec/blob/release/riscv-debug-release.pdf) and essentially provide a simple mechanism to read and write to a register space.
 In the case of the life cycle TAP controller this register space is essentially the life cycle CSR space.
 Hence, the [register table](./registers.md) is identical for both the SW view and the view through the DMI, with the only difference that the byte offsets have to be converted to word offsets for the DMI.

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv
@@ -278,7 +278,6 @@ package lc_ctrl_state_pkg;
 
   // Use lc_state_t and lc_cnt_t in interfaces as very wide enumerations ( > 64 bits )
   // are not supported for virtual interfaces by Xcelium yet
-  // https://github.com/lowRISC/opentitan/issues/8884 (Cadence issue: cds_46570160)
   // The enumeration types lc_state_e and lc_cnt_e are still ok in other circumstances
 
   typedef logic [LcStateWidth-1:0] lc_state_t;

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv.tpl
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv.tpl
@@ -171,7 +171,6 @@ package lc_ctrl_state_pkg;
 
   // Use lc_state_t and lc_cnt_t in interfaces as very wide enumerations ( > 64 bits )
   // are not supported for virtual interfaces by Xcelium yet
-  // https://github.com/lowRISC/opentitan/issues/8884 (Cadence issue: cds_46570160)
   // The enumeration types lc_state_e and lc_cnt_e are still ok in other circumstances
 
   typedef logic [LcStateWidth-1:0] lc_state_t;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -34,7 +34,6 @@ package otp_ctrl_pkg;
     logic                            error;
     // Use lc_state_t and lc_cnt_t here as very wide enumerations ( > 64 bits )
     // are not supported for virtual interfaces by Xcelium yet
-    // https://github.com/lowRISC/opentitan/issues/8884 (Cadence issue: cds_46570160)
     // The enumeration types lc_state_e and lc_cnt_e are still ok in other circumstances
     lc_ctrl_state_pkg::lc_state_t    state;
     lc_ctrl_state_pkg::lc_cnt_t      count;

--- a/hw/ip/prim/doc/prim_keccak.md
+++ b/hw/ip/prim/doc/prim_keccak.md
@@ -6,7 +6,7 @@
 Keccak primitive module assumes the number of rounds is less than or equal to 12 + 2L.
 It supports all combinations of the data width described in the [spec][fibs-pub-202].
 Note that this implementation does not include any countermeasures for security hardening against implementation attacks.
-Please refer to the [`keccak_2share` module](https://github.com/lowRISC/opentitan/blob/master/hw/ip/kmac/rtl/keccak_2share.sv) for the side-channel-hardened implementation used in the [hardened KMAC hardware IP block](../../kmac/README.md).
+Please refer to the [`keccak_2share` module](../../kmac/rtl/keccak_2share.sv) for the side-channel-hardened implementation used in the [hardened KMAC hardware IP block](../../kmac/README.md).
 
 [fibs-pub-202]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf
 

--- a/hw/ip/prim/rtl/prim_lc_sync.sv
+++ b/hw/ip/prim/rtl/prim_lc_sync.sv
@@ -6,7 +6,7 @@
 // output buffers and life-cycle specific assertions.
 //
 // Should be used exactly as recommended in the life cycle controller spec:
-// https://opentitan.org/book/hw/ip/lc_ctrl/doc/interfaces.html#control-signal-propagation
+// hw/ip/lc_ctrl/doc/interfaces.md#control-signal-propagation
 
 `include "prim_assert.sv"
 

--- a/hw/ip/rv_dm/doc/checklist.md
+++ b/hw/ip/rv_dm/doc/checklist.md
@@ -34,7 +34,7 @@ Code Quality  | [LINT_SETUP][]                 | Done        |
 Type          | Item                      | Resolution  | Note/Collaterals
 --------------|---------------------------|-------------|------------------
 Documentation | [NEW_FEATURES][]          | Done        |
-Documentation | [BLOCK_DIAGRAM][]         | Done        | Available in external [PULP RISC-V Debug System Documentation](https://github.com/lowRISC/opentitan/blob/master/hw/vendor/pulp_riscv_dbg/doc/debug-system.md)
+Documentation | [BLOCK_DIAGRAM][]         | Done        | Available in external [PULP RISC-V Debug System Documentation](../../../vendor/pulp_riscv_dbg/doc/debug-system.md)
 Documentation | [DOC_INTERFACE][]       | Done        |
 Documentation | [DOC_INTERFACE][]         | Done        |
 Documentation | [DOC_INTEGRATION_GUIDE][] | Waived      | This checklist item has been added retrospectively.

--- a/hw/ip/rv_dm/doc/interfaces.md
+++ b/hw/ip/rv_dm/doc/interfaces.md
@@ -1,6 +1,6 @@
 # Hardware Interfaces
 
-All hardware interfaces of the debug system are documented in the [PULP RISC-V Debug System Documentation](https://github.com/lowRISC/opentitan/blob/master/hw/vendor/pulp_riscv_dbg/doc/debug-system.md), with the exception of the bus interfaces, which are converted to TL-UL by this wrapper.
+All hardware interfaces of the debug system are documented in the [PULP RISC-V Debug System Documentation](../../../vendor/pulp_riscv_dbg/doc/debug-system.md), with the exception of the bus interfaces, which are converted to TL-UL by this wrapper.
 
 ## Signals
 
@@ -124,7 +124,7 @@ input  logic [NrHarts-1:0]    unavailable_i, // communicate whether the hart is 
 The debug system implements execution-based debug according to the RISC-V Debug Specification.
 Most interactions between the core and the debug system are performed through the debug memory, a bus-exposed memory.
 The memory needs to be accessible from the core instruction *and* data interfaces.
-A full memory map is part of the [PULP RISC-V Debug System Documentation](https://github.com/lowRISC/opentitan/blob/master/hw/vendor/pulp_riscv_dbg/doc/debug-system.md).
+A full memory map is part of the [PULP RISC-V Debug System Documentation](../../../vendor/pulp_riscv_dbg/doc/debug-system.md).
 
 ```verilog
 input  tlul_pkg::tl_h2d_t tl_d_i,

--- a/hw/ip/rv_dm/doc/theory_of_operation.md
+++ b/hw/ip/rv_dm/doc/theory_of_operation.md
@@ -3,7 +3,7 @@
 ## Memory Maps
 
 ### TL-UL device
-The memory map accessible over the TL-UL device interface is documented in the [Debug Memory](https://github.com/lowRISC/opentitan/blob/master/hw/vendor/pulp_riscv_dbg/doc/debug-system.md#debug-memory) section of the [PULP RISC-V Debug System Documentation](https://github.com/lowRISC/opentitan/blob/master/hw/vendor/pulp_riscv_dbg/doc/debug-system.md).
+The memory map accessible over the TL-UL device interface is documented in the [Debug Memory](../../../vendor/pulp_riscv_dbg/doc/debug-system.md#debug-memory) section of the [PULP RISC-V Debug System Documentation](../../../vendor/pulp_riscv_dbg/doc/debug-system.md).
 Note this contains a mixture of read only and read-write regions and which is which isn't documented.
 The read-write regions are:
 
@@ -14,7 +14,7 @@ All other regions are read only.
 
 ### Debug Module Registers
 
-The [Debug Module Registers](https://github.com/lowRISC/opentitan/blob/master/hw/vendor/pulp_riscv_dbg/doc/debug-system.md#debug-module-registers) are only accessible via the Debug Module Interface (DMI) accessed via JTAG.
+The [Debug Module Registers](../../../vendor/pulp_riscv_dbg/doc/debug-system.md#debug-module-registers) are only accessible via the Debug Module Interface (DMI) accessed via JTAG.
 There is no access to these via the TL-UL device interface.
 
 

--- a/hw/ip/rv_timer/doc/checklist.md
+++ b/hw/ip/rv_timer/doc/checklist.md
@@ -45,7 +45,7 @@ Documentation | [FEATURE_FROZEN][]        | Done           |
 RTL           | [FEATURE_COMPLETE][]      | Done           |
 RTL           | [PORT_FROZEN][]           | Done w/ waiver | Change intr port name
 RTL           | [ARCHITECTURE_FROZEN][]   | Done           |
-RTL           | [REVIEW_TODO][]           | [#68][]        |
+RTL           | [REVIEW_TODO][]           |                |
 RTL           | [STYLE_X][]               | Done           |
 RTL           | [CDC_SYNCMACRO][]         | N/A            |
 Code Quality  | [LINT_PASS][]             | Done           |
@@ -54,8 +54,6 @@ Code Quality  | [RDC_SETUP][]             | Waived         | No block-level flow
 Code Quality  | [AREA_CHECK][]            | Done           |
 Code Quality  | [TIMING_CHECK][]          | Done           |
 Security      | [SEC_CM_DOCUMENTED][]     | N/A            |
-
-[#68]: https://github.com/lowRISC/opentitan/issues/68
 
 [NEW_FEATURES]:          ../../../../doc/contributing/hw/checklist/README.md#new_features
 [BLOCK_DIAGRAM]:         ../../../../doc/contributing/hw/checklist/README.md#block_diagram
@@ -197,11 +195,9 @@ Coverage      | [FPV_CODE_COVERAGE_V2][]                | N/A         |
 Coverage      | [FPV_COI_COVERAGE_V2][]                 | N/A         |
 Integration   | [PRE_VERIFIED_SUB_MODULES_V2][]         | N/A         |
 Issues        | [NO_HIGH_PRIORITY_ISSUES_PENDING][]     | Done        |
-Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Done        | [#68][], [#69][]
+Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Done        |
 Review        | [DV_DOC_TESTPLAN_REVIEWED][]            | Not Started |
 Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
-
-[#69]: https://github.com/lowRISC/opentitan/issues/69
 
 [DESIGN_DELTAS_CAPTURED_V2]:          ../../../../doc/contributing/hw/checklist/README.md#design_deltas_captured_v2
 [DV_DOC_COMPLETED]:                   ../../../../doc/contributing/hw/checklist/README.md#dv_doc_completed
@@ -256,11 +252,9 @@ Code Quality  | [ALL_TODOS_RESOLVED][]            | Done        |
 Code Quality  | [NO_TOOL_WARNINGS_THROWN][]       | Done        |
 Code Quality  | [TB_LINT_COMPLETE][]              | Done        |
 Integration   | [PRE_VERIFIED_SUB_MODULES_V3][]   | N/A         |
-Issues        | [NO_ISSUES_PENDING][]             | Done        | [#18918] Part of a future release
+Issues        | [NO_ISSUES_PENDING][]             | Done        |
 Review        | Reviewer(s)                       | Done        | @rswarbrick
 Review        | Signoff date                      | Done        | 2025-05-09
-
-[#18918]: https://github.com/lowRISC/opentitan/issues/18918
 
 [DESIGN_DELTAS_CAPTURED_V3]:     ../../../../doc/contributing/hw/checklist/README.md#design_deltas_captured_v3
 [X_PROP_ANALYSIS_COMPLETED]:     ../../../../doc/contributing/hw/checklist/README.md#x_prop_analysis_completed

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -332,8 +332,8 @@ module sram_ctrl
   // This is specialised for different tops that use it but the req/ack protocol is the same in each
   // case. For one example, see
   //
-  // https://opentitan.org/book/hw/top_earlgrey/
-  //    ip_autogen/otp_ctrl/doc/interfaces.html#interfaces-to-sram-and-acc-scramblers
+  // hw/top_earlgrey/
+  //    ip_autogen/otp_ctrl/doc/interfaces.md#interfaces-to-sram-and-acc-scramblers
   logic key_req, key_ack;
   assign key_req = reg2hw.ctrl.renew_scr_key.q &&
                    reg2hw.ctrl.renew_scr_key.qe &&

--- a/hw/ip/tlul/data/tlul.hjson
+++ b/hw/ip/tlul/data/tlul.hjson
@@ -24,7 +24,7 @@
         commit_id:          "dae702d55b89a18621607b34f7ab8161be3706eb",
         notes:              '''Only the XBAR instances (xbar_main and xbar_peri) and TLUL components
                             that go into them are certified to V2. For exceptions see
-                            [DV_DOC](https://opentitan.org/book/hw/ip/tlul/doc/dv/index.html#design-features)
+                            DV_DOC (hw/ip/tlul/doc/dv/README.md#design-features).
                             '''
       }
     ]

--- a/hw/ip/tlul/doc/TlulProtocolChecker.md
+++ b/hw/ip/tlul/doc/TlulProtocolChecker.md
@@ -6,7 +6,7 @@
 ## **Overview**
 
 This document details the protocol checker
-[tlul_assert.sv](https://github.com/lowRISC/opentitan/blob/master/hw/ip/tlul/rtl/tlul_assert.sv)
+[tlul_assert.sv](../rtl/tlul_assert.sv)
 for TL-UL (TileLink Uncached Lightweight), based on
 [TileLink specification version 1.7.1](https://sifive.cdn.prismic.io/sifive%2F57f93ecf-2c42-46f7-9818-bcdd7d39400a_tilelink-spec-1.7.1.pdf).
 
@@ -18,7 +18,7 @@ transactions rather than physical agents. A single agent can use multiple
 source IDs to track multiple outstanding transactions. See spec section 5.4
 "Source and Sink Identifiers" for more details.
 *   The source fields are `TL_AIW` bits wide (defined in
-[tlul_pkg.sv](https://github.com/lowRISC/opentitan/blob/master/hw/ip/tlul/rtl/tlul_pkg.sv)).
+[tlul_pkg.sv](../rtl/tlul_pkg.sv)).
 Therefore, there can be up to 2<sup>TL_AIW</sup> outstanding
 requests at the same time. To keep track of these outstanding requests, the
 protocol checker stores pending requests in the array `pend_req` of depth
@@ -27,7 +27,7 @@ protocol checker stores pending requests in the array `pend_req` of depth
 accepted. Therefore, in each clock cycle, the protocol checker first processes
 requests and thereafter responses.
 *   The package
-[tlul_pkg.sv](https://github.com/lowRISC/opentitan/blob/master/hw/ip/tlul/rtl/tlul_pkg.sv)
+[tlul_pkg.sv](../rtl/tlul_pkg.sv)
 defines the structs for channels A and D.
 *   In below tables, "known" means that a signal should have a value other
 than X.

--- a/hw/ip/uart/doc/checklist.md
+++ b/hw/ip/uart/doc/checklist.md
@@ -275,5 +275,5 @@ Review        | Signoff date                      | Done        | 2019-11-01
 [PRE_VERIFIED_SUB_MODULES_V3]:   ../../../../doc/contributing/hw/checklist/README.md#pre_verified_sub_modules_v3
 [NO_ISSUES_PENDING]:             ../../../../doc/contributing/hw/checklist/README.md#no_issues_pending
 
-[common_cov_excl.cfg]:https://github.com/lowRISC/opentitan/blob/master/hw/dv/tools/vcs/common_cov_excl.cfg
-[uart_cov_excl.el]:  https://github.com/lowRISC/opentitan/blob/04bb36e0ae1430262b048d400102b0fed43377ac/hw/ip/uart/dv/cov/uart_cov_excl.el
+[common_cov_excl.cfg]: ../../../dv/tools/vcs/common_cov_excl.cfg
+[uart_cov_excl.el]: ../dv/cov/uart_cov_excl.el

--- a/hw/ip/usbdev/doc/programmers_guide.md
+++ b/hw/ip/usbdev/doc/programmers_guide.md
@@ -151,7 +151,7 @@ There is a resistive divider to set the sense pin at half of the VBUS voltage wh
 
 The PMOD PCB is [available from OSH Park](https://oshpark.com/shared_projects/xMKhTIHn).
 
-The PMOD design files for KiCad version 5 are in the [`usbdev/pmod`](https://github.com/lowRISC/opentitan/tree/master/hw/ip/usbdev/pmod) directory.
+The PMOD design files for KiCad version 5 are in the [`usbdev/pmod`](../pmod) directory.
 The BOM can be filled by parts from Digikey.
 
 | Item | Qty | Reference(s) | Value | LibPart | Footprint | Datasheet | Category | DK_Datasheet_Link | DK_Detail_Page | Description | Digi-Key_PN | Family | MPN | Manufacturer | Status|

--- a/hw/ip_templates/clkmgr/data/clkmgr_sec_cm_testplan.hjson.tpl
+++ b/hw/ip_templates/clkmgr/data/clkmgr_sec_cm_testplan.hjson.tpl
@@ -63,8 +63,7 @@
             Verify the countermeasure(s) MEAS.CONFIG.SHADOW.
 
             This is covered by shadow_reg_errors_tests
-            (https://github.com/lowRISC/opentitan/blob/master/
-            hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson)
+            ($REPO_TOP/hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson)
             '''
       stage: V2S
       tests: ["clkmgr_shadow_reg_errors"]

--- a/hw/ip_templates/clkmgr/dv/sva/clkmgr_extclk_sva_if.sv
+++ b/hw/ip_templates/clkmgr/dv/sva/clkmgr_extclk_sva_if.sv
@@ -5,7 +5,7 @@
 // This contains SVA assertions to check the external clock bypass control outputs.
 //
 // Notice when a condition fails we allow the logic to generate non strict mubi values. Ideally it
-// would generate mubi False: see https://github.com/lowRISC/opentitan/issues/11400.
+// would generate mubi False.
 interface clkmgr_extclk_sva_if
   import prim_mubi_pkg::*, lc_ctrl_pkg::*;
 (

--- a/hw/ip_templates/gpio/doc/checklist.md
+++ b/hw/ip_templates/gpio/doc/checklist.md
@@ -185,25 +185,20 @@ Testbench     | [FUNCTIONAL_COVERAGE_IMPLEMENTED][]     | Done        |
 Testbench     | [ALL_INTERFACES_EXERCISED][]            | Done        |
 Testbench     | [ALL_ASSERTION_CHECKS_ADDED][]          | Done        |
 Testbench     | [SIM_TB_ENV_COMPLETED][]                | Done        |
-Tests         | [SIM_ALL_TESTS_PASSING][]               | Done        | Resolved: [#680][]
+Tests         | [SIM_ALL_TESTS_PASSING][]               | Done        |
 Tests         | [FPV_ALL_ASSERTIONS_WRITTEN][]          | N/A         |
 Tests         | [FPV_ALL_ASSUMPTIONS_REVIEWED][]        | N/A         |
 Tests         | [SIM_FW_SIMULATED][]                    | N/A         |
 Regression    | [SIM_NIGHTLY_REGRESSION_V2][]           | Done        |
 Coverage      | [SIM_CODE_COVERAGE_V2][]                | Done        |
-Coverage      | [SIM_FUNCTIONAL_COVERAGE_V2][]          | Done        | Resolved: [#807][]
+Coverage      | [SIM_FUNCTIONAL_COVERAGE_V2][]          | Done        |
 Coverage      | [FPV_CODE_COVERAGE_V2][]                | N/A         |
 Coverage      | [FPV_COI_COVERAGE_V2][]                 | N/A         |
 Integration   | [PRE_VERIFIED_SUB_MODULES_V2][]         | N/A         |
 Issues        | [NO_HIGH_PRIORITY_ISSUES_PENDING][]     | Done        |
-Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Done        | [#41][] Not quite related, [#45][] root caused
+Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Done        |
 Review        | [DV_DOC_TESTPLAN_REVIEWED][]            | Done        |
 Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
-
-[#41]: https://github.com/lowRISC/opentitan/issues/41
-[#45]: https://github.com/lowRISC/opentitan/issues/45
-[#680]: https://github.com/lowRISC/opentitan/pull/680
-[#807]: https://github.com/lowRISC/opentitan/pull/807
 
 [DESIGN_DELTAS_CAPTURED_V2]:          ../../../../../doc/contributing/hw/checklist/README.md#design_deltas_captured_v2
 [DV_DOC_COMPLETED]:                   ../../../../../doc/contributing/hw/checklist/README.md#dv_doc_completed
@@ -249,9 +244,9 @@ Review        | [SEC_CM_DV_REVIEWED][]                  | Done        | Waived t
 Documentation | [DESIGN_DELTAS_CAPTURED_V3][]     | N/A         |
 Tests         | [X_PROP_ANALYSIS_COMPLETED][]     | Waived      | Revisit later. Tool setup in progress.
 Tests         | [FPV_ASSERTIONS_PROVEN_AT_V3][]   | N/A         |
-Regression    | [SIM_NIGHTLY_REGRESSION_AT_V3][]  | Done        | Resolved: [#680][]
-Coverage      | [SIM_CODE_COVERAGE_AT_100][]      | Done        | [common_cov_excl.el][], [gpio_cov_excl.el][]
-Coverage      | [SIM_FUNCTIONAL_COVERAGE_AT_100][]| Done        | [#807][]
+Regression    | [SIM_NIGHTLY_REGRESSION_AT_V3][]  | Done        |
+Coverage      | [SIM_CODE_COVERAGE_AT_100][]      | Done        | [common_cov_excl.cfg][], [gpio_cov_excl.el][]
+Coverage      | [SIM_FUNCTIONAL_COVERAGE_AT_100][]| Done        |
 Coverage      | [FPV_CODE_COVERAGE_AT_100][]      | N/A         |
 Coverage      | [FPV_COI_COVERAGE_AT_100][]       | N/A         |
 Code Quality  | [ALL_TODOS_RESOLVED][]            | Done        |
@@ -261,8 +256,6 @@ Integration   | [PRE_VERIFIED_SUB_MODULES_V3][]   | N/A         |
 Issues        | [NO_ISSUES_PENDING][]             | Done        |
 Review        | Reviewer(s)                       | Done        | @eunchan @sriyerg @sjgitty
 Review        | Signoff date                      | Done        | 2019-11-04
-
-[#807]: https://github.com/lowRISC/opentitan/pull/807
 
 [DESIGN_DELTAS_CAPTURED_V3]:     ../../../../../doc/contributing/hw/checklist/README.md#design_deltas_captured_v3
 [X_PROP_ANALYSIS_COMPLETED]:     ../../../../../doc/contributing/hw/checklist/README.md#x_prop_analysis_completed
@@ -278,5 +271,5 @@ Review        | Signoff date                      | Done        | 2019-11-04
 [PRE_VERIFIED_SUB_MODULES_V3]:   ../../../../../doc/contributing/hw/checklist/README.md#pre_verified_sub_modules_v3
 [NO_ISSUES_PENDING]:             ../../../../../doc/contributing/hw/checklist/README.md#no_issues_pending
 
-[common_cov_excl.el]:https://github.com/lowRISC/opentitan/blob/9dff09b6c57f4962d67f5f64f8e69ac9bea6885c/hw/dv/tools/vcs/common_cov_excl.el
-[gpio_cov_excl.el]:  https://github.com/lowRISC/opentitan/blob/39aaeefdb43661b065c29ceab2efc1065aebf6dd/hw/ip/gpio/dv/cov/gpio_cov_excl.el
+[common_cov_excl.cfg]: ../../../../dv/tools/vcs/common_cov_excl.cfg
+[gpio_cov_excl.el]:  ../dv/cov/gpio_cov_excl.el

--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl.sv.tpl
@@ -931,8 +931,8 @@ end
   // This is specialised for different tops that use it but the req/ack protocol is the same in each
   // case. For one example, see
   //
-  // https://opentitan.org/book/hw/top_earlgrey/
-  //    ip_autogen/otp_ctrl/doc/interfaces.html#interfaces-to-sram-and-acc-scramblers
+  // hw/top_earlgrey/
+  //    ip_autogen/otp_ctrl/doc/interfaces.md#interfaces-to-sram-and-acc-scramblers
 
 
   // Note: as opposed to the OTP arbitration above, we do not perform cycle-wise arbitration, but

--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
@@ -62,7 +62,7 @@
 //
 // References:
 //  - The block diagram in ../doc/theory_of_operation.md
-//  - https://opentitan.org/book/hw/ip/prim/doc/prim_present.html
+//  - hw/ip/prim/doc/prim_present.md
 //  - https://en.wikipedia.org/wiki/Merkle-Damgard_construction
 //  - https://en.wikipedia.org/wiki/One-way_compression_function#Davies%E2%80%93Meyer
 //  - https://en.wikipedia.org/wiki/PRESENT

--- a/hw/ip_templates/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/ip_templates/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
@@ -110,8 +110,7 @@
       desc: '''Verify the countermeasure(s) ESC_RX.CLK.LOCAL_ESC.
 
             This is triggered by common cm primitives (SecCmPrimCount).
-            (https://github.com/lowRISC/opentitan/blob/master
-            /hw/dv/sv/cip_lib/doc/index.md#security-verification
+            ($REPO_TOP/hw/dv/sv/cip_lib/doc/README.md#security-verification
             -for-common-countermeasure-primitives)
 
             **Check**:
@@ -126,8 +125,7 @@
       name: sec_cm_fsm_sparse
       desc: '''Verify the countermeasure(s) FSM.SPARSE.
             This is triggered by common cm primitives (SecCmPrimSparseFsmFlop).
-            (https://github.com/lowRISC/opentitan/blob/master
-            /hw/dv/sv/cip_lib/doc/index.md#security-verification
+            ($REPO_TOP/hw/dv/sv/cip_lib/doc/README.md#security-verification
             -for-common-countermeasure-primitives)
             '''
       stage: V2S

--- a/hw/ip_templates/pwrmgr/dv/README.md.tpl
+++ b/hw/ip_templates/pwrmgr/dv/README.md.tpl
@@ -22,12 +22,12 @@ ${"###"} Block diagram
 ![Block diagram](./doc/tb.svg)
 
 ${"###"} Top level testbench
-Top level testbench is located at [`hw/${top_name}/ip_autogen/pwrmgr/dv/tb.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/${top_name}/ip_autogen/pwrmgr/dv/tb.sv).
-It instantiates the PWRMGR DUT module [`hw/${top_name}/ip_autogen/pwrmgr/rtl/pwrmgr.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/${top_name}/ip_autogen/pwrmgr/rtl/pwrmgr.sv).
+Top level testbench is located at [`hw/${top_name}/ip_autogen/pwrmgr/dv/tb.sv`](./tb.sv).
+It instantiates the PWRMGR DUT module [`hw/${top_name}/ip_autogen/pwrmgr/rtl/pwrmgr.sv`](../rtl/pwrmgr.sv).
 In addition, it instantiates the following interfaces, connects them to the DUT and sets their handle into `uvm_config_db`:
 * [Clock and reset interface](../../../../dv/sv/common_ifs/README.md)
 * [TileLink host interface](../../../../dv/sv/tl_agent/README.md)
-* PWRMGR interface [`hw/${top_name}/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/${top_name}/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv).
+* PWRMGR interface [`hw/${top_name}/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv`](./env/pwrmgr_if.sv).
 * Interrupts ([`pins_if`](../../../../dv/sv/common_ifs/README.md))
 * Alerts ([`alert_esc_if`](../../../../dv/sv/alert_esc_agent/README.md))
 
@@ -38,7 +38,7 @@ The following utilities provide generic helper tasks and functions to perform ac
 
 ${"###"} Global types & methods
 All common types and methods defined at the package level can be found in
-[`pwrmgr_env_pkg`](https://github.com/lowRISC/opentitan/blob/master/hw/${top_name}/ip_autogen/pwrmgr/dv/env/pwrmgr_env_pkg.sv).
+[`pwrmgr_env_pkg`](./env/pwrmgr_env_pkg.sv).
 Some of them in use are:
 ```systemverilog
   typedef enum int {
@@ -79,7 +79,7 @@ It can be created manually by invoking [`regtool`](../../../../../util/reggen/do
 ${"###"} Stimulus strategy
 The sequences are closely related to the testplan's testpoints.
 Testpoints and coverage are described in more detail in the [testplan](#testplan).
-All test sequences reside in [`hw/${top_name}/ip_autogen/pwrmgr/dv/env/seq_lib`](https://github.com/lowRISC/opentitan/blob/master/hw/${top_name}/ip_autogen/pwrmgr/dv/env/seq_lib), and extend `pwrmgr_base_vseq`.
+All test sequences reside in [`hw/${top_name}/ip_autogen/pwrmgr/dv/env/seq_lib`](./env/seq_lib), and extend `pwrmgr_base_vseq`.
 The `pwrmgr_base_vseq` virtual sequence is extended from `cip_base_vseq` and serves as a starting point.
 It provides commonly used handles, variables, functions and tasks used by the test sequences.
 Some of the most commonly used tasks and functions are as follows:
@@ -157,7 +157,7 @@ ${"#####"} AST
 - Outputs `core_clk_en`, `io_clk_en`, and `usb_clk_en` reset low, and go high prior to the slow fsm requesting the fast fsm to wakeup.
   Notice the usb clock can be programmed to stay low on wakeup via the `control` CSR.
   These clock enables are cleared on reset, and should match their corresponding enables in the `control` CSR on low power transitions.
-  These clock enables are checked via SVAs in [`hw/${top_name}/ip_autogen/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/${top_name}/ip_autogen/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv).
+  These clock enables are checked via SVAs in [`hw/${top_name}/ip_autogen/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv`](./sva/pwrmgr_clock_enables_sva_if.sv).
   When slow fsm transitions to `SlowPwrStateReqPwrUp` the clock enables should be on (except usb should match `control.usb_clk_en_active`).
   When slow fsm transitions to `SlowPwrStatePwrClampOn` the clock enables should match their bits in the `control` CSR.
 - Inputs `core_clk_val`, `io_clk_val`, and `usb_clk_val` track the corresponding enables.
@@ -165,7 +165,7 @@ ${"#####"} AST
   Slow fsm waits for them to go high prior to requesting fast fsm wakeup.
   Lack of a high transition when needed is detected via timeout.
   Such timeout would be due to the corresponding enables being set incorrectly.
-  These inputs are checked via SVAs in [`hw/${top_name}/ip_autogen/pwrmgr/dv/sva/pwrmgr_ast_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/${top_name}/ip_autogen/pwrmgr/dv/sva/pwrmgr_ast_sva_if.sv).
+  These inputs are checked via SVAs in [`hw/${top_name}/ip_autogen/pwrmgr/dv/sva/pwrmgr_ast_sva_if.sv`](./sva/pwrmgr_ast_sva_if.sv).
 - Output `main_pd_n` should go high when slow fsm transitions to `SlowPwrStateMainPowerOn`, and should match `control.main_pd_n` CSR when slow fsm transitions to `SlowPwrStateMainPowerOff`.
 - Input `main_pok` should turn on for the slow fsm to start power up sequence.
   This is also driven by `slow_responder`, which turn this off in response to `main_pd_n` going low, and turn it back on after a few random slow clock cycles from `main_pd_n` going high.
@@ -230,7 +230,7 @@ There are a number of wakeup and reset requests.
 They are driven by sequences as they need to.
 
 ${"####"} Assertions
-The [`hw/${top_name}/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/${top_name}/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv) module binds a few modules containing assertions to the IP as follows:
+The [`hw/${top_name}/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv`](./sva/pwrmgr_bind.sv) module binds a few modules containing assertions to the IP as follows:
 * TLUL assertions: the `tlul_assert` [assertions](../../../../ip/tlul/doc/TlulProtocolChecker.md) ensures TileLink interface protocol compliance.
 * Clock enables assertions:
   The `pwrmgr_clock_enables_sva_if` module contains assertions checking that the various clk_en outputs correspond to the settings in the `control` CSR.

--- a/hw/ip_templates/rstmgr/dv/README.md.tpl
+++ b/hw/ip_templates/rstmgr/dv/README.md.tpl
@@ -22,12 +22,12 @@ RSTMGR testbench has been constructed based on the [CIP testbench architecture](
 ![Block diagram](./doc/tb.svg)
 
 ### Top level testbench
-The top level testbench is located at [`hw/top_${topname}/ip_autogen/rstmgr/dv/tb.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_${topname}/ip_autogen/rstmgr/dv/tb.sv).
-It instantiates the RSTMGR DUT module [`hw/top_${topname}/ip_autogen/rstmgr/rtl/rstmgr.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_${topname}/ip_autogen/rstmgr/rtl/rstmgr.sv).
+The top level testbench is located at [`hw/top_${topname}/ip_autogen/rstmgr/dv/tb.sv`](./tb.sv).
+It instantiates the RSTMGR DUT module [`hw/top_${topname}/ip_autogen/rstmgr/rtl/rstmgr.sv`](../rtl/rstmgr.sv).
 In addition, it instantiates the following interfaces, connects them to the DUT and sets their handle into `uvm_config_db`:
 * [Clock and reset interface](../../../../dv/sv/common_ifs/README.md)
 * [TileLink host interface](../../../../dv/sv/tl_agent/README.md)
-* RSTMGR interface [`hw/top_${topname}/ip_autogen/rstmgr/dv/env/rstmgr_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_${topname}/ip_autogen/rstmgr/dv/env/rstmgr_if.sv)
+* RSTMGR interface [`hw/top_${topname}/ip_autogen/rstmgr/dv/env/rstmgr_if.sv`](./env/rstmgr_if.sv)
 * Alerts ([`alert_esc_if`](../../../../dv/sv/alert_esc_agent/README.md))
 
 ### Common DV utility components
@@ -69,7 +69,7 @@ Besides the POR resets above, the test sequences mostly assert various reset req
 Alert and CPU dump info is randomized and checked on resets.
 
 #### Test sequences
-The test sequences reside in [`hw/top_${topname}/ip_autogen/rstmgr/dv/env/seq_lib`](https://github.com/lowRISC/opentitan/blob/master/hw/top_${topname}/ip_autogen/rstmgr/dv/env/seq_lib).
+The test sequences reside in [`hw/top_${topname}/ip_autogen/rstmgr/dv/env/seq_lib`](./env/seq_lib).
 All test sequences are extended from `rstmgr_base_vseq`, which is extended from `cip_base_vseq` and serves as a starting point.
 It provides commonly used handles, variables, functions and tasks that the test sequences can simple use / call.
 Some of the most commonly used tasks / functions are as follows:
@@ -106,19 +106,19 @@ The latter are described in the testplan.
 * TLUL assertions: The `tb/rstmgr_bind.sv` file binds the `tlul_assert` [assertions](../../../../ip/tlul/doc/TlulProtocolChecker.md) to the IP to ensure TileLink interface protocol compliance.
 * Unknown checks on DUT outputs: The RTL has assertions to ensure all outputs are initialized to known values after coming out of reset.
 * Response to pwrmgr's `rst_lc_req` and `rst_sys_req` inputs: these trigger transitions in `rst_lc_src_n` and `rst_sys_rst_n` outputs.
-  Checked via SVAs in [`hw/top_${topname}/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_${topname}/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv).
+  Checked via SVAs in [`hw/top_${topname}/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv`](../../../../dv/sv/mgr_lib/pwrmgr_rstmgr_sva_if.sv).
 * Response to `cpu_i.ndmreset_req` input: after it is asserted, rstmgr's `rst_sys_src_n` should go active.
-  Checked via SVA in [`hw/top_${topname}/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_${topname}/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv).
+  Checked via SVA in [`hw/top_${topname}/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv`](../../../../dv/sv/mgr_lib/pwrmgr_rstmgr_sva_if.sv).
 * Resets cascade hierarchically per [Reset Topology](../doc/theory_of_operation.md#reset-topology).
-  Checked via SVA in [`hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv).
+  Checked via SVA in [`hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](./sva/rstmgr_cascading_sva_if.sv).
 * POR must be active for at least 32 consecutive cycles before going inactive before output resets go inactive.
-  Checked via SVA in [`hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv).
+  Checked via SVA in [`hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](./sva/rstmgr_cascading_sva_if.sv).
 * The scan reset `scan_rst_ni` qualified by `scanmode_i` triggers all cascaded resets that `por_n_i` does.
-  Checked via SVA in [`hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv).
+  Checked via SVA in [`hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](./sva/rstmgr_cascading_sva_if.sv).
 * Software resets to peripherals also cascade hierarchically.
-  Checked via SVA in [`hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv).
+  Checked via SVA in [`hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv`](./sva/rstmgr_sw_rst_sva_if.sv).
 * The output `rst_en_o` for alert_handler tracks their corresponding resets.
-  Checked via SVA in both [`hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv) and [`hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv).
+  Checked via SVA in both [`hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](./sva/rstmgr_cascading_sva_if.sv) and [`hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv`](./sva/rstmgr_sw_rst_sva_if.sv).
 * The `alert` and `cpu_info_attr` indicate the number of 32-bit words needed to capture their inputs.
   Checked via SVA in `hw/top_${topname}/ip_autogen/rstmgr/dv/sva/rstmgr_attrs_sva_if.sv`.
 

--- a/hw/ip_templates/rstmgr/rtl/rstmgr_cnsty_chk.sv
+++ b/hw/ip_templates/rstmgr/rtl/rstmgr_cnsty_chk.sv
@@ -68,8 +68,6 @@ module rstmgr_cnsty_chk
     // 2-flop synchronizer (see u_rst_sync in rstmgr_leaf_rst) which is clocked using the same
     // clock (clk_io_div4_i). This means child_rst_asserted always de-asserts after
     // parent_rst_asserted unless we are under attack.
-    //
-    // For details, refer to https://github.com/lowRISC/opentitan/issues/27659 .
     .EnablePrimCdcRand(0)
   ) u_parent_sync (
     .clk_i,

--- a/hw/top/README.md
+++ b/hw/top/README.md
@@ -99,7 +99,7 @@ You can create your own annotations by using the macros described in the next se
 
 ## The `//hw/top:defs.bzl` library
 
-This bazel library provides several important definitions are macros which can be used by rule creators and users to interact with the build system. See the documentation in [the file](https://github.com/lowRISC/opentitan/blob/master/hw/top/defs.bzl) for more details.
+This bazel library provides several important definitions are macros which can be used by rule creators and users to interact with the build system. See the documentation in [the file](./defs.bzl) for more details.
 - `opentitan_if_ip(ip, obj, default)` provides a way to conditionally do something the top selected by `//hw/top` contains at least one instance of a given IP. For example, if we want to conditionally compile code only if the usbdev block is present, we could do:
 Example:
 ```python

--- a/hw/top/doc/create_top.md
+++ b/hw/top/doc/create_top.md
@@ -48,7 +48,7 @@ AES = opentitan_ip(
     hjson = "//hw/ip/aes:data/aes.hjson",
 )
 ```
-For concrete examples, you can look at the [AES module](https://github.com/lowRISC/opentitan/blob/master/hw/ip/aes/defs.bzl) or the [AST module](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip/ast/defs.bzl).
+For concrete examples, you can look at the [AES module](../../ip/aes/defs.bzl) or the [AST module](../../top_earlgrey/ip/ast/defs.bzl).
 
 ### Registering generated IPs
 
@@ -73,7 +73,7 @@ ${module_instance_name.upper()} = opentitan_ip(
     ipconfig = "//hw/top_${topname}/ip_autogen/${module_instance_name}:data/top_${topname}_${module_instance_name}.ipconfig.hjson",
 )
 ```
-For concrete examples, you can look at the [clkmgr module](https://github.com/lowRISC/opentitan/blob/master/hw/ip_templates/clkmgr/defs.bzl.tpl).
+For concrete examples, you can look at the [clkmgr module](../../ip_templates/clkmgr/defs.bzl.tpl).
 
 ## Automatically generated files
 
@@ -90,7 +90,7 @@ The following steps require manual edits or creation of files and only need to b
 ### Adding your top to the build system
 
 The first step is to make the build system aware of your top so you can use the [top-selection mechanism](../README.md).
-To do this, edit [`hw/top/defs.bzl`](https://github.com/lowRISC/opentitan/blob/master/hw/top/defs.bzl) and add the following lines marked as `NEW`:
+To do this, edit [`hw/top/defs.bzl`](../../top/defs.bzl) and add the following lines marked as `NEW`:
 ```py
 # In hw/top/defs.bzl`:
 load("//rules/opentitan:hw.bzl", "opentitan_top")
@@ -153,13 +153,13 @@ sim_dv(
     rom = "//sw/device/lib/testing/test_rom:test_rom",
 )
 ```
-For concrete examples see [Darjeeling (simple)](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/BUILD) or [Earlgrey (very complex)](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/BUILD).
+For concrete examples see [Darjeeling (simple)](../../top_darjeeling/BUILD) or [Earlgrey (very complex)](../../top_earlgrey/BUILD).
 
 **Important note:** creating an execution environment does not automatically enroll tests, those must manually be enabled for your execution environment.
 
 ### Build the test ROM for your top
 
-At minimum, you will want to build the test ROM for your DV execution environment. To do so, edit [`sw/device/lib/testing/test_rom/BUILD`](https://github.com/lowRISC/opentitan/blob/61427e7cb1d5c4ba5d0bd16199349033536cfce9/sw/device/lib/testing/test_rom/BUILD#L38) and add the following:
+At minimum, you will want to build the test ROM for your DV execution environment. To do so, edit [`sw/device/lib/testing/test_rom/BUILD`](../../../sw/device/lib/testing/test_rom/BUILD) and add the following:
 ```py
 # In sw/device/lib/testing/test_rom/BUILD
 opentitan_binary(
@@ -182,7 +182,7 @@ Once done, you should be able to compile a test ROM for your top by running:
 ### Adding your execution environment to tests
 
 This is usually done in two ways:
-- manually add a `//hw/top_match:sim_dv` to the `exec_env` attribute of a test, see [`example_test_from_rom`](https://github.com/lowRISC/opentitan/blob/61427e7cb1d5c4ba5d0bd16199349033536cfce9/sw/device/tests/BUILD#L1732C10-L1732C36) for example:
+- manually add a `//hw/top_match:sim_dv` to the `exec_env` attribute of a test, see [`example_test_from_rom`](../../../sw/device/tests/BUILD) for example:
 ```py
 opentitan_test(
     name = "example_test_from_rom",
@@ -197,7 +197,7 @@ opentitan_test(
     # ...
 )
 ```
-- create a new list of execution environment for your top in [`rules/opentitan/defs.bzl`](https://github.com/lowRISC/opentitan/blob/master/rules/opentitan/defs.bzl#L134)
+- create a new list of execution environment for your top in [`rules/opentitan/defs.bzl`](../../../rules/opentitan/defs.bzl)
 ```py
 # In rules/opentitan/defs.bzl
 
@@ -207,7 +207,7 @@ MATCHA_TEST_ENVS = {
     "//hw/top_matcha:sim_dv": None,
 }
 ```
-and add it to tests that you want to enroll, e.g. in [`sw/device/tests/BUILD`](https://github.com/lowRISC/opentitan/blob/master/sw/device/tests/BUILD)
+and add it to tests that you want to enroll, e.g. in [`sw/device/tests/BUILD`](../../../sw/device/tests/BUILD)
 ```py
 # In sw/device/tests/BUILD:
 load(

--- a/hw/top/doc/top_desc.md
+++ b/hw/top/doc/top_desc.md
@@ -8,7 +8,7 @@ To solve this issue, a minimal description of each top is created in Bazel so th
 
 ## Creating the top description
 
-The description is created in `.bzl` files using two macros provided by [`//rules/opentitan:hw.bzl`](https://github.com/lowRISC/opentitan/blob/master/rules/opentitan/hw.bzl):
+The description is created in `.bzl` files using two macros provided by [`//rules/opentitan:hw.bzl`](../../../rules/opentitan/hw.bzl):
 - `opentitan_ip`: create the description of an IP,
 - `opentitan_top`: create the description of a top.
 
@@ -97,7 +97,7 @@ Access to the top's description is available through two APIs:
 
 ### High-level API
 
-The recommended way to access attributes is through the macros defined in [`//hw/top:defs.bzl`](https://github.com/lowRISC/opentitan/blob/master/hw/top/defs.bzl).
+The recommended way to access attributes is through the macros defined in [`//hw/top:defs.bzl`](../defs.bzl).
 The following macros are particularly useful. To see examples of use, see the [Example section](#Examples).
 For more details, look at the documentation in `//hw/top:defs.bzl`
 - The most general macro is `opentitan_select_top_attr(attr_name, required = True, default = None, fn = None)`.

--- a/hw/top_darjeeling/data/otp/otp_ctrl_img_owner_sw_cfg.hjson
+++ b/hw/top_darjeeling/data/otp/otp_ctrl_img_owner_sw_cfg.hjson
@@ -169,9 +169,7 @@
                 //
                 //    sw/host/opentitanlib/src/otp/alert_handler_regs.rs
                 //
-                //    is up to date. See also
-                //
-                //    https://github.com/lowRISC/opentitan/issues/19501
+                //    is up to date.
                 //
                 // 2. Run opentitantool
                 //

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -1836,7 +1836,7 @@
         // boot time during certain life cycle states in order to determine
         // DFT modes and the TAP mux selection index (the JTAG signals can be
         // muxed to either the lifecycle TAP, DFT TAP or RISC-V processor
-        // TAP). TODO: add more documentation to https://docs.opentitan.org/hw/ip/pinmux/doc/index.html
+        // TAP).
         // Each entry must have the following two keys:
         //
         // - name: Basename for the SV parameter.

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_alert_handler_shorten_ping_wait_cycle_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_alert_handler_shorten_ping_wait_cycle_vseq.sv
@@ -10,8 +10,7 @@ class chip_sw_alert_handler_shorten_ping_wait_cycle_vseq extends chip_sw_base_vs
   virtual task pre_start();
     // The wait-time between two ping requests is a 16-bit value, coming from an LFSR.
     // In DV, the wait-time can be overridden by using ping_timer's wait_cyc_mask_i input,
-    // which is a right-aligned mask. For more info:
-    // https://github.com/lowRISC/opentitan/blob/master/hw/ip_templates/alert_handler/rtl/alert_handler.sv#L132-L136
+    // which is a right-aligned mask.
     //
     // The minimum-allowed value,7, is chosen here to use only the least-significant 3 bits of
     // the LFSR output as the wait-time between two ping requests.

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -892,7 +892,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
   endfunction
   // Indicate LC state where cpu_en == 1
   // This has to follow Manufacturing State description
-  // https://opentitan.org/book/doc/security/specs/device_life_cycle/#manufacturing-states
+  // doc/security/specs/device_life_cycle/README.md#manufacturing-states
   virtual function bit is_cpu_enabled_lc_state(lc_state_e state);
     return ((state inside {LcStDev, LcStProd, LcStProdEnd, LcStRma}) ||
             (is_test_unlocked_lc_state(state) == 1));

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_rv_core_ibex_lockstep_glitch_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_rv_core_ibex_lockstep_glitch_vseq.sv
@@ -609,8 +609,6 @@ class chip_sw_rv_core_ibex_lockstep_glitch_vseq extends chip_sw_base_vseq;
       //    that it's infeasible to always correctly model how the glitching of any internal signal
       //    impacts core behavior and ultimately whether this should be detected. Forcing inputs
       //    of ibex_core is a way to make the test feasible in the first place.
-      //
-      // For more details refer to https://github.com/lowRISC/ibex/pull/1967 .
       `DV_CHECK_FATAL(uvm_hdl_force(glitch_path_lockstep, orig_val));
       `uvm_info(`gfn, $sformatf("Forcing %s to value 'h%0x.", glitch_path_lockstep, orig_val),
           UVM_LOW)

--- a/hw/top_darjeeling/ip/ast/README.md
+++ b/hw/top_darjeeling/ip/ast/README.md
@@ -22,12 +22,7 @@ shown in the diagram, but will be explained as well.
 
 ### Signal naming conventions used in this document
 
-It complies with OpenTitan-conventional
-[<u>names</u>](https://github.com/lowRISC/style-guides/blob/master/VerilogCodingStyle.md#naming)
-and
-[<u>suffixes</u>](https://github.com/lowRISC/style-guides/blob/master/VerilogCodingStyle.md#suffixes)
-with some augmentations.
-
+Signal naming generally complies with the [Verilog style guide](../../../../doc/contributing/style_guides/verilog_coding_style.md) names and suffixes with some augmentations:
 - Clock signals start with clk_*
 
 - Inputs and outputs are marked with *_i/o

--- a/hw/top_darjeeling/ip_autogen/clkmgr/data/clkmgr_sec_cm_testplan.hjson
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/data/clkmgr_sec_cm_testplan.hjson
@@ -63,8 +63,7 @@
             Verify the countermeasure(s) MEAS.CONFIG.SHADOW.
 
             This is covered by shadow_reg_errors_tests
-            (https://github.com/lowRISC/opentitan/blob/master/
-            hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson)
+            ($REPO_TOP/hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson)
             '''
       stage: V2S
       tests: ["clkmgr_shadow_reg_errors"]

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/sva/clkmgr_extclk_sva_if.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/sva/clkmgr_extclk_sva_if.sv
@@ -5,7 +5,7 @@
 // This contains SVA assertions to check the external clock bypass control outputs.
 //
 // Notice when a condition fails we allow the logic to generate non strict mubi values. Ideally it
-// would generate mubi False: see https://github.com/lowRISC/opentitan/issues/11400.
+// would generate mubi False.
 interface clkmgr_extclk_sva_if
   import prim_mubi_pkg::*, lc_ctrl_pkg::*;
 (

--- a/hw/top_darjeeling/ip_autogen/gpio/doc/checklist.md
+++ b/hw/top_darjeeling/ip_autogen/gpio/doc/checklist.md
@@ -185,25 +185,20 @@ Testbench     | [FUNCTIONAL_COVERAGE_IMPLEMENTED][]     | Done        |
 Testbench     | [ALL_INTERFACES_EXERCISED][]            | Done        |
 Testbench     | [ALL_ASSERTION_CHECKS_ADDED][]          | Done        |
 Testbench     | [SIM_TB_ENV_COMPLETED][]                | Done        |
-Tests         | [SIM_ALL_TESTS_PASSING][]               | Done        | Resolved: [#680][]
+Tests         | [SIM_ALL_TESTS_PASSING][]               | Done        |
 Tests         | [FPV_ALL_ASSERTIONS_WRITTEN][]          | N/A         |
 Tests         | [FPV_ALL_ASSUMPTIONS_REVIEWED][]        | N/A         |
 Tests         | [SIM_FW_SIMULATED][]                    | N/A         |
 Regression    | [SIM_NIGHTLY_REGRESSION_V2][]           | Done        |
 Coverage      | [SIM_CODE_COVERAGE_V2][]                | Done        |
-Coverage      | [SIM_FUNCTIONAL_COVERAGE_V2][]          | Done        | Resolved: [#807][]
+Coverage      | [SIM_FUNCTIONAL_COVERAGE_V2][]          | Done        |
 Coverage      | [FPV_CODE_COVERAGE_V2][]                | N/A         |
 Coverage      | [FPV_COI_COVERAGE_V2][]                 | N/A         |
 Integration   | [PRE_VERIFIED_SUB_MODULES_V2][]         | N/A         |
 Issues        | [NO_HIGH_PRIORITY_ISSUES_PENDING][]     | Done        |
-Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Done        | [#41][] Not quite related, [#45][] root caused
+Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Done        |
 Review        | [DV_DOC_TESTPLAN_REVIEWED][]            | Done        |
 Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
-
-[#41]: https://github.com/lowRISC/opentitan/issues/41
-[#45]: https://github.com/lowRISC/opentitan/issues/45
-[#680]: https://github.com/lowRISC/opentitan/pull/680
-[#807]: https://github.com/lowRISC/opentitan/pull/807
 
 [DESIGN_DELTAS_CAPTURED_V2]:          ../../../../../doc/contributing/hw/checklist/README.md#design_deltas_captured_v2
 [DV_DOC_COMPLETED]:                   ../../../../../doc/contributing/hw/checklist/README.md#dv_doc_completed
@@ -249,9 +244,9 @@ Review        | [SEC_CM_DV_REVIEWED][]                  | Done        | Waived t
 Documentation | [DESIGN_DELTAS_CAPTURED_V3][]     | N/A         |
 Tests         | [X_PROP_ANALYSIS_COMPLETED][]     | Waived      | Revisit later. Tool setup in progress.
 Tests         | [FPV_ASSERTIONS_PROVEN_AT_V3][]   | N/A         |
-Regression    | [SIM_NIGHTLY_REGRESSION_AT_V3][]  | Done        | Resolved: [#680][]
-Coverage      | [SIM_CODE_COVERAGE_AT_100][]      | Done        | [common_cov_excl.el][], [gpio_cov_excl.el][]
-Coverage      | [SIM_FUNCTIONAL_COVERAGE_AT_100][]| Done        | [#807][]
+Regression    | [SIM_NIGHTLY_REGRESSION_AT_V3][]  | Done        |
+Coverage      | [SIM_CODE_COVERAGE_AT_100][]      | Done        | [common_cov_excl.cfg][], [gpio_cov_excl.el][]
+Coverage      | [SIM_FUNCTIONAL_COVERAGE_AT_100][]| Done        |
 Coverage      | [FPV_CODE_COVERAGE_AT_100][]      | N/A         |
 Coverage      | [FPV_COI_COVERAGE_AT_100][]       | N/A         |
 Code Quality  | [ALL_TODOS_RESOLVED][]            | Done        |
@@ -261,8 +256,6 @@ Integration   | [PRE_VERIFIED_SUB_MODULES_V3][]   | N/A         |
 Issues        | [NO_ISSUES_PENDING][]             | Done        |
 Review        | Reviewer(s)                       | Done        | @eunchan @sriyerg @sjgitty
 Review        | Signoff date                      | Done        | 2019-11-04
-
-[#807]: https://github.com/lowRISC/opentitan/pull/807
 
 [DESIGN_DELTAS_CAPTURED_V3]:     ../../../../../doc/contributing/hw/checklist/README.md#design_deltas_captured_v3
 [X_PROP_ANALYSIS_COMPLETED]:     ../../../../../doc/contributing/hw/checklist/README.md#x_prop_analysis_completed
@@ -278,5 +271,5 @@ Review        | Signoff date                      | Done        | 2019-11-04
 [PRE_VERIFIED_SUB_MODULES_V3]:   ../../../../../doc/contributing/hw/checklist/README.md#pre_verified_sub_modules_v3
 [NO_ISSUES_PENDING]:             ../../../../../doc/contributing/hw/checklist/README.md#no_issues_pending
 
-[common_cov_excl.el]:https://github.com/lowRISC/opentitan/blob/9dff09b6c57f4962d67f5f64f8e69ac9bea6885c/hw/dv/tools/vcs/common_cov_excl.el
-[gpio_cov_excl.el]:  https://github.com/lowRISC/opentitan/blob/39aaeefdb43661b065c29ceab2efc1065aebf6dd/hw/ip/gpio/dv/cov/gpio_cov_excl.el
+[common_cov_excl.cfg]: ../../../../dv/tools/vcs/common_cov_excl.cfg
+[gpio_cov_excl.el]:  ../dv/cov/gpio_cov_excl.el

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl.sv
@@ -943,8 +943,8 @@ end
   // This is specialised for different tops that use it but the req/ack protocol is the same in each
   // case. For one example, see
   //
-  // https://opentitan.org/book/hw/top_earlgrey/
-  //    ip_autogen/otp_ctrl/doc/interfaces.html#interfaces-to-sram-and-acc-scramblers
+  // hw/top_earlgrey/
+  //    ip_autogen/otp_ctrl/doc/interfaces.md#interfaces-to-sram-and-acc-scramblers
 
 
   // Note: as opposed to the OTP arbitration above, we do not perform cycle-wise arbitration, but

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
@@ -62,7 +62,7 @@
 //
 // References:
 //  - The block diagram in ../doc/theory_of_operation.md
-//  - https://opentitan.org/book/hw/ip/prim/doc/prim_present.html
+//  - hw/ip/prim/doc/prim_present.md
 //  - https://en.wikipedia.org/wiki/Merkle-Damgard_construction
 //  - https://en.wikipedia.org/wiki/One-way_compression_function#Davies%E2%80%93Meyer
 //  - https://en.wikipedia.org/wiki/PRESENT

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
@@ -110,8 +110,7 @@
       desc: '''Verify the countermeasure(s) ESC_RX.CLK.LOCAL_ESC.
 
             This is triggered by common cm primitives (SecCmPrimCount).
-            (https://github.com/lowRISC/opentitan/blob/master
-            /hw/dv/sv/cip_lib/doc/index.md#security-verification
+            ($REPO_TOP/hw/dv/sv/cip_lib/doc/README.md#security-verification
             -for-common-countermeasure-primitives)
 
             **Check**:
@@ -126,8 +125,7 @@
       name: sec_cm_fsm_sparse
       desc: '''Verify the countermeasure(s) FSM.SPARSE.
             This is triggered by common cm primitives (SecCmPrimSparseFsmFlop).
-            (https://github.com/lowRISC/opentitan/blob/master
-            /hw/dv/sv/cip_lib/doc/index.md#security-verification
+            ($REPO_TOP/hw/dv/sv/cip_lib/doc/README.md#security-verification
             -for-common-countermeasure-primitives)
             '''
       stage: V2S

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/README.md
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/README.md
@@ -22,12 +22,12 @@ PWRMGR testbench has been constructed based on the [CIP testbench architecture](
 ![Block diagram](./doc/tb.svg)
 
 ### Top level testbench
-Top level testbench is located at [`hw/top_darjeeling/ip_autogen/pwrmgr/dv/tb.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/pwrmgr/dv/tb.sv).
-It instantiates the PWRMGR DUT module [`hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr.sv).
+Top level testbench is located at [`hw/top_darjeeling/ip_autogen/pwrmgr/dv/tb.sv`](./tb.sv).
+It instantiates the PWRMGR DUT module [`hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr.sv`](../rtl/pwrmgr.sv).
 In addition, it instantiates the following interfaces, connects them to the DUT and sets their handle into `uvm_config_db`:
 * [Clock and reset interface](../../../../dv/sv/common_ifs/README.md)
 * [TileLink host interface](../../../../dv/sv/tl_agent/README.md)
-* PWRMGR interface [`hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv).
+* PWRMGR interface [`hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv`](./env/pwrmgr_if.sv).
 * Interrupts ([`pins_if`](../../../../dv/sv/common_ifs/README.md))
 * Alerts ([`alert_esc_if`](../../../../dv/sv/alert_esc_agent/README.md))
 
@@ -38,7 +38,7 @@ The following utilities provide generic helper tasks and functions to perform ac
 
 ### Global types & methods
 All common types and methods defined at the package level can be found in
-[`pwrmgr_env_pkg`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_env_pkg.sv).
+[`pwrmgr_env_pkg`](./env/pwrmgr_env_pkg.sv).
 Some of them in use are:
 ```systemverilog
   typedef enum int {
@@ -73,7 +73,7 @@ It can be created manually by invoking [`regtool`](../../../../../util/reggen/do
 ### Stimulus strategy
 The sequences are closely related to the testplan's testpoints.
 Testpoints and coverage are described in more detail in the [testplan](#testplan).
-All test sequences reside in [`hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib), and extend `pwrmgr_base_vseq`.
+All test sequences reside in [`hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib`](./env/seq_lib), and extend `pwrmgr_base_vseq`.
 The `pwrmgr_base_vseq` virtual sequence is extended from `cip_base_vseq` and serves as a starting point.
 It provides commonly used handles, variables, functions and tasks used by the test sequences.
 Some of the most commonly used tasks and functions are as follows:
@@ -151,7 +151,7 @@ See also the test plan for specific ways these are driven to trigger different t
 - Outputs `core_clk_en`, `io_clk_en`, and `usb_clk_en` reset low, and go high prior to the slow fsm requesting the fast fsm to wakeup.
   Notice the usb clock can be programmed to stay low on wakeup via the `control` CSR.
   These clock enables are cleared on reset, and should match their corresponding enables in the `control` CSR on low power transitions.
-  These clock enables are checked via SVAs in [`hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv).
+  These clock enables are checked via SVAs in [`hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv`](./sva/pwrmgr_clock_enables_sva_if.sv).
   When slow fsm transitions to `SlowPwrStateReqPwrUp` the clock enables should be on (except usb should match `control.usb_clk_en_active`).
   When slow fsm transitions to `SlowPwrStatePwrClampOn` the clock enables should match their bits in the `control` CSR.
 - Inputs `core_clk_val`, `io_clk_val`, and `usb_clk_val` track the corresponding enables.
@@ -159,7 +159,7 @@ See also the test plan for specific ways these are driven to trigger different t
   Slow fsm waits for them to go high prior to requesting fast fsm wakeup.
   Lack of a high transition when needed is detected via timeout.
   Such timeout would be due to the corresponding enables being set incorrectly.
-  These inputs are checked via SVAs in [`hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_ast_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_ast_sva_if.sv).
+  These inputs are checked via SVAs in [`hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_ast_sva_if.sv`](./sva/pwrmgr_ast_sva_if.sv).
 - Output `main_pd_n` should go high when slow fsm transitions to `SlowPwrStateMainPowerOn`, and should match `control.main_pd_n` CSR when slow fsm transitions to `SlowPwrStateMainPowerOff`.
 - Input `main_pok` should turn on for the slow fsm to start power up sequence.
   This is also driven by `slow_responder`, which turn this off in response to `main_pd_n` going low, and turn it back on after a few random slow clock cycles from `main_pd_n` going high.
@@ -224,7 +224,7 @@ There are a number of wakeup and reset requests.
 They are driven by sequences as they need to.
 
 #### Assertions
-The [`hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv) module binds a few modules containing assertions to the IP as follows:
+The [`hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv`](./sva/pwrmgr_bind.sv) module binds a few modules containing assertions to the IP as follows:
 * TLUL assertions: the `tlul_assert` [assertions](../../../../ip/tlul/doc/TlulProtocolChecker.md) ensures TileLink interface protocol compliance.
 * Clock enables assertions:
   The `pwrmgr_clock_enables_sva_if` module contains assertions checking that the various clk_en outputs correspond to the settings in the `control` CSR.

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/README.md
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/README.md
@@ -16,12 +16,12 @@ RSTMGR testbench has been constructed based on the [CIP testbench architecture](
 
 ![Block diagram](./doc/tb.svg)
 
-The top level testbench is located at [`hw/top_darjeeling/ip_autogen/rstmgr/dv/tb.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/rstmgr/dv/tb.sv).
-It instantiates the RSTMGR DUT module [`hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr.sv).
+The top level testbench is located at [`hw/top_darjeeling/ip_autogen/rstmgr/dv/tb.sv`](./tb.sv).
+It instantiates the RSTMGR DUT module [`hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr.sv`](../rtl/rstmgr.sv).
 In addition, it instantiates the following interfaces, connects them to the DUT and sets their handle into `uvm_config_db`:
 * [Clock and reset interface](../../../../dv/sv/common_ifs/README.md)
 * [TileLink host interface](../../../../dv/sv/tl_agent/README.md)
-* RSTMGR interface [`hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_if.sv)
+* RSTMGR interface [`hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_if.sv`](./env/rstmgr_if.sv)
 * Alerts ([`alert_esc_if`](../../../../dv/sv/alert_esc_agent/README.md))
 
 The following utilities provide generic helper tasks and functions to perform activities that are common across the project:
@@ -56,7 +56,7 @@ This is consistent with this IP being in charge of all derived resets in the chi
 Besides the POR resets above, the test sequences mostly assert various reset requests from pwrmgr and trigger resets vir RESET_REQ CSR.
 Alert and CPU dump info is randomized and checked on resets.
 
-The test sequences reside in [`hw/top_darjeeling/ip_autogen/rstmgr/dv/env/seq_lib`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/seq_lib).
+The test sequences reside in [`hw/top_darjeeling/ip_autogen/rstmgr/dv/env/seq_lib`](./env/seq_lib).
 All test sequences are extended from `rstmgr_base_vseq`, which is extended from `cip_base_vseq` and serves as a starting point.
 It provides commonly used handles, variables, functions and tasks that the test sequences can simple use / call.
 Some of the most commonly used tasks / functions are as follows:
@@ -90,19 +90,19 @@ The latter are described in the testplan.
 * TLUL assertions: The `tb/rstmgr_bind.sv` file binds the `tlul_assert` [assertions](../../../../ip/tlul/doc/TlulProtocolChecker.md) to the IP to ensure TileLink interface protocol compliance.
 * Unknown checks on DUT outputs: The RTL has assertions to ensure all outputs are initialized to known values after coming out of reset.
 * Response to pwrmgr's `rst_lc_req` and `rst_sys_req` inputs: these trigger transitions in `rst_lc_src_n` and `rst_sys_rst_n` outputs.
-  Checked via SVAs in [`hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv).
+  Checked via SVAs in [`hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv`](../../../../dv/sv/mgr_lib/pwrmgr_rstmgr_sva_if.sv).
 * Response to `cpu_i.ndmreset_req` input: after it is asserted, rstmgr's `rst_sys_src_n` should go active.
-  Checked via SVA in [`hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv).
+  Checked via SVA in [`hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv`](../../../../dv/sv/mgr_lib/pwrmgr_rstmgr_sva_if.sv).
 * Resets cascade hierarchically per [Reset Topology](../doc/theory_of_operation.md#reset-topology).
-  Checked via SVA in [`hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv).
+  Checked via SVA in [`hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](./sva/rstmgr_cascading_sva_if.sv).
 * POR must be active for at least 32 consecutive cycles before going inactive before output resets go inactive.
-  Checked via SVA in [`hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv).
+  Checked via SVA in [`hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](./sva/rstmgr_cascading_sva_if.sv).
 * The scan reset `scan_rst_ni` qualified by `scanmode_i` triggers all cascaded resets that `por_n_i` does.
-  Checked via SVA in [`hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv).
+  Checked via SVA in [`hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](./sva/rstmgr_cascading_sva_if.sv).
 * Software resets to peripherals also cascade hierarchically.
-  Checked via SVA in [`hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv).
+  Checked via SVA in [`hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv`](./sva/rstmgr_sw_rst_sva_if.sv).
 * The output `rst_en_o` for alert_handler tracks their corresponding resets.
-  Checked via SVA in both [`hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv) and [`hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv).
+  Checked via SVA in both [`hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](./sva/rstmgr_cascading_sva_if.sv) and [`hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv`](./sva/rstmgr_sw_rst_sva_if.sv).
 * The `alert` and `cpu_info_attr` indicate the number of 32-bit words needed to capture their inputs.
   Checked via SVA in `hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_attrs_sva_if.sv`.
 

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_cnsty_chk.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_cnsty_chk.sv
@@ -68,8 +68,6 @@ module rstmgr_cnsty_chk
     // 2-flop synchronizer (see u_rst_sync in rstmgr_leaf_rst) which is clocked using the same
     // clock (clk_io_div4_i). This means child_rst_asserted always de-asserts after
     // parent_rst_asserted unless we are under attack.
-    //
-    // For details, refer to https://github.com/lowRISC/opentitan/issues/27659 .
     .EnablePrimCdcRand(0)
   ) u_parent_sync (
     .clk_i,

--- a/hw/top_earlgrey/data/placement.xdc
+++ b/hw/top_earlgrey/data/placement.xdc
@@ -1,7 +1,5 @@
 # While the code below looks messy, it was taken directly from a vivado example
 # See here (https://www.xilinx.com/support/answers/66386.html)
-# See also this link (https://github.com/lowRISC/opentitan/pull/8138#issuecomment-916696830)
-# for a thorough explanation of why such a custom placement helps.
 #
 # The placement location has been chosen by evaluating the resulting place and route times of
 # all possible options.

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -1737,8 +1737,7 @@
         // boot time during certain life cycle states in order to determine
         // DFT modes and the TAP mux selection index (the JTAG signals can be
         // muxed to either the lifecycle TAP, DFT TAP or RISC-V processor
-        // TAP). TODO: add more documentation to
-        // https://opentitan.org/book/hw/top_earlgrey/ip_autogen/pinmux/index.html
+        // TAP).
         // Each entry must have the following two keys:
         //
         // - name: Basename for the SV parameter.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_shorten_ping_wait_cycle_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_alert_handler_shorten_ping_wait_cycle_vseq.sv
@@ -11,7 +11,7 @@ class chip_sw_alert_handler_shorten_ping_wait_cycle_vseq extends chip_sw_base_vs
     // The wait-time between two ping requests is a 16-bit value, coming from an LFSR.
     // In DV, the wait-time can be overridden by using ping_timer's wait_cyc_mask_i input,
     // which is a right-aligned mask. For more info:
-    // https://github.com/lowRISC/opentitan/blob/master/hw/ip_templates/alert_handler/rtl/alert_handler.sv#L132-L136
+    // $REPO_TOP/hw/ip_templates/alert_handler/rtl/alert_handler.sv
     //
     // The minimum-allowed value,7, is chosen here to use only the least-significant 3 bits of
     // the LFSR output as the wait-time between two ping requests.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -745,7 +745,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
 
   // Indicate LC state where cpu_en == 1
   // This has to follow Manufacturing State description
-  // https://opentitan.org/book/doc/security/specs/device_life_cycle/#manufacturing-states
+  // doc/security/specs/device_life_cycle/README.md#manufacturing-states
   virtual function bit is_cpu_enabled_lc_state(lc_state_e state);
     return ((state inside {LcStDev, LcStProd, LcStProdEnd, LcStRma}) ||
             (is_test_unlocked_lc_state(state) == 1));

--- a/hw/top_earlgrey/ip/ast/doc/interfaces.md
+++ b/hw/top_earlgrey/ip/ast/doc/interfaces.md
@@ -4,7 +4,7 @@
 
 ### Signal naming conventions used in this document
 
-Naming here is compliant with the OpenTitan [names](https://github.com/lowRISC/style-guides/blob/master/VerilogCodingStyle.md#naming) and [suffixes](https://github.com/lowRISC/style-guides/blob/master/VerilogCodingStyle.md#suffixes) specification, with the following augmentations:
+Naming here is compliant with the [Verilog style guide](../../../../../doc/contributing/style_guides/verilog_coding_style.md) names and suffixes specification, with the following augmentations:
 
 - Clock signals start with `clk_*`
 - Inputs and outputs are marked with `*_i/o`

--- a/hw/top_earlgrey/ip/xbar/doc/checklist.md
+++ b/hw/top_earlgrey/ip/xbar/doc/checklist.md
@@ -45,7 +45,7 @@ Documentation | [FEATURE_FROZEN][]        | Done        |
 RTL           | [FEATURE_COMPLETE][]      | Done        |
 RTL           | [PORT_FROZEN][]           | Done        | Targeting for current top_earlgrey( Port can be changed later based on top_earlgrey config)
 RTL           | [ARCHITECTURE_FROZEN][]   | Done        |
-RTL           | [REVIEW_TODO][]           | Done        | PR [#837][] is pending
+RTL           | [REVIEW_TODO][]           | Done        |
 RTL           | [STYLE_X][]               | Done        |
 RTL           | [CDC_SYNCMACRO][]         | N/A         |
 Code Quality  | [LINT_PASS][]             | Done        |
@@ -54,8 +54,6 @@ Code Quality  | [RDC_SETUP][]             | Waived      | No block-level flow av
 Code Quality  | [AREA_CHECK][]            | Done        |
 Code Quality  | [TIMING_CHECK][]          | Done        | Pipeline inserted in front of Core IBEX. meet timing @ 50MHz on NexysVideo
 Security      | [SEC_CM_DOCUMENTED][]     | N/A         |
-
-[#837]: https://github.com/lowRISC/opentitan/pull/837
 
 [NEW_FEATURES]:          ../../../../../doc/contributing/hw/checklist/README.md#new_features
 [BLOCK_DIAGRAM]:         ../../../../../doc/contributing/hw/checklist/README.md#block_diagram
@@ -267,4 +265,4 @@ Review        | Signoff date                      | Done        | 2019-11-07
 [PRE_VERIFIED_SUB_MODULES_V3]:   ../../../../../doc/contributing/hw/checklist/README.md#pre_verified_sub_modules_v3
 [NO_ISSUES_PENDING]:             ../../../../../doc/contributing/hw/checklist/README.md#no_issues_pending
 
-[xbar_cov_excl.el]: https://github.com/weicaiyang/opentitan/blob/6cd55ad23aac96374bfa0bec315b904c6ffbdb8f/hw/ip/tlul/dv/cov/xbar_cov_excl.el
+[xbar_cov_excl.el]: ../../xbar_main/dv/autogen/xbar_cov_excl.el

--- a/hw/top_earlgrey/ip_autogen/clkmgr/data/clkmgr_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/data/clkmgr_sec_cm_testplan.hjson
@@ -63,8 +63,7 @@
             Verify the countermeasure(s) MEAS.CONFIG.SHADOW.
 
             This is covered by shadow_reg_errors_tests
-            (https://github.com/lowRISC/opentitan/blob/master/
-            hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson)
+            ($REPO_TOP/hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson)
             '''
       stage: V2S
       tests: ["clkmgr_shadow_reg_errors"]

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/sva/clkmgr_extclk_sva_if.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/sva/clkmgr_extclk_sva_if.sv
@@ -5,7 +5,7 @@
 // This contains SVA assertions to check the external clock bypass control outputs.
 //
 // Notice when a condition fails we allow the logic to generate non strict mubi values. Ideally it
-// would generate mubi False: see https://github.com/lowRISC/opentitan/issues/11400.
+// would generate mubi False.
 interface clkmgr_extclk_sva_if
   import prim_mubi_pkg::*, lc_ctrl_pkg::*;
 (

--- a/hw/top_earlgrey/ip_autogen/gpio/doc/checklist.md
+++ b/hw/top_earlgrey/ip_autogen/gpio/doc/checklist.md
@@ -185,25 +185,20 @@ Testbench     | [FUNCTIONAL_COVERAGE_IMPLEMENTED][]     | Done        |
 Testbench     | [ALL_INTERFACES_EXERCISED][]            | Done        |
 Testbench     | [ALL_ASSERTION_CHECKS_ADDED][]          | Done        |
 Testbench     | [SIM_TB_ENV_COMPLETED][]                | Done        |
-Tests         | [SIM_ALL_TESTS_PASSING][]               | Done        | Resolved: [#680][]
+Tests         | [SIM_ALL_TESTS_PASSING][]               | Done        |
 Tests         | [FPV_ALL_ASSERTIONS_WRITTEN][]          | N/A         |
 Tests         | [FPV_ALL_ASSUMPTIONS_REVIEWED][]        | N/A         |
 Tests         | [SIM_FW_SIMULATED][]                    | N/A         |
 Regression    | [SIM_NIGHTLY_REGRESSION_V2][]           | Done        |
 Coverage      | [SIM_CODE_COVERAGE_V2][]                | Done        |
-Coverage      | [SIM_FUNCTIONAL_COVERAGE_V2][]          | Done        | Resolved: [#807][]
+Coverage      | [SIM_FUNCTIONAL_COVERAGE_V2][]          | Done        |
 Coverage      | [FPV_CODE_COVERAGE_V2][]                | N/A         |
 Coverage      | [FPV_COI_COVERAGE_V2][]                 | N/A         |
 Integration   | [PRE_VERIFIED_SUB_MODULES_V2][]         | N/A         |
 Issues        | [NO_HIGH_PRIORITY_ISSUES_PENDING][]     | Done        |
-Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Done        | [#41][] Not quite related, [#45][] root caused
+Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Done        |
 Review        | [DV_DOC_TESTPLAN_REVIEWED][]            | Done        |
 Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
-
-[#41]: https://github.com/lowRISC/opentitan/issues/41
-[#45]: https://github.com/lowRISC/opentitan/issues/45
-[#680]: https://github.com/lowRISC/opentitan/pull/680
-[#807]: https://github.com/lowRISC/opentitan/pull/807
 
 [DESIGN_DELTAS_CAPTURED_V2]:          ../../../../../doc/contributing/hw/checklist/README.md#design_deltas_captured_v2
 [DV_DOC_COMPLETED]:                   ../../../../../doc/contributing/hw/checklist/README.md#dv_doc_completed
@@ -249,9 +244,9 @@ Review        | [SEC_CM_DV_REVIEWED][]                  | Done        | Waived t
 Documentation | [DESIGN_DELTAS_CAPTURED_V3][]     | N/A         |
 Tests         | [X_PROP_ANALYSIS_COMPLETED][]     | Waived      | Revisit later. Tool setup in progress.
 Tests         | [FPV_ASSERTIONS_PROVEN_AT_V3][]   | N/A         |
-Regression    | [SIM_NIGHTLY_REGRESSION_AT_V3][]  | Done        | Resolved: [#680][]
-Coverage      | [SIM_CODE_COVERAGE_AT_100][]      | Done        | [common_cov_excl.el][], [gpio_cov_excl.el][]
-Coverage      | [SIM_FUNCTIONAL_COVERAGE_AT_100][]| Done        | [#807][]
+Regression    | [SIM_NIGHTLY_REGRESSION_AT_V3][]  | Done        |
+Coverage      | [SIM_CODE_COVERAGE_AT_100][]      | Done        | [common_cov_excl.cfg][], [gpio_cov_excl.el][]
+Coverage      | [SIM_FUNCTIONAL_COVERAGE_AT_100][]| Done        |
 Coverage      | [FPV_CODE_COVERAGE_AT_100][]      | N/A         |
 Coverage      | [FPV_COI_COVERAGE_AT_100][]       | N/A         |
 Code Quality  | [ALL_TODOS_RESOLVED][]            | Done        |
@@ -261,8 +256,6 @@ Integration   | [PRE_VERIFIED_SUB_MODULES_V3][]   | N/A         |
 Issues        | [NO_ISSUES_PENDING][]             | Done        |
 Review        | Reviewer(s)                       | Done        | @eunchan @sriyerg @sjgitty
 Review        | Signoff date                      | Done        | 2019-11-04
-
-[#807]: https://github.com/lowRISC/opentitan/pull/807
 
 [DESIGN_DELTAS_CAPTURED_V3]:     ../../../../../doc/contributing/hw/checklist/README.md#design_deltas_captured_v3
 [X_PROP_ANALYSIS_COMPLETED]:     ../../../../../doc/contributing/hw/checklist/README.md#x_prop_analysis_completed
@@ -278,5 +271,5 @@ Review        | Signoff date                      | Done        | 2019-11-04
 [PRE_VERIFIED_SUB_MODULES_V3]:   ../../../../../doc/contributing/hw/checklist/README.md#pre_verified_sub_modules_v3
 [NO_ISSUES_PENDING]:             ../../../../../doc/contributing/hw/checklist/README.md#no_issues_pending
 
-[common_cov_excl.el]:https://github.com/lowRISC/opentitan/blob/9dff09b6c57f4962d67f5f64f8e69ac9bea6885c/hw/dv/tools/vcs/common_cov_excl.el
-[gpio_cov_excl.el]:  https://github.com/lowRISC/opentitan/blob/39aaeefdb43661b065c29ceab2efc1065aebf6dd/hw/ip/gpio/dv/cov/gpio_cov_excl.el
+[common_cov_excl.cfg]: ../../../../dv/tools/vcs/common_cov_excl.cfg
+[gpio_cov_excl.el]:  ../dv/cov/gpio_cov_excl.el

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl.sv
@@ -931,8 +931,8 @@ end
   // This is specialised for different tops that use it but the req/ack protocol is the same in each
   // case. For one example, see
   //
-  // https://opentitan.org/book/hw/top_earlgrey/
-  //    ip_autogen/otp_ctrl/doc/interfaces.html#interfaces-to-sram-and-acc-scramblers
+  // hw/top_earlgrey/
+  //    ip_autogen/otp_ctrl/doc/interfaces.md#interfaces-to-sram-and-acc-scramblers
 
 
   // Note: as opposed to the OTP arbitration above, we do not perform cycle-wise arbitration, but

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
@@ -62,7 +62,7 @@
 //
 // References:
 //  - The block diagram in ../doc/theory_of_operation.md
-//  - https://opentitan.org/book/hw/ip/prim/doc/prim_present.html
+//  - hw/ip/prim/doc/prim_present.md
 //  - https://en.wikipedia.org/wiki/Merkle-Damgard_construction
 //  - https://en.wikipedia.org/wiki/One-way_compression_function#Davies%E2%80%93Meyer
 //  - https://en.wikipedia.org/wiki/PRESENT

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
@@ -110,8 +110,7 @@
       desc: '''Verify the countermeasure(s) ESC_RX.CLK.LOCAL_ESC.
 
             This is triggered by common cm primitives (SecCmPrimCount).
-            (https://github.com/lowRISC/opentitan/blob/master
-            /hw/dv/sv/cip_lib/doc/index.md#security-verification
+            ($REPO_TOP/hw/dv/sv/cip_lib/doc/README.md#security-verification
             -for-common-countermeasure-primitives)
 
             **Check**:
@@ -126,8 +125,7 @@
       name: sec_cm_fsm_sparse
       desc: '''Verify the countermeasure(s) FSM.SPARSE.
             This is triggered by common cm primitives (SecCmPrimSparseFsmFlop).
-            (https://github.com/lowRISC/opentitan/blob/master
-            /hw/dv/sv/cip_lib/doc/index.md#security-verification
+            ($REPO_TOP/hw/dv/sv/cip_lib/doc/README.md#security-verification
             -for-common-countermeasure-primitives)
             '''
       stage: V2S

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/README.md
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/README.md
@@ -22,12 +22,12 @@ PWRMGR testbench has been constructed based on the [CIP testbench architecture](
 ![Block diagram](./doc/tb.svg)
 
 ### Top level testbench
-Top level testbench is located at [`hw/top_earlgrey/ip_autogen/pwrmgr/dv/tb.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/pwrmgr/dv/tb.sv).
-It instantiates the PWRMGR DUT module [`hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr.sv).
+Top level testbench is located at [`hw/top_earlgrey/ip_autogen/pwrmgr/dv/tb.sv`](./tb.sv).
+It instantiates the PWRMGR DUT module [`hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr.sv`](../rtl/pwrmgr.sv).
 In addition, it instantiates the following interfaces, connects them to the DUT and sets their handle into `uvm_config_db`:
 * [Clock and reset interface](../../../../dv/sv/common_ifs/README.md)
 * [TileLink host interface](../../../../dv/sv/tl_agent/README.md)
-* PWRMGR interface [`hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv).
+* PWRMGR interface [`hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv`](./env/pwrmgr_if.sv).
 * Interrupts ([`pins_if`](../../../../dv/sv/common_ifs/README.md))
 * Alerts ([`alert_esc_if`](../../../../dv/sv/alert_esc_agent/README.md))
 
@@ -38,7 +38,7 @@ The following utilities provide generic helper tasks and functions to perform ac
 
 ### Global types & methods
 All common types and methods defined at the package level can be found in
-[`pwrmgr_env_pkg`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_env_pkg.sv).
+[`pwrmgr_env_pkg`](./env/pwrmgr_env_pkg.sv).
 Some of them in use are:
 ```systemverilog
   typedef enum int {
@@ -75,7 +75,7 @@ It can be created manually by invoking [`regtool`](../../../../../util/reggen/do
 ### Stimulus strategy
 The sequences are closely related to the testplan's testpoints.
 Testpoints and coverage are described in more detail in the [testplan](#testplan).
-All test sequences reside in [`hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib), and extend `pwrmgr_base_vseq`.
+All test sequences reside in [`hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib`](./env/seq_lib), and extend `pwrmgr_base_vseq`.
 The `pwrmgr_base_vseq` virtual sequence is extended from `cip_base_vseq` and serves as a starting point.
 It provides commonly used handles, variables, functions and tasks used by the test sequences.
 Some of the most commonly used tasks and functions are as follows:
@@ -153,7 +153,7 @@ See also the test plan for specific ways these are driven to trigger different t
 - Outputs `core_clk_en`, `io_clk_en`, and `usb_clk_en` reset low, and go high prior to the slow fsm requesting the fast fsm to wakeup.
   Notice the usb clock can be programmed to stay low on wakeup via the `control` CSR.
   These clock enables are cleared on reset, and should match their corresponding enables in the `control` CSR on low power transitions.
-  These clock enables are checked via SVAs in [`hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv).
+  These clock enables are checked via SVAs in [`hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv`](./sva/pwrmgr_clock_enables_sva_if.sv).
   When slow fsm transitions to `SlowPwrStateReqPwrUp` the clock enables should be on (except usb should match `control.usb_clk_en_active`).
   When slow fsm transitions to `SlowPwrStatePwrClampOn` the clock enables should match their bits in the `control` CSR.
 - Inputs `core_clk_val`, `io_clk_val`, and `usb_clk_val` track the corresponding enables.
@@ -161,7 +161,7 @@ See also the test plan for specific ways these are driven to trigger different t
   Slow fsm waits for them to go high prior to requesting fast fsm wakeup.
   Lack of a high transition when needed is detected via timeout.
   Such timeout would be due to the corresponding enables being set incorrectly.
-  These inputs are checked via SVAs in [`hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_ast_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_ast_sva_if.sv).
+  These inputs are checked via SVAs in [`hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_ast_sva_if.sv`](./sva/pwrmgr_ast_sva_if.sv).
 - Output `main_pd_n` should go high when slow fsm transitions to `SlowPwrStateMainPowerOn`, and should match `control.main_pd_n` CSR when slow fsm transitions to `SlowPwrStateMainPowerOff`.
 - Input `main_pok` should turn on for the slow fsm to start power up sequence.
   This is also driven by `slow_responder`, which turn this off in response to `main_pd_n` going low, and turn it back on after a few random slow clock cycles from `main_pd_n` going high.
@@ -226,7 +226,7 @@ There are a number of wakeup and reset requests.
 They are driven by sequences as they need to.
 
 #### Assertions
-The [`hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv) module binds a few modules containing assertions to the IP as follows:
+The [`hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv`](./sva/pwrmgr_bind.sv) module binds a few modules containing assertions to the IP as follows:
 * TLUL assertions: the `tlul_assert` [assertions](../../../../ip/tlul/doc/TlulProtocolChecker.md) ensures TileLink interface protocol compliance.
 * Clock enables assertions:
   The `pwrmgr_clock_enables_sva_if` module contains assertions checking that the various clk_en outputs correspond to the settings in the `control` CSR.

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/README.md
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/README.md
@@ -16,12 +16,12 @@ RSTMGR testbench has been constructed based on the [CIP testbench architecture](
 
 ![Block diagram](./doc/tb.svg)
 
-The top level testbench is located at [`hw/top_earlgrey/ip_autogen/rstmgr/dv/tb.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/rstmgr/dv/tb.sv).
-It instantiates the RSTMGR DUT module [`hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr.sv).
+The top level testbench is located at [`hw/top_earlgrey/ip_autogen/rstmgr/dv/tb.sv`](./tb.sv).
+It instantiates the RSTMGR DUT module [`hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr.sv`](../rtl/rstmgr.sv).
 In addition, it instantiates the following interfaces, connects them to the DUT and sets their handle into `uvm_config_db`:
 * [Clock and reset interface](../../../../dv/sv/common_ifs/README.md)
 * [TileLink host interface](../../../../dv/sv/tl_agent/README.md)
-* RSTMGR interface [`hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_if.sv)
+* RSTMGR interface [`hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_if.sv`](./env/rstmgr_if.sv)
 * Alerts ([`alert_esc_if`](../../../../dv/sv/alert_esc_agent/README.md))
 
 The following utilities provide generic helper tasks and functions to perform activities that are common across the project:
@@ -56,7 +56,7 @@ This is consistent with this IP being in charge of all derived resets in the chi
 Besides the POR resets above, the test sequences mostly assert various reset requests from pwrmgr and trigger resets vir RESET_REQ CSR.
 Alert and CPU dump info is randomized and checked on resets.
 
-The test sequences reside in [`hw/top_earlgrey/ip_autogen/rstmgr/dv/env/seq_lib`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/seq_lib).
+The test sequences reside in [`hw/top_earlgrey/ip_autogen/rstmgr/dv/env/seq_lib`](./env/seq_lib).
 All test sequences are extended from `rstmgr_base_vseq`, which is extended from `cip_base_vseq` and serves as a starting point.
 It provides commonly used handles, variables, functions and tasks that the test sequences can simple use / call.
 Some of the most commonly used tasks / functions are as follows:
@@ -90,19 +90,19 @@ The latter are described in the testplan.
 * TLUL assertions: The `tb/rstmgr_bind.sv` file binds the `tlul_assert` [assertions](../../../../ip/tlul/doc/TlulProtocolChecker.md) to the IP to ensure TileLink interface protocol compliance.
 * Unknown checks on DUT outputs: The RTL has assertions to ensure all outputs are initialized to known values after coming out of reset.
 * Response to pwrmgr's `rst_lc_req` and `rst_sys_req` inputs: these trigger transitions in `rst_lc_src_n` and `rst_sys_rst_n` outputs.
-  Checked via SVAs in [`hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv).
+  Checked via SVAs in [`hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv`](../../../../dv/sv/mgr_lib/pwrmgr_rstmgr_sva_if.sv).
 * Response to `cpu_i.ndmreset_req` input: after it is asserted, rstmgr's `rst_sys_src_n` should go active.
-  Checked via SVA in [`hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv).
+  Checked via SVA in [`hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv`](../../../../dv/sv/mgr_lib/pwrmgr_rstmgr_sva_if.sv).
 * Resets cascade hierarchically per [Reset Topology](../doc/theory_of_operation.md#reset-topology).
-  Checked via SVA in [`hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv).
+  Checked via SVA in [`hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](./sva/rstmgr_cascading_sva_if.sv).
 * POR must be active for at least 32 consecutive cycles before going inactive before output resets go inactive.
-  Checked via SVA in [`hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv).
+  Checked via SVA in [`hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](./sva/rstmgr_cascading_sva_if.sv).
 * The scan reset `scan_rst_ni` qualified by `scanmode_i` triggers all cascaded resets that `por_n_i` does.
-  Checked via SVA in [`hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv).
+  Checked via SVA in [`hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](./sva/rstmgr_cascading_sva_if.sv).
 * Software resets to peripherals also cascade hierarchically.
-  Checked via SVA in [`hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv).
+  Checked via SVA in [`hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv`](./sva/rstmgr_sw_rst_sva_if.sv).
 * The output `rst_en_o` for alert_handler tracks their corresponding resets.
-  Checked via SVA in both [`hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv) and [`hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv).
+  Checked via SVA in both [`hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](./sva/rstmgr_cascading_sva_if.sv) and [`hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv`](./sva/rstmgr_sw_rst_sva_if.sv).
 * The `alert` and `cpu_info_attr` indicate the number of 32-bit words needed to capture their inputs.
   Checked via SVA in `hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_attrs_sva_if.sv`.
 

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_cnsty_chk.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_cnsty_chk.sv
@@ -68,8 +68,6 @@ module rstmgr_cnsty_chk
     // 2-flop synchronizer (see u_rst_sync in rstmgr_leaf_rst) which is clocked using the same
     // clock (clk_io_div4_i). This means child_rst_asserted always de-asserts after
     // parent_rst_asserted unless we are under attack.
-    //
-    // For details, refer to https://github.com/lowRISC/opentitan/issues/27659 .
     .EnablePrimCdcRand(0)
   ) u_parent_sync (
     .clk_i,

--- a/hw/top_earlgrey/lint/chip_earlgrey_asic.waiver
+++ b/hw/top_earlgrey/lint/chip_earlgrey_asic.waiver
@@ -145,7 +145,6 @@ waive -rules {RESET_MUX} -location {usb_clk.sv} \
       -regexp {Asynchronous reset 'rst_n' is driven by a multiplexer here, used as a reset 'rst_ni' at prim_flop.sv} \
       -comment "This is reset generation logic, hence reset muxes are allowed."
 
-# See https://github.com/lowRISC/opentitan/issues/15674
 waive -rules {LHS_TOO_SHORT} -location {aes_prng_masking.sv} \
       -regexp {Bitlength mismatch between 'unused_assert_static_lint_error' length 1 and 'AesSecAllowForcingMasksNonDefault'\(1'b1\)' length 2} \
-      -comment "We want to be able to switch off the masking inside AES, see https://github.com/lowRISC/opentitan/issues/14240."
+      -comment "We want to be able to switch off the masking inside AES."

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/data/clkmgr_sec_cm_testplan.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/data/clkmgr_sec_cm_testplan.hjson
@@ -63,8 +63,7 @@
             Verify the countermeasure(s) MEAS.CONFIG.SHADOW.
 
             This is covered by shadow_reg_errors_tests
-            (https://github.com/lowRISC/opentitan/blob/master/
-            hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson)
+            ($REPO_TOP/hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson)
             '''
       stage: V2S
       tests: ["clkmgr_shadow_reg_errors"]

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/sva/clkmgr_extclk_sva_if.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/sva/clkmgr_extclk_sva_if.sv
@@ -5,7 +5,7 @@
 // This contains SVA assertions to check the external clock bypass control outputs.
 //
 // Notice when a condition fails we allow the logic to generate non strict mubi values. Ideally it
-// would generate mubi False: see https://github.com/lowRISC/opentitan/issues/11400.
+// would generate mubi False.
 interface clkmgr_extclk_sva_if
   import prim_mubi_pkg::*, lc_ctrl_pkg::*;
 (

--- a/hw/top_englishbreakfast/ip_autogen/gpio/doc/checklist.md
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/doc/checklist.md
@@ -185,25 +185,20 @@ Testbench     | [FUNCTIONAL_COVERAGE_IMPLEMENTED][]     | Done        |
 Testbench     | [ALL_INTERFACES_EXERCISED][]            | Done        |
 Testbench     | [ALL_ASSERTION_CHECKS_ADDED][]          | Done        |
 Testbench     | [SIM_TB_ENV_COMPLETED][]                | Done        |
-Tests         | [SIM_ALL_TESTS_PASSING][]               | Done        | Resolved: [#680][]
+Tests         | [SIM_ALL_TESTS_PASSING][]               | Done        |
 Tests         | [FPV_ALL_ASSERTIONS_WRITTEN][]          | N/A         |
 Tests         | [FPV_ALL_ASSUMPTIONS_REVIEWED][]        | N/A         |
 Tests         | [SIM_FW_SIMULATED][]                    | N/A         |
 Regression    | [SIM_NIGHTLY_REGRESSION_V2][]           | Done        |
 Coverage      | [SIM_CODE_COVERAGE_V2][]                | Done        |
-Coverage      | [SIM_FUNCTIONAL_COVERAGE_V2][]          | Done        | Resolved: [#807][]
+Coverage      | [SIM_FUNCTIONAL_COVERAGE_V2][]          | Done        |
 Coverage      | [FPV_CODE_COVERAGE_V2][]                | N/A         |
 Coverage      | [FPV_COI_COVERAGE_V2][]                 | N/A         |
 Integration   | [PRE_VERIFIED_SUB_MODULES_V2][]         | N/A         |
 Issues        | [NO_HIGH_PRIORITY_ISSUES_PENDING][]     | Done        |
-Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Done        | [#41][] Not quite related, [#45][] root caused
+Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Done        |
 Review        | [DV_DOC_TESTPLAN_REVIEWED][]            | Done        |
 Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
-
-[#41]: https://github.com/lowRISC/opentitan/issues/41
-[#45]: https://github.com/lowRISC/opentitan/issues/45
-[#680]: https://github.com/lowRISC/opentitan/pull/680
-[#807]: https://github.com/lowRISC/opentitan/pull/807
 
 [DESIGN_DELTAS_CAPTURED_V2]:          ../../../../../doc/contributing/hw/checklist/README.md#design_deltas_captured_v2
 [DV_DOC_COMPLETED]:                   ../../../../../doc/contributing/hw/checklist/README.md#dv_doc_completed
@@ -249,9 +244,9 @@ Review        | [SEC_CM_DV_REVIEWED][]                  | Done        | Waived t
 Documentation | [DESIGN_DELTAS_CAPTURED_V3][]     | N/A         |
 Tests         | [X_PROP_ANALYSIS_COMPLETED][]     | Waived      | Revisit later. Tool setup in progress.
 Tests         | [FPV_ASSERTIONS_PROVEN_AT_V3][]   | N/A         |
-Regression    | [SIM_NIGHTLY_REGRESSION_AT_V3][]  | Done        | Resolved: [#680][]
-Coverage      | [SIM_CODE_COVERAGE_AT_100][]      | Done        | [common_cov_excl.el][], [gpio_cov_excl.el][]
-Coverage      | [SIM_FUNCTIONAL_COVERAGE_AT_100][]| Done        | [#807][]
+Regression    | [SIM_NIGHTLY_REGRESSION_AT_V3][]  | Done        |
+Coverage      | [SIM_CODE_COVERAGE_AT_100][]      | Done        | [common_cov_excl.cfg][], [gpio_cov_excl.el][]
+Coverage      | [SIM_FUNCTIONAL_COVERAGE_AT_100][]| Done        |
 Coverage      | [FPV_CODE_COVERAGE_AT_100][]      | N/A         |
 Coverage      | [FPV_COI_COVERAGE_AT_100][]       | N/A         |
 Code Quality  | [ALL_TODOS_RESOLVED][]            | Done        |
@@ -261,8 +256,6 @@ Integration   | [PRE_VERIFIED_SUB_MODULES_V3][]   | N/A         |
 Issues        | [NO_ISSUES_PENDING][]             | Done        |
 Review        | Reviewer(s)                       | Done        | @eunchan @sriyerg @sjgitty
 Review        | Signoff date                      | Done        | 2019-11-04
-
-[#807]: https://github.com/lowRISC/opentitan/pull/807
 
 [DESIGN_DELTAS_CAPTURED_V3]:     ../../../../../doc/contributing/hw/checklist/README.md#design_deltas_captured_v3
 [X_PROP_ANALYSIS_COMPLETED]:     ../../../../../doc/contributing/hw/checklist/README.md#x_prop_analysis_completed
@@ -278,5 +271,5 @@ Review        | Signoff date                      | Done        | 2019-11-04
 [PRE_VERIFIED_SUB_MODULES_V3]:   ../../../../../doc/contributing/hw/checklist/README.md#pre_verified_sub_modules_v3
 [NO_ISSUES_PENDING]:             ../../../../../doc/contributing/hw/checklist/README.md#no_issues_pending
 
-[common_cov_excl.el]:https://github.com/lowRISC/opentitan/blob/9dff09b6c57f4962d67f5f64f8e69ac9bea6885c/hw/dv/tools/vcs/common_cov_excl.el
-[gpio_cov_excl.el]:  https://github.com/lowRISC/opentitan/blob/39aaeefdb43661b065c29ceab2efc1065aebf6dd/hw/ip/gpio/dv/cov/gpio_cov_excl.el
+[common_cov_excl.cfg]: ../../../../dv/tools/vcs/common_cov_excl.cfg
+[gpio_cov_excl.el]:  ../dv/cov/gpio_cov_excl.el

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
@@ -110,8 +110,7 @@
       desc: '''Verify the countermeasure(s) ESC_RX.CLK.LOCAL_ESC.
 
             This is triggered by common cm primitives (SecCmPrimCount).
-            (https://github.com/lowRISC/opentitan/blob/master
-            /hw/dv/sv/cip_lib/doc/index.md#security-verification
+            ($REPO_TOP/hw/dv/sv/cip_lib/doc/README.md#security-verification
             -for-common-countermeasure-primitives)
 
             **Check**:
@@ -126,8 +125,7 @@
       name: sec_cm_fsm_sparse
       desc: '''Verify the countermeasure(s) FSM.SPARSE.
             This is triggered by common cm primitives (SecCmPrimSparseFsmFlop).
-            (https://github.com/lowRISC/opentitan/blob/master
-            /hw/dv/sv/cip_lib/doc/index.md#security-verification
+            ($REPO_TOP/hw/dv/sv/cip_lib/doc/README.md#security-verification
             -for-common-countermeasure-primitives)
             '''
       stage: V2S

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/README.md
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/README.md
@@ -22,12 +22,12 @@ PWRMGR testbench has been constructed based on the [CIP testbench architecture](
 ![Block diagram](./doc/tb.svg)
 
 ### Top level testbench
-Top level testbench is located at [`hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/tb.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/tb.sv).
-It instantiates the PWRMGR DUT module [`hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr.sv).
+Top level testbench is located at [`hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/tb.sv`](./tb.sv).
+It instantiates the PWRMGR DUT module [`hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr.sv`](../rtl/pwrmgr.sv).
 In addition, it instantiates the following interfaces, connects them to the DUT and sets their handle into `uvm_config_db`:
 * [Clock and reset interface](../../../../dv/sv/common_ifs/README.md)
 * [TileLink host interface](../../../../dv/sv/tl_agent/README.md)
-* PWRMGR interface [`hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv).
+* PWRMGR interface [`hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv`](./env/pwrmgr_if.sv).
 * Interrupts ([`pins_if`](../../../../dv/sv/common_ifs/README.md))
 * Alerts ([`alert_esc_if`](../../../../dv/sv/alert_esc_agent/README.md))
 
@@ -38,7 +38,7 @@ The following utilities provide generic helper tasks and functions to perform ac
 
 ### Global types & methods
 All common types and methods defined at the package level can be found in
-[`pwrmgr_env_pkg`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_env_pkg.sv).
+[`pwrmgr_env_pkg`](./env/pwrmgr_env_pkg.sv).
 Some of them in use are:
 ```systemverilog
   typedef enum int {
@@ -75,7 +75,7 @@ It can be created manually by invoking [`regtool`](../../../../../util/reggen/do
 ### Stimulus strategy
 The sequences are closely related to the testplan's testpoints.
 Testpoints and coverage are described in more detail in the [testplan](#testplan).
-All test sequences reside in [`hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib), and extend `pwrmgr_base_vseq`.
+All test sequences reside in [`hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib`](./env/seq_lib), and extend `pwrmgr_base_vseq`.
 The `pwrmgr_base_vseq` virtual sequence is extended from `cip_base_vseq` and serves as a starting point.
 It provides commonly used handles, variables, functions and tasks used by the test sequences.
 Some of the most commonly used tasks and functions are as follows:
@@ -153,7 +153,7 @@ See also the test plan for specific ways these are driven to trigger different t
 - Outputs `core_clk_en`, `io_clk_en`, and `usb_clk_en` reset low, and go high prior to the slow fsm requesting the fast fsm to wakeup.
   Notice the usb clock can be programmed to stay low on wakeup via the `control` CSR.
   These clock enables are cleared on reset, and should match their corresponding enables in the `control` CSR on low power transitions.
-  These clock enables are checked via SVAs in [`hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv).
+  These clock enables are checked via SVAs in [`hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv`](./sva/pwrmgr_clock_enables_sva_if.sv).
   When slow fsm transitions to `SlowPwrStateReqPwrUp` the clock enables should be on (except usb should match `control.usb_clk_en_active`).
   When slow fsm transitions to `SlowPwrStatePwrClampOn` the clock enables should match their bits in the `control` CSR.
 - Inputs `core_clk_val`, `io_clk_val`, and `usb_clk_val` track the corresponding enables.
@@ -161,7 +161,7 @@ See also the test plan for specific ways these are driven to trigger different t
   Slow fsm waits for them to go high prior to requesting fast fsm wakeup.
   Lack of a high transition when needed is detected via timeout.
   Such timeout would be due to the corresponding enables being set incorrectly.
-  These inputs are checked via SVAs in [`hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_ast_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_ast_sva_if.sv).
+  These inputs are checked via SVAs in [`hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_ast_sva_if.sv`](./sva/pwrmgr_ast_sva_if.sv).
 - Output `main_pd_n` should go high when slow fsm transitions to `SlowPwrStateMainPowerOn`, and should match `control.main_pd_n` CSR when slow fsm transitions to `SlowPwrStateMainPowerOff`.
 - Input `main_pok` should turn on for the slow fsm to start power up sequence.
   This is also driven by `slow_responder`, which turn this off in response to `main_pd_n` going low, and turn it back on after a few random slow clock cycles from `main_pd_n` going high.
@@ -226,7 +226,7 @@ There are a number of wakeup and reset requests.
 They are driven by sequences as they need to.
 
 #### Assertions
-The [`hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv) module binds a few modules containing assertions to the IP as follows:
+The [`hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv`](./sva/pwrmgr_bind.sv) module binds a few modules containing assertions to the IP as follows:
 * TLUL assertions: the `tlul_assert` [assertions](../../../../ip/tlul/doc/TlulProtocolChecker.md) ensures TileLink interface protocol compliance.
 * Clock enables assertions:
   The `pwrmgr_clock_enables_sva_if` module contains assertions checking that the various clk_en outputs correspond to the settings in the `control` CSR.

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/README.md
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/README.md
@@ -16,12 +16,12 @@ RSTMGR testbench has been constructed based on the [CIP testbench architecture](
 
 ![Block diagram](./doc/tb.svg)
 
-The top level testbench is located at [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/tb.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/tb.sv).
-It instantiates the RSTMGR DUT module [`hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr.sv).
+The top level testbench is located at [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/tb.sv`](./tb.sv).
+It instantiates the RSTMGR DUT module [`hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr.sv`](../rtl/rstmgr.sv).
 In addition, it instantiates the following interfaces, connects them to the DUT and sets their handle into `uvm_config_db`:
 * [Clock and reset interface](../../../../dv/sv/common_ifs/README.md)
 * [TileLink host interface](../../../../dv/sv/tl_agent/README.md)
-* RSTMGR interface [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_if.sv)
+* RSTMGR interface [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_if.sv`](./env/rstmgr_if.sv)
 * Alerts ([`alert_esc_if`](../../../../dv/sv/alert_esc_agent/README.md))
 
 The following utilities provide generic helper tasks and functions to perform activities that are common across the project:
@@ -56,7 +56,7 @@ This is consistent with this IP being in charge of all derived resets in the chi
 Besides the POR resets above, the test sequences mostly assert various reset requests from pwrmgr and trigger resets vir RESET_REQ CSR.
 Alert and CPU dump info is randomized and checked on resets.
 
-The test sequences reside in [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/seq_lib`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/seq_lib).
+The test sequences reside in [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/seq_lib`](./env/seq_lib).
 All test sequences are extended from `rstmgr_base_vseq`, which is extended from `cip_base_vseq` and serves as a starting point.
 It provides commonly used handles, variables, functions and tasks that the test sequences can simple use / call.
 Some of the most commonly used tasks / functions are as follows:
@@ -90,19 +90,19 @@ The latter are described in the testplan.
 * TLUL assertions: The `tb/rstmgr_bind.sv` file binds the `tlul_assert` [assertions](../../../../ip/tlul/doc/TlulProtocolChecker.md) to the IP to ensure TileLink interface protocol compliance.
 * Unknown checks on DUT outputs: The RTL has assertions to ensure all outputs are initialized to known values after coming out of reset.
 * Response to pwrmgr's `rst_lc_req` and `rst_sys_req` inputs: these trigger transitions in `rst_lc_src_n` and `rst_sys_rst_n` outputs.
-  Checked via SVAs in [`hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv).
+  Checked via SVAs in [`hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv`](../../../../dv/sv/mgr_lib/pwrmgr_rstmgr_sva_if.sv).
 * Response to `cpu_i.ndmreset_req` input: after it is asserted, rstmgr's `rst_sys_src_n` should go active.
-  Checked via SVA in [`hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv).
+  Checked via SVA in [`hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv`](../../../../dv/sv/mgr_lib/pwrmgr_rstmgr_sva_if.sv).
 * Resets cascade hierarchically per [Reset Topology](../doc/theory_of_operation.md#reset-topology).
-  Checked via SVA in [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv).
+  Checked via SVA in [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](./sva/rstmgr_cascading_sva_if.sv).
 * POR must be active for at least 32 consecutive cycles before going inactive before output resets go inactive.
-  Checked via SVA in [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv).
+  Checked via SVA in [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](./sva/rstmgr_cascading_sva_if.sv).
 * The scan reset `scan_rst_ni` qualified by `scanmode_i` triggers all cascaded resets that `por_n_i` does.
-  Checked via SVA in [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv).
+  Checked via SVA in [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](./sva/rstmgr_cascading_sva_if.sv).
 * Software resets to peripherals also cascade hierarchically.
-  Checked via SVA in [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv).
+  Checked via SVA in [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv`](./sva/rstmgr_sw_rst_sva_if.sv).
 * The output `rst_en_o` for alert_handler tracks their corresponding resets.
-  Checked via SVA in both [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv) and [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv).
+  Checked via SVA in both [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv`](./sva/rstmgr_cascading_sva_if.sv) and [`hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv`](./sva/rstmgr_sw_rst_sva_if.sv).
 * The `alert` and `cpu_info_attr` indicate the number of 32-bit words needed to capture their inputs.
   Checked via SVA in `hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_attrs_sva_if.sv`.
 

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_cnsty_chk.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_cnsty_chk.sv
@@ -68,8 +68,6 @@ module rstmgr_cnsty_chk
     // 2-flop synchronizer (see u_rst_sync in rstmgr_leaf_rst) which is clocked using the same
     // clock (clk_io_div4_i). This means child_rst_asserted always de-asserts after
     // parent_rst_asserted unless we are under attack.
-    //
-    // For details, refer to https://github.com/lowRISC/opentitan/issues/27659 .
     .EnablePrimCdcRand(0)
   ) u_parent_sync (
     .clk_i,

--- a/sw/device/lib/crypto/drivers/acc.c
+++ b/sw/device/lib/crypto/drivers/acc.c
@@ -41,7 +41,7 @@ enum {
    * Although some parts of the ERR_BITS register are marked reserved, the ACC
    * documentation explicitly guarantees that ERR_BITS is zero for a successful
    * execution:
-   *   https://opentitan.org/book/hw/ip/acc/doc/theory_of_operation.html#software-execution-design-details
+   *   hw/ip/acc/doc/theory_of_operation.md#software-execution-design-details
    */
   kAccErrBitsNoError = 0,
 };
@@ -99,7 +99,7 @@ static status_t check_offset_len(uint32_t offset_bytes, size_t num_words,
  * Update a checksum value with a given DMEM write.
  *
  * Calculates the checksum stream according to:
- * https://opentitan.org/book/hw/ip/acc/doc/theory_of_operation.html#memory-load-integrity
+ * hw/ip/acc/doc/theory_of_operation.md#memory-load-integrity
  *
  * This means each write is a 48b value, where the most significant two bytes
  * indicate the location and the least significant four bytes are the 32-bit

--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -445,7 +445,7 @@ static status_t csrng_send_app_cmd(uint32_t base_address,
   }
 
   // Build and write application command header. For details see
-  // https://docs.opentitan.org/hw/ip/csrng/doc/#command-header
+  // hw/ip/csrng/doc/theory_of_operation.md#command-header
   uint32_t cmd_reg = 0;
   switch (launder32(cmd.id)) {
     case kEntropyDrbgOpInstantiate:

--- a/sw/device/lib/crypto/drivers/entropy_kat.c
+++ b/sw/device/lib/crypto/drivers/entropy_kat.c
@@ -92,7 +92,7 @@ static void entropy_csrng_internal_state_get(
   uint32_t flags = abs_mmio_read32(kBase + CSRNG_INT_STATE_VAL_REG_OFFSET);
 
   // The following bit indexes are defined in
-  // https://opentitan.org/book/hw/ip/csrng/doc/theory_of_operation.html#working-state-values
+  // hw/ip/csrng/doc/theory_of_operation.md#working-state-values
   state->instantiated = bitfield_bit32_read(flags, /*bit_index=*/0u);
   state->fips_compliance = bitfield_bit32_read(flags, /*bit_index=*/1u);
 }

--- a/sw/device/lib/dif/dif_aes.c
+++ b/sw/device/lib/dif/dif_aes.c
@@ -12,7 +12,7 @@
 #include "hw/top/aes_regs.h"  // Generated.
 
 /*
- * From: https://opentitan.org/book/hw/ip/aes/doc/registers.html,
+ * From: hw/ip/aes/doc/registers.md,
  * aes.CTRL.
  */
 

--- a/sw/device/lib/dif/dif_aes.h
+++ b/sw/device/lib/dif/dif_aes.h
@@ -43,7 +43,7 @@ extern "C" {
  * AES registers must be securely cleared, by calling `dif_aes_end`.
  *
  * Please see the following documentation for further information:
- * https://opentitan.org/book/hw/ip/aes/
+ * hw/ip/aes/
  * https://csrc.nist.gov/csrc/media/publications/fips/197/final/documents/fips-197.pdf
  * https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf
  */

--- a/sw/device/lib/dif/dif_csrng.c
+++ b/sw/device/lib/dif/dif_csrng.c
@@ -326,7 +326,7 @@ dif_result_t dif_csrng_get_internal_state(
       mmio_region_read32(csrng->base_addr, CSRNG_INT_STATE_VAL_REG_OFFSET);
 
   // The following bit indexes are defined in
-  // https://opentitan.org/book/hw/ip/csrng/doc/theory_of_operation.html#working-state-values
+  // hw/ip/csrng/doc/theory_of_operation.md#working-state-values
   state->instantiated = bitfield_bit32_read(flags, /*bit_index=*/0u);
   state->fips_compliance = bitfield_bit32_read(flags, /*bit_index=*/1u);
 

--- a/sw/device/lib/dif/dif_csrng.h
+++ b/sw/device/lib/dif/dif_csrng.h
@@ -60,7 +60,7 @@ extern "C" {
  * - `dif_csrng_get_output_status()`
  *
  * Please see the following documentation for more information:
- * https://opentitan.org/book/hw/ip/csrng/
+ * hw/ip/csrng/
  *
  * Remaining work:
  *

--- a/sw/device/lib/dif/dif_csrng_shared.h
+++ b/sw/device/lib/dif/dif_csrng_shared.h
@@ -27,7 +27,7 @@ enum {
 /**
  * Supported CSRNG application commands.
  * See
- * https://opentitan.org/book/hw/ip/csrng/doc/theory_of_operation.html#command-header
+ * hw/ip/csrng/doc/theory_of_operation.md#command-header
  * for details.
  */
 typedef enum csrng_app_cmd_id {

--- a/sw/device/lib/dif/dif_i2c.c
+++ b/sw/device/lib/dif/dif_i2c.c
@@ -204,7 +204,7 @@ dif_result_t dif_i2c_compute_timing(dif_i2c_timing_config_t timing_config,
   }
 
   // This code follows the algorithm given in
-  // https://opentitan.org/book/hw/ip/i2c/doc/programmers_guide.html#initialization
+  // hw/ip/i2c/doc/programmers_guide.md#initialization
 
   *config = default_timing_for_speed(timing_config.lowest_target_device_speed,
                                      timing_config.clock_period_nanos);

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -57,7 +57,7 @@ extern "C" {
  *
  * Please see the following documentation for more information about the KMAC
  * hardware:
- * https://opentitan.org/book/hw/ip/kmac/
+ * hw/ip/kmac/
  *
  * References:
  * [1] - NIST FIPS 202

--- a/sw/device/lib/testing/hmac_testutils.h
+++ b/sw/device/lib/testing/hmac_testutils.h
@@ -21,7 +21,7 @@
  *
  * All timeouts are calculated against the `kClockFreqCpuHz`, in order
  * to cover a range of targets. Please see:
- * https://opentitan.org/book/hw/ip/hmac/
+ * hw/ip/hmac/
  *
  * 10 cycles are added to the length of the corresponding operation as
  * described in the documentation. This is to cover any potential

--- a/sw/device/lib/testing/i2c_testutils.h
+++ b/sw/device/lib/testing/i2c_testutils.h
@@ -227,7 +227,7 @@ status_t i2c_testutils_read(const dif_i2c_t *i2c, uint8_t addr,
 /**
  * Set the i2c timing parameters based on the desired speed mode.
  * Also see
- * https://opentitan.org/book/hw/ip/i2c/doc/programmers_guide.html#initialization
+ * hw/ip/i2c/doc/programmers_guide.md#initialization
  *
  * @param i2c An I2C DIF handle.
  * @param speed The speed mode.

--- a/sw/device/lib/testing/sysrst_ctrl_testutils.c
+++ b/sw/device/lib/testing/sysrst_ctrl_testutils.c
@@ -12,8 +12,8 @@
 
 void sysrst_ctrl_testutils_setup_dio(dif_pinmux_t *pinmux) {
   // Make sure that the DIO pins EC reset and flash WP are configured correctly
-  // https://opentitan.org/book/hw/ip/sysrst_ctrl/doc/theory_of_operation.html#ec-and-power-on-reset
-  // https://opentitan.org/book/hw/ip/sysrst_ctrl/doc/theory_of_operation.html#flash-write-protect-output
+  // hw/ip/sysrst_ctrl/doc/theory_of_operation.md#ec-and-power-on-reset
+  // hw/ip/sysrst_ctrl/doc/theory_of_operation.md#flash-write-protect-output
   //
   // The documentation says that they should be configured as open drain.
   dif_pinmux_pad_attr_t out_attr;
@@ -46,8 +46,8 @@ void sysrst_ctrl_testutils_release_dio(dif_sysrst_ctrl_t *sysrst_ctrl,
                                        bool release_ec, bool release_flash) {
   // Make sure that the DIO pins EC reset and flash WP are released according to
   // the documentation:
-  // https://opentitan.org/book/hw/ip/sysrst_ctrl/doc/theory_of_operation.html#ec-and-power-on-reset
-  // https://opentitan.org/book/hw/ip/sysrst_ctrl/doc/theory_of_operation.html#flash-write-protect-output
+  // hw/ip/sysrst_ctrl/doc/theory_of_operation.md#ec-and-power-on-reset
+  // hw/ip/sysrst_ctrl/doc/theory_of_operation.md#flash-write-protect-output
   // We also need to disable the output override mecanism (i.e. "release the
   // pin").
   if (release_ec) {

--- a/sw/device/silicon_creator/lib/drivers/kmac.c
+++ b/sw/device/silicon_creator/lib/drivers/kmac.c
@@ -308,7 +308,7 @@ void kmac_shake256_absorb(const uint8_t *in, size_t inlen) {
   // produce entropy requests anyway). Since KMAC will therefore not block on
   // EDN, it is guaranteed to keep processing message blocks. For more details,
   // see the KMAC documentation:
-  // https://opentitan.org/book/hw/ip/kmac/doc/theory_of_operation.html#fifo-depth-and-empty-status
+  // hw/ip/kmac/doc/theory_of_operation.md#fifo-depth-and-empty-status
 
   // Use byte-wide writes until the input pointer is aligned.
   // Note: writes to the KMAC message FIFO are not required to be aligned.
@@ -338,7 +338,7 @@ void kmac_shake256_absorb_words(const uint32_t *in, size_t inlen) {
   // produce entropy requests anyway). Since KMAC will therefore not block on
   // EDN, it is guaranteed to keep processing message blocks. For more details,
   // see the KMAC documentation:
-  // https://opentitan.org/book/hw/ip/kmac/doc/theory_of_operation.html#fifo-depth-and-empty-status
+  // hw/ip/kmac/doc/theory_of_operation.md#fifo-depth-and-empty-status
 
   for (; inlen > 0; --inlen, ++in) {
     abs_mmio_write32(kBase + KMAC_MSG_FIFO_REG_OFFSET, *in);

--- a/sw/device/silicon_owner/tock/kernel/src/main.rs
+++ b/sw/device/silicon_owner/tock/kernel/src/main.rs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Board file for LowRISC OpenTitan RISC-V development platform.
-//!
-//! - <https://opentitan.org/>
+//! Board file for a RISC-V development platform.
 
 #![no_std]
 // Disable this attribute when documenting, as a workaround for

--- a/sw/device/tests/aon_timer_irq_test.c
+++ b/sw/device/tests/aon_timer_irq_test.c
@@ -51,7 +51,7 @@ static volatile uint64_t irq_tick;
  * the `wfi` instruction the best approach then to measure the time elapsed is
  * to use the mtime register, which is basically attached to rv_timer in the
  * opentitan.
- * https://opentitan.org/book/hw/ip/rv_timer/
+ * hw/ip/rv_timer/
  *
  * This is fine due to the test running in a single thread of execution,
  * however, care should be taken in case it changes. OTTF configures the

--- a/sw/device/tests/flash_ctrl_info_access_lc.c
+++ b/sw/device/tests/flash_ctrl_info_access_lc.c
@@ -244,7 +244,7 @@ bool test_main(void) {
 
   // Read lc state and execute info part access test.
   // Life cycle controlled info partition access is summarized in
-  // (https://opentitan.org/book/hw/ip/lc_ctrl/doc/theory_of_operation.html#
+  // (hw/ip/lc_ctrl/doc/theory_of_operation.md#
   // life-cycle-access-control-signals)
   CHECK_DIF_OK(dif_lc_ctrl_get_state(&lc_ctrl, &lc_state));
   CHECK_STATUS_OK(lc_ctrl_testutils_lc_state_log(&lc_state));

--- a/sw/host/opentitanlib/src/test_utils/load_sram_program.rs
+++ b/sw/host/opentitanlib/src/test_utils/load_sram_program.rs
@@ -347,10 +347,10 @@ pub fn load_sram_program(jtag: &mut dyn Jtag, file: &SramProgramFile) -> Result<
 /// defined in "RISC-V External Debug Support Version 0.13.2" [2]. OpenTitan's
 /// (vendored-in) implementation lives in hw/vendor/pulp_riscv_dbg.
 ///
-/// [0]: https://opentitan.org/book/sw/device/silicon_creator/rom/doc/memory_protection.html
+/// [0]: sw/device/silicon_creator/rom/doc/memory_protection.md
 /// [1]: https://github.com/lowRISC/opentitan/issues/14978
 /// [2]: https://riscv.org/wp-content/uploads/2019/03/riscv-debug-release.pdf
-/// [3]: https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/rtl/ibex_pmp_reset_pkg.sv
+/// [3]: hw/top_earlgrey/rtl/ibex_pmp_reset_pkg.sv
 pub fn prepare_epmp(jtag: &mut dyn Jtag) -> Result<()> {
     // Setup ePMP for SRAM execution.
     log::info!("Configure ePMP for SRAM execution.");

--- a/sw/host/ot_hal/src/dif/lc_ctrl.rs
+++ b/sw/host/ot_hal/src/dif/lc_ctrl.rs
@@ -385,7 +385,7 @@ impl LcCtrlReg {
         *self as u32
     }
     /// Converts the register's byte offset into a word offset for use with DMI.
-    /// <https://opentitan.org/book/hw/ip/lc_ctrl/doc/theory_of_operation.html#life-cycle-tap-controller>
+    /// <hw/ip/lc_ctrl/doc/theory_of_operation.md#life-cycle-tap-controller>
     pub fn word_offset(&self) -> u32 {
         const BYTES_PER_WORD: u32 = std::mem::size_of::<u32>() as u32;
         assert_eq!(self.byte_offset() % BYTES_PER_WORD, 0);

--- a/util/dvsim/style.css
+++ b/util/dvsim/style.css
@@ -3,7 +3,7 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-/* CSS for reports.opentitan.org.
+/* CSS for reports.
  * This is referenced by all results published to the reports server for some basic styling.
  */
 

--- a/util/openocd/target/lowrisc-earlgrey-lc.cfg
+++ b/util/openocd/target/lowrisc-earlgrey-lc.cfg
@@ -7,7 +7,7 @@
 # This works because lc_ctrl uses an instance of the RISC-V debug
 # module [0]. Its IRLEN is hardcoded to 5 [1] and its IDCODE is 0x04f5484d [2].
 #
-# [0]: https://opentitan.org/book/hw/ip/lc_ctrl/doc/theory_of_operation.html#life-cycle-tap-controller
+# [0]: hw/ip/lc_ctrl/doc/theory_of_operation.md#life-cycle-tap-controller
 # [1]: See where `dmi_jtag_tap` is created in hw/vendor/pulp_riscv_dbg/src/dmi_jtag.sv
 # [2]: See where `IdcodeValue` for `lc_ctrl` in hw/top_earlgrey/data/top_earlgrey.hjson
 

--- a/util/reggen/countermeasure.py
+++ b/util/reggen/countermeasure.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Sequence, Tuple
 from reggen.lib import check_keys, check_str, check_list
 
 # The documentation of assets and cm_types can be found here
-# https://opentitan.org/book/doc/contributing/hw/comportability/#security-countermeasures
+# doc/contributing/hw/comportability/README.md#security-countermeasures
 # yapf: disable
 CM_ASSETS = [
     'KEY',

--- a/util/reggen/gen_cfg_html.py
+++ b/util/reggen/gen_cfg_html.py
@@ -31,7 +31,7 @@ def gen_kv(outfile: TextIO, key: str, value: str) -> None:
 def gen_cfg_html(cfgs: IpBlock, outfile: TextIO) -> None:
     rnames = cfgs.get_rnames()
 
-    comport_url = "https://opentitan.org/book/doc/contributing/hw/comportability"
+    comport_url = "https://github.com/pavona/pavona/blob/master/doc/contributing/hw/comportability"
     genout(outfile,
            '<p>Referring to the <a href="{url}">Comportable guideline for '
            'peripheral device functionality</a>, the module '

--- a/util/reggen/register.py
+++ b/util/reggen/register.py
@@ -427,7 +427,7 @@ class Register(RegBase):
             go to the staged register). This is useful for software in case
             it lost track of the current phase. See comportability spec for
             more details:
-            https://opentitan.org/book/util/reggen/index.html#shadow-registers
+            util/reggen/README.md#shadow-registers
 
           - There's an RC field (where we'll attach the read-enable signal to
             the subreg's we port)


### PR DESCRIPTION
As this repo is expected to diverge from OpenTitan, references to old external code/issues/docs are no longer relevant.

This PR contains two commits:
* one amending the links to `opentitan.org`
* one amending links to `github.com/lowRISC/opentitan`

For files that are not Markdown files (ie., files not expected to reside in documentation), `$REPO_TOP` was used instead of relative paths to clarify where to find the reference in the repository. Additionally, links to the Pavona repository on GitHub were avoided in favor of relative links because locally regenerated documentation will be more applicable to a copy of the repo than the remote master branch.