### PR TITLE
[otp_ctrl,dv] Fix value of OTP_MACRO_FULL_WIDTH

### DIFF
--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv.tpl
@@ -59,8 +59,10 @@ package otp_ctrl_env_pkg;
   parameter int OTP_ADDR_WIDTH = OtpByteAddrWidth-2;
 
   // The full word size of the OTP macro, including ECC.
-  parameter int OTP_MACRO_FULL_WIDTH = OtpWidth + prim_secded_pkg::get_synd_width(
-              prim_secded_pkg::SecdedHamming, OtpWidth);
+  parameter int OTP_MACRO_FULL_WIDTH = otp_ctrl_macro_pkg::OtpWidth +
+      prim_secded_pkg::get_synd_width(
+          prim_secded_pkg::SecdedHamming,
+          otp_ctrl_macro_pkg::OtpWidth);
 
   parameter uint NUM_PRIM_REG = 8;
 

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -51,8 +51,10 @@ package otp_ctrl_env_pkg;
   parameter int OTP_ADDR_WIDTH = OtpByteAddrWidth-2;
 
   // The full word size of the OTP macro, including ECC.
-  parameter int OTP_MACRO_FULL_WIDTH = OtpWidth + prim_secded_pkg::get_synd_width(
-              prim_secded_pkg::SecdedHamming, OtpWidth);
+  parameter int OTP_MACRO_FULL_WIDTH = otp_ctrl_macro_pkg::OtpWidth +
+      prim_secded_pkg::get_synd_width(
+          prim_secded_pkg::SecdedHamming,
+          otp_ctrl_macro_pkg::OtpWidth);
 
   parameter uint NUM_PRIM_REG = 8;
 

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -51,8 +51,10 @@ package otp_ctrl_env_pkg;
   parameter int OTP_ADDR_WIDTH = OtpByteAddrWidth-2;
 
   // The full word size of the OTP macro, including ECC.
-  parameter int OTP_MACRO_FULL_WIDTH = OtpWidth + prim_secded_pkg::get_synd_width(
-              prim_secded_pkg::SecdedHamming, OtpWidth);
+  parameter int OTP_MACRO_FULL_WIDTH = otp_ctrl_macro_pkg::OtpWidth +
+      prim_secded_pkg::get_synd_width(
+          prim_secded_pkg::SecdedHamming,
+          otp_ctrl_macro_pkg::OtpWidth);
 
   parameter uint NUM_PRIM_REG = 8;
 


### PR DESCRIPTION
This value should use the otp data word width, which is otp_ctrl_macro_pkg::OtpWidth.
The old code was using otp_ctrl_reg_pkg::OtpWidth, which is 2 (bytes).

Notice OTP_MACRO_FULL_WIDTH was only used in uvm_info messages so it would not affect test outcomes.