### PR TITLE
[verilator] Build verilator in-tree using Bazel

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -5,14 +5,6 @@ name: Prepare environment
 description: Install dependencies and prepare environment needed for OpenTitan
 
 inputs:
-  verilator-version:
-    description: Verilator version to install
-    required: true
-    default: '4.210'
-  verilator-path:
-    description: Path at which to install Veriltator
-    required: true
-    default: /tools/verilator
   verible-version:
     description: Verible version to install
     required: true
@@ -111,18 +103,6 @@ runs:
       shell: bash
       run: |
         uv pip install -r python-requirements.txt --require-hashes
-      working-directory: ${{ inputs.working-directory }}
-
-    - name: Install Verilator
-      run: |
-        VERILATOR_TAR="verilator-v${{ inputs.verilator-version }}.tar.gz"
-        VERILATOR_URL="https://storage.googleapis.com/verilator-builds/${VERILATOR_TAR}"
-        source ci/scripts/utils.sh
-        sudo mkdir -p "${{ inputs.verilator-path }}"
-        retry 5 2 2 curl -sSfL "$VERILATOR_URL" -o "${{ runner.temp }}/${VERILATOR_TAR}"
-        sudo tar -C "${{ inputs.verilator-path }}" -xvzf "${{ runner.temp }}/${VERILATOR_TAR}"
-        echo "${{ inputs.verilator-path }}/v${{ inputs.verilator-version }}/bin" >> "$GITHUB_PATH"
-      shell: bash
       working-directory: ${{ inputs.working-directory }}
 
     - name: Install Verible

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,6 @@ jobs:
         run: |
           python3 --version
           fusesoc --version
-          verilator --version
       - name: ACC ISS test
         run: make -C hw/ip/acc/dv/accsim test
       - name: ACC smoke test

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -354,6 +354,10 @@ use_repo(mlkem_native, "mlkem_native")
 mldsa_native = use_extension("//third_party/mldsa_native:extensions.bzl", "mldsa_native")
 use_repo(mldsa_native, "mldsa_native")
 
+# Verilator
+verilator = use_extension("//third_party/verilator:extensions.bzl", "verilator")
+use_repo(verilator, "verilator")
+
 # Hooks:
 # Extension for linking in externally managed test and provisioning customizations
 # for both secure/non-secure manufacturer domains.

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1082,6 +1082,35 @@
         ]
       }
     },
+    "//third_party/verilator:extensions.bzl%verilator": {
+      "general": {
+        "bzlTransitiveDigest": "/Ke06sSoOXrC7r/N3rtimfCN/ptSCclcl7INQqmF5Xc=",
+        "usagesDigest": "AKoOM1VCby0PmHWIO0B2K3VSzddPxnqOo8SHRkgpbpY=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "verilator": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/verilator/verilator/archive/refs/tags/v5.046.tar.gz"
+              ],
+              "strip_prefix": "verilator-5.046",
+              "build_file": "@@//third_party/verilator:BUILD.verilator.bazel",
+              "sha256": "002bc6d92b203eb8b4612e1d198d8108517d4ec9859e131ef328015352fe6d0c"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "//third_party/wycheproof:extensions.bzl%wycheproof": {
       "general": {
         "bzlTransitiveDigest": "P/4xE9z72PWw4KN3Mzb9nTuKK1qFvLh8BSOcqZ7o2gk=",

--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -10,14 +10,17 @@
 #
 # Keep it sorted.
 autoconf
+bison
 brotli
 build-essential
 cmake
 curl
 dfu-util
 file
+flex
 g++
 git
+help2man
 lcov
 libelf1
 libelf-dev

--- a/hw/check_tool_requirements.core
+++ b/hw/check_tool_requirements.core
@@ -23,11 +23,6 @@ scripts:
     # copyto.
     #filesets:
     #  - files_check_tool_requirements
-  check_tool_requirements_verilator:
-    cmd:
-      - python3
-      - check_tool_requirements.py
-      - 'verilator'
 
 targets:
   default:
@@ -35,5 +30,4 @@ targets:
       - files_check_tool_requirements
     hooks:
       pre_build:
-        - tool_verilator   ? (check_tool_requirements_verilator)
         - tool_veriblelint ? (check_tool_requirements_verible)

--- a/hw/check_tool_requirements.py
+++ b/hw/check_tool_requirements.py
@@ -198,22 +198,6 @@ class ToolReq:
                 .format(actual_version, self.min_version))
 
 
-class VerilatorToolReq(ToolReq):
-    def get_version(self):
-        try:
-            # Note: "verilator" needs to be called through a shell and with all
-            # arguments in a string, as it doesn't have a shebang, but instead
-            # relies on perl magic to parse command line arguments.
-            version_str = subprocess.run('verilator --version', shell=True,
-                                         check=True, stdout=subprocess.PIPE,
-                                         universal_newlines=True)
-        except subprocess.CalledProcessError as err:
-            raise RuntimeError('Unable to call Verilator to check version: {}'
-                               .format(err)) from None
-
-        return version_str.stdout.split(' ')[1].strip()
-
-
 class VeribleToolReq(ToolReq):
     tool_cmd = ['verible-verilog-lint', '--version']
 
@@ -352,7 +336,6 @@ def dict_to_tool_req(path, tool, raw):
         'edalize': EdalizeToolReq,
         'vcs': VcsToolReq,
         'verible': VeribleToolReq,
-        'verilator': VerilatorToolReq,
         'vivado': VivadoToolReq,
         'ninja': NinjaToolReq
     }

--- a/hw/ip/acc/BUILD
+++ b/hw/ip/acc/BUILD
@@ -26,5 +26,63 @@ filegroup(
     ]) + [
         "//hw/ip/acc/data:all_files",
         "//hw/ip/acc/dv/accsim:doc_files",
+        "//hw/ip/acc/dv/memutil:doc_files",
+        "//hw/ip/acc/dv/tracer:doc_files",
+    ],
+)
+
+filegroup(
+    name = "cores",
+    srcs = [
+        "acc.core",
+        "acc_pkg.core",
+    ],
+)
+
+filegroup(
+    name = "sim_cores",
+    srcs = [
+        ":cores",
+        "//hw/ip/acc/dv/memutil:cores",
+        "//hw/ip/acc/dv/model:cores",
+        "//hw/ip/acc/dv/tracer:cores",
+        "//hw/ip/acc/dv/uvm/env/pqc_off_env_pkg:cores",
+        "//hw/ip/acc/dv/verilator:cores",
+    ],
+)
+
+filegroup(
+    name = "sim_lint_files",
+    srcs = [
+        "//hw/ip/acc/dv/tracer:lint_files",
+        "//hw/ip/acc/dv/verilator:lint_files",
+    ],
+)
+
+filegroup(
+    name = "sim_dpi_files",
+    srcs = [
+        "//hw/ip/acc/dv/model:dpi_files",
+    ],
+)
+
+filegroup(
+    name = "sim_rtl_files",
+    srcs = [
+        "//hw/ip/acc/dv/memutil:rtl_files",
+        "//hw/ip/acc/dv/model:rtl_files",
+        "//hw/ip/acc/dv/tracer:rtl_files",
+        "//hw/ip/acc/dv/uvm/env/pqc_off_env_pkg:rtl_files",
+        "//hw/ip/acc/dv/verilator:rtl_files",
+    ],
+)
+
+filegroup(
+    name = "sim_cc_files",
+    srcs = [
+        "//hw/ip/acc/dv/memutil:cc_files",
+        "//hw/ip/acc/dv/model:cc_files",
+        "//hw/ip/acc/dv/tracer:cc_files",
+        "//hw/ip/acc/dv/verilator:cc_files",
     ],
 )

--- a/hw/ip/acc/acc.core
+++ b/hw/ip/acc/acc.core
@@ -107,8 +107,6 @@ targets:
     tools:
       verilator:
         mode: lint-only
-        verilator_options:
-          - "-Wall"
 
   lint-core:
     filesets:
@@ -120,8 +118,6 @@ targets:
     tools:
       verilator:
         mode: lint-only
-        verilator_options:
-          - "-Wall"
 
   syn:
     <<: *default_target

--- a/hw/ip/acc/dv/memutil/BUILD
+++ b/hw/ip/acc/dv/memutil/BUILD
@@ -1,0 +1,35 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+filegroup(
+    name = "cores",
+    srcs = [
+        "acc_memutil.core",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "cc_files",
+    srcs = [
+        "acc_memutil.cc",
+        "acc_memutil.h",
+        "sv_utils.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "doc_files",
+    srcs = [
+        "README.md",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "rtl_files",
+    srcs = ["acc_memutil_pkg.sv"],
+    visibility = ["//visibility:public"],
+)

--- a/hw/ip/acc/dv/model/BUILD
+++ b/hw/ip/acc/dv/model/BUILD
@@ -1,0 +1,43 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "cores",
+    srcs = [
+        "acc_model.core",
+    ],
+)
+
+filegroup(
+    name = "cc_files",
+    srcs = [
+        "acc_model.cc",
+        "acc_model.h",
+        "acc_model_dpi.h",
+        "acc_trace_checker.cc",
+        "acc_trace_checker.h",
+        "acc_trace_entry.cc",
+        "acc_trace_entry.h",
+        "iss_wrapper.cc",
+        "iss_wrapper.h",
+    ],
+)
+
+filegroup(
+    name = "dpi_files",
+    srcs = [
+        "acc_model_dpi.svh",
+    ],
+)
+
+filegroup(
+    name = "rtl_files",
+    srcs = [
+        "acc_core_model.sv",
+        "acc_rf_snooper_if.sv",
+        "acc_stack_snooper_if.sv",
+    ],
+)

--- a/hw/ip/acc/dv/smoke/BUILD
+++ b/hw/ip/acc/dv/smoke/BUILD
@@ -2,7 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//hw/top:defs.bzl", "opentitan_select_top_attr")
 load("//rules:acc.bzl", "acc_binary")
+load("//rules:fusesoc.bzl", "fusesoc_build")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -21,4 +23,36 @@ acc_binary(
     srcs = [
         "smoke_test.s",
     ],
+)
+
+fusesoc_build(
+    name = "verilator_acc",
+    srcs = [
+        "//hw:dpi_files",
+        "//hw:dv_common_files",
+        "//hw:rtl_files",
+        "//hw:verilator_files",
+        "//hw/ip/acc:sim_cc_files",
+        "//hw/ip/acc:sim_cores",
+        "//hw/ip/acc:sim_dpi_files",
+        "//hw/ip/acc:sim_lint_files",
+        "//hw/ip/acc:sim_rtl_files",
+    ],
+    cores = [
+        "//hw:cores",
+    ],
+    data = ["//hw/ip/acc:rtl_files"],
+    make_options = "//hw:make_options",
+    output_groups = {
+        "binary": [
+            "lowrisc_ip_acc_top_sim_0.1/sim-verilator/Vacc_top_sim",
+        ],
+    },
+    systems = ["lowrisc:ip:acc_top_sim"],
+    tags = [
+        "manual",
+        "verilator",
+    ],
+    target = "sim",
+    verilator_options = "//hw:verilator_options",
 )

--- a/hw/ip/acc/dv/smoke/run_smoke.sh
+++ b/hw/ip/acc/dv/smoke/run_smoke.sh
@@ -24,12 +24,10 @@ source "$UTIL_DIR/build_consts.sh"
 
 SMOKE_SRC_DIR=$ROOT_DIR/hw/ip/acc/dv/smoke
 
-(cd $ROOT_DIR;
- fusesoc --cores-root=. run --target=sim --setup --build \
-    --mapping=lowrisc:prim_generic:all:0.1 lowrisc:ip:acc_top_sim \
-    --make_options="-j$(nproc)" || fail "HW Sim build failed")
-
-./bazelisk.sh build //hw/ip/acc/dv/smoke:smoke_test_nondeterministic
+./bazelisk.sh build \
+  //hw/ip/acc/dv/smoke:verilator_acc \
+  //hw/ip/acc/dv/smoke:smoke_test_nondeterministic
+SIM_BINARY=$(./bazelisk.sh cquery --output=files //hw/ip/acc/dv/smoke:verilator_acc)
 SMOKE_ELF=$(./bazelisk.sh cquery --output=files //hw/ip/acc/dv/smoke:smoke_test_nondeterministic | grep "\\.elf$" | head -1)
 
 RUN_LOG=`mktemp`
@@ -37,9 +35,7 @@ readonly RUN_LOG
 # shellcheck disable=SC2064 # The RUN_LOG tempfile path should not change
 trap "rm -rf $RUN_LOG" EXIT
 
-timeout 5s \
-  $ROOT_DIR/build/lowrisc_ip_acc_top_sim_0.1/sim-verilator/Vacc_top_sim \
-  --load-elf=$SMOKE_ELF -t | tee $RUN_LOG
+timeout 5s ${SIM_BINARY} --load-elf=${SMOKE_ELF} -t | tee $RUN_LOG
 
 if [ $? -eq 124 ]; then
   fail "Simulation timeout"

--- a/hw/ip/acc/dv/tracer/BUILD
+++ b/hw/ip/acc/dv/tracer/BUILD
@@ -1,0 +1,45 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "cores",
+    srcs = [
+        "acc_tracer.core",
+    ],
+)
+
+filegroup(
+    name = "lint_files",
+    srcs = [
+        "lint/acc_tracer_waivers.vlt",
+    ],
+)
+
+filegroup(
+    name = "cc_files",
+    srcs = [
+        "cpp/acc_trace_listener.h",
+        "cpp/acc_trace_source.cc",
+        "cpp/acc_trace_source.h",
+        "cpp/log_trace_listener.cc",
+        "cpp/log_trace_listener.h",
+    ],
+)
+
+filegroup(
+    name = "doc_files",
+    srcs = [
+        "README.md",
+    ],
+)
+
+filegroup(
+    name = "rtl_files",
+    srcs = [
+        "rtl/acc_trace_if.sv",
+        "rtl/acc_tracer.sv",
+    ],
+)

--- a/hw/ip/acc/dv/uvm/env/pqc_off_env_pkg/BUILD
+++ b/hw/ip/acc/dv/uvm/env/pqc_off_env_pkg/BUILD
@@ -1,0 +1,19 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+exports_files(["acc_pqc_env_pkg.core"])
+
+filegroup(
+    name = "cores",
+    srcs = [
+        "acc_pqc_env_pkg.core",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "rtl_files",
+    srcs = ["acc_pqc_env_pkg.sv"],
+    visibility = ["//visibility:public"],
+)

--- a/hw/ip/acc/dv/verilator/BUILD
+++ b/hw/ip/acc/dv/verilator/BUILD
@@ -1,0 +1,34 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "cores",
+    srcs = [
+        "acc_top_sim.core",
+    ],
+)
+
+filegroup(
+    name = "cc_files",
+    srcs = [
+        "acc_top_sim.cc",
+    ],
+)
+
+filegroup(
+    name = "lint_files",
+    srcs = [
+        "acc_top_sim_waivers.vlt",
+    ],
+)
+
+filegroup(
+    name = "rtl_files",
+    srcs = [
+        "acc_mock_edn.sv",
+        "acc_top_sim.sv",
+    ],
+)

--- a/hw/ip/acc/dv/verilator/acc_top_sim.core
+++ b/hw/ip/acc/dv/verilator/acc_top_sim.core
@@ -43,7 +43,6 @@ targets:
       verilator:
         mode: lint-only
         verilator_options:
-          - "-Wall"
           # RAM primitives wider than 64bit (required for ECC) fail to build in
           # Verilator without increasing the unroll count (see Verilator#1266)
           - "--unroll-count 72"
@@ -66,9 +65,8 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-std=c++17 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=acc_top_sim"'
+          - '-CFLAGS "-std=c++17 -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=acc_top_sim"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
-          - "-Wall"
           # RAM primitives wider than 64bit (required for ECC) fail to build in
           # Verilator without increasing the unroll count (see Verilator#1266)
           - "--unroll-count 72"

--- a/hw/ip/acc/rtl/acc_controller.sv
+++ b/hw/ip/acc/rtl/acc_controller.sv
@@ -212,6 +212,7 @@ module acc_controller
   logic recoverable_err;
   logic software_err;
   logic non_insn_addr_software_err;
+  /* verilator lint_off UNOPTFLAT */
   logic fatal_err;
   logic internal_fatal_err;
   logic done_complete;

--- a/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/prince_ref.h
+++ b/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/prince_ref.h
@@ -200,8 +200,12 @@ static uint64_t prince_shift_rows(const uint64_t in, int inverse) {
   uint64_t shift_rows_out = 0;
   for (unsigned int i = 0; i < 4; i++) {
     const uint64_t row = in & (row_mask >> (4 * i));
-    const unsigned int shift = inverse ? i * 16 : 64 - i * 16;
-    shift_rows_out |= (row >> shift) | (row << (64 - shift));
+    if (i == 0) {
+      shift_rows_out |= row;
+    } else {
+      const unsigned int shift = inverse ? i * 16 : 64 - i * 16;
+      shift_rows_out |= (row >> shift) | (row << (64 - shift));
+    }
   }
   return shift_rows_out;
 }

--- a/hw/top_darjeeling/chip_darjeeling_verilator.core
+++ b/hw/top_darjeeling/chip_darjeeling_verilator.core
@@ -34,6 +34,7 @@ targets:
         verilator_options:
           # required to support OTP constants
           - "--max-num-width 131072"
+          - "--no-timing"
 
   lint:
     <<: *default_target

--- a/hw/top_earlgrey/chip_earlgrey_verilator.core
+++ b/hw/top_earlgrey/chip_earlgrey_verilator.core
@@ -32,6 +32,10 @@ targets:
     parameters:
       - AST_BYPASS_CLK=true
     toplevel: chip_earlgrey_verilator
+    tools:
+      verilator:
+        verilator_options:
+          - "--no-timing"
 
 
   lint:

--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -88,16 +88,22 @@ def _fusesoc_build_impl(ctx):
         inputs = ctx.files.srcs + ctx.files.cores + ctx.files._fusesoc + [
             cfg_file,
         ],
+        tools = [ctx.executable._verilator] if ctx.attr.target != "synth" else [],
         arguments = [args],
         executable = ctx.executable._fusesoc,
         use_default_shell_env = False,
         env = dicts.add(
             # Verilator build doesn't need nonhermetic environment variables
-            ENV if ctx.attr.target == "synth" else {},
+            ENV if ctx.attr.target == "synth" else {
+                # Contains the `execroot`-relative path for verilator provided
+                # by Bazel. `fusesoc_build.py` converts this into an absolute
+                # path once the working directory is known.
+                "VERILATOR_BINARY": ctx.executable._verilator.path,
+            },
             {
                 "HOME": home_dir,
                 # Obtain the non-hermetic binary path and append Bazel's default PATH.
-                "PATH": BIN_PATHS["vivado" if ctx.attr.target == "synth" else "verilator"] + ":/bin:/usr/bin:/usr/local/bin",
+                "PATH": (BIN_PATHS["vivado"] + ":" if ctx.attr.target == "synth" else "") + "/bin:/usr/bin:/usr/local/bin",
                 "LD_PRELOAD": "/lib/x86_64-linux-gnu/libudev.so.1",
             },
         ),
@@ -135,6 +141,12 @@ fusesoc_build = rule(
         "_fusesoc": attr.label(
             default = "//util:fusesoc_build",
             executable = True,
+            cfg = "exec",
+        ),
+        "_verilator": attr.label(
+            executable = True,
+            default = "//third_party/verilator",
+            doc = "Verilator binary target",
             cfg = "exec",
         ),
     },

--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -85,20 +85,30 @@ def _fusesoc_build_impl(ctx):
     ctx.actions.run(
         mnemonic = "FuseSoC",
         outputs = outputs,
-        inputs = ctx.files.srcs + ctx.files.cores + ctx.files._fusesoc + [
+        inputs = ctx.files.srcs + ctx.files.cores + ctx.files._fusesoc + ctx.files._libcxx + ctx.files._include + [
             cfg_file,
         ],
-        tools = [ctx.executable._verilator] if ctx.attr.target != "synth" else [],
+        tools = ([
+            ctx.executable._verilator,
+            ctx.executable._ar,
+            ctx.executable._cc,
+            ctx.executable._cxx,
+        ]) if ctx.attr.target != "synth" else [],
         arguments = [args],
         executable = ctx.executable._fusesoc,
         use_default_shell_env = False,
         env = dicts.add(
             # Verilator build doesn't need nonhermetic environment variables
             ENV if ctx.attr.target == "synth" else {
-                # Contains the `execroot`-relative path for verilator provided
-                # by Bazel. `fusesoc_build.py` converts this into an absolute
-                # path once the working directory is known.
+                # Contains the `execroot`-relative paths for verilator and C/C++
+                # compiler provided by Bazel. `fusesoc_build.py` converts these
+                # into absolute paths once the working directory is known.
                 "VERILATOR_BINARY": ctx.executable._verilator.path,
+                "VERILATOR_AR": ctx.executable._ar.path,
+                "VERILATOR_CC": ctx.executable._cc.path,
+                "VERILATOR_CXX": ctx.executable._cxx.path,
+                "VERILATOR_LIBCXX": ctx.files._libcxx[0].path,
+                "VERILATOR_INCLUDE": ctx.files._include[0].path,
             },
             {
                 "HOME": home_dir,
@@ -148,6 +158,42 @@ fusesoc_build = rule(
             default = "//third_party/verilator",
             doc = "Verilator binary target",
             cfg = "exec",
+        ),
+        "_ar": attr.label(
+            allow_files = True,
+            executable = True,
+            default = "@llvm_toolchain//:bin/llvm-ar",
+            doc = "Archive target.",
+            cfg = "exec",
+        ),
+        "_cc": attr.label(
+            allow_files = True,
+            executable = True,
+            default = "@llvm_toolchain_llvm//:bin/clang",
+            doc = "C compiler target.",
+            cfg = "exec",
+        ),
+        "_cxx": attr.label(
+            allow_files = True,
+            executable = True,
+            default = "@llvm_toolchain_llvm//:bin/clang++",
+            doc = "C++ compiler target.",
+            cfg = "exec",
+        ),
+        "_libc": attr.label(
+            allow_files = True,
+            default = "@llvm_toolchain_llvm//:lib",
+            doc = "C standard library archive.",
+        ),
+        "_libcxx": attr.label(
+            allow_files = True,
+            default = "@llvm_toolchain_llvm//:lib",
+            doc = "C++ standard library archive.",
+        ),
+        "_include": attr.label(
+            allow_files = True,
+            default = "@llvm_toolchain_llvm//:include",
+            doc = "C/C++ standard library include headers.",
         ),
     },
 )

--- a/rules/nonhermetic.bzl
+++ b/rules/nonhermetic.bzl
@@ -9,7 +9,6 @@ NONHERMETIC_ENV_VARS = [
 
 # Binarys that Bazel rule may depend on from the PATH.
 NONHERMETIC_BINS = [
-    "verilator",
     "vivado",
     "updatemem",
 ]

--- a/third_party/verilator/BUILD
+++ b/third_party/verilator/BUILD
@@ -1,0 +1,40 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
+
+exports_files(["BUILD.verilator.bazel"])
+
+configure_make(
+    name = "build_verilator",
+    # Speed up the build with multiple jobs, but set an upper bound to constrain
+    # memory consumption. Bazel is not aware of foreign builds' resource usage.
+    # See <https://github.com/bazelbuild/rules_foreign_cc/issues/329>.
+    args = [
+        "-j",
+        "`nproc`",
+    ],
+    autoconf = True,
+    configure_in_place = True,
+    lib_source = "@verilator//:all_srcs",
+    out_binaries = [
+        "verilator",
+        "verilator_bin",
+        "verilator_bin_dbg",
+        "verilator_coverage",
+        "verilator_coverage_bin_dbg",
+        "verilator_gantt",
+        "verilator_profcfunc",
+    ],
+    out_data_dirs = ["share"],
+)
+
+# Extract the `verilator` binary from :build_verilator. Although the binary itself
+# is executable, Bazel does not believe it is runnable.
+filegroup(
+    name = "verilator",
+    srcs = [":build_verilator"],
+    output_group = "verilator",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/verilator/BUILD.verilator.bazel
+++ b/third_party/verilator/BUILD.verilator.bazel
@@ -1,0 +1,11 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+exports_files(glob(["**"]))
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/third_party/verilator/extensions.bzl
+++ b/third_party/verilator/extensions.bzl
@@ -1,0 +1,21 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+verilator = module_extension(
+    implementation = lambda _: _verilator_repos(),
+)
+
+def _verilator_repos():
+    VERILATOR_VERSION = "5.046"
+    http_archive(
+        name = "verilator",
+        urls = [
+            "https://github.com/verilator/verilator/archive/refs/tags/v{}.tar.gz".format(VERILATOR_VERSION),
+        ],
+        strip_prefix = "verilator-" + VERILATOR_VERSION,
+        build_file = "@lowrisc_opentitan//third_party/verilator:BUILD.verilator.bazel",
+        sha256 = "002bc6d92b203eb8b4612e1d198d8108517d4ec9859e131ef328015352fe6d0c",
+    )

--- a/util/fusesoc_build.py
+++ b/util/fusesoc_build.py
@@ -18,6 +18,13 @@ if __name__ == "__main__":
     if path_env is not None:
         path_env = ":" + path_env
     path_env = os.path.dirname(sys.executable) + path_env
+
+    # VERILATOR_BINARY` is passed in as a relative path to the Bazel
+    # `execroot`. Convert this to an absolute path in PATH, if present.
+    if "VERILATOR_BINARY" in os.environ:
+        verilator_binary = os.environ["VERILATOR_BINARY"]
+        verilator_dirname = os.path.dirname(os.path.join(os.getcwd(), verilator_binary))
+        path_env += os.pathsep + verilator_dirname
     os.environ["PATH"] = path_env
 
     # Start fusesoc

--- a/util/fusesoc_build.py
+++ b/util/fusesoc_build.py
@@ -7,9 +7,11 @@ is used for generators.
 """
 
 
+import argparse
 import os
 import sys
 from fusesoc.main import main
+from pathlib import Path
 
 if __name__ == "__main__":
     # First, ensure the calling interpreter is on the PATH first, so any
@@ -19,12 +21,72 @@ if __name__ == "__main__":
         path_env = ":" + path_env
     path_env = os.path.dirname(sys.executable) + path_env
 
-    # VERILATOR_BINARY` is passed in as a relative path to the Bazel
+    cwd = os.getcwd()
+    # `VERILATOR_CXX` is passed in as a relative path to the Bazel
+    # `execroot`. Convert this to an absolute path in --make_options, if present.
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--make_options', type=str, default = "")
+    args, others = parser.parse_known_args()
+    make_options = args.make_options
+    # Modify the --make_options to include the `VERILATOR_CXX` path as the
+    # C/C++ compiler.
+    #
+    # Use LLVM libc++ as the C++ standard library, and prevent clang from
+    # searching for the host `libstdc++`.
+    cxxflags = ["-stdlib=libc++"]
+    ldflags = [
+        "-fuse-ld=lld",
+        "-static",
+        "-stdlib=libc++",
+        "-lc++abi",
+        "-lzstd",
+    ]
+    if "VERILATOR_AR" in os.environ:
+        verilator_ar = os.environ["VERILATOR_AR"]
+        verilator_ar_abs = os.path.join(cwd, verilator_ar)
+        make_options += " AR=" + verilator_ar_abs
+    if "VERILATOR_CC" in os.environ:
+        verilator_cc = os.environ["VERILATOR_CC"]
+        verilator_cc_abs = os.path.join(cwd, verilator_cc)
+        make_options += " CC=" + verilator_cc_abs
+    if "VERILATOR_CXX" in os.environ:
+        verilator_cxx = os.environ["VERILATOR_CXX"]
+        verilator_cxx_abs = os.path.join(cwd, verilator_cxx)
+        make_options += " CXX={path} LINK={path}".format(path=verilator_cxx_abs)
+    if "VERILATOR_LIBCXX" in os.environ:
+        verilator_libcxx = os.environ["VERILATOR_LIBCXX"]
+        verilator_libcxx_abs = str(Path(
+            os.path.join(cwd, verilator_libcxx),
+        ).parent)
+        cxxflags += [
+            # Specify library paths for libc++.
+            "-L" + verilator_libcxx_abs,
+        ]
+        ldflags += [
+            "-Wl,-rpath," + verilator_libcxx_abs,
+        ]
+    if "VERILATOR_INCLUDE" in os.environ:
+        # A path to a specific header is passed in. Get the great-grandparent
+        # directory containing all the headers.
+        verilator_include = os.environ["VERILATOR_INCLUDE"]
+        verilator_include_abs = str(Path(
+            os.path.join(cwd, verilator_include),
+        ).parents[3])
+        cxxflags += [
+            # Specify include paths for libc/libc++.
+            "-I" + verilator_include_abs,
+        ]
+    make_options += " CXXFLAGS='{}'".format(" ".join(cxxflags))
+    make_options += " LDFLAGS='{}'".format(" ".join(ldflags))
+
+    # `VERILATOR_BINARY` is passed in as a relative path to the Bazel
     # `execroot`. Convert this to an absolute path in PATH, if present.
     if "VERILATOR_BINARY" in os.environ:
         verilator_binary = os.environ["VERILATOR_BINARY"]
-        verilator_dirname = os.path.dirname(os.path.join(os.getcwd(), verilator_binary))
+        verilator_dirname = os.path.dirname(os.path.join(cwd, verilator_binary))
         path_env += os.pathsep + verilator_dirname
+        # If running verilator, include make options.
+        sys.argv = others + ["--make_options=" + make_options]
     os.environ["PATH"] = path_env
 
     # Start fusesoc


### PR DESCRIPTION
This PR removes the dependency on a nonhermetic verilator installation on the host, replacing it with a Bazel repository dependency in `third_party/verilator`.

The verilator binary can now be run hermetically within the repo using `bazel run @verilator//:verilator`. Test targets using a `sim_verilator` environment automatically use the hermetic target thanks to an update to `rules/fusesoc.bzl`.

This PR also bumps the verilator version from v4.210 to v5.046.

Dependent on #88 