### PR TITLE
[doc] Restore style guides

### DIFF
--- a/doc/contributing/style_guides/README.md
+++ b/doc/contributing/style_guides/README.md
@@ -1,13 +1,10 @@
 # Style Guides
 
-OpenTitan's CI enforces what it can of the following style guides to avoid conflict, toil and confusion.
-However, code reviewers are also responsible for enforcing coding style guidelines and best practices.
-
+- [Verilog Coding Style Guide](./verilog_coding_style.md)
+  - [SystemVerilog Coding Style Guide for Design Verification (DV)](./dv_coding_style.md)
 - [RISC-V Assembly Style Guide](./asm_coding_style.md)
+- [ACC Assembly Style Guide](./acc_style_guide.md)
 - [C and C++ Coding Style Guide](./c_cpp_coding_style.md)
+- [Python Coding Style Guide](./python_coding_style.md)
 - [Hjson Usage and Style Guide](./hjson_usage_style.md)
 - [Markdown Usage and Style Guide](./markdown_usage_style.md)
-- [OTBN Assembly Style Guide](./otbn_style_guide.md)
-- [Python Coding Style Guide](./python_coding_style.md)
-- [Verilog Coding Style Guide](https://github.com/lowRISC/style-guides/blob/master/VerilogCodingStyle.md)
-- [SystemVerilog Coding Style Guide for Design Verification (DV)](https://github.com/lowRISC/style-guides/blob/master/DVCodingStyle.md)

--- a/doc/contributing/style_guides/README.md
+++ b/doc/contributing/style_guides/README.md
@@ -1,1 +1,13 @@
-# TBD
+# Style Guides
+
+OpenTitan's CI enforces what it can of the following style guides to avoid conflict, toil and confusion.
+However, code reviewers are also responsible for enforcing coding style guidelines and best practices.
+
+- [RISC-V Assembly Style Guide](./asm_coding_style.md)
+- [C and C++ Coding Style Guide](./c_cpp_coding_style.md)
+- [Hjson Usage and Style Guide](./hjson_usage_style.md)
+- [Markdown Usage and Style Guide](./markdown_usage_style.md)
+- [OTBN Assembly Style Guide](./otbn_style_guide.md)
+- [Python Coding Style Guide](./python_coding_style.md)
+- [Verilog Coding Style Guide](https://github.com/lowRISC/style-guides/blob/master/VerilogCodingStyle.md)
+- [SystemVerilog Coding Style Guide for Design Verification (DV)](https://github.com/lowRISC/style-guides/blob/master/DVCodingStyle.md)

--- a/doc/contributing/style_guides/acc_style_guide.md
+++ b/doc/contributing/style_guides/acc_style_guide.md
@@ -1,13 +1,13 @@
-# OTBN Assembly Style Guide
+# ACC Assembly Style Guide
 
-Where possible, OTBN assembly should follow the same principles as the [RISC-V assembly style guide](./asm_coding_style.md).
-This guide describes additional OTBN-specific guidelines, and places where OTBN assembly can or should diverge from the RISC-V style guidelines.
+Where possible, ACC assembly should follow the same principles as the [RISC-V assembly style guide](./asm_coding_style.md).
+This guide describes additional ACC-specific guidelines, and places where ACC assembly can or should diverge from the RISC-V style guidelines.
 
 ## General Advice
 
 ### Register Names
 
-There's no ABI, so OTBN registers cannot be referred to by ABI names.
+There's no ABI, so ACC registers cannot be referred to by ABI names.
 
 ### Capitalization
 
@@ -36,19 +36,19 @@ Example:
 
 ### Pseudoinstructions
 
-As in RISC-V, prefer pseudoinstructions (e.g. `ret`, `li`) in OTBN code where they exist.
+As in RISC-V, prefer pseudoinstructions (e.g. `ret`, `li`) in ACC code where they exist.
 However, `loop` and `loopi` instructions require counting the number of instructions in the loop body, which can be tricky for pseudoinstructions that can expand to multiple instructions.
 (For example, `li` can expand to either 1 or 2 instructions depending on the immediate value.)
 Therefore, it is permitted to avoid pseudoinstructions that can expand to multiple instructions within loop bodies.
 
 ### Wrappers and ecall
 
-Generally, OTBN routines should be written so that they finish in `ret`.
+Generally, ACC routines should be written so that they finish in `ret`.
 Use of `ecall` should be restricted to thin wrapper files which serve as an interface for the more substantial assembly files, usually just reading one or two arguments and then calling subroutines from the other files.
 
 ### Comments
 
-The `//` syntax is not currently available for OTBN because it is not supported by `riscv32-unknown-as`.
+The `//` syntax is not currently available for ACC because it is not supported by `riscv32-unknown-as`.
 Use the `/* */` syntax instead.
 
 ### Labels
@@ -58,7 +58,7 @@ Labels should not be indented.
 
 ### Operand Alignment
 
-***Operands should be aligned within blocks of OTBN code.***
+***Operands should be aligned within blocks of ACC code.***
 
 The exact spacing between mnemonic and operand is not important, as long as it is consistent within the block.
 
@@ -82,10 +82,10 @@ Example:
 
 ### Register and flag group clobbering
 
-***Always document which registers and flag groups are clobbered by an OTBN "function", and which flags have meaning.***
+***Always document which registers and flag groups are clobbered by an ACC "function", and which flags have meaning.***
 
-OTBN subroutines should always document the registers and flag groups whose values they overwrite, including those used for output.
-In addition to Doxygen-style `@param[in]` and `@param[out]` notations, OTBN subroutines should also state whether the flags have meaning at the end of the subroutine.
+ACC subroutines should always document the registers and flag groups whose values they overwrite, including those used for output.
+In addition to Doxygen-style `@param[in]` and `@param[out]` notations, ACC subroutines should also state whether the flags have meaning at the end of the subroutine.
 If a subroutine jumps to another subroutine that clobbers additional registers or flag groups, these additional names should be added to the caller's list.
 
 Example:
@@ -144,11 +144,11 @@ Prefer `.word` over alternatives such as `.quad`.
 
 ## Secure Coding for Cryptography
 
-The following guidelines address cryptography-specific concerns for OTBN assembly.
+The following guidelines address cryptography-specific concerns for ACC assembly.
 
 ### Handling secret shares
 
-The following guidelines were determined with the [help of the COCO-Alma tool](https://github.com/lowRISC/opentitan/tree/master/hw/ip/otbn/pre_sca/alma) and help protect against SCA attacks.
+The following guidelines were determined with the [help of the COCO-Alma tool](../../../hw/ip/acc/pre_sca/alma) and help protect against SCA attacks.
 
 **1. Do not overwrite a share with its counterpart share.**
 
@@ -235,7 +235,7 @@ bn.mov  w5, w6
 
 **7. Do not use two shares of the same secret as the sources of the `bn.sel` instruction.**
 
-Due to [blanking limitations](https://github.com/lowRISC/opentitan/blob/ef42c7498534583141e16a6cd5c8df9e4c041bb2/hw/ip/otbn/rtl/otbn_controller.sv#L1018-L1030) of the bn.sel instruction, do not use shares of the same secret as the sources of `bn.sel`.
+Due to [blanking limitations](../../../hw/ip/acc/rtl/acc_controller.sv) of the bn.sel instruction, do not use shares of the same secret as the sources of `bn.sel`.
 This would cause a transient leakage.
 ```
 bn.sel w4, w1, w0, FG0.C
@@ -244,7 +244,7 @@ bn.sel w4, w1, w0, FG0.C
 **8. Clear `ACC` and flags between `bn.mulqacc` instructions which use shares of the same secret.**
 
 It is also necessary to use a dummy instruction to eliminate the transient leakage.
-Be aware there are some [flag blanking limitations](https://github.com/lowRISC/opentitan/blob/82bcfcae473e779a77fdabd789476b479cca0077/hw/ip/otbn/rtl/otbn_alu_bignum.sv#L257-L266) on `bn.mulqacc` instructions.
+Be aware there are some [flag blanking limitations](../../../hw/ip/acc/rtl/acc_alu_bignum.sv) on `bn.mulqacc` instructions.
 Note that only the writeback versions of `bn.mulqacc` (`bn.mulqacc.wo` and `bn.mulqacc.so`) affect flags.
 ```armasm
 /* Leakage (if w0, w1 contain two shares of a secret) */

--- a/doc/contributing/style_guides/asm_coding_style.md
+++ b/doc/contributing/style_guides/asm_coding_style.md
@@ -1,1 +1,362 @@
-# TBD
+# RISC-V Assembly Style Guide
+
+## Basics
+
+### Summary
+
+OpenTitan needs to implement substantial functionality directly in RISC-V assembly.
+This document describes best practices for both assembly `.S` files and inline assembly statements in C and C++.
+It also codifies otherwise unwritten style guidelines in one central location.
+
+This document is not an introduction to RISC-V assembly; for that purpose, see the [RISC-V Assembly Programmer's Manual](https://github.com/riscv-non-isa/riscv-asm-manual/releases).
+
+Assembly is typically very specialized; the following rules do not presume to describe every use-case, so use your best judgment.
+
+This style guide is specialized for R32IMC, the ISA implemented by Ibex.
+As such, no advice is provided for other RISC-V extensions, though this style guide is written such that advice for other extensions could be added without conflicts.
+
+## General Advice
+
+### Register Names
+
+***When referring to a RISC-V register, they must be referred to by their ABI names.***
+
+See the [psABI Reference](https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/712449f8efcf6b3acd9e2a2a7ddfe89486317877/riscv-cc.adoc#register-convention) for a reference to these names.
+
+Example:
+```S
+  // Correct:
+  li a0, 42
+  // Wrong:
+  li x10, 42
+```
+
+This rule can be ignored when the ABI meaning of a register is unimportant, e.g., such as when clobbering all 31 general-purpose registers.
+
+### Pseudoinstructions
+
+***When performing an operation for which a pseudoinstruction exists, that pseudoinstruction must be used.***
+
+Pseudoinstructions make RISC-V's otherwise verbose RISC style more readable; for consistency, these must be used where possible.
+
+Example:
+```S
+  // Correct:
+  sw t0, _my_global, t1
+  // Wrong:
+  la t1, _my_global
+  sw t0, 0(t1)
+
+  // Correct:
+  ret
+  // Wrong:
+  jr ra
+```
+
+### Operation-with-immediate mnemonics
+
+***Do not use aliases for operation-with-immediate instructions, like `add rd, rs, imm`.***
+
+Assemblers usually recognize instructions like `add t0, t1, 5` as an alias for `addi`. These should be avoided, since they are confusing and a potential source of errors.
+
+Example:
+```S
+  // Correct:
+  addi t0, t1, 0xf
+  ori  a0, a0, 0x4
+  // Wrong:
+  add  t0, t1, 0xf
+  or   a0, a0, 0x4
+```
+
+### Loading Addresses
+
+***Always use `la` to load the address of a symbol; always use `li` to load an address stored in a `#define`.***
+
+Some assemblers allow `la` with an immediate expression instead of a symbol, allowing a form of symbol+offset.
+However, support for this behavior is patchy, and the semantics of PIC `la` with immediate are unclear (in PIC mode, `la` should perform a GOT lookup, not a `pc`-relative load).
+
+### Jumping into C
+
+***Jumping into a C function must be done either with a `call` instruction, or, if that function is marked `noreturn`, a `tail` instruction.***
+
+The RISC-V jump instructions take a "link register", which holds the return address (this should always be `zero` or `ra`), and a small `pc`-relative immediate.
+For jumping to a symbol, there are two user-controlled settings: "near" or "far", and "returnable" (i.e., a link register of `zero` or `ra`).
+The mnemonics for these are:
+- `j sym`, for a near non-returnable jump.
+- `jal sym`, for a near returnable jump.
+- `tail sym`, for a far non-returnable jump (i.e., a non-unwinding tail-call).
+- `call sym`, for a far returnable jump (i.e., function calls).
+
+Far jumps are implemented in the assembler by emitting `auipc` instructions as necessary (since the jump-and-link instruction takes only a small immediate).
+Jumps into C should always be treated as far jumps, and as such use the `call` instruction, unless the C function is marked `noreturn`, in which case `tail` can be used.
+
+Example:
+```S
+  call _syscall_start
+
+  tail _crt0
+```
+
+### Control and Status Register (CSR) Names
+
+***CSRs defined in the RISC-V spec must be referred to by those names (like `mstatus`), while custom non-standard ones must be encapsulated in a `#define`.***
+
+Naturally, if a pseudoinstruction exists to read that CSR (like `rdtime`) that one should be used, instead.
+
+`#define`s for CSRs should be prefixed with `CSR_<design>_`, where `<design>` is the name of the design the CSR corresponds to.
+
+Recognized CSR prefixes:
+- `CSR_IBEX_` - A CSR specific to the Ibex core.
+- `CSR_OT_` - A CSR specific to the OpenTitan chip, beyond the Ibex core.
+
+Example:
+```S
+  csrr t0, mstatus
+
+  #define CSR_OT_HMAC_ENABLED ...
+  csrw CSR_OT_HMAC_ENABLED, 0x1
+```
+
+### Load and Store From Pointer in Register
+
+***When loading and storing from a pointer in a register, prefer to use `n(reg)` shorthand.***
+
+In the case that a pointer is being read without an offset, prefer `0(reg)` over `(reg)`.
+
+```S
+  // Correct:
+  lw t3, 8(sp)
+  sb t3, 0(a0)
+  // Wrong:
+  lw t3, sp, 8
+  sb t3, a0
+```
+
+### Compressed Instruction Mnemonics
+
+***Do not use compressed instruction mnemonics.***
+
+While Ibex implements the RISC-V C extension, it is expected that the toolchain will automatically compress instructions where possible.
+
+Of course, this advice should be ignored when it is necessary to prove that a certain block of instructions does not exceed a particular width.
+
+### "Current Point" Label
+
+***Do not use the current point (`.`) label.***
+
+The current point label does not look like a label, and can be easily missed during review.
+
+### Label Names
+
+***Local labels (for control flow) should start with `.L_`.***
+
+This is the convention for private symbols in ELF files.
+After the prefix, labels should be `snake_case` like other symbols.
+
+```S
+.L_my_label:
+  beqz a0, .L_my_label
+```
+
+## `.S` Files
+
+This advice applies specifically to `.S` files, as well as globally-scoped assembly in `.c` and `.cc` files.
+
+While this is already implicit, we only use the `.S` extension for assembly files; not `.s` or `.asm`. Note that `.s` actually means something else; `.S`
+files have the preprocessor run on them; `.s` files do not.
+
+### Indentation
+
+Assembly files must be formatted with all directives indented two spaces, except for labels.
+Comments should be indented as usual.
+
+There is no mandated requirement on aligning instruction operands.
+
+Example:
+```S
+_trap_start:
+  csrr a0, mcause
+  sw x1, 0(sp)
+  sw x2, 4(sp)
+  // ...
+```
+
+### Comments
+
+***Comments must use either the `//` or `/* */` syntaxes.***
+
+Every function-like label which is meant to be called like a function (*especially* `.global`s) should be given a Doxygen-style comment.
+While Doxygen is not suited for assembly, that style should be used for consistency.
+See the [C/C++ style guide](./c_cpp_coding_style.md) for more information.
+
+Comments should be indented to match the line immediately after. For example:
+```S
+  // This comment is correctly indented.
+  call foo
+
+// This one is not.
+  call foo
+```
+
+All other advice for writing comments, as in the C/C++ style guide, also applies.
+
+
+### Declaring a Symbol
+
+***All "top-level" symbols must have the correct preamble and footer of directives.***
+
+To aid the disassembler, every function must follow the following template:
+
+```S
+  /**
+   * Comment describing what my function does
+   */
+  .section .some_section  // Optional if the previous symbol is in this setion.
+  .balign 4
+  .global my_function  // Only for exported symbols.
+  .type my_function, @function
+my_function:
+  // Instructions and stuff.
+  .size my_function, .-my_function
+```
+
+Note that `.global` is not spelled with the legacy `.globl` spelling.
+If the symbol represents a global variable that does not consist of encoded RISC-V instructions, `@function` should be replaced with `@object`, so that the disassembler does not disassemble it as code.
+Thus, interrupt vectors, although not actually functions, are marked with  `@function`.
+
+The first instruction in the function should immediately follow the opening label.
+
+### Register usage
+
+***Register usage in a "function" that diverges from the RISC-V function call ABI must be documented.***
+
+This includes non-standard calling conventions, non-standard clobbers, and other behavior not expected of a well-behaved RISC-V function.
+Non-standard input and output registers should use Doxygen's `param[in] reg` and
+`param[out] reg` annotations, respectively.
+
+Within a function, whether or not it conforms to RISC-V's calling convention, comments should be present to describe the assignment of logical values to registers.
+
+Example:
+```S
+  /**
+   * Compute some stuff, outputing a 96-bit integer.
+   *
+   * @param[out] a0 bits [31:0] of the result.
+   * @param[out] a1 bits [63:32] of the result.
+   * @param[out] a2 bits [95:64] of the result.
+   */
+  .balign 4
+  .global compute_stuff
+  .type compute_stuff, @function
+compute_stuff:
+  // a0 is to be used as an accumulator, which will be returned as-is.
+  li a0, 0xdeadbeef
+  // t0 is a loop variable.
+  li t0, 0x0
+1:
+  // ...
+  bnez t0, 1b
+
+  li   a1, 0xbeefcafe
+  li   a2, 0xcafedead
+  ret
+  .size compute_stuff, .-compute_stuff
+```
+
+### Ending an Instruction Sequence
+
+***Every code path within an assembly file must end in a non-linking jump.***
+
+Assembly should be written such that the program counter can't wander off past the written instructions.
+As such, all assembly should be ended with `ret` (or any of the protection ring returns like `mret`), an infinite `wfi` loop, or an instruction that is guaranteed to trap and not return, like an `exit`-like syscall or `unimp`.
+
+Example:
+```S
+loop_forever:
+  wfi
+  j loop_forever
+```
+
+Functions may end without a terminator instruction if they are intended to fall
+through to the next one, so long as this is explicitly noted in a comment.
+
+### Alignment Directives
+
+***Do not use `.align`; use `.p2align` and `.balign` as the situation requires.***
+
+The exact meaning of `.align` depends on architecture; rather than asking readers to second-guess themselves, use alignment directives with strongly-typed arguments.
+
+Example:
+```S
+  // Correct:
+  .balign 8 // 8-byte aligned.
+  tail _magic_symbol
+
+  // Wrong:
+  .align 8 // Is this 8-byte aligned, or 256-byte aligned?
+  tail _magic_symbol
+```
+
+### Inline Binary Directives
+
+***Always use `.byte`/`.2byte`/`.4byte`/`.8byte` for inline binary data.***
+
+`.word`, `.long`, and friends are confusing, for the same reason `.align` is.
+
+If a sequence of zeroes is required, use `.zero count`, instead.
+
+### The `.extern` Directive
+
+***All symbols are implicitly external unless defined in the current file; there is no need to use the `.extern` directive.***
+
+`.extern` was previously allowed to "bring" symbols into scope, but GNU-flavored assemblers ignore it.
+Because it is not checked, it can bit-rot, and thus provides diminishing value.
+
+## Inline Assembly
+
+This advice applies to function-scope inline assembly in `.c` and `.cc` files.
+For an introduction on this syntax, check out [GCC's documentation](https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html).
+
+### When to Use
+
+***Avoid inline assembly as much as possible, as long as correctness and readability are not impacted.***
+
+Inline assembly is best reserved for when a high-level language cannot express what we need to do, such as expressing complex control flow or talking to the hardware.
+If a compiler intrinsic can achieve the same effect, such as `__builtin_clz()`, then that should be used instead.
+
+> The compiler is *always* smarter than you; only in the rare case where it is not, assembly should be used instead.
+
+### Formatting
+
+Inline assembly statements must conform to the following formatting requirements, which are chosen to closely resemble how Google's clang-format rules format function calls.
+- Neither the `asm` or `__asm__` keyword is specified in C; the former must be used, and should be `#define`d into existence if not supported by the compiler.
+  C++ specifies `asm` to be part of the grammar, and should be used exclusively.
+- There should not be a space after the `asm` qualifiers and the opening parentheses:
+  ```c
+  asm(...);
+  asm volatile(...);
+  ```
+- Single-instruction `asm` statements should be written on one line, if possible:
+  ```c
+  asm volatile("wfi");
+  ```
+- Multiple-instruction `asm` statements should be written with one instruction per line, formatted as follows:
+  ```c
+  asm volatile(
+    "my_label:"
+    "  la   sp, _stack_start;"
+    "  tail _crt0;"
+    ::: "memory");
+  ```
+- The colons separating register constraints should be surrounded with spaces, unless there are no constraints between them, in which case they should be adjacent.
+  ```c
+  asm("..." : "=a0"(foo) :: "memory");
+  ```
+
+### Non-returning `asm`
+
+***Functions with non-returning `asm` must be marked as `noreturn`.***
+
+C and C++ compilers are, in general, not supposed to introspect `asm` blocks, and as such cannot determine that they never return.
+Functions marked as never returning should end in `__builtin_unreachable()`, which the compiler will usually turn into an `unimp`.

--- a/doc/contributing/style_guides/asm_coding_style.md
+++ b/doc/contributing/style_guides/asm_coding_style.md
@@ -4,7 +4,6 @@
 
 ### Summary
 
-OpenTitan needs to implement substantial functionality directly in RISC-V assembly.
 This document describes best practices for both assembly `.S` files and inline assembly statements in C and C++.
 It also codifies otherwise unwritten style guidelines in one central location.
 
@@ -108,7 +107,7 @@ Naturally, if a pseudoinstruction exists to read that CSR (like `rdtime`) that o
 
 Recognized CSR prefixes:
 - `CSR_IBEX_` - A CSR specific to the Ibex core.
-- `CSR_OT_` - A CSR specific to the OpenTitan chip, beyond the Ibex core.
+- `CSR_OT_` - A CSR specific to the chip, beyond the Ibex core.
 
 Example:
 ```S

--- a/doc/contributing/style_guides/c_cpp_coding_style.md
+++ b/doc/contributing/style_guides/c_cpp_coding_style.md
@@ -356,7 +356,7 @@ This rule deviates from the Google C++ style guide to align closer with a typica
 
 ***All symbols in a particular header must share the same unique prefix.***
 
-"Prefix" in this case refers to the identifying string of words, and not the specific type/struct/enum/constant/macro-based capitalization.
+"Prefix" in this case refers to the identifying string of words, and not the specific type/struct/enum/constant/macro-based capitalisation.
 This rule also deviates from the Google C++ style guide, because C does not have namespaces, so we have to use long names to avoid name clashes.
 Symbols that have specific, global meaning imparted by an external script or specification may break this rule.
 For example:
@@ -372,7 +372,7 @@ my_unit_return_t my_unit_init(void);
 ***The names of enumeration constants must be prefixed with the name of their respective enumeration type.***
 
 Again, this is because C does not have namespaces.
-The exact capitalization does not need to match, as enumeration type names have a different capitalization rule to enumeration constants.
+The exact capitalisation does not need to match, as enumeration type names have a different capitalisation rule to enumeration constants.
 For example:
 ```c
 typedef enum my_wonderful_option {
@@ -454,7 +454,7 @@ Functions that we strongly wish to be inlined, and which are part of a public in
 This annotation serves as an indication to the programmer that the function has a low calling overhead, despite being part of a public interface.
 Presence---or lack---of an `inline` annotation does not imply a function will---or will not---be inlined by the compiler.
 
-[C11](#c-version) standardized inline functions, learning from the mistakes in C++ and various nonstandard extensions.
+[C11](#c-version) standardised inline functions, learning from the mistakes in C++ and various nonstandard extensions.
 This means there are many legacy ways to define an inline function in C.
 We have chosen to follow how C11 designed the `inline` keyword.
 
@@ -490,7 +490,7 @@ The compiler is capable of inlining static functions without the `inline` annota
 ### `volatile` Type Qualifier
 
 Do not use `volatile` in production, i.e. non-test, silicon creator code unless you are implementing a library explicitly for this purpose like `sec_mmio`, `abs_mmio`, or `hardened`.
-See [guidance for volatile](../sw/guidance_for_volatile.md) for more details.
+See [guidance for volatile](./guidance_for_volatile.md) for more details.
 When in doubt, please do not hesitate to reach out by creating a GitHub issue (preferably with the "Type:Question" label).
 
 ### Nonstandard Attributes

--- a/doc/contributing/style_guides/c_cpp_coding_style.md
+++ b/doc/contributing/style_guides/c_cpp_coding_style.md
@@ -122,7 +122,7 @@ Example:
 
 ```c
 // TODO: This algorithm should be rewritten to be more efficient.
-// (Bug lowrisc/reponame#27)
+// (Bug pavona/pavona#27)
 ```
 
 ### Included files
@@ -356,7 +356,7 @@ This rule deviates from the Google C++ style guide to align closer with a typica
 
 ***All symbols in a particular header must share the same unique prefix.***
 
-"Prefix" in this case refers to the identifying string of words, and not the specific type/struct/enum/constant/macro-based capitalisation.
+"Prefix" in this case refers to the identifying string of words, and not the specific type/struct/enum/constant/macro-based capitalization.
 This rule also deviates from the Google C++ style guide, because C does not have namespaces, so we have to use long names to avoid name clashes.
 Symbols that have specific, global meaning imparted by an external script or specification may break this rule.
 For example:
@@ -372,7 +372,7 @@ my_unit_return_t my_unit_init(void);
 ***The names of enumeration constants must be prefixed with the name of their respective enumeration type.***
 
 Again, this is because C does not have namespaces.
-The exact capitalisation does not need to match, as enumeration type names have a different capitalisation rule to enumeration constants.
+The exact capitalization does not need to match, as enumeration type names have a different capitalization rule to enumeration constants.
 For example:
 ```c
 typedef enum my_wonderful_option {
@@ -454,7 +454,7 @@ Functions that we strongly wish to be inlined, and which are part of a public in
 This annotation serves as an indication to the programmer that the function has a low calling overhead, despite being part of a public interface.
 Presence---or lack---of an `inline` annotation does not imply a function will---or will not---be inlined by the compiler.
 
-[C11](#c-version) standardised inline functions, learning from the mistakes in C++ and various nonstandard extensions.
+[C11](#c-version) standardized inline functions, learning from the mistakes in C++ and various nonstandard extensions.
 This means there are many legacy ways to define an inline function in C.
 We have chosen to follow how C11 designed the `inline` keyword.
 
@@ -490,7 +490,7 @@ The compiler is capable of inlining static functions without the `inline` annota
 ### `volatile` Type Qualifier
 
 Do not use `volatile` in production, i.e. non-test, silicon creator code unless you are implementing a library explicitly for this purpose like `sec_mmio`, `abs_mmio`, or `hardened`.
-See [guidance for volatile](./guidance_for_volatile.md) for more details.
+See [guidance for volatile](../sw/guidance_for_volatile.md) for more details.
 When in doubt, please do not hesitate to reach out by creating a GitHub issue (preferably with the "Type:Question" label).
 
 ### Nonstandard Attributes

--- a/doc/contributing/style_guides/hjson_usage_style.md
+++ b/doc/contributing/style_guides/hjson_usage_style.md
@@ -74,7 +74,7 @@ Anything enclosed should have two space indentation.
 In most cases, before the opening `{` the file should start with a comment containing the copyright and license details and the SPDX-License-Identifier.
 
 ```hjson {.good}
-// Copyright lowRISC contributors (OpenTitan project).
+// Copyright Your Name/Organization.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {

--- a/doc/contributing/style_guides/hjson_usage_style.md
+++ b/doc/contributing/style_guides/hjson_usage_style.md
@@ -1,1 +1,222 @@
-# TBD
+# Hjson Usage and Style Guide
+
+## Basics
+
+### Summary
+
+Json files are used to provide input data to many of the tools.
+The preference is to use [Hjson](https://hjson.github.io), which is a variation of regular JSON that is easier to write.
+In particular, it allows the quote marks to be left off the key names, it allows a single string to be quoted with triple quote marks and flow over multiple lines (which is often needed in text descriptions) and it allows comments using the # or // style.
+
+This guide covers the enhancements provided by Hjson that are used in the project along with a recommended style.
+As with all style guides the intention is to:
+
+*   promote consistency across projects
+*   promote best practices
+*   increase code sharing and re-use
+
+
+### Terminology Conventions
+
+Unless otherwise noted, the following terminology conventions apply to this style guide:
+
+*   The word ***must*** indicates a mandatory requirement.
+    Similarly, ***do not*** indicates a prohibition.
+    Imperative and declarative statements correspond to ***must***.
+*   The word ***recommended*** indicates that a certain course of action is preferred or is most suitable.
+    Similarly, ***not recommended*** indicates that a course of action is unsuitable, but not prohibited.
+    There may be reasons to use other options, but the implications and reasons for doing so must be fully understood.
+*   The word ***may*** indicates a course of action is permitted and optional.
+*   The word ***can*** indicates a course of action is possible given material, physical, or causal constraints.
+
+### Style Guide Exceptions
+
+***Justify exceptions with a comment.***
+
+No style guide is perfect.
+There are times when the best path to a working design, or for working around a tool issue, is to simply cut the Gordian Knot and create code that is at variance with this style guide.
+It is always okay to deviate from the style guide by necessity, as long as that necessity is clearly justified by a brief comment.
+
+
+## Hjson file format
+
+Hjson is a variation of regular JSON that is easier to write.
+There are parsers in a number of languages and the tools make extensive use of the `hjson` package provided for Python 3.
+A full description can be found on the [Hjson website](https://hjson.github.io), but the main features that make it convenient are that it keeps files cleaner by allowing the quote marks to be left off the key names, it enables long descriptive text by allowing a single string to flow over multiple lines and it allows comments using the # or // style.
+
+For example:
+
+```hjson
+  key1: "value1",
+  // Now a key with a long value
+  key2: '''
+        A long descriptive value2 that can
+        span over multiple lines
+        '''
+```
+
+### Text Format
+
+Where possible, please restrict Hjson text to the ASCII character set to avoid downstream tool issues.
+Unicode may be used when referring to proper names.
+
+### File delimiters and header
+
+***Use `{}` to delimit the file***
+
+***Include a header comment with copyright and license information***
+
+The file must start with a `{` and end with a `}` to be well-formed json.
+In both cases, these should be on a single line and have no indentation.
+Anything enclosed should have two space indentation.
+(Hjson allows these to be omitted but this is not recommended style.)
+
+In most cases, before the opening `{` the file should start with a comment containing the copyright and license details and the SPDX-License-Identifier.
+
+```hjson {.good}
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // details...
+}
+```
+
+In cases where the file may need to be parsed by a standard JSON parser, the comments must be omitted, but the SPDX license information should be provided as a top-level key/value using pure JSON syntax and ignored by any tool.
+
+```json {.good}
+
+{
+  "SPDX-License-Identifier": "Apache-2.0",
+  ...
+}
+```
+
+### Simple key-value entries
+
+***Use unquoted alphanumeric strings for keys***
+
+***Include all values in quote marks***
+
+Single entries are of the form `key: "value"` Keys must be alphanumeric strings and should not be in quotes.
+(Hjson allows this.
+The quotes may be included as an exception to the style guide if there is an expectation that the file needs to be parsed with a more traditional JSON parser.)
+The valid keys for each tool are described in the tool documentation.
+The style is for a simple value to be in quotes (even if it is a number) and the tool should manage any type conversions.
+
+In some cases Hjson allows the quotes to be omitted from values, but this is not recommended because the value string will not be terminated by a comma so there is potential for confusion when multiple key-value pairs are put on the same line.
+For example:
+
+```hjson {.good}
+      // This is recommended usage and will work as expected
+      { name: "fred", tag: "2", desc: "fred has tag 2" }
+```
+
+But:
+
+```hjson {.bad}
+      // This will cause confusion. The value for tag
+      // is the rest of the line after the colon
+      // so desc is not defined and the close } is lost
+      { name: "fred", tag: 2, desc: "fred has tag 2" }
+```
+
+### Groups of entries
+
+***Use two character indentation for items in groups***
+
+Groups of entries are made by enclosing a comma separated list of key/value pairs in {}.
+For example
+
+```hjson {.good}
+    { name:"odd", value:"1", desc:"odd parity"}
+```
+
+In most cases, a group will be too long for a single line, particularly where it has a good descriptive string.
+In that case, the entry should contain one key-value pair per line with a 2 character indent from the opening bracket.
+The closing bracket should not have the extra indentation.
+
+```hjson {.good}
+    {
+      name:"odd",
+      value:"1",
+      desc:"odd parity"
+    }
+```
+
+The first entry in a group may be on the same line as the opening bracket, with a single space.
+
+```hjson
+    { name:"odd",
+      value:"1",
+      desc:"odd parity"
+    }
+```
+
+Unless the group fits on a single line, the closing bracket should not be on the same line as the final item in the group.
+
+```hjson {.bad}
+    { name:"odd",
+      value:"1",
+      desc:"odd parity"}
+```
+
+
+### Lists
+
+***Use two character indentation for items in lists***
+
+A list value is a comma-separated list of entries or groups enclosed in [].
+For example, a list of groups could be presented:
+```hjson
+  registers: [{name:"reg1", desc:"description 1"},
+              {name:"reg2", desc:"description 2"}]
+```
+
+Longer lists and anywhere elements split over multiple lines should use a 2 character indent from the opening bracket.
+The closing bracket should not have the extra indentation.
+
+
+```hjson {.good}
+  registers: [
+    {
+      name:"reg1",
+      desc:"description 1"
+    },
+    {
+      name:"reg2",
+      desc:"description 2"
+    }
+  ]
+```
+
+Hjson allows commas to be omitted when an item that would be terminated with a comma is terminated by the end of a line, and will tolerate extra "trailing" commas.
+There is currently no style-guide rule on this.
+In general, use the comma if it is likely items may be combined on a single line and omit it if it keeps the file cleaner.
+
+
+### Long strings
+
+Long strings are encouraged for descriptive text that will be presented to users.
+They are delimited by three single-quote marks.
+
+The string should be indented to line up under the opening quote marks and the closing quote marks should be on their own line with the same indentation.
+
+```hjson {.good}
+       key: '''
+            A long descriptive value that can
+            span over multiple lines
+            '''
+```
+
+The first line of the string may be on the same line as the opening quotes.
+
+```hjson
+       key: '''A long descriptive value that can
+            span over multiple lines
+            '''
+```
+### Comments
+
+Comments should be used where needed.
+The use of `//` as the comment delimiter is recommended, but `#` may also be used.

--- a/doc/contributing/style_guides/markdown_usage_style.md
+++ b/doc/contributing/style_guides/markdown_usage_style.md
@@ -7,7 +7,7 @@ The main Markdown tool is [mdBook](https://rust-lang.github.io/mdBook/).
 It is normally run as part of the `./util/site/build-docs.sh` script that builds all `mdbook` books as well as run documentation generators such as `doxygen`.
 *See [Contributing to Documentation](../doc/README.md) for more information.*
 
-In OpenTitan, most readers will read the documentation once it has been rendered to HTML on the website or GitHub.
+Many readers will read the documentation once it has been rendered to HTML on the website or GitHub.
 However, it is important that files are pleasant to read in plain text because viewing in the plain text can be more convenient when working in the codebase and when contributing to documentation the plain text form is what has to be read and edited.
 
 ## About this Style Guide
@@ -49,7 +49,7 @@ The Markdown file names should be in snake case and should use the `.md` file ex
 One must only use [CommonMark][] with the exception of the following extensions:
 - [GFM Tables](https://github.github.com/gfm/#tables-extension-)
 - [GFM Task Items](https://github.github.com/gfm/#task-list-items-extension-)
-- [Inline maths and maths blocks](#maths)
+- [Inline math and math blocks](#math)
 
 ## Line length and Whitespace
 
@@ -145,9 +145,9 @@ Waveforms can be included by describing them in [wavejson](https://github.com/wa
 
 [Mermaid](https://mermaid.js.org/) can be used for creating quick diagrams, like the one below, by surround mermaiding markup in a code block with a `mermaid` [info string][].
 
-## Maths
+## Math
 
-Maths can be included inline or within blocks using a single or double `$` respectively.
+Math can be included inline or within blocks using a single or double `$` respectively.
 As a result, the `$` symbol has to be escaped when not wishing to write mathematical notation.
 
 ````md

--- a/doc/contributing/style_guides/markdown_usage_style.md
+++ b/doc/contributing/style_guides/markdown_usage_style.md
@@ -1,1 +1,181 @@
-# TBD
+# Markdown Usage and Style Guide
+
+## Summary
+
+Markdown is used to write most documentation, specifically [Commonmark][] with [minimal extensions](#extensions).
+The main Markdown tool is [mdBook](https://rust-lang.github.io/mdBook/).
+It is normally run as part of the `./util/site/build-docs.sh` script that builds all `mdbook` books as well as run documentation generators such as `doxygen`.
+*See [Contributing to Documentation](../doc/README.md) for more information.*
+
+In OpenTitan, most readers will read the documentation once it has been rendered to HTML on the website or GitHub.
+However, it is important that files are pleasant to read in plain text because viewing in the plain text can be more convenient when working in the codebase and when contributing to documentation the plain text form is what has to be read and edited.
+
+## About this Style Guide
+
+As with all style guides the intention is to:
+
+* Promote consistency across projects.
+* Promote best practices.
+* Increase code sharing and re-use.
+
+### Terminology Conventions
+
+Unless otherwise noted, the following terminology conventions apply to this style guide:
+
+*   The word ***must*** indicates a mandatory requirement.
+    Similarly, ***do not*** indicates a prohibition.
+    Imperative and declarative statements correspond to ***must***.
+*   The word ***recommended*** indicates that a certain course of action is preferred or is most suitable.
+    Similarly, ***not recommended*** indicates that a course of action is unsuitable, but not prohibited.
+    There may be reasons to use other options, but the implications and reasons for doing so must be fully understood.
+*   The word ***may*** indicates a course of action is permitted and optional.
+*   The word ***can*** indicates a course of action is possible given material, physical, or causal constraints.
+
+### Style Guide Exceptions
+
+***Justify exceptions with a comment.***
+
+No style guide is perfect.
+There are times when the best path to a working design, or for working around a tool issue, is to simply cut the Gordian Knot and create code that is at variance with this style guide.
+It is always okay to deviate from the style guide by necessity, as long as that necessity is clearly justified by a brief comment.
+
+
+## Filename
+
+The Markdown file names should be in snake case and should use the `.md` file extension.
+
+## Extensions
+
+One must only use [CommonMark][] with the exception of the following extensions:
+- [GFM Tables](https://github.github.com/gfm/#tables-extension-)
+- [GFM Task Items](https://github.github.com/gfm/#task-list-items-extension-)
+- [Inline maths and maths blocks](#maths)
+
+## Line length and Whitespace
+
+Files must have exactly one sentence per line, with no line breaks in the middle of a sentence.
+This way change reviews will highlight only those sentences which are modified.
+Though the long line lengths make the files slightly less convenient to read from the command-line, this greatly simplifies the review process.
+When reviewing Markdown changes, every altered sentence will be included in its entirety in the file diff.
+
+Markdown files must contain no trailing white space.
+As a result, two or more spaces must not be used for [hard line breaks][].
+Instead, a double new line is recommended.
+[Backslash hard breaks][] can also be used.
+
+## HTML
+
+Do not use inline HTML within markdown documents.
+Although it offers a lot of flexibility, this flexibility is hard to handle.
+- It is possible to break the website
+- Markdown renderers often support different subsets of HTML.
+- The use of HTML restricts the ease at which documentation could be converted to other forms in the future, such as PDF.
+
+Reaching for HTML may suggest that:
+- You need to split the concepts into more smaller parts that can be expressed in markdown syntax.
+- The concept would be better explained in an svg diagram.
+
+*The one exception to this is [comments](#comments).*
+
+## Links
+
+The [GFM autolinks extention][] is not used so links should be flanked by `<` and `>` characters.
+
+One must not use [shortcut reference link][]s, but instead use [collapsed reference link][]s.
+This is because it can be ambiguous whether [shortcut reference link][] are meant to be links or not.
+Consequently, linters and other tool, such as [marksman](https://github.com/artempyanykh/marksman), cannot warn you of referencing errors.
+*Note: [link labels are case insensitive](https://spec.commonmark.org/0.30/#example-554).*
+
+Example of reference syntaxes:
+
+````md
+Don't use shortcut references like [this].
+Instead use collapsed references like [this][].
+[These][this] full reference links are fine as well of course.
+
+[this]: https://example.com
+````
+
+## Headings and Sections
+
+Only [ATX headings][] must be used.
+Do not use [Setext headings][] for the following reasons.
+- Their depth isn't as immediately obvious.
+- They only go to a maximum depth of 2.
+- They take longer to type and maintain in a nice manner.
+
+Headings and sections are given ID tags, by the mdBook and GitHub when rendering, to allow cross references.
+The ID is the text of the heading, converted to lower case with spaces converted to `-` and non-alphanumeric characters removed.
+Thus `### Headings and sections` gets the ID `headings-and-sections` and can be referenced using the Markdown hyperlink syntax `[link text](#headings-and-sections)`.
+
+## Code Blocks
+
+Only [fenced code blocks][] must be used and not [indented code blocks][].
+Fenced blocks allow more context through [info string][]s and are easier to distinguish from the rest of the text than indented blocks, especially when nested in lists.
+
+Shell code blocks should default using `sh` in their [info string][], unless a non posix shell syntax is used.
+These blocks must not include `$` at the beginning of lines, and one must make sure to escape new lines when splitting up a command for readability.
+It is recommended that arguments a user is likely to change are made variables; this highlights them to the user.
+
+```sh
+util/dvsim/dvsim.py \
+    hw/ip/uart/dv/uart_sim_cfg.hjson \
+    -i uart_smoke \
+    --fixed-seed=$SEED
+```
+
+When one wants to show the output of an interactive session in the same code block, for example as part of a guide, one may use the `console` [info string][].
+In this case, it is recommended to use `$` or `#` at the beginning of command lines, where `$` denotes the command being run as a non-root user and `#` a root user.
+
+```console
+$ echo "Hello world"
+Hello World
+# sudo apt install cowsay
+...
+```
+
+## Images
+
+Pictures can be included using the standard Commonmark syntax (`![Alt Text](url)`).
+The preferred format is Scalable Vector Graphics (`.svg`), alternatively Portable Network Graphics (`.png`).
+
+## Code Blocks Renderers
+
+Waveforms can be included by describing them in [wavejson](https://github.com/wavedrom/schema/blob/master/WaveJSON.md) within a code block with a `wavejson` [info string][].
+
+[Mermaid](https://mermaid.js.org/) can be used for creating quick diagrams, like the one below, by surround mermaiding markup in a code block with a `mermaid` [info string][].
+
+## Maths
+
+Maths can be included inline or within blocks using a single or double `$` respectively.
+As a result, the `$` symbol has to be escaped when not wishing to write mathematical notation.
+
+````md
+$$
+\nabla \cdot \boldsymbol{B} = 0
+$$
+
+where $\boldsymbol{B}$ is the magnetic field.
+
+That's saved you \$100 on a text book.
+````
+
+## Comments
+
+Comments are rare, but should be used where needed.
+Use the HTML `<!--` and `-->` as the comment delimiters.
+
+
+[commonmark]: https://spec.commonmark.org/
+[atx headings]: https://spec.commonmark.org/0.30/#atx-headings
+[setext headings]: https://spec.commonmark.org/0.30/#setext-heading
+[collapsed reference link]: https://spec.commonmark.org/0.30/#collapsed-reference-link
+[shortcut reference link]: https://spec.commonmark.org/0.30/#shortcut-reference-link
+[indented code blocks]: https://spec.commonmark.org/0.30/#indented-code-block
+[fenced code blocks]: https://spec.commonmark.org/0.30/#fenced-code-blocks
+[info string]: https://spec.commonmark.org/0.30/#info-string
+[hard line breaks]: https://spec.commonmark.org/0.30/#hard-line-breaks
+[backslash hard breaks]: https://spec.commonmark.org/0.30/#example-634
+[gfm tables]: https://github.github.com/gfm/#tables-extension-
+[gfm list items]: https://github.github.com/gfm/#task-list-items-extension-
+[gfm autolinks extention]: https://github.github.com/gfm/#autolinks-extension-

--- a/doc/contributing/style_guides/python_coding_style.md
+++ b/doc/contributing/style_guides/python_coding_style.md
@@ -1,1 +1,198 @@
-# TBD
+# Python Coding Style Guide
+
+## Basics
+
+### Summary
+
+Python3 is the main language used for simple tools.
+As tools grow in complexity, or the requirements on them develop, they serve as valuable prototypes to re-implement tools or their behaviors more maintainably.
+
+Python can be written in vastly different styles, which can lead to code conflicts and code review latency.
+This style guide aims to promote Python readability across groups.
+To quote the C++ style guide: "Creating common, required idioms and patterns makes code much easier to understand."
+
+This guide defines the lowRISC style for Python version 3.
+The goals are to:
+
+*   promote consistency across hardware development projects
+*   promote best practices
+*   increase code sharing and re-use
+
+
+### Terminology Conventions
+
+Unless otherwise noted, the following terminology conventions apply to this style guide:
+
+*   The word ***must*** indicates a mandatory requirement.
+    Similarly, ***do not*** indicates a prohibition.
+    Imperative and declarative statements correspond to ***must***.
+*   The word ***recommended*** indicates that a certain course of action is preferred or is most suitable.
+    Similarly, ***not recommended*** indicates that a course of action is unsuitable, but not prohibited.
+    There may be reasons to use other options, but the implications and reasons for doing so must be fully understood.
+*   The word ***may*** indicates a course of action is permitted and optional.
+*   The word ***can*** indicates a course of action is possible given material, physical, or causal constraints.
+
+### Style Guide Exceptions
+
+***Justify exceptions with a comment.***
+
+No style guide is perfect.
+There are times when the best path to a working design, or for working around a tool issue, is to simply cut the Gordian Knot and create code that is at variance with this style guide.
+It is always okay to deviate from the style guide by necessity, as long as that necessity is clearly justified by a brief comment, as well as a lint waiver pragma where appropriate.
+
+A common case where you may wish to disable tool-enforced reformatting is for large manually formatted data literals.
+In this case, no explanatory comment is required and yapf can be disabled for that literal [with a single pragma](https://github.com/google/yapf#why-does-yapf-destroy-my-awesome-formatting).
+
+## Python Conventions
+
+### Summary
+
+The lowRISC style matches [PEP8](https://www.python.org/dev/peps/pep-0008/) with the following options:
+* Bitwise operators should be placed before a line split
+* Logical operators should be placed before a line split
+
+To avoid doubt, the interpretation of PEP8 is done by [yapf](https://github.com/google/yapf) and the style guide is set using a `.style.yapf` file in the top level directory of the repository.
+This just sets the base style to pep8 and overrides with the exceptions given above.
+
+In addition to the basic style, imports must be ordered alphabetically within sections:
+* Future
+* Python Standard Library
+* Third Party
+* Current Python Project
+
+The import ordering matches that enforced by [isort](https://github.com/timothycrosley/isort).
+Currently the `isort` defaults are used.
+If this changes a `.isort.cfg` file will be placed in the top level directory of the repository.
+
+### Lint tool
+
+The `lintpy.py` utility in `util` can be used to check Python code.
+It checks all Python (`.py`) files that are modified in the local repository and will report problems.
+Both `yapf` and `isort` checks are run.
+
+Basic lintpy usage is just to run from the util directory.
+If everything is fine the command produces no output, otherwise it will report the problems.
+Additional information will be printed if the `--verbose` or `-v` flag is given.
+
+```console
+$ cd $REPO_TOP/util
+$ ./lintpy.py
+$ ./lintpy.py -v
+```
+
+Checking can be done on an explicit list of files using the `--file` or `-f` flag.
+In this case the tool will not derive the list from git, so any file can be checked even if it has not been modified.
+
+```console
+$ cd $REPO_TOP/util
+$ ./lintpy.py -f a.py subdir/*.py
+```
+
+Errors may be fixed using the same tool to edit the problem file(s) in-place (you may need to refresh the file(s) in your editor after doing this).
+This uses the same set of files as are being checked, so unless the`--file` or `-f` flag is used this will only affect files that have already been modified (or staged for commit if `-c`is used) and will not fix errors in Python files that have not been touched.
+
+```console
+$ cd $REPO_TOP/util
+$ ./lintpy.py --fix
+```
+
+lintpy.py can be installed as a git pre-commit hook which will prevent commits if there are any lint errors.
+This will normally be a symlink to the tool in util so changes are automatically used (it also works if `lintpy.py` is copied to `.git/hooks/pre-commit` but in that case the hook must be reinstalled each time the tool changes).
+Since git hooks are not automatically installed the symlink hook can be installed if required using the tool:
+
+```console
+$ cd $REPO_TOP/util
+$ ./lintpy.py --hook
+```
+
+
+Fixing style errors for a single file can also be done with `yapf` directly:
+```console
+$ yapf -i file.py
+```
+
+Fixing import ordering errors for a single file can be done with `isort`:
+```console
+$ isort file.py
+```
+
+Yapf and isort are Python packages and should be installed with pip:
+
+```console
+$ pip3 install --user yapt
+$ pip3 install --user isort
+```
+
+### File Extensions
+
+***Use the `.py` extension for Python files***
+
+### General File Appearance
+
+#### Characters
+
+***Use only UTF-8 characters with UNIX-style line endings(`"\n"`).***
+
+Follows PEP8.
+
+#### POSIX File Endings
+
+***All lines on non-empty files must end with a newline (`"\n"`).***
+
+#### Line Length
+
+***Wrap the code at 79 characters per line.***
+
+The maximum line length follows PEP8.
+
+Exceptions:
+
+-   Any place where line wraps are impossible (for example, an include path might extend past 79 characters).
+
+#### No Tabs
+
+***Do not use tabs anywhere.***
+
+Use spaces to indent or align text.
+
+To convert tabs to spaces on any file, you can use the [UNIX `expand`](https://linux.die.net/man/1/expand) utility.
+
+#### No Trailing Spaces
+
+***Delete trailing whitespace at the end of lines.***
+
+### Indentation
+
+***Indentation is four spaces per level.***
+
+Follows PEP8.
+Use spaces for indentation.
+Do not use tabs.
+You should set your editor to emit spaces when you hit the tab key.
+
+### Executable Python tools
+
+Tools that can be executed should use `env` to avoid making assumptions about the location of the Python interpreter.
+Thus they should begin with the line:
+
+```console
+#!/usr/bin/env python3
+```
+
+This should be followed by a comment with the license information and the doc string describing the command.
+
+#### Argument Parsing
+
+***Use argparse to parse command line arguments.***
+
+In command line tools use the [argparse library](https://docs.python.org/3/library/argparse.html) to parse arguments.
+This will provide support for `--help` and `-h` to get usage information.
+
+Every command line program should provide `--version` to provide standard version information.
+This lists the git repository information for the tool and the version numbers of any Python packages that are used.
+The `show_and_exit` routine in `reggen/version.py` can be used to do this.
+
+Options that consume an arbitrary number of command line arguments with `nargs="*"` or `nargs="+"` should be avoided wherever possible.
+Comma separated lists can be passed to form single arguments and can be split after arguments are parsed.
+Args that allow for lists should mention that capability and the separator using the help keyword.
+To display proper delimiting of lists, args that allow for lists may demonstrate the separator with the metavar keyword.

--- a/doc/contributing/style_guides/python_coding_style.md
+++ b/doc/contributing/style_guides/python_coding_style.md
@@ -11,7 +11,7 @@ Python can be written in vastly different styles, which can lead to code conflic
 This style guide aims to promote Python readability across groups.
 To quote the C++ style guide: "Creating common, required idioms and patterns makes code much easier to understand."
 
-This guide defines the lowRISC style for Python version 3.
+This guide defines style for Python version 3.
 The goals are to:
 
 *   promote consistency across hardware development projects
@@ -47,7 +47,7 @@ In this case, no explanatory comment is required and yapf can be disabled for th
 
 ### Summary
 
-The lowRISC style matches [PEP8](https://www.python.org/dev/peps/pep-0008/) with the following options:
+Coding style should match [PEP8](https://www.python.org/dev/peps/pep-0008/) with the following options:
 * Bitwise operators should be placed before a line split
 * Logical operators should be placed before a line split
 


### PR DESCRIPTION
Documentation that got deleted originally but belongs as contributor guidance in this repo.