### PR TITLE
[spi_host,dv] Work-around for simulator defects and clean up

### DIFF
--- a/hw/dv/sv/spi_agent/spi_if.sv
+++ b/hw/dv/sv/spi_agent/spi_if.sv
@@ -11,7 +11,7 @@ interface spi_if
 );
   // standard spi interface pins
   logic       sck;
-  logic [CSB_WIDTH-1:0] csb;
+  logic [NUM_CSB-1:0] csb;
 
   // spi host drives sio to x when idle. release to z in case the io is used for other peripheral
   bit disconnected;
@@ -71,6 +71,6 @@ interface spi_if
   // check only 1 csb can be active
   initial forever begin
     @(csb);
-    if (en_chk) `DV_CHECK_LE($countones(CSB_WIDTH'(~csb)), 1, , , msg_id)
+    if (en_chk) `DV_CHECK_LE($countones(NUM_CSB'(~csb)), 1, , , msg_id)
   end
 endinterface : spi_if

--- a/hw/dv/sv/spi_agent/spi_monitor.sv
+++ b/hw/dv/sv/spi_agent/spi_monitor.sv
@@ -47,7 +47,12 @@ class spi_monitor extends dv_base_monitor#(
     bit flash_opcode_received;
 
     wait (cfg.en_monitor);
-    wait (&cfg.vif.csb === 0);
+    // It would be simpler to just do `wait (&cfg.vif.csb === 1'b0);` but for some
+    // simulators that wait can be erroneously satisfied even when csb is all 1's.
+    if (&cfg.vif.csb !== 1'b0) begin
+      @cfg.vif.csb;
+      if (&cfg.vif.csb !== 1'b0) return;
+    end
     active_csb = cfg.vif.get_active_csb();
 
     cfg.vif.sck_polarity = cfg.sck_polarity[active_csb];

--- a/hw/ip/spi_host/dv/env/spi_host_env_cov.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env_cov.sv
@@ -109,7 +109,7 @@ class spi_host_env_cov extends cip_base_env_cov #(.CFG_T(spi_host_env_cfg));
       }
     csaat_cp : coverpoint spi_cmd_reg.csaat;
     len_cp : coverpoint spi_cmd_reg.len{
-      bins lenl[5] = {[1:3]};
+      bins lenl[3] = {[1:3]};
       bins lenh[10] = {[4:$]};
       }
     direction_mode_cross: cross  direction_cp, mode_cp;

--- a/hw/ip/spi_host/dv/env/spi_host_env_cov.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env_cov.sv
@@ -28,48 +28,48 @@ class spi_host_env_cov extends cip_base_env_cov #(.CFG_T(spi_host_env_cfg));
   endgroup : rx_fifo_underflow_cg
 
   covergroup config_opts_cg with function sample(spi_host_configopts_t spi_configopts);
-    cpol_cp : coverpoint spi_configopts.cpol{ bins cpol[] = {[0:1]}; }
-    cpha_cp : coverpoint spi_configopts.cpha{ bins cpha[] = {[0:1]}; }
-    fullcyc_cp : coverpoint spi_configopts.fullcyc{
-    bins fullcyc[] = {[0:1]};
+    cpol_cp : coverpoint spi_configopts.cpol { bins cpol[] = {[0:1]}; }
+    cpha_cp : coverpoint spi_configopts.cpha { bins cpha[] = {[0:1]}; }
+    fullcyc_cp : coverpoint spi_configopts.fullcyc {
+      bins fullcyc[] = {[0:1]};
     }
-    csnlead_cp : coverpoint spi_configopts.csnlead{
-    bins csnlead[] = {[0:15]};
+    csnlead_cp : coverpoint spi_configopts.csnlead {
+      bins csnlead[] = {[0:15]};
     }
-    csnidle_cp : coverpoint spi_configopts.csnidle{
-    bins csnidle[] = {[0:15]};
+    csnidle_cp : coverpoint spi_configopts.csnidle {
+      bins csnidle[] = {[0:15]};
     }
-    clkdiv_cp : coverpoint spi_configopts.clkdiv{
-    // (Period) T_sck = 2*(clkdiv+1)*T_core
-    // If clkdiv == 16'h00fe, F_sck = F_core / 254
-    bins clk_div_zero = {0};
-    bins clk_divm_bottom_eight[30] = {[16'h1:16'h00fe]};
-    bins clk_divm_upper_eight[30] = {[16'h00ff:16'hfffe]};
-    bins clk_divm_max = {16'hffff};
+    clkdiv_cp : coverpoint spi_configopts.clkdiv {
+      // (Period) T_sck = 2*(clkdiv+1)*T_core
+      // If clkdiv == 16'h00fe, F_sck = F_core / 254
+      bins clk_div_zero = {0};
+      bins clk_divm_bottom_eight[30] = {[16'h1:16'h00fe]};
+      bins clk_divm_upper_eight[30] = {[16'h00ff:16'hfffe]};
+      bins clk_divm_max = {16'hffff};
     }
-    csntrail_cp : coverpoint spi_configopts.csntrail{
+    csntrail_cp : coverpoint spi_configopts.csntrail {
       bins csntrail[] = {[0:15]};
     }
     cpol_cpha_cross :  cross cpol_cp, cpha_cp;
-    csnlead_csnidle_csntrail_cross: cross csnlead_cp, csnidle_cp, csntrail_cp{
+    csnlead_csnidle_csntrail_cross: cross csnlead_cp, csnidle_cp, csntrail_cp {
       bins csncross = binsof(csnlead_cp) && binsof(csnidle_cp) && binsof(csntrail_cp);
     }
   endgroup
 
   covergroup unaligned_data_cg with function sample(bit [3:0] mask);
-    unaligned_data_cp: coverpoint mask{ bins mask = {[0:15]}; }
+    unaligned_data_cp: coverpoint mask { bins mask = {[0:15]}; }
   endgroup
 
   covergroup duplex_cg with function sample(spi_dir_e  direction);
-    duplex_cp : coverpoint direction{ ignore_bins unsupported_dir = {None}; }
+    duplex_cp : coverpoint direction { ignore_bins unsupported_dir = {None}; }
   endgroup
 
   covergroup control_cg with function sample(spi_host_ctrl_t spi_ctrl_reg, bit active);
-    tx_watermark_cp : coverpoint spi_ctrl_reg.tx_watermark{
+    tx_watermark_cp : coverpoint spi_ctrl_reg.tx_watermark {
       bins lower[10] = {[1:30]};
       bins upper[20] = {[31:SPI_HOST_TX_DEPTH]};
     }
-    rx_watermark_cp : coverpoint spi_ctrl_reg.rx_watermark{
+    rx_watermark_cp : coverpoint spi_ctrl_reg.rx_watermark {
       bins lower[10] = {[1:30]};
       bins upper[20] = {[31:SPI_HOST_RX_DEPTH]};
     }
@@ -106,12 +106,12 @@ class spi_host_env_cov extends cip_base_env_cov #(.CFG_T(spi_host_env_cfg));
     direction_cp : coverpoint spi_cmd_reg.direction;
     mode_cp : coverpoint spi_cmd_reg.mode {
       ignore_bins unsupported_mode = {RsvdSpd};
-      }
+    }
     csaat_cp : coverpoint spi_cmd_reg.csaat;
-    len_cp : coverpoint spi_cmd_reg.len{
+    len_cp : coverpoint spi_cmd_reg.len {
       bins lenl[3] = {[1:3]};
       bins lenh[10] = {[4:$]};
-      }
+    }
     direction_mode_cross: cross  direction_cp, mode_cp;
     csaat_mode_cross: cross csaat_cp, mode_cp;
   endgroup
@@ -157,7 +157,7 @@ class spi_host_env_cov extends cip_base_env_cov #(.CFG_T(spi_host_env_cfg));
 
     csaat_cp: coverpoint spi_cmd_reg.csaat;
 
-    speed_cp : coverpoint spi_cmd_reg.mode{
+    speed_cp : coverpoint spi_cmd_reg.mode {
       ignore_bins unsupported_speed = {RsvdSpd};
     }
     speed_trans_cp : coverpoint spi_cmd_reg.mode {
@@ -165,11 +165,11 @@ class spi_host_env_cov extends cip_base_env_cov #(.CFG_T(spi_host_env_cfg));
       bins Any2Any[] = ([Standard:Quad] => [Standard:Quad]);
     }
     direction_cp: coverpoint spi_cmd_reg.direction;
-    direction_transition_cp: coverpoint spi_cmd_reg.direction{
+    direction_transition_cp: coverpoint spi_cmd_reg.direction {
       // Creates a bin for each of the possible transitions
       bins Any2Any[] = ([None:Bidir] => [None:Bidir]);
     }
-    len_cp: coverpoint spi_cmd_reg.len{
+    len_cp: coverpoint spi_cmd_reg.len {
       bins zero = {0};
       bins one = {1};
       bins middle_range_val = {[2:2**SPI_HOST_COMMAND_LEN_SIZE_BITS - 2]};

--- a/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
@@ -313,7 +313,13 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
       txt = "\n\t byte      actual     expected";
       for (int i=0; i < exp_segment.command_reg.len+1; i++) begin
 
-        wait(&cfg.m_spi_agent_cfg.vif.csb == 0);
+        // It would be simpler to just do `wait (&cfg.vif.csb === 1'b0);` but for some
+        // simulators that wait can be erroneously satisfied even when csb is all 1's.
+        if (&cfg.m_spi_agent_cfg.vif.csb !== 1'b0) begin
+          do
+            @cfg.m_spi_agent_cfg.vif.csb;
+          while (&cfg.m_spi_agent_cfg.vif.csb !== 1'b0);
+        end
         // After the sampling edge the plain_item should've been populated
         cfg.m_spi_agent_cfg.wait_sck_edge(SamplingEdge, cfg.m_spi_agent_cfg.vif.get_active_csb());
 

--- a/hw/ip/spi_host/dv/tb.sv
+++ b/hw/ip/spi_host/dv/tb.sv
@@ -97,16 +97,18 @@ module tb;
 
   // configure spi_if i/o
   assign spi_if.sck = (cio_sck_en_o) ? cio_sck_o : 1'bz;
+  // This iterates over the number of spi data pins.
   for (genvar i = 0; i < 4; i++) begin : gen_tri_state
     pullup (weak1) pd_in_i (si_pulldown[i]);
     pullup (weak1) pd_out_i (so_pulldown[i]);
     assign sio[i]  = (cio_sd_en_o[i]) ? cio_sd_o[i] : 'z;
     assign (highz0, pull1) sio[i] = !cio_sd_en_o[i];
     assign si_pulldown[i] = sio[i];
+  end
 
-    if (i < SPI_HOST_NUM_CS) begin : gen_drive_csb
-      assign spi_if.csb[i] = cio_csb_en_o[i] ? cio_csb_o[i] : 1'b1;
-    end
+  // Connect spi csb.
+  for (genvar i = 0; i < spi_agent_pkg::NUM_CSB; i++) begin : gen_csb
+    assign spi_if.csb[i] = (i < SPI_HOST_NUM_CS) && cio_csb_en_o[i] ? cio_csb_o[i] : 1'b1;
   end
 
   assign interrupts[SpiHostError] = intr_error;


### PR DESCRIPTION
This has 4 commits:
- Fix the size of a bin in command_cg covergroup: this is just to avoid a warning and should have no side-effects since the simulator resized the array as expected
- Fix the csb size: it was sized with the wrong parameter, but won't affect things since this block uses a single external endpoint
- Fix SV format of covergroups, no functional change
- Add workaround for simulator defects: this is a real change in DV. Without it the spi_host_passthrough_mode test was consistently failing