### PR TITLE
[doc,hw,sw] Remove links to documents that aren't publicly visible

### DIFF
--- a/doc/security/specs/device_life_cycle/README.md
+++ b/doc/security/specs/device_life_cycle/README.md
@@ -38,8 +38,6 @@ transition is legal and allowed by the life cycle definition.
 
 See the table below for more details.
 
-<!--SVG for flow chart below in google docs at
-https://docs.google.com/drawings/d/1kENEhJzrWDkzonu8ZC6SKDRtjETyH6S4SslcO1RpVPM/edit?usp=sharing-->
 <img src="device_life_cycle_fig1.svg" alt="Fig1" style="width: 800px;"/>
 
 In the diagram above,

--- a/doc/security/specs/ownership_transfer/README.md
+++ b/doc/security/specs/ownership_transfer/README.md
@@ -184,10 +184,6 @@ Definitions:
 <table>
   <tr>
     <td>
-    <!--
-    svgs are made in google docs, and can be found here:
-    https://docs.google.com/drawings/d/1hnC2EgkYpkxhVJ6I0prxdoQbglstqfwxvBYh_JIt8TA/edit?usp=sharing
-    -->
       <img src="ownership_transfer_fig1.svg" width="900" alt="fig1">
     </td>
   </tr>

--- a/hw/ip/acc/doc/theory_of_operation.md
+++ b/hw/ip/acc/doc/theory_of_operation.md
@@ -87,11 +87,6 @@ If a fault causes the state to become zero, ACC raises a `BAD_INTERNAL_STATE` fa
 
 ### Operational States
 
-<!--
-Source: https://docs.google.com/drawings/d/1C0D4UriRk5pKGFoFtAXYLcJ1oBG1BCDd2omCLPYHtr0/edit
-
-Download the SVG from Google Draw, open it in Inkscape once and save it without changes to add width/height information to the image.
--->
 ![ACC operational states](./acc_operational_states.svg)
 
 ACC can be in different operational states.

--- a/hw/ip/spi_device/rtl/spid_status.sv
+++ b/hw/ip/spi_device/rtl/spid_status.sv
@@ -155,9 +155,6 @@ module spid_status
   // the signal is broadcasted to Passthrough to filter-out the following
   // commands until the BUSY signal is released.
 
-  // Design Doc
-  //  https://docs.google.com/document/d/1wUIynMYVfVg9HmCL0q5-6r9BuN-XM0z--wGqU0bXRQ0
-
   // assumes BUSY bit as 0
   `ASSERT_INIT(BusyBitZero_A, BitBusy == 0)
 

--- a/hw/ip_templates/ac_range_check/dv/README.md.tpl
+++ b/hw/ip_templates/ac_range_check/dv/README.md.tpl
@@ -20,7 +20,6 @@ The `ac_range_check` UVM DV testbench has been constructed based on the [CIP tes
 
 ${"###"} Block diagram
 ![Block diagram](./doc/tb.svg)
-Note: this diagram is editable from [this address](https://docs.google.com/drawings/d/1-0r4V6H8RwLeiAa3ng73vcDZdCbeeuFDYPZcX-QXRYo/edit?usp=sharing).
 
 ${"###"} Top level testbench
 Top level testbench is located at `hw/top_${topname}/ip_autogen/${module_instance_name}/dv/tb/tb.sv`.

--- a/hw/ip_templates/pwrmgr/doc/programmers_guide.md
+++ b/hw/ip_templates/pwrmgr/doc/programmers_guide.md
@@ -74,8 +74,6 @@ Since in these scenarios the system was not reset, software continues executing 
 5. Re-enable interrupts for normal operation and wakeup handling.
 6. Once wake is handled, clear the wake indication in [`WAKE_INFO`](registers.md#wake_info).
 
-For an in-depth discussion, please see [power management programmers model](https://docs.google.com/document/d/1w86rmvylJgZVmmQ6Q1YBcCp2VFctkQT3zJ408SJMLPE/edit?usp=sharing) for additional details.
-
 ## Device Interface Functions (DIFs)
 
 - [Device Interface Functions](../../../../../sw/device/lib/dif/dif_pwrmgr.h)

--- a/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex_addr_trans.sv.tpl
+++ b/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex_addr_trans.sv.tpl
@@ -4,8 +4,7 @@
 
 /**
  * Simple address translation for rv_core_ibex
- * This performs a configurable address translation, please see
- * https://docs.google.com/document/d/1uU2Zh46SJtoaOqZ9dCRO7oAQnhTUcWWZ7CstOa1PZiM/edit?usp=sharing
+ * This performs a configurable address translation.
  */
 
 module ${module_instance_name}_addr_trans import rv_core_ibex_pkg::*; #(

--- a/hw/top_darjeeling/dv/env/chip_if.sv
+++ b/hw/top_darjeeling/dv/env/chip_if.sv
@@ -6,8 +6,6 @@
 // The top_darjeeling SoC provides a bunch of fixed-function and muxed IO pads. The interface serves
 // as the gateway connection between the chip IOs and ALL functions mapped to the fixed and muxed
 // IOs. It creates sub-interfaces for all functions and connects them all to the chip IOs together.
-// The pin mapping to each function is provided in the following spreadsheet:
-// https://docs.google.com/spreadsheets/d/1jp-paagh2_sJFMUFnewx0XAUmLdCCgXn8NnB2BNEk-Q
 //
 // All functional interfaces are internally (or externally, in this interface) gated off from
 // driving the IOs at the same time. Since there are more functions than IOs, it is the test

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/README.md
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/README.md
@@ -20,7 +20,6 @@ The `ac_range_check` UVM DV testbench has been constructed based on the [CIP tes
 
 ### Block diagram
 ![Block diagram](./doc/tb.svg)
-Note: this diagram is editable from [this address](https://docs.google.com/drawings/d/1-0r4V6H8RwLeiAa3ng73vcDZdCbeeuFDYPZcX-QXRYo/edit?usp=sharing).
 
 ### Top level testbench
 Top level testbench is located at `hw/top_darjeeling/ip_autogen/ac_range_check/dv/tb/tb.sv`.

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/doc/programmers_guide.md
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/doc/programmers_guide.md
@@ -74,8 +74,6 @@ Since in these scenarios the system was not reset, software continues executing 
 5. Re-enable interrupts for normal operation and wakeup handling.
 6. Once wake is handled, clear the wake indication in [`WAKE_INFO`](registers.md#wake_info).
 
-For an in-depth discussion, please see [power management programmers model](https://docs.google.com/document/d/1w86rmvylJgZVmmQ6Q1YBcCp2VFctkQT3zJ408SJMLPE/edit?usp=sharing) for additional details.
-
 ## Device Interface Functions (DIFs)
 
 - [Device Interface Functions](../../../../../sw/device/lib/dif/dif_pwrmgr.h)

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_addr_trans.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_addr_trans.sv
@@ -4,8 +4,7 @@
 
 /**
  * Simple address translation for rv_core_ibex
- * This performs a configurable address translation, please see
- * https://docs.google.com/document/d/1uU2Zh46SJtoaOqZ9dCRO7oAQnhTUcWWZ7CstOa1PZiM/edit?usp=sharing
+ * This performs a configurable address translation.
  */
 
 module rv_core_ibex_addr_trans import rv_core_ibex_pkg::*; #(

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -6,8 +6,6 @@
 // The top_earlgrey SoC provides a bunch of fixed-function and muxed IO pads. The interface serves
 // as the gateway connection between the chip IOs and ALL functions mapped to the fixed and muxed
 // IOs. It creates sub-interfaces for all functions and connects them all to the chip IOs together.
-// The pin mapping to each function is provided in the following spreadsheet:
-// https://docs.google.com/spreadsheets/d/1jp-paagh2_sJFMUFnewx0XAUmLdCCgXn8NnB2BNEk-Q
 //
 // All functional interfaces are internally (or externally, in this interface) gated off from
 // driving the IOs at the same time. Since there are more functions than IOs, it is the test

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/doc/programmers_guide.md
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/doc/programmers_guide.md
@@ -74,8 +74,6 @@ Since in these scenarios the system was not reset, software continues executing 
 5. Re-enable interrupts for normal operation and wakeup handling.
 6. Once wake is handled, clear the wake indication in [`WAKE_INFO`](registers.md#wake_info).
 
-For an in-depth discussion, please see [power management programmers model](https://docs.google.com/document/d/1w86rmvylJgZVmmQ6Q1YBcCp2VFctkQT3zJ408SJMLPE/edit?usp=sharing) for additional details.
-
 ## Device Interface Functions (DIFs)
 
 - [Device Interface Functions](../../../../../sw/device/lib/dif/dif_pwrmgr.h)

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_addr_trans.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_addr_trans.sv
@@ -4,8 +4,7 @@
 
 /**
  * Simple address translation for rv_core_ibex
- * This performs a configurable address translation, please see
- * https://docs.google.com/document/d/1uU2Zh46SJtoaOqZ9dCRO7oAQnhTUcWWZ7CstOa1PZiM/edit?usp=sharing
+ * This performs a configurable address translation.
  */
 
 module rv_core_ibex_addr_trans import rv_core_ibex_pkg::*; #(

--- a/hw/top_earlgrey/syn/chip_earlgrey_asic.sdc
+++ b/hw/top_earlgrey/syn/chip_earlgrey_asic.sdc
@@ -808,7 +808,6 @@ set_false_path -hold -from [get_clocks SPI_TPM_CLK] \
 ##################
 # SPI host core logic operates on the IO_CLK
 #
-# See https://docs.google.com/drawings/d/1qkUnXaRafIPyBnVpreqfbF_zSy0xlpHqXMZp6F-j8Cc/edit?usp=sharing
 # During pre-layout, the SPI_HOST_CLK source latencies are estimated to account
 # for pad and logic latencies. After CTS, source latency must be removed as all
 # clocks are propagated.
@@ -872,8 +871,6 @@ set_output_delay -max $spi_host_out_val_max \
 # SPI DEV SLOW clock Passthru Operation  #
 ##########################################
 # Passthrough target freq for slow commands is 24MHz. Using 25MHz to over-constrain
-# For details on SPI passthrough timing, please see
-# https://docs.google.com/presentation/d/1GEPxKaOsr9ZcJwI_MBEL74P7jQvBFzOdzSbgru_yVLQ/edit?usp=sharing
 # See the SPI TPM section for half-cycle sampling with non-passthrough modes.
 #
 # The constraints below take the following approach:
@@ -1031,8 +1028,6 @@ set_false_path -from [get_clocks SPI_DEV_SLOW_PASS_CSB_CLK] \
 # SPI DEV FAST clock Passthru Operation  #
 ##########################################
 # Passthrough target freq for fast commands is 33MHz. Using 40MHz to over-constrain
-# For details on SPI passthrough timing, please see
-# https://docs.google.com/presentation/d/1GEPxKaOsr9ZcJwI_MBEL74P7jQvBFzOdzSbgru_yVLQ/edit?usp=sharing
 # See the SPI TPM section for half-cycle sampling with non-passthrough modes.
 #
 # The constraints below take the following approach:

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/doc/programmers_guide.md
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/doc/programmers_guide.md
@@ -74,8 +74,6 @@ Since in these scenarios the system was not reset, software continues executing 
 5. Re-enable interrupts for normal operation and wakeup handling.
 6. Once wake is handled, clear the wake indication in [`WAKE_INFO`](registers.md#wake_info).
 
-For an in-depth discussion, please see [power management programmers model](https://docs.google.com/document/d/1w86rmvylJgZVmmQ6Q1YBcCp2VFctkQT3zJ408SJMLPE/edit?usp=sharing) for additional details.
-
 ## Device Interface Functions (DIFs)
 
 - [Device Interface Functions](../../../../../sw/device/lib/dif/dif_pwrmgr.h)

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_addr_trans.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_addr_trans.sv
@@ -4,8 +4,7 @@
 
 /**
  * Simple address translation for rv_core_ibex
- * This performs a configurable address translation, please see
- * https://docs.google.com/document/d/1uU2Zh46SJtoaOqZ9dCRO7oAQnhTUcWWZ7CstOa1PZiM/edit?usp=sharing
+ * This performs a configurable address translation.
  */
 
 module rv_core_ibex_addr_trans import rv_core_ibex_pkg::*; #(

--- a/sw/device/silicon_creator/lib/shutdown_unittest.cc
+++ b/sw/device/silicon_creator/lib/shutdown_unittest.cc
@@ -94,8 +94,8 @@ constexpr uint32_t Pack32(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
   Pack32(kAlertClass##prod, kAlertClass##prodend, kAlertClass##dev, \
          kAlertClass##rma)
 
-// This alert configuration is described in the ROM Shutdown specification:
-// https://docs.google.com/document/d/1V8hRvQnJhsvddieJbRHS3azbPZvoBWxfxPZV_0YA1QU/edit#
+// See the ROM Shutdown specification in
+// sw/device/silicon_creator/rom/doc/shutdown.md.
 // Dummy alerts have been added to prevent the tests breaking when new alerts
 // are added (see #7183). These lists of alerts and local alerts are for test
 // purposes only and may not be complete and/or up to date.

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -299,10 +299,8 @@
             - Apply bootstrap pin strapping.
             - Reset the chip.
             - Verify that the chip responds to `READ_SFDP` (`0x5a`).
-            - Verify the SFDP header structure. See this
-              [document](https://docs.google.com/document/d/1X_x7f62IrPeHRLGBzybhDu9TsvsSCb6_1uKOjQO_fI4/edit?resourcekey=0-vLsVqyrt1F2mGwLrz73uwA#heading=h.gc2hf662pvy9).
-            - Verify the JEDEC Basic Flash Parameter Table. See this
-              [spreadsheet](https://docs.google.com/spreadsheets/d/1cioU3HgsWZXD4-eoUiH9TuVLZeFpucSdjyq5HND-FpQ/edit#gid=0).
+            - Verify the SFDP header structure.
+            - Verify the JEDEC Basic Flash Parameter Table.
             '''
       tags: ["rom", "no_dv", "fpga", "silicon"]
       stage: V2
@@ -925,14 +923,8 @@
 
             - For TEST, DEV, and RMA:
               - Connect a debugger.
-              - Follow the steps
-                [here](https://docs.google.com/document/d/1i6V3tFTv0UhWeM-IGCxgxkC07Bo_zpbgr6u1KE1Rehs/edit?resourcekey=0-L-XaP9QeLAkEsp8najVkUQ#heading=h.m4f6p97t15j8)
-                and execute `//sw/device/examples/sram_program` binary from SRAM.
+              - Execute `//sw/device/examples/sram_program` binary from SRAM.
               - Verify that chip sends the expected message over UART.
-
-            See this
-            [doc](https://docs.google.com/document/d/1i6V3tFTv0UhWeM-IGCxgxkC07Bo_zpbgr6u1KE1Rehs/edit?resourcekey=0-L-XaP9QeLAkEsp8najVkUQ)
-            for detils.
             '''
       tags: ["rom", "verilator", "dv", "fpga", "silicon"]
       stage: V3

--- a/sw/device/silicon_creator/rom/doc/sigverify.md
+++ b/sw/device/silicon_creator/rom/doc/sigverify.md
@@ -63,8 +63,4 @@ The advantage of this approach is that it does not require any changes in
 signature generation or off-target signature verification. See the usage
 constraints fields (`selector_bits`, `device_id`, `manuf_state_creator`,
 `manuf_state_owner`, `life_cycle_state`) in
-[manifest documentation](../../rom_ext/doc/manifest.md) for more details. See
-this
-[document](https://docs.google.com/document/d/1V9O-YTaUVWoXMq85qIYaSS6x7Bl9Li4Z2KqZ6u_jG98/edit?resourcekey=0-TfuDj6NU3Ir0L1PrkcNyog)
-for a brief explanation of why this approach is not susceptible to length
-extension attacks.
+[manifest documentation](../../rom_ext/doc/manifest.md) for more details.

--- a/sw/host/opentitantool/src/command/transport.rs
+++ b/sw/host/opentitantool/src/command/transport.rs
@@ -76,9 +76,7 @@ impl CommandDispatch for TransportSetJtagPins {
 }
 
 /// Updates the firmware of the debugger/transport.  If no argument is given, a suitable
-/// "official" firmware will be used, if one such was compiled into the OpenTitanTool binary.  For
-/// instructions on how to build HyperDebug firmware locally, see
-/// https://docs.google.com/document/d/1ZEH7L5j9-wMw4tkW28-xt6JU5B6hTX0RdZD4h4OZzDo .
+/// "official" firmware will be used, if one such was compiled into the OpenTitanTool binary.
 #[derive(Debug, Args)]
 pub struct TransportUpdateFirmware {
     /// Local firmware file to use instead of official release.

--- a/sw/host/provisioning/orchestrator/src/util.py
+++ b/sw/host/provisioning/orchestrator/src/util.py
@@ -88,8 +88,6 @@ def resolve_runfile(path):
     #
     # The old scheme does not work within a zipped py_binary, so this logic is a
     # hack to fix up the supplied path.
-    #
-    # See https://docs.google.com/document/d/1skNx5o-8k5-YXUAyEETvr39eKoh9fecJbGUquPh5iy8/edit.
     REPO = "lowrisc_opentitan"
     if path.startswith("external/"):
         corrected_path = path[len("external/"):]


### PR DESCRIPTION
These all result in Access Denied, which makes it hard to understand design decisions.

Going forward, these kinds of diagrams and documents need to be on the repo, whether as part of a PR's comments or in the source itself. It's also just easier to keep track of.