### PR TITLE
[cla] Add individual and corporate CLAs

### DIFF
--- a/CLA
+++ b/CLA
@@ -1,1 +1,0 @@
-This CLA is for informational purposes only.

--- a/CLA-Corporate
+++ b/CLA-Corporate
@@ -1,0 +1,156 @@
+GLOBALPLATFORM/PAVONA PROJECT FOUNDATION
+
+CORPORATE CONTRIBUTOR LICENSE AGREEMENT ("AGREEMENT")
+
+This Agreement reproduces without alteration The Apache Software Foundation
+Software Grant and Corporate Contributor License Agreement
+http://www.apache.org/licenses/ (v r190612) except for changing appropriate
+references
+
+Thank you for your interest in the Pavona Project Foundation, hosted by
+GlobalPlatform, Inc. (collectively, the "Foundation"). In order to clarify the
+intellectual property license granted with Contributions from any person or
+entity, the Foundation must have a Contributor License Agreement (CLA) on file
+that has been signed by each Contributor, indicating agreement to the license
+terms below. This license is for your protection as a Contributor as well as the
+protection of the Foundation and its users; it does not change your rights to
+use your own Contributions for any other purpose. This version of the Agreement
+allows an entity (the "Corporation") to submit Contributions to the Foundation,
+to authorize Contributions submitted by its designated employees to the
+Foundation, and to grant copyright and patent licenses thereto. If you have not
+already done so, please complete and sign, then scan and email a pdf file of
+this Agreement to secretariat@globalplatform.org. Please read this document
+carefully before signing and keep a copy for your records.
+
+Corporation name:    ________________________________________________
+
+Corporation address: ________________________________________________
+
+                     ________________________________________________
+
+                     ________________________________________________
+
+Point of Contact:    ________________________________________________
+
+E-Mail:              ________________________________________________
+
+Telephone:           _____________________ Fax: _____________________
+
+You accept and agree to the following terms and conditions for Your present and
+future Contributions submitted to the Foundation. In return, the Foundation
+shall not use Your Contributions in a way that is contrary to the public benefit
+or inconsistent with its nonprofit status and bylaws in effect at the time of
+the Contribution. Except for the license granted herein to the Foundation and
+recipients of software distributed by the Foundation, You reserve all right,
+title, and interest in and to Your Contributions.
+
+1. Definitions.
+
+  "You" (or "Your") shall mean the copyright owner or legal entity authorized by
+  the copyright owner that is making this Agreement with the Foundation. For
+  legal entities, the entity making a Contribution and all other entities that
+  control, are controlled by, or are under common control with that entity are
+  considered to be a single Contributor. For the purposes of this definition,
+  "control" means (i) the power, direct or indirect, to cause the direction or
+  management of such entity, whether by contract or otherwise, or (ii) ownership
+  of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
+  ownership of such entity.
+
+  "Contribution" shall mean the code, documentation or other original works of
+  authorship expressly identified in Schedule B, as well as any original work of
+  authorship, including any modifications or additions to an existing work, that
+  is intentionally submitted by You to the Foundation for inclusion in, or
+  documentation of, any of the products owned or managed by the Foundation (the
+  "Work"). For the purposes of this definition, "submitted" means any form of
+  electronic, verbal, or written communication sent to the Foundation or its
+  representatives, including but not limited to communication on electronic
+  mailing lists, source code control systems, and issue tracking systems that
+  are managed by, or on behalf of, the Foundation for the purpose of discussing
+  and improving the Work, but excluding communication that is conspicuously
+  marked or otherwise designated in writing by You as "Not a Contribution."
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+Agreement, You hereby grant to the Foundation and to recipients of software
+distributed by the Foundation a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable copyright license to reproduce, prepare derivative
+works of, publicly display, publicly perform, sublicense, and distribute Your
+Contributions and such derivative works.
+
+3. Grant of Patent License. Subject to the terms and conditions of this
+Agreement, You hereby grant to the Foundation and to recipients of software
+distributed by the Foundation a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license to
+make, have made, use, offer to sell, sell, import, and otherwise transfer the
+Work, where such license applies only to those patent claims licensable by You
+that are necessarily infringed by Your Contribution(s) alone or by combination
+of Your Contribution(s) with the Work to which such Contribution(s) were
+submitted. If any entity institutes patent litigation against You or any other
+entity (including a cross-claim or counterclaim in a lawsuit) alleging that your
+Contribution, or the Work to which you have contributed, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or Work shall terminate as of
+the date such litigation is filed.
+
+4. You represent that You are legally entitled to grant the above license. You
+represent further that each employee of the Corporation designated on Schedule A
+below (or in a subsequent written modification to that Schedule) is authorized
+to submit Contributions on behalf of the Corporation.
+
+5. You represent that each of Your Contributions is Your original creation (see
+section 7 for submissions on behalf of others).
+
+6. You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. You may provide support for free, for a
+fee, or not at all. Unless required by applicable law or agreed to in writing,
+You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including, without
+limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+7. Should You wish to submit work that is not Your original creation, You may
+submit it to the Foundation separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which you are personally aware, and conspicuously marking the
+work as "Submitted on behalf of a third-party: [named here]".
+
+8. It is your responsibility to notify the Foundation when any change is
+required to the list of designated employees authorized to submit Contributions
+on behalf of the Corporation, or to the Corporation's Point of Contact with the
+Foundation.
+
+Please sign:     __________________________________  Date: ___________________
+
+Title:           __________________________________
+
+Corporation:     __________________________________
+
+Schedule A [Initial list of designated employees. NB: authorization is not tied
+to particular Contributions.]
+
+_______________________________ _________________________________
+
+_______________________________ _________________________________
+
+_______________________________ _________________________________
+
+_______________________________ _________________________________
+
+_______________________________ _________________________________
+
+_______________________________ _________________________________
+
+_______________________________ _________________________________
+
+_______________________________ _________________________________
+
+_______________________________ _________________________________
+
+_______________________________ _________________________________
+
+_______________________________ _________________________________
+
+Schedule B [Identification of optional concurrent software grant. Would be left
+blank or omitted if there is no concurrent software grant.]
+
+[describe grant here]

--- a/CLA-Individual
+++ b/CLA-Individual
@@ -1,0 +1,125 @@
+GLOBALPLATFORM/PAVONA PROJECT FOUNDATION
+
+Individual Contributor License Agreement ("Agreement") V2.0
+
+This Agreement reproduces without alteration The Apache Software Foundation
+Individual Contributor License Agreement V2.0 except for changing appropriate
+references
+
+Thank you for your interest in the Pavona Project Foundation, hosted by
+GlobalPlatform, Inc. (collectively, the "Foundation"). In order to clarify the
+intellectual property license granted with Contributions from any person or
+entity, the Foundation must have a Contributor License Agreement ("CLA") on
+file that has been signed by each Contributor, indicating agreement to the
+license terms below. This license is for your protection as a Contributor as
+well as the protection of the Foundation and its users; it does not change your
+rights to use your own Contributions for any other purpose. If you have not
+already done so, please complete and sign, then scan and email a pdf file of
+this Agreement to secretariat@globalplatform.org. Please read this document
+carefully before signing and keep a copy for your records.
+
+Full name:              _______________________________________________________
+
+(optional) Public name: _______________________________________________________
+
+Postal Address:         _______________________________________________________
+
+                        _______________________________________________________
+
+Country:                _______________________________________________________
+
+Telephone:              _______________________________________________________
+
+E-Mail:                 _______________________________________________________
+
+(optional) preferred Foundation id(s): ________________________________________
+
+(optional) notify project: ____________________________________________________
+
+You accept and agree to the following terms and conditions for Your present and
+future Contributions submitted to the Foundation. In return, the Foundation
+shall not use Your Contributions in a way that is contrary to the public benefit
+or inconsistent with its nonprofit status and bylaws in effect at the time of
+the Contribution. Except for the license granted herein to the Foundation and
+recipients of software distributed by the Foundation, You reserve all right,
+title, and interest in and to Your Contributions.
+
+1. Definitions.
+
+  "You" (or "Your") shall mean the copyright owner or legal entity authorized by
+  the copyright owner that is making this Agreement with the Foundation. For
+  legal entities, the entity making a Contribution and all other entities that
+  control, are controlled by, or are under common control with that entity are
+  considered to be a single Contributor. For the purposes of this definition,
+  "control" means (i) the power, direct or indirect, to cause the direction or
+  management of such entity, whether by contract or otherwise, or (ii) ownership
+  of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
+  ownership of such entity.
+
+  "Contribution" shall mean any original work of authorship, including any
+  modifications or additions to an existing work, that is intentionally
+  submitted by You to the Foundation for inclusion in, or documentation of, any
+  of the products owned or managed by the Foundation (the "Work"). For the
+  purposes of this definition, "submitted" means any form of electronic, verbal,
+  or written communication sent to the Foundation or its representatives,
+  including but not limited to communication on electronic mailing lists, source
+  code control systems, and issue tracking systems that are managed by, or on
+  behalf of, the Foundation for the purpose of discussing and improving the
+  Work, but excluding communication that is conspicuously marked or otherwise
+  designated in writing by You as "Not a Contribution."
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+Agreement, You hereby grant to the Foundation and to recipients of software
+distributed by the Foundation a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable copyright license to reproduce, prepare derivative
+works of, publicly display, publicly perform, sublicense, and distribute Your
+Contributions and such derivative works.
+
+3. Grant of Patent License. Subject to the terms and conditions of this
+Agreement, You hereby grant to the Foundation and to recipients of software
+distributed by the Foundation a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license to
+make, have made, use, offer to sell, sell, import, and otherwise transfer the
+Work, where such license applies only to those patent claims licensable by You
+that are necessarily infringed by Your Contribution(s) alone or by combination
+of Your Contribution(s) with the Work to which such Contribution(s) was
+submitted. If any entity institutes patent litigation against You or any other
+entity (including a cross-claim or counterclaim in a lawsuit) alleging that your
+Contribution, or the Work to which you have contributed, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or Work shall terminate as of
+the date such litigation is filed.
+
+4. You represent that you are legally entitled to grant the above license. If
+your employer(s) has rights to intellectual property that you create that
+includes your Contributions, you represent that you have received permission to
+make Contributions on behalf of that employer, that your employer has waived
+such rights for your Contributions to the Foundation, or that your employer has
+executed a separate Corporate CLA with the Foundation.
+
+5. You represent that each of Your Contributions is Your original creation (see
+section 7 for submissions on behalf of others). You represent that Your
+Contribution submissions include complete details of any third-party license or
+other restriction (including, but not limited to, related patents and
+trademarks) of which you are personally aware and which are associated with any
+part of Your Contributions.
+
+6. You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. You may provide support for free, for a
+fee, or not at all. Unless required by applicable law or agreed to in writing,
+You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including, without
+limitation, any warranties or conditions of TITLE, NON- INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+7. Should You wish to submit work that is not Your original creation, You may
+submit it to the Foundation separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which you are personally aware, and conspicuously marking the
+work as "Submitted on behalf of a third-party: [named here]".
+
+8. You agree to notify the Foundation of any facts or circumstances of which you
+become aware that would make these representations inaccurate in any respect.
+
+Please sign: _______________________________________ Date: ____________________


### PR DESCRIPTION
I have formatted the CLAs into two plaintext files, CLA-Individual and CLA-Corporate. Other than spacing these are identical to their *.docx counterparts from the legal team.