### PR TITLE
[dv,clkmgr] Fix clkmgr_frequency_vseq

### DIFF
--- a/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv.tpl
@@ -85,8 +85,12 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
   }
 
   function void post_randomize();
+% if ext_clk_bypass:
     calib_rdy = get_rand_mubi4_val(6, 2, 2);
     `uvm_info(`gfn, $sformatf("randomize: calib_rdy=0x%x", calib_rdy), UVM_MEDIUM)
+% else:
+    calib_rdy = MuBi4True;
+% endif
     super.post_randomize();
   endfunction
 

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
@@ -72,8 +72,7 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
   }
 
   function void post_randomize();
-    calib_rdy = get_rand_mubi4_val(6, 2, 2);
-    `uvm_info(`gfn, $sformatf("randomize: calib_rdy=0x%x", calib_rdy), UVM_MEDIUM)
+    calib_rdy = MuBi4True;
     super.post_randomize();
   endfunction
 


### PR DESCRIPTION
The calib_rdy_i is unconnected so it should not affect the test. This test should always consider it to be MuBi4True.