### PR TITLE
[kmac,rtl] Made the ACC connection agnostic to app index

### DIFF
--- a/hw/ip/acc/dv/accsim/sim/kmac.py
+++ b/hw/ip/acc/dv/accsim/sim/kmac.py
@@ -29,9 +29,12 @@ class KmacBlock:
     _STATUS_IDLE = 'IDLE'
     _STATUS_ABSORB = 'ABSORB'
     _STATUS_SQUEEZE = 'SQUEEZE'
+    # The following MODE and STRENGTH values are mapped to their corresponding enums in
+    # `hw/ip/kmac/rtl/kmac_pkg.sv`. This is required to do any hardware simulation that
+    # uses the real KMAC IP and accsim.
     _MODE_SHA3 = 0x0
-    _MODE_SHAKE = 0x1
-    _MODE_CSHAKE = 0x2
+    _MODE_SHAKE = 0x2
+    _MODE_CSHAKE = 0x3
     _STRENGTH_128 = 0x0
     _STRENGTH_224 = 0x1
     _STRENGTH_256 = 0x2

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -215,6 +215,7 @@ module kmac_app
   logic pack_digest_word;
   logic shift_and_pack_digest;
   logic [2:0] digest_word_idx_q, digest_word_idx_d;
+  logic acc_app_data_valid;
 
   // Output length
   logic [OutLenW-1:0] encoded_outlen, encoded_outlen_mask;
@@ -261,9 +262,11 @@ module kmac_app
 
   // Set SHA3 mode and Keccak strength if ACC mode
   always_ff @(posedge clk_i) begin
-    if (app_i[AppConfigDynamic].valid && set_appid) begin
-      dynamic_sha3_mode_q <= sha3_pkg::sha3_mode_e'(app_i[AppConfigDynamic].data[1:0]);
-      dynamic_keccak_strength_q <= sha3_pkg::keccak_strength_e'(app_i[AppConfigDynamic].data[4:2]);
+    if (AppCfg[app_id_d].Mode == AppConfigDynamic) begin
+      if (app_i[app_id_d].valid && set_appid) begin
+        dynamic_sha3_mode_q <= sha3_pkg::sha3_mode_e'(app_i[app_id_d].data[1:0]);
+        dynamic_keccak_strength_q <= sha3_pkg::keccak_strength_e'(app_i[app_id_d].data[4:2]);
+      end
     end
   end
 
@@ -279,10 +282,11 @@ module kmac_app
   end
 
   // Control the word index for XOFs with ACC
-  assign digest_word_idx_d = digest_word_idx_q;
+  assign digest_word_idx_d  = digest_word_idx_q;
+  assign acc_app_data_valid = (AppCfg[app_id_d].Mode == AppConfigDynamic) && app_i[app_id_d].valid;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) digest_word_idx_q <= 3'h0;
-    else if ((app_i[AppConfigDynamic].valid && set_appid) || reset_digest_word) begin
+    else if ((acc_app_data_valid && set_appid) || reset_digest_word) begin
       digest_word_idx_q <= 3'h0;
     end else if (next_digest_word) digest_word_idx_q <= digest_word_idx_d + 3'h1;
   end


### PR DESCRIPTION
Porting PR from https://github.com/zerorisc/expo/pull/216

This PR will fix issues with potential top-level configurations that have multiple `ACC` connections. It replaces some logic in `kmac_app.sv` to act based on the current app mode rather than just the single `ACC` connection. It also updated the hash modes in `kmac.py` model in `ACC` to match the encoding used by verilog packages. This fixes an issue with using `accsim` and a real `KMAC` connection to `ACC`.