### PR TITLE
[dvsim] Include batchgroups option in sim_cfgs

### DIFF
--- a/hw/dv/all_sim_cfgs.hjson
+++ b/hw/dv/all_sim_cfgs.hjson
@@ -10,8 +10,7 @@
 
 {
   // This is a cfg hjson group for DV simulations. It includes ALL individual DV simulation
-  // cfgs across all IPs and tops in the project. This enables the common
-  // regression sets to be run in one shot.
+  // cfgs across all IPs and tops in the project. This enables the common regression sets to be run in one shot.
   name: all_tops_batch
 
   import_cfgs: [// Project wide common cfg file
@@ -29,83 +28,91 @@
     }
   ]
 
-  use_cfgs: [
-             // Unit tests for UVCs.
-             "{proj_root}/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson",
-             // IPs.
-             "{proj_root}/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson",
-             "{proj_root}/hw/ip/aes/dv/aes_masked_sim_cfg.hjson",
-             "{proj_root}/hw/ip/aes/dv/aes_unmasked_sim_cfg.hjson",
-             "{proj_root}/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson",
-             "{proj_root}/hw/ip/csrng/dv/csrng_sim_cfg.hjson",
-             "{proj_root}/hw/ip/dma/dv/dma_sim_cfg.hjson",
-             "{proj_root}/hw/ip/edn/dv/edn_edn0_sim_cfg.hjson",
-             "{proj_root}/hw/ip/edn/dv/edn_edn1_sim_cfg.hjson",
-             "{proj_root}/hw/ip/entropy_src/dv/entropy_src_rng16bits_sim_cfg.hjson",
-             "{proj_root}/hw/ip/entropy_src/dv/entropy_src_rng4bits_sim_cfg.hjson",
-             "{proj_root}/hw/ip/hmac/dv/hmac_sim_cfg.hjson",
-             "{proj_root}/hw/ip/i2c/dv/i2c_sim_cfg.hjson",
-             "{proj_root}/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson",
-             "{proj_root}/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson",
-             "{proj_root}/hw/ip/kmac/dv/kmac_masked_sim_cfg.hjson",
-             "{proj_root}/hw/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson",
-             "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_disabled_sim_cfg.hjson",
-             "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_enabled_sim_cfg.hjson",
-             "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_volatile_unlock_disabled_sim_cfg.hjson",
-             "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_volatile_unlock_enabled_sim_cfg.hjson",
-             "{proj_root}/hw/ip/mbx/dv/mbx_sim_cfg.hjson",
-             "{proj_root}/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson",
-             "{proj_root}/hw/ip/rom_ctrl/dv/rom_ctrl_32kB_sim_cfg.hjson",
-             "{proj_root}/hw/ip/rom_ctrl/dv/rom_ctrl_64kB_sim_cfg.hjson",
-             "{proj_root}/hw/ip/rv_dm/dv/rv_dm_use_dmi_interface_sim_cfg.hjson",
-             "{proj_root}/hw/ip/rv_dm/dv/rv_dm_use_jtag_interface_sim_cfg.hjson",
-             "{proj_root}/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson",
-             "{proj_root}/hw/ip/soc_dbg_ctrl/dv/soc_dbg_ctrl_sim_cfg.hjson",
-             "{proj_root}/hw/ip/spi_device/dv/spi_device_1r1w_sim_cfg.hjson",
-             "{proj_root}/hw/ip/spi_device/dv/spi_device_2p_sim_cfg.hjson",
-             "{proj_root}/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson",
-             "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_exec_64kB_sim_cfg.hjson",
-             "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson",
-             "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_ret_sim_cfg.hjson",
-             "{proj_root}/hw/ip/sysrst_ctrl/dv/sysrst_ctrl_sim_cfg.hjson",
-             "{proj_root}/hw/ip/uart/dv/uart_sim_cfg.hjson",
-             "{proj_root}/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson",
-             "{proj_root}/hw/ip/acc/dv/uvm/acc_pqc_sim_cfg.hjson",
-             "{proj_root}/hw/ip/acc/dv/uvm/acc_standard_sim_cfg.hjson",
-             "{proj_root}/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson",
-             "{proj_root}/hw/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson",
-             "{proj_root}/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson",
-             "{proj_root}/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson",
-             "{proj_root}/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson",
-             // top_earlgrey autogen IPs.
-             "{proj_root}/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson",
-             "{proj_root}/hw/top_earlgrey/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson",
-             "{proj_root}/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson",
-             "{proj_root}/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim_cfg.hjson",
-             "{proj_root}/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson",
-             "{proj_root}/hw/top_earlgrey/ip_autogen/pwm/dv/pwm_sim_cfg.hjson",
-             "{proj_root}/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson",
-             "{proj_root}/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson",
-             "{proj_root}/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson",
-             "{proj_root}/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson",
-             "{proj_root}/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
-             // top_earlgrey chip.
-             "{proj_root}/hw/top_earlgrey/dv/chip_earlgrey_sim_cfg.hjson",
-             // top_darjeeling autogen IPs.
-             "{proj_root}/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson",
-             "{proj_root}/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson",
-             "{proj_root}/hw/top_darjeeling/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson",
-             "{proj_root}/hw/top_darjeeling/ip_autogen/gpio/dv/gpio_sim_cfg.hjson",
-             "{proj_root}/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson",
-             "{proj_root}/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson",
-             "{proj_root}/hw/top_darjeeling/ip_autogen/racl_ctrl/dv/racl_ctrl_sim_cfg.hjson",
-             "{proj_root}/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson",
-             "{proj_root}/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson",
-             "{proj_root}/hw/top_darjeeling/ip/xbar_dbg/dv/autogen/xbar_dbg_sim_cfg.hjson",
-             "{proj_root}/hw/top_darjeeling/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson",
-             "{proj_root}/hw/top_darjeeling/ip/xbar_mbx/dv/autogen/xbar_mbx_sim_cfg.hjson",
-             "{proj_root}/hw/top_darjeeling/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
-             // top_darjeeling chip.
-             "{proj_root}/hw/top_darjeeling/dv/chip_darjeeling_sim_cfg.hjson",
-            ]
+  use_cfgs: {
+             ip: [
+                 // Unit tests for UVCs.
+                 "{proj_root}/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson",
+                 // IPs.
+                 "{proj_root}/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/aes/dv/aes_masked_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/aes/dv/aes_unmasked_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/csrng/dv/csrng_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/dma/dv/dma_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/edn/dv/edn_edn0_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/edn/dv/edn_edn1_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/entropy_src/dv/entropy_src_rng16bits_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/entropy_src/dv/entropy_src_rng4bits_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/hmac/dv/hmac_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/i2c/dv/i2c_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/kmac/dv/kmac_masked_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_disabled_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_enabled_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_volatile_unlock_disabled_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_volatile_unlock_enabled_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/mbx/dv/mbx_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/rom_ctrl/dv/rom_ctrl_32kB_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/rom_ctrl/dv/rom_ctrl_64kB_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/rv_dm/dv/rv_dm_use_dmi_interface_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/rv_dm/dv/rv_dm_use_jtag_interface_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/soc_dbg_ctrl/dv/soc_dbg_ctrl_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/spi_device/dv/spi_device_1r1w_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/spi_device/dv/spi_device_2p_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_exec_64kB_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_ret_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/sysrst_ctrl/dv/sysrst_ctrl_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/uart/dv/uart_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/acc/dv/uvm/acc_pqc_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/acc/dv/uvm/acc_standard_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson",
+                 "{proj_root}/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson",
+             ]
+
+             top_earlgrey: [
+                 // top_earlgrey autogen IPs.
+                 "{proj_root}/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson",
+                 "{proj_root}/hw/top_earlgrey/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson",
+                 "{proj_root}/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson",
+                 "{proj_root}/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim_cfg.hjson",
+                 "{proj_root}/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson",
+                 "{proj_root}/hw/top_earlgrey/ip_autogen/pwm/dv/pwm_sim_cfg.hjson",
+                 "{proj_root}/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson",
+                 "{proj_root}/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson",
+                 "{proj_root}/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson",
+                 "{proj_root}/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson",
+                 "{proj_root}/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
+                 // top_earlgrey chip.
+                 "{proj_root}/hw/top_earlgrey/dv/chip_earlgrey_sim_cfg.hjson",
+             ]
+
+             top_darjeeling: [
+                 // top_darjeeling autogen IPs.
+                 "{proj_root}/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson",
+                 "{proj_root}/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson",
+                 "{proj_root}/hw/top_darjeeling/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson",
+                 "{proj_root}/hw/top_darjeeling/ip_autogen/gpio/dv/gpio_sim_cfg.hjson",
+                 "{proj_root}/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson",
+                 "{proj_root}/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson",
+                 "{proj_root}/hw/top_darjeeling/ip_autogen/racl_ctrl/dv/racl_ctrl_sim_cfg.hjson",
+                 "{proj_root}/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson",
+                 "{proj_root}/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson",
+                 "{proj_root}/hw/top_darjeeling/ip/xbar_dbg/dv/autogen/xbar_dbg_sim_cfg.hjson",
+                 "{proj_root}/hw/top_darjeeling/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson",
+                 "{proj_root}/hw/top_darjeeling/ip/xbar_mbx/dv/autogen/xbar_mbx_sim_cfg.hjson",
+                 "{proj_root}/hw/top_darjeeling/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
+                 // top_darjeeling chip.
+                 "{proj_root}/hw/top_darjeeling/dv/chip_darjeeling_sim_cfg.hjson",
+             ]
+  }
 }

--- a/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
+++ b/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
@@ -11,8 +11,7 @@
 
 {
   // This is a cfg hjson group for DV simulations. It includes ALL individual DV simulation
-  // cfgs of the IPs and the full chip used in top_darjeeling. This enables the common
-  // regression sets to be run in one shot.
+  // cfgs of the IPs and the full chip used in top_darjeeling. This enables the common regression sets to be run in one shot.
   name: top_darjeeling_batch
 
   import_cfgs: [// Project wide common cfg file
@@ -78,6 +77,7 @@
              "{proj_root}/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson",
              "{proj_root}/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson",
              "{proj_root}/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson",
+
              // top_darjeeling autogen IPs.
              "{proj_root}/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson",
@@ -94,5 +94,5 @@
              "{proj_root}/hw/top_darjeeling/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
              // top_darjeeling chip.
              "{proj_root}/hw/top_darjeeling/dv/chip_darjeeling_sim_cfg.hjson",
-            ]
+  ]
 }

--- a/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
+++ b/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
@@ -11,8 +11,7 @@
 
 {
   // This is a cfg hjson group for DV simulations. It includes ALL individual DV simulation
-  // cfgs of the IPs and the full chip used in top_earlgrey. This enables the common
-  // regression sets to be run in one shot.
+  // cfgs of the IPs and the full chip used in top_earlgrey. This enables the common regression sets to be run in one shot.
   name: top_earlgrey_batch
 
   import_cfgs: [// Project wide common cfg file
@@ -78,6 +77,7 @@
              "{proj_root}/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson",
              "{proj_root}/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson",
              "{proj_root}/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson",
+
              // top_earlgrey autogen IPs.
              "{proj_root}/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson",
@@ -92,5 +92,5 @@
              "{proj_root}/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
              // top_earlgrey chip.
              "{proj_root}/hw/top_earlgrey/dv/chip_earlgrey_sim_cfg.hjson",
-            ]
+  ]
 }

--- a/util/dvsim/CfgJson.py
+++ b/util/dvsim/CfgJson.py
@@ -89,8 +89,8 @@ def _load_single_file(target, path, is_first, arg_keys):
                 raise RuntimeError('{!r}: File is included by another one, '
                                    'but defines "use_cfgs".'
                                    .format(path))
-            if not isinstance(dict_val, list):
-                raise RuntimeError('{!r}: use_cfgs must be a list. Saw {!r}.'
+            if not isinstance(dict_val, list) and not isinstance(dict_val, dict):
+                raise RuntimeError('{!r}: use_cfgs must be a list or a dict. Saw {!r}.'
                                    .format(path, dict_val))
 
         # Otherwise, update target with this attribute

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -545,6 +545,21 @@ class FlowCfg():
             shutil.copy2(latest_report, os.path.join(dest_dir, 'report.html'))
             log.info("Copied report for %s", item.name)
 
+            if self.args.cov_reports:
+                cov_dir = os.path.join(item.scratch_path, 'cov_report')
+                if not os.path.exists(cov_dir):
+                    log.warning("No coverage reports found for %s at %s, skipping.", item.name, 
+                                cov_dir)
+                else:
+                    cov_dest_dir = os.path.join(repo_dir,
+                                                f"{self.name}_{flow}",
+                                                f"{self.name}_{flow}_{self.timestamp}",
+                                                os.path.basename(item.scratch_path),
+                                                'cov_report')
+                    os.makedirs(cov_dest_dir, exist_ok=True)
+                    shutil.copytree(cov_dir, cov_dest_dir, dirs_exist_ok=True)
+                    log.info("Copied coverage reports for %s", item.name)
+
         subprocess.run(["git", "-C", repo_dir, "add", "-A"], check=True, env=env)
         subprocess.run(["git", "-C", repo_dir, "commit", "-m",
                         f"[dashboard] Update {self.name} {self.flow} {self.timestamp}"],
@@ -585,10 +600,21 @@ class FlowCfg():
     def clone_or_pull(self, repository: str, local_path: str, env: dict):
         """Clone the repo if it doesn't exist locally, otherwise pull latest."""
         try:
-            if not os.path.exists(local_path):
-                subprocess.run(["git", "clone", repository, local_path], check=True, env=env)
+            if os.path.exists(local_path):
+                result = subprocess.run(
+                    ["git", "-C", local_path, "remote", "get-url", "origin"],
+                    check=True, capture_output=True, text=True, env=env
+                )
+                existing_remote = result.stdout.strip()
+                if existing_remote != repository:
+                    log.warning("Existing repo at %s points to %s, expected %s. Recloning.",
+                                local_path, existing_remote, repository)
+                    shutil.rmtree(local_path)
+                    subprocess.run(["git", "clone", repository, local_path], check=True, env=env)
+                else:
+                    subprocess.run(["git", "-C", local_path, "pull"], check=True, env=env)
             else:
-                subprocess.run(["git", "-C", local_path, "pull"], check=True, env=env)
+                subprocess.run(["git", "clone", repository, local_path], check=True, env=env)
         except FileNotFoundError:
             log.error("git is not installed or not on PATH. Cannot publish results.")
             raise

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -553,20 +553,23 @@ class FlowCfg():
         log.info("Results published successfully.")
 
     def _setup_ssh_env(self) -> dict:
-        """Start an ssh-agent, add the key via askpass, and return the env dict."""
+        """Return an env dict with SSH configured, using passphrase or deploy key."""
+        env = os.environ.copy()
+        env["GIT_SSH_COMMAND"] = "ssh -o StrictHostKeyChecking=no"
+
         passphrase = os.environ.get("SSH_KEY_PASSPHRASE")
+        if not passphrase:
+            # Rely on deploy key already configured in the environment
+            log.info("SSH_KEY_PASSPHRASE not set, assuming deploy key is available.")
+            return env
 
         with tempfile.NamedTemporaryFile(mode='w', suffix='.sh', delete=False) as f:
             f.write(f'#!/bin/sh\necho "{passphrase}"\n')
             askpass_script = f.name
         os.chmod(askpass_script, stat.S_IRWXU)
-
-        env = os.environ.copy()
         env["SSH_ASKPASS"] = askpass_script
         env["SSH_ASKPASS_REQUIRE"] = "force"
         env["DISPLAY"] = ""
-        env["GIT_SSH_COMMAND"] = "ssh -o StrictHostKeyChecking=no"
-
         try:
             agent = subprocess.run(["ssh-agent", "-s"], check=True, capture_output=True, text=True)
             for line in agent.stdout.splitlines():

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -497,7 +497,7 @@ class FlowCfg():
                                         relative_to)
         return "[%s](%s)" % (link_text, relative_link)
 
-    def publish_results(self, repository: str, flow: str):
+    def publish_results(self, repository: str, test: str):
         """Publish these results to a corresponding repository."""
         log.info("Publishing results to %s", repository)
         repo_dir = os.path.expanduser("./scratch/results_repo")
@@ -507,26 +507,27 @@ class FlowCfg():
 
         latest_batch_report = os.path.join(self.scratch_path, 'reports', 'latest', 'report.html')
         # Destination directory should be
-        dest_batch_dir = os.path.join(repo_dir, f"{self.name}_{flow}",
-                                      f"{self.name}_{flow}_{self.timestamp}",
+        dest_batch_dir = os.path.join(repo_dir, f"{self.name}_{test}_{self.flow}",
+                                      f"{self.name}_{test}_{self.flow}_{self.timestamp}",
                                       f"{self.name}", 'reports', 'latest')
         os.makedirs(dest_batch_dir, exist_ok=True)
         shutil.copy2(latest_batch_report, os.path.join(dest_batch_dir, 'report.html'))
         log.info("Copied report for %s", self.name)
 
-        self._write_index_html(os.path.join(repo_dir, f"{self.name}_{flow}"),
-                               f"{self.name}_{flow}",
-                               f"{self.name}_{flow}_index",
-                               f"{self.name}_{flow}_{self.timestamp}",
-                               os.path.join(f"{self.name}_{flow}_{self.timestamp}",
+        self._write_index_html(os.path.join(repo_dir, f"{self.name}_{test}_{self.flow}"),
+                               f"{self.name}_{test}_{self.flow}",
+                               f"{self.name}_{test}_{self.flow}_index",
+                               f"{self.name}_{test}_{self.flow}_{self.timestamp}",
+                               os.path.join(f"{self.name}_{test}_{self.flow}_{self.timestamp}",
                                             self.name,
                                             'reports', 'latest', 'report.html'))
 
         self._write_index_html(repo_dir,
                                "Reports",
                                "index",
-                               f"{self.name}_{flow}",
-                               f"{self.name}_{flow}/{self.name}_{flow}_index.html")
+                               f"{self.name}_{test}_{self.flow}",
+                               f"{self.name}_{test}_{self.flow}/"
+                               f"{self.name}_{test}_{self.flow}_index.html")
 
         shutil.copy2(os.path.join(self.proj_root, 'util', 'dvsim', 'style.css'), repo_dir)
 
@@ -536,8 +537,8 @@ class FlowCfg():
                 log.warning("No report found for %s at %s, skipping.", item.name, latest_report)
                 continue
             dest_dir = os.path.join(repo_dir,
-                                    f"{self.name}_{flow}",
-                                    f"{self.name}_{flow}_{self.timestamp}",
+                                    f"{self.name}_{test}_{self.flow}",
+                                    f"{self.name}_{test}_{self.flow}_{self.timestamp}",
                                     os.path.basename(item.scratch_path),
                                     'reports',
                                     'latest')
@@ -552,8 +553,8 @@ class FlowCfg():
                                 cov_dir)
                 else:
                     cov_dest_dir = os.path.join(repo_dir,
-                                                f"{self.name}_{flow}",
-                                                f"{self.name}_{flow}_{self.timestamp}",
+                                                f"{self.name}_{test}_{self.flow}",
+                                                f"{self.name}_{test}_{self.flow}_{self.timestamp}",
                                                 os.path.basename(item.scratch_path),
                                                 'cov_report')
                     os.makedirs(cov_dest_dir, exist_ok=True)
@@ -562,7 +563,7 @@ class FlowCfg():
 
         subprocess.run(["git", "-C", repo_dir, "add", "-A"], check=True, env=env)
         subprocess.run(["git", "-C", repo_dir, "commit", "-m",
-                        f"[dashboard] Update {self.name} {self.flow} {self.timestamp}"],
+                        f"[dashboard] Update {self.name}_{test}_{self.flow} {self.timestamp}"],
                        check=True, env=env)
         subprocess.run(["git", "-C", repo_dir, "push"], check=True, env=env)
         log.info("Results published successfully.")

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -549,7 +549,7 @@ class FlowCfg():
             if self.args.cov_reports:
                 cov_dir = os.path.join(item.scratch_path, 'cov_report')
                 if not os.path.exists(cov_dir):
-                    log.warning("No coverage reports found for %s at %s, skipping.", item.name, 
+                    log.warning("No coverage reports found for %s at %s, skipping.", item.name,
                                 cov_dir)
                 else:
                     cov_dest_dir = os.path.join(repo_dir,

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -127,11 +127,26 @@ class FlowCfg():
         # configuration".
         self.is_primary_cfg = 'use_cfgs' in hjson_data
 
+        # If it's a primary_cfg, it's results can be grouped for reporting
+        # purposes in the 'use_cfgs' section of the hjson. If that's the case
+        # we group the reports
+        self.batchgroups = False
+
         if not self.is_primary_cfg:
             self.cfgs.append(self)
         else:
-            for entry in self.use_cfgs:
-                self._load_child_cfg(entry, mk_config)
+            if isinstance(self.use_cfgs, dict):
+                for batchgroup, entries in self.use_cfgs.items():
+                    for entry in entries:
+                        self._load_child_cfg(entry, mk_config, batchgroup)
+                self.batchgroups = True
+            elif isinstance(self.use_cfgs, list):
+                for entry in self.use_cfgs:
+                    self._load_child_cfg(entry, mk_config)
+            else:
+                log.error("use_cfgs must be either a dict of batchgroups",
+                          " or a list of configs")
+                sys.exit(1)
 
         if self.rel_path == "":
             self.rel_path = os.path.dirname(self.flow_cfg_file).replace(
@@ -194,7 +209,7 @@ class FlowCfg():
                 log.error("Parse error!\n%s", self.cfgs)
                 sys.exit(1)
 
-    def create_instance(self, mk_config, flow_cfg_file):
+    def create_instance(self, mk_config, flow_cfg_file, batchgroup=None):
         '''Create a new instance of this class for the given config file.
 
         mk_config is a factory method (passed explicitly to avoid a circular
@@ -213,22 +228,24 @@ class FlowCfg():
                           type(new_instance).__name__))
             sys.exit(1)
 
+        new_instance.batchgroup = batchgroup
+
         return new_instance
 
-    def _load_child_cfg(self, entry, mk_config):
+    def _load_child_cfg(self, entry, mk_config, batchgroup=None):
         '''Load a child configuration for a primary cfg'''
         if type(entry) is str:
             # Treat this as a file entry. Substitute wildcards in cfg_file
             # files since we need to process them right away.
             cfg_file = subst_wildcards(entry, self.__dict__, ignore_error=True)
-            self.cfgs.append(self.create_instance(mk_config, cfg_file))
+            self.cfgs.append(self.create_instance(mk_config, cfg_file, batchgroup))
 
         elif type(entry) is dict:
             # Treat this as a cfg expanded in-line
             temp_cfg_file = self._conv_inline_cfg_to_hjson(entry)
             if not temp_cfg_file:
                 return
-            self.cfgs.append(self.create_instance(mk_config, temp_cfg_file))
+            self.cfgs.append(self.create_instance(mk_config, temp_cfg_file, batchgroup))
 
             # Delete the temp_cfg_file once the instance is created
             log.log(VERBOSE, "Deleting temp cfg file:\n%s", temp_cfg_file)
@@ -427,15 +444,26 @@ class FlowCfg():
             self.errors_seen |= item.errors_seen
 
         if self.is_primary_cfg:
-            self.gen_results_summary()
+            self.gen_results_summary(self.batchgroups)
             self.write_results(self.results_html_name,
                                self.results_summary_md, is_primary_cfg=True)
             log.info("[report]: [%s] [%s/report.html]", self.name, self.results_dir)
 
-    def gen_results_summary(self):
+    def gen_results_summary(self, batchgroups=False):
         '''Public facing API to generate summary results for each IP/cfg file
         '''
         return
+
+    def _add_to_row_dict(self, row_dict, batch_flag, cfg, row):
+        '''Checks if the cfgs are divided into batchgroups and adds it to the
+        corresponding batchgroup or to the default.
+        '''
+        if batch_flag:
+            if cfg.batchgroup not in row_dict:
+                row_dict[cfg.batchgroup] = []
+            row_dict[cfg.batchgroup].append(row)
+        else:
+            row_dict["default"].append(row)
 
     def write_results(self, html_filename, text_md, json_str=None, is_primary_cfg=False):
         """Write results to files.

--- a/util/dvsim/FormalCfg.py
+++ b/util/dvsim/FormalCfg.py
@@ -38,6 +38,7 @@ class FormalCfg(OneShotCfg):
         ]
         self.results_title = self.name.upper(
         ) + " Formal " + self.sub_flow.upper() + " Results"
+        self.batchgroup = None
 
     def parse_dict_to_str(self, input_dict, excl_keys=[]):
         # This is a helper function to parse dictionary items into a string.
@@ -133,7 +134,7 @@ class FormalCfg(OneShotCfg):
                 summary = ["N/A", "N/A", "N/A"]
         return results_str, summary
 
-    def gen_results_summary(self):
+    def gen_results_summary(self, batchgroups=False):
         # Gathers the aggregated results from all sub configs
         # The results_summary will only contain the passing rate and
         # percentages of the stimuli, coi, and proven coverage
@@ -146,22 +147,34 @@ class FormalCfg(OneShotCfg):
 
         colalign = ("center", ) * len(self.summary_header)
         table = [self.summary_header]
+
+        rows = {} if batchgroups else {"default": []}
         for cfg in self.cfgs:
             try:
-                table.append(cfg.result_summary[cfg.name])
+                row = cfg.result_summary[cfg.name]
             except KeyError as e:
-                table.append([cfg.name, "ERROR", "N/A", "N/A", "N/A"])
+                row = [cfg.name, "ERROR", "N/A", "N/A", "N/A"]
                 log.error(
                     "cfg: %s could not find generated results_summary: %s",
                     cfg.name, e)
+            self._add_to_row_dict(rows, batchgroups, cfg, row)
+
+        if any(rows.values()):
+            for batchgroup, group_rows in rows.items():
+                if batchgroups:
+                    # Insert a separator row for this batchgroup
+                    separator = [f"**{batchgroup}**"] + [""] * len(self.summary_header)
+                    table.append(separator)
+                for row in group_rows:
+                    table.append(row)
+
         if len(table) > 1:
             self.results_summary_md = results_str + tabulate(
                 table, headers="firstrow", tablefmt="pipe", colalign=colalign)
         else:
             self.results_summary_md = results_str
 
-        log.info("[result summary]: %s", self.results_summary_md)
-
+        print(str(self.results_summary_md))
         return self.results_summary_md
 
     def _gen_results(self, results):

--- a/util/dvsim/LintCfg.py
+++ b/util/dvsim/LintCfg.py
@@ -38,6 +38,9 @@ class LintCfg(OneShotCfg):
         # fusesoc argument before the name of the core to invoke.
         # Format: str
         self.additional_fusesoc_argument = ''
+        # This key is a structure used to know if the result summary
+        # of a primary config is going to be divided into batchgroups
+        self.batchgroup = None
 
         super().__init__(flow_cfg_file, hjson_data, args, mk_config)
 
@@ -52,7 +55,7 @@ class LintCfg(OneShotCfg):
         else:
             self.results_title = f'{self.name.upper()} Lint Results'
 
-    def gen_results_summary(self):
+    def gen_results_summary(self, batchgroups=False):
         '''
         Gathers the aggregated results from all sub configs
         '''
@@ -78,14 +81,24 @@ class LintCfg(OneShotCfg):
         colalign = ('center', ) * len(header)
         table = [header]
 
+        rows = {} if batchgroups else {"default": []}
         keys = self.totals.get_keys(self.report_severities)
+
         for cfg in self.cfgs:
             name_with_link = cfg._get_results_page_link(
                 self.results_dir)
-
             row = [name_with_link]
             row += cfg.result_summary.get_counts_md(keys)
-            table.append(row)
+            self._add_to_row_dict(rows, batchgroups, cfg, row)
+
+        if any(rows.values()):
+            for batchgroup, group_rows in rows.items():
+                if batchgroups:
+                    # Insert a separator row for this batchgroup
+                    separator = [f"**{batchgroup}**"] + [""] * (len(keys) - 1)
+                    table.append(separator)
+                for row in group_rows:
+                    table.append(row)
 
         if len(table) > 1:
             self.results_summary_md = results_str + tabulate(
@@ -94,9 +107,7 @@ class LintCfg(OneShotCfg):
         else:
             self.results_summary_md = f'{results_str}\nNo results to display.\n'
 
-        print(self.results_summary_md)
-
-        # Return only the tables
+        print(str(self.results_summary_md))
         return self.results_summary_md
 
     # TODO(#9079): This way of parsing out messages into an intermediate

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -873,17 +873,15 @@ class SimCfg(FlowCfg):
                 report_status = run_results[self.cov_report_deploy]
                 if report_status == "P":
                     results_str += "\n## Coverage Results\n"
-                    # Link the dashboard page using "cov_report_page" value.
-                    if hasattr(self, "cov_report_page"):
+                    if self.args.cov_reports:
+                        # Link the dashboard page using "cov_report_page" value.
+                        if hasattr(self, "cov_report_page"):
+                            results_str += "\n### [Coverage Dashboard]"
+                            cov_report_page_path = "../../cov_report"
+                            cov_report_page_path += "/" + self.cov_report_page
+                            results_str += "({})\n\n".format(cov_report_page_path)
+                    else:
                         results_str += "\n### Coverage Dashboard\n\n"
-                        # TODO: modify to include differentiation between public and private
-                        # dashboard usage.
-                        # if self.args.publish:
-                        #     cov_report_page_path = "cov_report"
-                        # else:
-                        #     cov_report_page_path = "../../cov_report"
-                        # cov_report_page_path += "/" + self.cov_report_page
-                        # results_str += "({})\n\n".format(cov_report_page_path)
                     results_str += self.cov_report_deploy.cov_results
                     self.results_summary[
                         "Overall Coverage"] = self.cov_report_deploy.cov_total

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -915,9 +915,13 @@ class SimCfg(FlowCfg):
         DEFAULT_VALUE = "-- %"
 
         for cfg in self.cfgs:
-            cov_scores = cfg.cov_report_deploy.cov_results_dict
-            cov_scores = {f"{key.capitalize()} Coverage": val for key, val in cov_scores.items()}
-            row = cfg.results_summary | cov_scores
+            if self.cov_report_deploy:
+                cov_scores = cfg.cov_report_deploy.cov_results_dict
+                cov_scores = {f"{key.capitalize()} Coverage": val for key,
+                              val in cov_scores.items()}
+                row = cfg.results_summary | cov_scores
+            else:
+                row = cfg.results_summary
             if row:
                 # convert name entry to relative link
                 row["Name"] = cfg._get_results_page_link(
@@ -928,9 +932,10 @@ class SimCfg(FlowCfg):
         if any(rows.values()):
             all_rows = [row for group in rows.values() for row in group]
             all_keys = list(dict.fromkeys(key for row in all_rows for key in row))
-            # Move the "Overall Coverage" key to the end
-            all_keys.remove("Overall Coverage")
-            all_keys.append("Overall Coverage")
+            # Move the "Overall Coverage" key to the end (only if coverage is enabled)
+            if self.cov_report_deploy:
+                all_keys.remove("Overall Coverage")
+                all_keys.append("Overall Coverage")
 
             for batchgroup, group_rows in rows.items():
                 if batchgroups:

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -137,6 +137,7 @@ class SimCfg(FlowCfg):
         self.cov_merge_deploy = None
         self.cov_report_deploy = None
         self.results_summary = OrderedDict()
+        self.batchgroup = None
 
         super().__init__(flow_cfg_file, hjson_data, args, mk_config)
 
@@ -896,7 +897,7 @@ class SimCfg(FlowCfg):
         self.results_md = results_str
         return results_str
 
-    def gen_results_summary(self):
+    def gen_results_summary(self, batchgroups=False):
         '''Generate the summary results table.
 
         This method is specific to the primary cfg. It summarizes the results
@@ -912,8 +913,9 @@ class SimCfg(FlowCfg):
         lines += [f"### Branch: {self.branch}"]
 
         table = []
-        rows = []
+        rows = {} if batchgroups else {"default": []}
         DEFAULT_VALUE = "-- %"
+
         for cfg in self.cfgs:
             cov_scores = cfg.cov_report_deploy.cov_results_dict
             cov_scores = {f"{key.capitalize()} Coverage": val for key, val in cov_scores.items()}
@@ -923,17 +925,23 @@ class SimCfg(FlowCfg):
                 row["Name"] = cfg._get_results_page_link(
                     self.results_dir,
                     row["Name"])
-                rows.append(row)
+                self._add_to_row_dict(rows, batchgroups, cfg, row)
 
-        if rows:
-            all_keys = list(dict.fromkeys(key for row in rows for key in row))
+        if any(rows.values()):
+            all_rows = [row for group in rows.values() for row in group]
+            all_keys = list(dict.fromkeys(key for row in all_rows for key in row))
             # Move the "Overall Coverage" key to the end
             all_keys.remove("Overall Coverage")
             all_keys.append("Overall Coverage")
 
-            for row in rows:
-                normalized = {key: row.get(key, DEFAULT_VALUE) for key in all_keys}
-                table.append(list(normalized.values()))
+            for batchgroup, group_rows in rows.items():
+                if batchgroups:
+                    # Insert a separator row for this batchgroup
+                    separator = [f"**{batchgroup}**"] + [""] * (len(all_keys) - 1)
+                    table.append(separator)
+                for row in group_rows:
+                    normalized = {key: row.get(key, DEFAULT_VALUE) for key in all_keys}
+                    table.append(list(normalized.values()))
 
         if table:
             colalign = ("center", ) * len(all_keys)

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -822,9 +822,13 @@ def main():
 
     # Error out if it is a non-publishable config or if we don't have the passphrase
     if args.publish is not None:
-        if (not args.cov and not args.cov_reports) or not cfg.is_primary_cfg:
-            log.fatal("--publish requires --cov to be enabled"
-                      " and for the config file to be a batch sim_cfg")
+        if cfg.flow == "sim":
+            if (not args.cov and not args.cov_reports) or not cfg.is_primary_cfg:
+                log.fatal("--publish requires --cov to be enabled for sim"
+                          " and for the config file to be a batch sim_cfg")
+                sys.exit(1)
+        elif not cfg.is_primary_cfg:
+            log.fatal("--publish needs the config file to be a batch cfg")
             sys.exit(1)
         check_ssh_git_access(args.publish, "publish")
 

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -270,6 +270,24 @@ def parse_reseed_multiplier(as_str: str) -> float:
     return ret
 
 
+def check_ssh_git_access(repository: str, flag: str):
+    '''
+    Helper function that checks whether we have access to the provided repository
+    through a deploy key or through an environment variable.
+    '''
+    has_passphrase = bool(os.environ.get("SSH_KEY_PASSPHRASE"))
+    has_deploy_key = subprocess.run(
+        ["git", "ls-remote", repository],
+        capture_output=True,
+        env={**os.environ, "GIT_SSH_COMMAND": "ssh -o BatchMode=yes"}
+    ).returncode == 0
+
+    if not has_passphrase and not has_deploy_key:
+        log.fatal(f"--{flag} requires either SSH_KEY_PASSPHRASE to be set"
+                  " or a deploy key with access to the repository")
+        sys.exit(1)
+
+
 def parse_args():
     cfg_metavar = "<cfg-hjson-file>"
     parser = argparse.ArgumentParser(
@@ -629,7 +647,18 @@ def parse_args():
                       metavar="REPO",
                       help="Publish results to the given GitHub repository "
                            "(e.g. git@github.com:org/repo.git). "
-                           "Requires the SSH_KEY_PASSPHRASE environment variable to be set.")
+                           "Requires the SSH_KEY_PASSPHRASE environment variable to be set "
+                           "or the possession of a deploy key.")
+
+    pubg.add_argument("--publish-prev",
+                      metavar="REPO",
+                      help="Publish previously generated results to the given GitHub repository "
+                           "(e.g. git@github.com:org/repo.git). "
+                           "It only publishes the reports from the /latest subdirectories. "
+                           "Requires the SSH_KEY_PASSPHRASE environment variable to be set "
+                           "or the possession of a deploy key. "
+                           "Also requires the corresponding tool and flow to be passed from "
+                           "the sim_cfg or manually with the --tool and -i flags.")
 
     dvg = parser.add_argument_group('Controlling DVSim itself')
 
@@ -754,6 +783,16 @@ def main():
         cfg.print_list()
         sys.exit(0)
 
+    # Run --publish-prev if it was provided
+    if args.publish_prev is not None:
+        check_ssh_git_access(args.publish_prev, "publish-prev")
+        if args.items is None:
+            log.fatal("We need to know the regression to publish it! Set the regression with -i")
+            sys.exit(1)
+
+        cfg.publish_results(args.publish_prev, args.items[0])
+        sys.exit(0)
+
     # Purge the scratch path if --purge option is set.
     if args.purge:
         cfg.purge()
@@ -772,12 +811,13 @@ def main():
         cfg.deploy_objects()
         sys.exit(0)
 
-    # Error out if it is a non-publishable config
+    # Error out if it is a non-publishable config or if we don't have the passphrase
     if args.publish is not None:
         if not args.cov or not cfg.is_primary_cfg:
             log.fatal("--publish requires --cov to be enabled"
                       " and for the config file to be a batch sim_cfg")
             sys.exit(1)
+        check_ssh_git_access(args.publish, "publish")
 
     # Deploy the builds and runs
     if args.items:

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -636,6 +636,11 @@ def parse_args():
                       help=('Rather than building or running any tests, '
                             'analyze the coverage from the last run.'))
 
+    covg.add_argument("--cov-reports",
+                      action='store_true',
+                      help=('Enable collection of coverage data, '
+                            'and include the generated reports.'))
+
     pubg = parser.add_argument_group('Generating and publishing results')
 
     pubg.add_argument("--map-full-testplan",
@@ -735,6 +740,10 @@ def main():
     if args.publish:
         args.map_full_testplan = True
 
+    # Set coverage flag to true if passed the cov_reports flag
+    if args.cov_reports:
+        args.cov = True
+
     args.branch = resolve_branch(args.branch)
     proj_root_src, proj_root = resolve_proj_root(args)
     args.scratch_root = resolve_scratch_root(args.scratch_root, proj_root)
@@ -813,7 +822,7 @@ def main():
 
     # Error out if it is a non-publishable config or if we don't have the passphrase
     if args.publish is not None:
-        if not args.cov or not cfg.is_primary_cfg:
+        if (not args.cov and not args.cov_reports) or not cfg.is_primary_cfg:
             log.fatal("--publish requires --cov to be enabled"
                       " and for the config file to be a batch sim_cfg")
             sys.exit(1)

--- a/util/dvsim/style.css
+++ b/util/dvsim/style.css
@@ -8,8 +8,7 @@
  */
 
 .results {
-  width: 80%;
-  max-width: 960px;
+  box-sizing: border-box;
   padding-left: 40px;
   padding-right: 40px;
   margin: 0 auto;
@@ -33,13 +32,11 @@
 }
 
 .results table {
-  width: 90%;
   margin: 2% auto;
   border: 1px solid #f2f2f2;
   border-collapse: collapse;
   text-align: center;
   vertical-align: middle;
-  display: table;
   table-layout: auto;
 }
 
@@ -175,10 +172,12 @@
 }
 
 .results.index-page h1 {
+  width: 70%;
+  margin: 0 auto;
+  text-align: left;
   color: #000000;
   letter-spacing: 0.01em;
   font-weight: 600;
-  text-align: left;
   font-size: 2.5rem;
 }
 
@@ -201,8 +200,11 @@
 }
 
 .results.index-page table {
-  width: 100%;
-  margin: 0;
+  width: 70%;
+  margin: 0 auto;
   border: none;
   box-shadow: none;
+  position: static;
+  left: auto;
+  transform: none;
 }

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -356,7 +356,7 @@ def md_results_to_html(title, css_file, md_text, is_primary_cfg=False):
     if title != "":
         html_text += "  <title>{}</title>\n".format(title)
     html_text += "</head>\n"
-    html_text += "<body>\n"
+    html_text += "<body style=\"margin:0; padding:0;\">\n"
     html_text += "<div class=\"results\">\n"
     html_text += mistletoe.markdown(md_text)
     html_text += "</div>\n"
@@ -367,6 +367,11 @@ def md_results_to_html(title, css_file, md_text, is_primary_cfg=False):
     html_text = transform(html_text,
                           external_styles=css_file,
                           cssutils_logging_level=log.ERROR)
+    html_text = html_text.replace(
+        'width:80%',
+        'box-sizing:border-box; width:80%'
+    )
+    html_text = re.sub(r'(<div class="results"[^>]*) width="80%"', r'\1', html_text)
     if is_primary_cfg:
         html_text = html_styling_batch_coverage(html_text)
     return html_text
@@ -526,22 +531,6 @@ def html_styling_batch_coverage(html_text):
     tag tables with a class based on their column count for CSS styling
     when making a batch coverage report.
     """
-    # Fix table centering: replace whatever margin was inlined with explicit auto margins
-    html_text = re.sub(
-        r'(<table[^>]*style="[^"]*?)margin:[^;]+;',
-        r'\1margin-left:auto; margin-right:auto;',
-        html_text
-    )
-    # Break out of the constrained .results div and center on full viewport
-    html_text = html_text.replace(
-        "<table",
-        "<div style=\"width:100vw; position:relative; left:50%;"
-        "transform:translateX(-50%); overflow-x:auto;\"><table"
-    )
-    html_text = html_text.replace(
-        "</table>",
-        "</table></div>"
-    )
     soup = BeautifulSoup(html_text, "html.parser")
     table = soup.select_one("table")
     table["class"] = table.get("class", []) + ["col-12"]

--- a/util/gen_ip_collection.py
+++ b/util/gen_ip_collection.py
@@ -105,57 +105,65 @@ def format_use_cfgs(cfgs, indent=13):
     return "\n".join(lines)
 
 
+def format_block(name, cfgs_sections, nested=False):
+    """Format a named block with optional nesting."""
+    BASE_INDENT = 13
+    NESTED_INDENT = BASE_INDENT + 4
+    indent = NESTED_INDENT if nested else BASE_INDENT
+    prefix = " " * BASE_INDENT
+    lines = []
+    if nested:
+        lines.append(f"{prefix}{name}: [")
+    for comment, cfgs in cfgs_sections:
+        if cfgs:
+            lines.append(f"{' ' * indent}// {comment}")
+            lines.append(format_use_cfgs(cfgs, indent))
+    if nested:
+        lines.append(f"{prefix}]")
+    return "\n".join(lines)
+
+
 def generate_hjson(ip_cfgs, top_cfgs, tops, copyright_header, top_specific=False):
     """Generate hjson for a batch sim_cfgs"""
-    sections = []
-
     tl_agent_cfgs = [c for c in ip_cfgs if "hw/dv/sv/" in c]
     pure_ip_cfgs = [c for c in ip_cfgs if "hw/ip/" in c]
 
-    if tl_agent_cfgs:
-        sections.append(
-            "             // Unit tests for UVCs.\n" +
-            format_use_cfgs(tl_agent_cfgs)
-        )
-    if pure_ip_cfgs:
-        sections.append(
-            "             // IPs.\n" +
-            format_use_cfgs(pure_ip_cfgs)
-        )
+    sections = []
 
+    # IP block
+    ip_sections = [
+        ("Unit tests for UVCs.", tl_agent_cfgs),
+        ("IPs.", pure_ip_cfgs),
+    ]
+    sections.append(format_block("ip", ip_sections, nested=not top_specific))
+
+    # Per-top blocks
     for top in tops:
         cfgs = top_cfgs[top]
-        autogen_cfgs = [c for c in cfgs if f"hw/{top}/ip_autogen/" in c
-                        or f"hw/{top}/ip/" in c]
-        chip_cfgs = [c for c in cfgs if f"hw/{top}/dv/" in c]
+        top_sections = [
+            (f"{top} autogen IPs.", [c for c in cfgs if f"hw/{top}/ip_autogen/" in c
+                                     or f"hw/{top}/ip/" in c]),
+            (f"{top} chip.", [c for c in cfgs if f"hw/{top}/dv/" in c]),
+        ]
+        sections.append(format_block(top, top_sections, nested=not top_specific))
 
-        if autogen_cfgs:
-            sections.append(
-                f"             // {top} autogen IPs.\n" +
-                format_use_cfgs(autogen_cfgs)
-            )
-        if chip_cfgs:
-            sections.append(
-                f"             // {top} chip.\n" +
-                format_use_cfgs(chip_cfgs)
-            )
-
-    use_cfgs_body = "\n".join(sections)
+    use_cfgs_body = "\n\n".join(s for s in sections if s)
 
     if not top_specific:
         batchname_desc = "across all IPs and tops in the project"
         batchname = "all_tops"
         rel_path = "hw/dv/summary"
+        open_br, close_br = "{", "}"
     else:
-        batchname_desc = f"of the IPs and the full chip used in {top}"
+        batchname_desc = f"of the IPs and the full chip used in {tops[0]}"
         batchname = tops[0]
         rel_path = f"hw/{tops[0]}/dv/summary"
+        open_br, close_br = "[", "]"
 
     return f"""{copyright_header}
 {{
   // This is a cfg hjson group for DV simulations. It includes ALL individual DV simulation
-  // cfgs {batchname_desc}. This enables the common
-  // regression sets to be run in one shot.
+  // cfgs {batchname_desc}. This enables the common regression sets to be run in one shot.
   name: {batchname}_batch
 
   import_cfgs: [// Project wide common cfg file
@@ -173,9 +181,9 @@ def generate_hjson(ip_cfgs, top_cfgs, tops, copyright_header, top_specific=False
     }}
   ]
 
-  use_cfgs: [
+  use_cfgs: {open_br}
 {use_cfgs_body}
-            ]
+  {close_br}
 }}
 """
 


### PR DESCRIPTION
With this commit, now `sim_cfgs` can have their `use_cfgs` be divided in several groups for more clear reporting.
Additionally, `--publish-prev` and `--cov_results` flag are introduced for publishing already existing `latest/` reports and for including tool-specific coverage reports in the `report.html`, respectively.
The directories are also renamed (this allows for users to publish lint runs and formal runs, if desired) and a bug for running batch `sim_cfgs` is fixed.

Builds on top of #53.