### PR TITLE
[otp_ctrl,rtl] Fix defect introduced in lowRISC/opentitan#28108

### DIFF
--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -349,8 +349,11 @@ module otp_ctrl_dai
           //   which is only updated after reset);
           // - the read doesn't address the zeroization marker (which means the zeroization marker
           //   can always be read without risking fatal integrity errors).
-          if (PartInfo[part_idx].integrity && mubi8_test_false_loose(zer_i[part_idx]) &&
-              !(otp_addr_o[OtpAddrWidth-1:2] == zeroize_addr_lut[part_idx][OtpAddrWidth-1:2])) begin
+          if (PartInfo[part_idx].integrity &&
+              (!PartInfo[part_idx].zeroizable ||
+               (mubi8_test_false_loose(zer_i[part_idx]) &&
+                !(otp_addr_o[OtpAddrWidth-1:2] ==
+                  zeroize_addr_lut[part_idx][OtpAddrWidth-1:2])))) begin
             otp_cmd_o = otp_ctrl_macro_pkg::Read;
           end else begin
             otp_cmd_o = otp_ctrl_macro_pkg::ReadRaw;

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -349,8 +349,11 @@ module otp_ctrl_dai
           //   which is only updated after reset);
           // - the read doesn't address the zeroization marker (which means the zeroization marker
           //   can always be read without risking fatal integrity errors).
-          if (PartInfo[part_idx].integrity && mubi8_test_false_loose(zer_i[part_idx]) &&
-              !(otp_addr_o[OtpAddrWidth-1:2] == zeroize_addr_lut[part_idx][OtpAddrWidth-1:2])) begin
+          if (PartInfo[part_idx].integrity &&
+              (!PartInfo[part_idx].zeroizable ||
+               (mubi8_test_false_loose(zer_i[part_idx]) &&
+                !(otp_addr_o[OtpAddrWidth-1:2] ==
+                  zeroize_addr_lut[part_idx][OtpAddrWidth-1:2])))) begin
             otp_cmd_o = otp_ctrl_macro_pkg::Read;
           end else begin
             otp_cmd_o = otp_ctrl_macro_pkg::ReadRaw;

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -349,8 +349,11 @@ module otp_ctrl_dai
           //   which is only updated after reset);
           // - the read doesn't address the zeroization marker (which means the zeroization marker
           //   can always be read without risking fatal integrity errors).
-          if (PartInfo[part_idx].integrity && mubi8_test_false_loose(zer_i[part_idx]) &&
-              !(otp_addr_o[OtpAddrWidth-1:2] == zeroize_addr_lut[part_idx][OtpAddrWidth-1:2])) begin
+          if (PartInfo[part_idx].integrity &&
+              (!PartInfo[part_idx].zeroizable ||
+               (mubi8_test_false_loose(zer_i[part_idx]) &&
+                !(otp_addr_o[OtpAddrWidth-1:2] ==
+                  zeroize_addr_lut[part_idx][OtpAddrWidth-1:2])))) begin
             otp_cmd_o = otp_ctrl_macro_pkg::Read;
           end else begin
             otp_cmd_o = otp_ctrl_macro_pkg::ReadRaw;


### PR DESCRIPTION
The PR mentioned above attempts to allow reads of zeroization markers with no concern for integrity errors, but it fails to restrict this only to zeroizable partitions.