### PR TITLE
[top_level,spi] Tighten width handling of csb and active_csb

### DIFF
--- a/hw/dv/sv/spi_agent/spi_host_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_host_driver.sv
@@ -18,11 +18,12 @@ class spi_host_driver extends spi_driver;
 
   // Resets signals
   virtual task reset_signals();
+    cfg.vif.csb = '1;
     forever begin
       @(negedge cfg.vif.rst_n or negedge cfg.vif.disconnected);
       if (cfg.vif.disconnected) continue;
       under_reset = 1'b1;
-      active_csb  = 1'b0;
+      active_csb  = CSB_WIDTH'(0);
       cfg.vif.sck <= cfg.sck_polarity[0];
       cfg.vif.sio_out <= 'x;
       cfg.vif.csb <= '1;

--- a/hw/dv/sv/spi_agent/spi_if.sv
+++ b/hw/dv/sv/spi_agent/spi_if.sv
@@ -29,7 +29,7 @@ interface spi_if
   bit         sck_phase;
 
   bit         en_chk = 1;
-  string      msg_id = "spi_if";
+  string      msg_id = $sformatf("%m");
 
   int unsigned clk_cycle;
   //---------------------------------

--- a/hw/top_darjeeling/dv/env/chip_if.sv
+++ b/hw/top_darjeeling/dv/env/chip_if.sv
@@ -21,6 +21,7 @@ interface chip_if;
   import top_darjeeling_pkg::*;
   import dv_utils_pkg::*;
   import uvm_pkg::*;
+  import spi_agent_pkg::NUM_CSB;
 
   `include "dv_macros.svh"
   `include "uvm_macros.svh"
@@ -209,7 +210,7 @@ interface chip_if;
       dios[top_darjeeling_pkg::DioPadSpiHostClk] : 1'bz;
 
   assign spi_device0_if.csb = __enable_spi_device[0] ?
-      {'1, dios[top_darjeeling_pkg::DioPadSpiHostCsL]} : '1;
+      {{NUM_CSB-1{1'b1}}, dios[top_darjeeling_pkg::DioPadSpiHostCsL]} : {NUM_CSB{1'b1}};
 
   initial begin
     uvm_config_db#(virtual spi_if)::set(null, "*.env.m_spi_device_agents0*", "vif", spi_device0_if);

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -21,6 +21,7 @@ interface chip_if;
   import top_earlgrey_pkg::*;
   import dv_utils_pkg::*;
   import uvm_pkg::*;
+  import spi_agent_pkg::NUM_CSB;
 
   `include "dv_macros.svh"
   `include "uvm_macros.svh"
@@ -238,7 +239,7 @@ interface chip_if;
       dios[top_earlgrey_pkg::DioPadSpiHostClk] : 1'bz;
 
   assign spi_device0_if.csb = __enable_spi_device[0] ?
-      {'1, dios[top_earlgrey_pkg::DioPadSpiHostCsL]} : '1;
+      {{NUM_CSB-1{1'b1}}, dios[top_earlgrey_pkg::DioPadSpiHostCsL]} : {NUM_CSB{1'b1}};
 
   initial begin
     uvm_config_db#(virtual spi_if)::set(null, "*.env.m_spi_device_agents0*", "vif", spi_device0_if);
@@ -261,7 +262,7 @@ interface chip_if;
       mios[top_earlgrey_pkg::MioPadIob0] : 1'bz;
 
   assign spi_device1_if.csb = __enable_spi_device[1] ?
-      {'1, mios[top_earlgrey_pkg::MioPadIob1]} : '1;
+      {{NUM_CSB-1{1'b1}}, mios[top_earlgrey_pkg::MioPadIob1]} : {NUM_CSB{1'b1}};
 
   initial begin
     uvm_config_db#(virtual spi_if)::set(null, "*.env.m_spi_device_agents1*", "vif", spi_device1_if);


### PR DESCRIPTION
The assignments to csb in chip_if seem to be handled incorrectly by the simulator. This explicitly uses the declared width of csb and active_csb to avoid any confusion.
Make sure csb is also initialized on initial reset.

Fixes #107