### PR TITLE
[otp_macro,lint] Enable lint of otp_macro via top_cfgs

### DIFF
--- a/hw/ip/otp_macro/otp_macro.core
+++ b/hw/ip/otp_macro/otp_macro.core
@@ -40,10 +40,27 @@ filesets:
       # common waivers
       - lowrisc:lint:common
 
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
 targets:
-  default:
+  default: &default_target
     filesets:
       - tool_verilator   ? (files_verilator_waiver)
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
       - files_rtl
+    toplevel: otp_macro
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/top_darjeeling/lint/top_darjeeling_lint_cfgs.hjson
+++ b/hw/top_darjeeling/lint/top_darjeeling_lint_cfgs.hjson
@@ -135,6 +135,12 @@
                   additional_fusesoc_argument: "--mapping=lowrisc:systems:top_darjeeling:0.1"
                   rel_path: "hw/top_darjeeling/ip_autogen/otp_ctrl/lint/{tool}"
              },
+             {    name: otp_macro
+                  fusesoc_core: lowrisc:ip:otp_macro
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  additional_fusesoc_argument: "--mapping=lowrisc:systems:top_darjeeling:0.1"
+                  rel_path: "hw/ip/otp_macro/lint/{tool}"
+             },
              //{    name: pinmux
              //     fusesoc_core: lowrisc:darjeeling_ip:pinmux
              //     import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]

--- a/hw/top_darjeeling/top_darjeeling.core
+++ b/hw/top_darjeeling/top_darjeeling.core
@@ -110,6 +110,7 @@ mapping:
   "lowrisc:virtual_constants:top_racl_pkg": "lowrisc:darjeeling_constants:top_racl_pkg"
   "lowrisc:systems:ast_pkg": "lowrisc:systems:top_darjeeling_ast_pkg"
   "lowrisc:virtual_constants:lc_ctrl_token_pkg": "lowrisc:darjeeling_constants:testing_lc_ctrl_token_pkg"
+  "lowrisc:virtual_ip:otp_ctrl_macro_pkg": "lowrisc:darjeeling_ip:otp_ctrl_macro_pkg"
   "lowrisc:virtual_constants:rnd_cnst_pkg": "lowrisc:darjeeling_constants:testing_rnd_cnst_pkg"
 
 parameters:

--- a/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
@@ -141,6 +141,12 @@
                   additional_fusesoc_argument: "--mapping=lowrisc:systems:top_earlgrey:0.1"
                   rel_path: "hw/top_earlgrey/ip_autogen/otp_ctrl/lint/{tool}"
              },
+             {    name: otp_macro
+                  fusesoc_core: lowrisc:ip:otp_macro
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  additional_fusesoc_argument: "--mapping=lowrisc:systems:top_earlgrey:0.1"
+                  rel_path: "hw/ip/otp_macro/lint/{tool}"
+             },
              {    name: pinmux
                   fusesoc_core: lowrisc:earlgrey_ip:pinmux
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -111,6 +111,7 @@ mapping:
   "lowrisc:systems:ast_pkg": "lowrisc:systems:top_earlgrey_ast_pkg"
   "lowrisc:virtual_ip:flash_ctrl_prim_reg_top": "lowrisc:earlgrey_ip:flash_ctrl_prim_reg_top"
   "lowrisc:virtual_constants:lc_ctrl_token_pkg": "lowrisc:earlgrey_constants:testing_lc_ctrl_token_pkg"
+  "lowrisc:virtual_ip:otp_ctrl_macro_pkg": "lowrisc:earlgrey_ip:otp_ctrl_macro_pkg"
   "lowrisc:virtual_constants:rnd_cnst_pkg": "lowrisc:earlgrey_constants:testing_rnd_cnst_pkg"
 
 parameters:


### PR DESCRIPTION
Add otp_macro in earlgrey and darjeeling top_cfgs. Add missing mapping for otp_ctrl_macro_pkg in the top core file for the tops above.