### PR TITLE
[pwrmgr,dv] Add pwrmgr_rstreqs assertions

### DIFF
--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv.tpl
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv.tpl
@@ -302,12 +302,12 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   // Uses macros because VCS flags an error for assignments to automatic variables,
   // even if the variable is a ref to an interface variable.
 
-  `define SLOW_DETECT(rsp_name_, req_) ${"\\"}
+  `define SLOW_DETECT(rsp_name_, req_, verb_ = UVM_MEDIUM) ${"\\"}
       forever ${"\\"}
         @req_ begin ${"\\"}
           raise_slow_objection(rsp_name_); ${"\\"}
           `uvm_info(`gfn, $sformatf( ${"\\"}
-                    "slow_responder: Will drive %0s to %b", rsp_name_, req_), UVM_MEDIUM) ${"\\"}
+                    "slow_responder: Will drive %0s to %b", rsp_name_, req_), verb_) ${"\\"}
         end
 
   `define SLOW_SHIFT_SR(req_, rsp_sr_) ${"\\"}
@@ -316,7 +316,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
           rsp_sr_ = {rsp_sr_[MaxCyclesBeforeEnable-1:0], req_}; ${"\\"}
         end
 
-  `define SLOW_ASSIGN(rsp_name_, cycles_, rsp_sr_, rsp_) ${"\\"}
+  `define SLOW_ASSIGN(rsp_name_, cycles_, rsp_sr_, rsp_, verb_ = UVM_MEDIUM) ${"\\"}
       forever ${"\\"}
         @(rsp_sr_[cycles_]) begin ${"\\"}
           `uvm_info(`gfn, $sformatf( ${"\\"}
@@ -324,7 +324,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
                     rsp_name_, ${"\\"}
                     rsp_sr_[cycles_], ${"\\"}
                     cycles_ ${"\\"}
-                    ), UVM_MEDIUM) ${"\\"}
+                    ), verb_) ${"\\"}
           rsp_ <= rsp_sr_[cycles_]; ${"\\"}
           drop_slow_objection(rsp_name_); ${"\\"}
         end
@@ -392,13 +392,13 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   // - Completes handshake with lc and otp: *_done needs to track *_init.
   // Macros for the same reason as the slow responder.
 
-  `define FAST_RESPONSE_ACTION(rsp_name, rsp, req, cycles) ${"\\"}
+  `define FAST_RESPONSE_ACTION(rsp_name, rsp, req, cycles, verb_ = UVM_HIGH) ${"\\"}
           `uvm_info(`gfn, $sformatf( ${"\\"}
                     "fast_responder %s: Will drive %0s to %b in %0d fast clock cycles", ${"\\"}
-                    rsp_name, rsp_name, req, cycles), UVM_HIGH) ${"\\"}
+                    rsp_name, rsp_name, req, cycles), verb_) ${"\\"}
           cfg.clk_rst_vif.wait_clks(cycles); ${"\\"}
           rsp <= req; ${"\\"}
-          `uvm_info(`gfn, $sformatf("fast_responder %s: Driving %0s to %b", rsp_name, rsp_name, req), UVM_HIGH) ${"\\"}
+          `uvm_info(`gfn, $sformatf("fast_responder %s: Driving %0s to %b", rsp_name, rsp_name, req), verb_) ${"\\"}
 
 
   task fast_responder();

--- a/hw/ip_templates/pwrmgr/dv/sva/pwrmgr_bind.sv.tpl
+++ b/hw/ip_templates/pwrmgr/dv/sva/pwrmgr_bind.sv.tpl
@@ -48,6 +48,22 @@ module pwrmgr_bind;
   );
 
 % endfor
+  bind pwrmgr pwrmgr_rstreqs_sva_if pwrmgr_rstreqs_sva_if (
+    .clk_i,
+    .rst_ni,
+    .clk_slow_i,
+    .rst_slow_ni,
+    .rstreqs_i,
+    .reset_en(reg2hw.reset_en),
+    .sw_rst_req_i(prim_mubi_pkg::mubi4_test_true_strict(sw_rst_req_i)),
+    .main_rst_req_i(!rst_main_ni),
+    .esc_rst_req_i(esc_rst_req_q),
+    .ndm_rst_req_i(ndmreset_req_i),
+    .main_pd_n(pwr_ast_o.main_pd_n),
+    .reset_cause(pwr_rst_o.reset_cause),
+    .rstreqs(pwr_rst_o.rstreqs)
+  );
+
   bind pwrmgr pwrmgr_sec_cm_checker_assert pwrmgr_sec_cm_checker_assert (
     .clk_i,
     .rst_ni,

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -293,12 +293,12 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   // Uses macros because VCS flags an error for assignments to automatic variables,
   // even if the variable is a ref to an interface variable.
 
-  `define SLOW_DETECT(rsp_name_, req_) \
+  `define SLOW_DETECT(rsp_name_, req_, verb_ = UVM_MEDIUM) \
       forever \
         @req_ begin \
           raise_slow_objection(rsp_name_); \
           `uvm_info(`gfn, $sformatf( \
-                    "slow_responder: Will drive %0s to %b", rsp_name_, req_), UVM_MEDIUM) \
+                    "slow_responder: Will drive %0s to %b", rsp_name_, req_), verb_) \
         end
 
   `define SLOW_SHIFT_SR(req_, rsp_sr_) \
@@ -307,7 +307,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
           rsp_sr_ = {rsp_sr_[MaxCyclesBeforeEnable-1:0], req_}; \
         end
 
-  `define SLOW_ASSIGN(rsp_name_, cycles_, rsp_sr_, rsp_) \
+  `define SLOW_ASSIGN(rsp_name_, cycles_, rsp_sr_, rsp_, verb_ = UVM_MEDIUM) \
       forever \
         @(rsp_sr_[cycles_]) begin \
           `uvm_info(`gfn, $sformatf( \
@@ -315,7 +315,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
                     rsp_name_, \
                     rsp_sr_[cycles_], \
                     cycles_ \
-                    ), UVM_MEDIUM) \
+                    ), verb_) \
           rsp_ <= rsp_sr_[cycles_]; \
           drop_slow_objection(rsp_name_); \
         end
@@ -379,13 +379,13 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   // - Completes handshake with lc and otp: *_done needs to track *_init.
   // Macros for the same reason as the slow responder.
 
-  `define FAST_RESPONSE_ACTION(rsp_name, rsp, req, cycles) \
+  `define FAST_RESPONSE_ACTION(rsp_name, rsp, req, cycles, verb_ = UVM_HIGH) \
           `uvm_info(`gfn, $sformatf( \
                     "fast_responder %s: Will drive %0s to %b in %0d fast clock cycles", \
-                    rsp_name, rsp_name, req, cycles), UVM_HIGH) \
+                    rsp_name, rsp_name, req, cycles), verb_) \
           cfg.clk_rst_vif.wait_clks(cycles); \
           rsp <= req; \
-          `uvm_info(`gfn, $sformatf("fast_responder %s: Driving %0s to %b", rsp_name, rsp_name, req), UVM_HIGH) \
+          `uvm_info(`gfn, $sformatf("fast_responder %s: Driving %0s to %b", rsp_name, rsp_name, req), verb_) \
 
 
   task fast_responder();

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv
@@ -44,6 +44,22 @@ module pwrmgr_bind;
     .status(pwr_clk_i.io_status)
   );
 
+  bind pwrmgr pwrmgr_rstreqs_sva_if pwrmgr_rstreqs_sva_if (
+    .clk_i,
+    .rst_ni,
+    .clk_slow_i,
+    .rst_slow_ni,
+    .rstreqs_i,
+    .reset_en(reg2hw.reset_en),
+    .sw_rst_req_i(prim_mubi_pkg::mubi4_test_true_strict(sw_rst_req_i)),
+    .main_rst_req_i(!rst_main_ni),
+    .esc_rst_req_i(esc_rst_req_q),
+    .ndm_rst_req_i(ndmreset_req_i),
+    .main_pd_n(pwr_ast_o.main_pd_n),
+    .reset_cause(pwr_rst_o.reset_cause),
+    .rstreqs(pwr_rst_o.rstreqs)
+  );
+
   bind pwrmgr pwrmgr_sec_cm_checker_assert pwrmgr_sec_cm_checker_assert (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -300,12 +300,12 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   // Uses macros because VCS flags an error for assignments to automatic variables,
   // even if the variable is a ref to an interface variable.
 
-  `define SLOW_DETECT(rsp_name_, req_) \
+  `define SLOW_DETECT(rsp_name_, req_, verb_ = UVM_MEDIUM) \
       forever \
         @req_ begin \
           raise_slow_objection(rsp_name_); \
           `uvm_info(`gfn, $sformatf( \
-                    "slow_responder: Will drive %0s to %b", rsp_name_, req_), UVM_MEDIUM) \
+                    "slow_responder: Will drive %0s to %b", rsp_name_, req_), verb_) \
         end
 
   `define SLOW_SHIFT_SR(req_, rsp_sr_) \
@@ -314,7 +314,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
           rsp_sr_ = {rsp_sr_[MaxCyclesBeforeEnable-1:0], req_}; \
         end
 
-  `define SLOW_ASSIGN(rsp_name_, cycles_, rsp_sr_, rsp_) \
+  `define SLOW_ASSIGN(rsp_name_, cycles_, rsp_sr_, rsp_, verb_ = UVM_MEDIUM) \
       forever \
         @(rsp_sr_[cycles_]) begin \
           `uvm_info(`gfn, $sformatf( \
@@ -322,7 +322,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
                     rsp_name_, \
                     rsp_sr_[cycles_], \
                     cycles_ \
-                    ), UVM_MEDIUM) \
+                    ), verb_) \
           rsp_ <= rsp_sr_[cycles_]; \
           drop_slow_objection(rsp_name_); \
         end
@@ -392,13 +392,13 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   // - Completes handshake with lc and otp: *_done needs to track *_init.
   // Macros for the same reason as the slow responder.
 
-  `define FAST_RESPONSE_ACTION(rsp_name, rsp, req, cycles) \
+  `define FAST_RESPONSE_ACTION(rsp_name, rsp, req, cycles, verb_ = UVM_HIGH) \
           `uvm_info(`gfn, $sformatf( \
                     "fast_responder %s: Will drive %0s to %b in %0d fast clock cycles", \
-                    rsp_name, rsp_name, req, cycles), UVM_HIGH) \
+                    rsp_name, rsp_name, req, cycles), verb_) \
           cfg.clk_rst_vif.wait_clks(cycles); \
           rsp <= req; \
-          `uvm_info(`gfn, $sformatf("fast_responder %s: Driving %0s to %b", rsp_name, rsp_name, req), UVM_HIGH) \
+          `uvm_info(`gfn, $sformatf("fast_responder %s: Driving %0s to %b", rsp_name, rsp_name, req), verb_) \
 
 
   task fast_responder();

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv
@@ -55,6 +55,22 @@ module pwrmgr_bind;
     .status(pwr_clk_i.usb_status)
   );
 
+  bind pwrmgr pwrmgr_rstreqs_sva_if pwrmgr_rstreqs_sva_if (
+    .clk_i,
+    .rst_ni,
+    .clk_slow_i,
+    .rst_slow_ni,
+    .rstreqs_i,
+    .reset_en(reg2hw.reset_en),
+    .sw_rst_req_i(prim_mubi_pkg::mubi4_test_true_strict(sw_rst_req_i)),
+    .main_rst_req_i(!rst_main_ni),
+    .esc_rst_req_i(esc_rst_req_q),
+    .ndm_rst_req_i(ndmreset_req_i),
+    .main_pd_n(pwr_ast_o.main_pd_n),
+    .reset_cause(pwr_rst_o.reset_cause),
+    .rstreqs(pwr_rst_o.rstreqs)
+  );
+
   bind pwrmgr pwrmgr_sec_cm_checker_assert pwrmgr_sec_cm_checker_assert (
     .clk_i,
     .rst_ni,

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -300,12 +300,12 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   // Uses macros because VCS flags an error for assignments to automatic variables,
   // even if the variable is a ref to an interface variable.
 
-  `define SLOW_DETECT(rsp_name_, req_) \
+  `define SLOW_DETECT(rsp_name_, req_, verb_ = UVM_MEDIUM) \
       forever \
         @req_ begin \
           raise_slow_objection(rsp_name_); \
           `uvm_info(`gfn, $sformatf( \
-                    "slow_responder: Will drive %0s to %b", rsp_name_, req_), UVM_MEDIUM) \
+                    "slow_responder: Will drive %0s to %b", rsp_name_, req_), verb_) \
         end
 
   `define SLOW_SHIFT_SR(req_, rsp_sr_) \
@@ -314,7 +314,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
           rsp_sr_ = {rsp_sr_[MaxCyclesBeforeEnable-1:0], req_}; \
         end
 
-  `define SLOW_ASSIGN(rsp_name_, cycles_, rsp_sr_, rsp_) \
+  `define SLOW_ASSIGN(rsp_name_, cycles_, rsp_sr_, rsp_, verb_ = UVM_MEDIUM) \
       forever \
         @(rsp_sr_[cycles_]) begin \
           `uvm_info(`gfn, $sformatf( \
@@ -322,7 +322,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
                     rsp_name_, \
                     rsp_sr_[cycles_], \
                     cycles_ \
-                    ), UVM_MEDIUM) \
+                    ), verb_) \
           rsp_ <= rsp_sr_[cycles_]; \
           drop_slow_objection(rsp_name_); \
         end
@@ -392,13 +392,13 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   // - Completes handshake with lc and otp: *_done needs to track *_init.
   // Macros for the same reason as the slow responder.
 
-  `define FAST_RESPONSE_ACTION(rsp_name, rsp, req, cycles) \
+  `define FAST_RESPONSE_ACTION(rsp_name, rsp, req, cycles, verb_ = UVM_HIGH) \
           `uvm_info(`gfn, $sformatf( \
                     "fast_responder %s: Will drive %0s to %b in %0d fast clock cycles", \
-                    rsp_name, rsp_name, req, cycles), UVM_HIGH) \
+                    rsp_name, rsp_name, req, cycles), verb_) \
           cfg.clk_rst_vif.wait_clks(cycles); \
           rsp <= req; \
-          `uvm_info(`gfn, $sformatf("fast_responder %s: Driving %0s to %b", rsp_name, rsp_name, req), UVM_HIGH) \
+          `uvm_info(`gfn, $sformatf("fast_responder %s: Driving %0s to %b", rsp_name, rsp_name, req), verb_) \
 
 
   task fast_responder();

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_bind.sv
@@ -55,6 +55,22 @@ module pwrmgr_bind;
     .status(pwr_clk_i.usb_status)
   );
 
+  bind pwrmgr pwrmgr_rstreqs_sva_if pwrmgr_rstreqs_sva_if (
+    .clk_i,
+    .rst_ni,
+    .clk_slow_i,
+    .rst_slow_ni,
+    .rstreqs_i,
+    .reset_en(reg2hw.reset_en),
+    .sw_rst_req_i(prim_mubi_pkg::mubi4_test_true_strict(sw_rst_req_i)),
+    .main_rst_req_i(!rst_main_ni),
+    .esc_rst_req_i(esc_rst_req_q),
+    .ndm_rst_req_i(ndmreset_req_i),
+    .main_pd_n(pwr_ast_o.main_pd_n),
+    .reset_cause(pwr_rst_o.reset_cause),
+    .rstreqs(pwr_rst_o.rstreqs)
+  );
+
   bind pwrmgr pwrmgr_sec_cm_checker_assert pwrmgr_sec_cm_checker_assert (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
This has two commits for pwrmgr DV:
- Add an argument to responder macros that control verbosity
- Bind interface pwrmgr_rstreqs_sva_if to pwrmgr: contains assertions checking reset requests and causes.