### PR TITLE
[entropy_src,cov] Prevent VCS from inferring an FSM for prim_max_tree

### DIFF
--- a/hw/ip/entropy_src/dv/cov/entropy_src_cover.cfg
+++ b/hw/ip/entropy_src/dv/cov/entropy_src_cover.cfg
@@ -1,0 +1,10 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+// VCS Specific coverage configuration for entropy_src
+
+// Exclude fsm coverage from prim_max_tree: it is purely combinational, yet
+// somehow VCS is inferring an FSM.
+begin fsm
+  -module prim_max_tree
+end

--- a/hw/ip/entropy_src/dv/entropy_src_base_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_base_sim_cfg.hjson
@@ -67,6 +67,12 @@
       name: scratch_path
       value: "{scratch_base_path}/{name}_{variant}-{flow}-{tool}"
     }
+    // Override coverage config files to add our elaboration time coverage exclusions.
+    //
+    {
+      name: default_vcs_cov_cfg_file
+      value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{proj_root}/hw/ip/entropy_src/dv/cov/entropy_src_cover.cfg"
+    }
   ]
 
   // Enable CDC instrumentation.


### PR DESCRIPTION
The prim_max_tree module is purely combinational.