### PR TITLE
[flash_ctrl,fpga] Support splicing `flash_info` images in FPGA bitstreams

### DIFF
--- a/hw/bitstream/universal/BUILD
+++ b/hw/bitstream/universal/BUILD
@@ -21,6 +21,15 @@ label_flag(
     build_setting_default = ":none",
 )
 
+[
+    label_flag(
+        name = "flash{}_info{}".format(bank, partition),
+        build_setting_default = ":none",
+    )
+    for partition in range(3)
+    for bank in range(2)
+]
+
 label_flag(
     name = "env",
     build_setting_default = ":none",
@@ -32,6 +41,12 @@ universal_splice(
     # When the src bitstream and mmi fields are empty, the rule will use values
     # from the exec_env.
     exec_env = ":env",
+    flash0_info0 = ":flash0_info0",
+    flash0_info1 = ":flash0_info1",
+    flash0_info2 = ":flash0_info2",
+    flash1_info0 = ":flash1_info0",
+    flash1_info1 = ":flash1_info1",
+    flash1_info2 = ":flash1_info2",
     otp = ":otp",
     rom = ":rom",
     tags = ["manual"],

--- a/hw/ip/rom_ctrl/util/gen_vivado_mem_image.py
+++ b/hw/ip/rom_ctrl/util/gen_vivado_mem_image.py
@@ -73,13 +73,19 @@ class UpdatememSimulator:
         return line_groups
 
 
-def parse_otp_init_strings(init_line_groups: List[List[str]]) -> List[int]:
-    """Parse a sequence of 22-bit OTP words from Vivado INIT_XX lines.
+def parse_init_strings(
+    init_line_groups: List[List[str]],
+    bram_size: int,
+    width: int,
+    padding: int,
+    reverse: bool,
+) -> List[int]:
+    """Parse a sequence of words from Vivado INIT_XX lines.
 
-    The data layout was determined by running a full Vivado bitstream build and
-    comparing the OTP image (//hw/top_earlgrey/data/otp:img_rma) with the
-    INIT_XX strings that Vivado produces (see the otp_init_strings.txt
-    artifact).
+    For OTP (width = 22, padding = 15, reverse), the data layout was determined
+    by running a full Vivado bitstream build and comparing the OTP image
+    (//hw/top_earlgrey/data/otp:img_rma) with the INIT_XX strings that Vivado
+    produces (see the otp_init_strings.txt artifact).
     """
 
     out = []
@@ -92,78 +98,95 @@ def parse_otp_init_strings(init_line_groups: List[List[str]]) -> List[int]:
             if not match:
                 continue
 
-            data = match.group(1)
+            rawdata = match.group(1)
+            data = int(rawdata, 16)
             bits = []
-            while len(data) > 0:
-                chunk = data[:4]
-                data = data[4:]
-                if chunk == '0000':
+            count = 0
+            while count < (4 * len(rawdata)) // (padding + 1):
+                chunk = data & ((1 << (padding + 1)) - 1)
+                data >>= (1 + padding)
+                count += 1
+                if chunk == 0:
                     bits.append(0)
-                elif chunk == '0001':
+                elif chunk == 1:
                     bits.append(1)
                 else:
-                    raise Exception("Unexpected chunk in OTP init string:", chunk)
-
+                    raise Exception("Unexpected chunk in init string:", hex(chunk))
+            bits.reverse()
             bram_scratch.append(bits)
         brams.append(bram_scratch)
 
-    for i in range(1024):
-        # Slice off the first 22 bits.
+    for i in range(bram_size):
+        # Slice off the first `width` bits.
         bits = []
         for bram in brams:
             if bram[0] == []:
                 bram.pop(0)
             bits.append(bram[0].pop())
 
+        if reverse:
+            bits = reversed(bits)
         value = 0
-        for bit in reversed(bits):
+        for bit in bits:
             value = (value << 1) | bit
 
-        logger.debug(f'@{i:06x}: {value:06x} = {bits}')
+        ceil_width = math.ceil(width / 4)
+        logger.debug(f'@{i:0{ceil_width}x}: {value:0{ceil_width}x} = {bits}')
         out.append(value)
 
     return out
 
 
-def otp_words_to_updatemem_pieces(words: List[int]) -> List[str]:
+def words_to_updatemem_pieces(
+    words: List[int],
+    bram_size: int,
+    width: int,
+    padding: int,
+    reverse: bool,
+) -> List[str]:
     """Transform `words` into pieces of an updatemem-compatible MEM file."""
 
     assert len(words) % 4 == 0
-    assert len(words) <= 1024
-    mask_22_bits = (1 << 22) - 1
-    assert all(word == (word & mask_22_bits) for word in words)
+    assert len(words) <= bram_size
+    assert width % 2 == 0
+    mask_bits = (1 << width) - 1
+    assert all(word == (word & mask_bits) for word in words)
 
     # The first line indicates that we're starting from the zero address. For
     # simplicity and to make `updatemem` more efficient, we will not print
     # any subsequent addresses.
     mem_pieces = ['@0']
+    words_to_write = []
     for word in words:
         # Examining the INIT_XX strings from a full Vivado bitstream build, it
-        # appears that each 22-bit word has its bits reversed and is padded with
-        # 15 zeroes. As a result, the hexadecimal init strings will only contain
+        # appears that each word has its bits reversed and is padded with 15
+        # zeroes. As a result, the hexadecimal init strings will only contain
         # '0' and '1' characters.
-        rev = 0
-        for _ in range(22):
-            rev = (rev << 1) | (word & 1)
-            word >>= 1
+        if reverse:
+            rev = 0
+            for _ in range(width):
+                rev = (rev << 1) | (word & 1)
+                word >>= 1
+        else:
+            rev = word
 
-        words_to_write = [rev] + [0] * 15
+        words_to_write += [rev] + [0] * padding
 
-        # Concatenate sequential pairs of OTP words before emitting a hex
-        # string. If we naively encoded each 22-bit OTP word as a 6-digit hex
-        # string, updatemem would dutifully write two unwanted zero bits. To
-        # work around this, we concatenate two words for each hex string; 11 hex
-        # digits cleanly represent 44 bits.
+        # Concatenate sequential pairs of words before emitting a hex string. If
+        # we naively encoded each word as a hex string if width % 4 == 2,
+        # updatemem would dutifully write two unwanted zero bits. To work around
+        # this, we concatenate two words for each hex string to get a clean
+        # multiple of 4 bits.
         #
         # Note that this complexity cannot be avoided by concatenating all the
         # words and emitting a single hex string because updatemem rejects long
         # hex strings, saying that they exceed data limits.
-        while len(words_to_write) > 0:
+        while len(words_to_write) > 1:
             word1, word2 = words_to_write[:2]
             words_to_write = words_to_write[2:]
 
-            # Write 44 bits in hexadecimal.
-            value = word1 << 22 | word2
+            # Write `width * 2` bits in hexadecimal.
+            value = word1 << width | word2
             col_string = f'{value:011X}'
             mem_pieces.append(col_string)
 
@@ -172,13 +195,14 @@ def otp_words_to_updatemem_pieces(words: List[int]) -> List[str]:
     # the real updatemem would print. We also know how to recover OTP memory
     # contents from INIT_XX strings. Composing these two functions should bring
     # us back to the original `words` input.
-    updatemem_sim = UpdatememSimulator(0x40, 22)
+    updatemem_sim = UpdatememSimulator(bram_size // 2, width)
     for piece in mem_pieces[1:]:
         updatemem_sim.write_updatemem_hex_string(piece)
     init_lines = updatemem_sim.render_init_lines()
 
-    reconstructed = parse_otp_init_strings(init_lines)
+    reconstructed = parse_init_strings(init_lines, bram_size, width, padding, reverse)
     if len(reconstructed) < len(words) or reconstructed[:len(words)] != words:
+        print([hex(x) for x in reconstructed], "\n\n\n", [hex(x) for x in words])
         raise Exception("Generated updatemem data for OTP failed self-check")
 
     return mem_pieces
@@ -200,9 +224,16 @@ def main() -> int:
     logger.setLevel(logging.INFO)
 
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'type',
+        choices = ["rom", "otp", "flash"],
+        help = "Splice image type to generate.",
+    )
     parser.add_argument('infile', type=argparse.FileType('rb'))
     parser.add_argument('outfile', type=argparse.FileType('w'))
+    parser.add_argument('intg_outfile', type=argparse.FileType('w'))
     parser.add_argument('--swap-nibbles', dest='swap_nibbles', action='store_true')
+    parser.add_argument('--bram-size', type=int, default=1024)
 
     args = parser.parse_args()
 
@@ -221,36 +252,58 @@ def main() -> int:
     assert len(vmem.chunks) == 1
     words = vmem.chunks[0].words
 
-    if width == 24:
+    if args.type == "otp":
         logger.info("Generating updatemem-compatible MEM file for OTP image.")
-        updatemem_pieces = otp_words_to_updatemem_pieces(words)
+        updatemem_pieces = words_to_updatemem_pieces(words, args.bram_size, 22, 15, True)
         updatemem_line = ' '.join(updatemem_pieces)
         args.outfile.write(updatemem_line + '\n')
         return 0
-
-    logger.info("Generating updatemem-compatible MEM file for ROM.")
-    # Loop over all words, and:
-    # 1) Generate the address,
-    # 2) convert the endianness, and
-    # 3) write this to the output file.
-    addr_chars = 8
-    word_chars = math.ceil(width / 4)
-    word_bytes = (word_chars + 1) // 2
-    prev_addr = None
-    for idx, word in enumerate(words):
-        # Generate the address.
-        addr = idx * math.ceil(width / 8)
-        # Convert endianness.
-        data = swap_bytes(width, word, args.swap_nibbles)
-        # Check for contiguous addresses. If any are found, omit this word's
-        # address to speed up `updatemem` operation.
-        toks = []
-        if prev_addr is None or addr != (prev_addr + word_bytes):
-            toks.append(f'@{addr:0{addr_chars}X}')
-        prev_addr = addr
-        # Write to file.
-        toks.append(f'{data:0{word_chars}X}')
-        args.outfile.write(' '.join(toks) + '\n')
+    elif args.type == "flash":
+        logger.info("Generating updatemem-compatible MEM file for flash image.")
+        data_updatemem_pieces = words_to_updatemem_pieces(
+            [word & ((1 << 64) - 1) for word in words],
+            args.bram_size,
+            64,
+            0,
+            True,
+        )
+        data_updatemem_line = ' '.join(data_updatemem_pieces)
+        args.outfile.write(data_updatemem_line + '\n')
+        intg_updatemem_pieces = words_to_updatemem_pieces(
+            [word >> 64 for word in words],
+            args.bram_size,
+            12,
+            0,
+            True,
+        )
+        intg_updatemem_line = ' '.join(intg_updatemem_pieces)
+        args.intg_outfile.write(intg_updatemem_line + '\n')
+        return 0
+    else:
+        assert args.type == "rom"
+        logger.info("Generating updatemem-compatible MEM file for ROM image.")
+        # Loop over all words, and:
+        # 1) Generate the address,
+        # 2) convert the endianness, and
+        # 3) write this to the output file.
+        addr_chars = 8
+        word_chars = math.ceil(width / 4)
+        word_bytes = (word_chars + 1) // 2
+        prev_addr = None
+        for idx, word in enumerate(words):
+            # Generate the address.
+            addr = idx * math.ceil(width / 8)
+            # Convert endianness.
+            data = swap_bytes(width, word, args.swap_nibbles)
+            # Check for contiguous addresses. If any are found, omit this word's
+            # address to speed up `updatemem` operation.
+            toks = []
+            if prev_addr is None or addr != (prev_addr + word_bytes):
+                toks.append(f'@{addr:0{addr_chars}X}')
+            prev_addr = addr
+            # Write to file.
+            toks.append(f'{data:0{word_chars}X}')
+            args.outfile.write(' '.join(toks) + '\n')
 
     return 0
 

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -93,6 +93,12 @@ fpga_cw310(
     base = ":fpga_cw310",
     base_bitstream = "//hw/bitstream/hyperdebug:bitstream",
     exec_env = "fpga_cw310_test_rom",
+    flash0_info0 = "//hw/top_earlgrey/data/flash_info:flash0_info0_rma",
+    flash0_info1 = "//hw/top_earlgrey/data/flash_info:flash0_info1_rma",
+    flash0_info2 = "//hw/top_earlgrey/data/flash_info:flash0_info2_rma",
+    flash1_info0 = "//hw/top_earlgrey/data/flash_info:flash1_info0_rma",
+    flash1_info1 = "//hw/top_earlgrey/data/flash_info:flash1_info1_rma",
+    flash1_info2 = "//hw/top_earlgrey/data/flash_info:flash1_info2_rma",
     mmi = "//hw/bitstream/hyperdebug:mmi",
     otp = "//hw/top_earlgrey/data/otp:img_rma",
     param = {

--- a/hw/top_earlgrey/data/flash_info/BUILD
+++ b/hw/top_earlgrey/data/flash_info/BUILD
@@ -1,0 +1,180 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:flash.bzl", "flash_image", "flash_partition")
+
+FLASH_PAGE_SIZE = 0x800
+
+# TODO: Replace these `genrule`s that fill the flash pages with all zeroes with
+# targets that generate the correct contents as necessary.
+[
+    genrule(
+        name = page,
+        outs = ["{}.img".format(page)],
+        cmd = "dd if=/dev/zero of=$(location :{}.img) bs={} count=1 2>/dev/null".format(
+            page,
+            FLASH_PAGE_SIZE,
+        ),
+    )
+    for page in [
+        # Bank 0 pages
+        "factory_id",
+        "creator_secret",
+        "owner_secret",
+        "wafer_auth_secret",
+        "attestation_key_seeds",
+        "owner_reserved_0",
+        "owner_reserved_1",
+        "owner_reserved_2",
+        "owner_reserved_3",
+        "factory_certs",
+        # Bank 1 pages
+        "boot_data_0",
+        "boot_data_1",
+        "owner_slot_0",
+        "owner_slot_1",
+        "creator_reserved_0",
+        "owner_reserved_4",
+        "owner_reserved_5",
+        "owner_reserved_6",
+        "owner_reserved_7",
+        "dice_certs",
+        # Unallocated pages
+        "unallocated",
+    ]
+]
+
+flash_partition(
+    name = "flash0_info0",
+    pages = {
+        "0": ":factory_id",
+        "1": ":creator_secret",
+        "2": ":owner_secret",
+        "3": ":wafer_auth_secret",
+        "4": ":attestation_key_seeds",
+        "5": ":owner_reserved_0",
+        "6": ":owner_reserved_1",
+        "7": ":owner_reserved_2",
+        "8": ":owner_reserved_3",
+        "9": ":factory_certs",
+    },
+)
+
+flash_partition(
+    name = "flash0_info1",
+    pages = {
+        "0": ":unallocated",
+        "1": ":unallocated",
+        "2": ":unallocated",
+        "3": ":unallocated",
+        "4": ":unallocated",
+        "5": ":unallocated",
+        "6": ":unallocated",
+        "7": ":unallocated",
+        "8": ":unallocated",
+        "9": ":unallocated",
+    },
+)
+
+flash_partition(
+    name = "flash0_info2",
+    pages = {
+        "0": ":unallocated",
+        "1": ":unallocated",
+        "2": ":unallocated",
+        "3": ":unallocated",
+        "4": ":unallocated",
+        "5": ":unallocated",
+        "6": ":unallocated",
+        "7": ":unallocated",
+        "8": ":unallocated",
+        "9": ":unallocated",
+    },
+)
+
+flash_partition(
+    name = "flash1_info0",
+    pages = {
+        "0": ":boot_data_0",
+        "1": ":boot_data_1",
+        "2": ":owner_slot_0",
+        "3": ":owner_slot_1",
+        "4": ":creator_reserved_0",
+        "5": ":owner_reserved_4",
+        "6": ":owner_reserved_5",
+        "7": ":owner_reserved_6",
+        "8": ":owner_reserved_7",
+        "9": ":dice_certs",
+    },
+)
+
+flash_partition(
+    name = "flash1_info1",
+    pages = {
+        "0": ":unallocated",
+        "1": ":unallocated",
+        "2": ":unallocated",
+        "3": ":unallocated",
+        "4": ":unallocated",
+        "5": ":unallocated",
+        "6": ":unallocated",
+        "7": ":unallocated",
+        "8": ":unallocated",
+        "9": ":unallocated",
+    },
+)
+
+flash_partition(
+    name = "flash1_info2",
+    pages = {
+        "0": ":unallocated",
+        "1": ":unallocated",
+        "2": ":unallocated",
+        "3": ":unallocated",
+        "4": ":unallocated",
+        "5": ":unallocated",
+        "6": ":unallocated",
+        "7": ":unallocated",
+        "8": ":unallocated",
+        "9": ":unallocated",
+    },
+)
+
+# Flash scrambled VMEM images.
+[
+    flash_image(
+        name = "flash{}_info{}_{}".format(bank, partition, lc_state),
+        otp = "//hw/top_earlgrey/data/otp:img_{}".format(lc_state),
+        otp_mmap = "//hw/top_earlgrey/data/otp:otp_ctrl_mmap.hjson",
+        partition = ":flash{}_info{}".format(bank, partition),
+        visibility = ["//visibility:public"],
+    )
+    for bank in range(2)
+    for partition in range(3)
+    for lc_state in [
+        "dev",
+        "rma",
+        "test_locked0",
+        "test_locked1",
+        "test_locked2",
+        "test_locked3",
+        "test_locked4",
+        "test_locked5",
+        "test_locked6",
+        "test_unlocked0",
+        "test_unlocked1",
+        "test_unlocked1_initial",
+        "test_unlocked2",
+        "test_unlocked3",
+        "test_unlocked4",
+        "test_unlocked5",
+        "test_unlocked6",
+        "test_unlocked7",
+        "prod",
+        "prod_end",
+        "exec_disabled",
+        "bootstrap_disabled",
+        "raw",
+    ]
+]

--- a/hw/top_earlgrey/data/otp/BUILD
+++ b/hw/top_earlgrey/data/otp/BUILD
@@ -43,6 +43,11 @@ otp_json(
                 # `kSigverifySpxDisabledOtp` in
                 # sw/device/silicon_creator/lib/sigverify/spx_verify.h.
                 "CREATOR_SW_CFG_SIGVERIFY_SPX_EN": otp_hex(0x8d6c8c17),
+                # Default values for flash scramble / ecc / he_en. This OTP word
+                # contains byte-aligned, packed, 4-bit mubi values.  See the
+                # flash_ctrl driver bitfield definitions in
+                # sw/device/silicon_creator/lib/drivers/flash_ctrl.h.
+                "CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG": otp_hex(0x0),
                 # Enable use of entropy for countermeasures. See the definition
                 # of `hardened_bool_t` in sw/device/lib/base/hardened.h.
                 "CREATOR_SW_CFG_RNG_EN": otp_hex(CONST.HARDENED_TRUE),

--- a/rules/flash.bzl
+++ b/rules/flash.bzl
@@ -1,0 +1,100 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rules for generating flash images."""
+
+load("//rules/opentitan:transform.bzl", "convert_to_vmem", "scramble_flash")
+load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
+load("//rules/opentitan:util.bzl", "assemble_for_test")
+
+def _flash_partition(ctx):
+    tc = ctx.toolchains[LOCALTOOLS_TOOLCHAIN]
+    """Concatenate the contents of several pages into a single partition image."""
+
+    output = ctx.actions.declare_file(ctx.label.name + ".img")
+    max_page = max([int(page) for page in ctx.attr.pages.keys()])
+    spec = [
+        "{}@{}".format(src.files.to_list()[0].path, ctx.attr.page_size * int(page))
+        for page, src in ctx.attr.pages.items()
+    ]
+    partition_img = assemble_for_test(
+        ctx,
+        ctx.label.name,
+        spec,
+        [
+            dep
+            for target in ctx.attr.pages.values()
+            for dep in target.files.to_list()
+        ],
+        tc.tools.opentitantool,
+        size = (max_page + 1) * ctx.attr.page_size,
+    )
+    return [DefaultInfo(files = depset([partition_img]))]
+
+flash_partition = rule(
+    implementation = _flash_partition,
+    attrs = {
+        "pages": attr.string_keyed_label_dict(
+            doc = "Map of pages to include in the image, indexed by page number.",
+        ),
+        "page_size": attr.int(
+            default = 0x800,
+            doc = "Flash page size in bytes.",
+        ),
+    },
+    toolchains = [LOCALTOOLS_TOOLCHAIN],
+)
+
+def _flash_image(ctx):
+    # First convert to VMEM, then scramble according to flash
+    # scrambling settings.
+    vmem_base = convert_to_vmem(
+        ctx,
+        name = ctx.label.name,
+        src = ctx.attr.partition.files.to_list()[0],
+        word_size = 64,
+    )
+    scrambled_vmem = scramble_flash(
+        ctx,
+        src = vmem_base,
+        otp = ctx.attr.otp.files.to_list()[0],
+        otp_mmap = ctx.attr.otp_mmap,
+        top_secret_cfg = ctx.attr.top_secret_cfg.files.to_list()[0],
+        otp_data_perm = ctx.attr.otp_data_perm,
+        suffix = "64.scr.vmem",
+        _tool = ctx.attr._tool.files.to_list()[0],
+    )
+    return [DefaultInfo(files = depset([scrambled_vmem]))]
+
+flash_image = rule(
+    implementation = _flash_image,
+    attrs = {
+        "partition": attr.label(
+            allow_single_file = [".img"],
+            doc = "Flash partition image file built by flash_partition.",
+        ),
+        "otp": attr.label(
+            allow_single_file = [".vmem"],
+            doc = "The OTP settings.",
+        ),
+        "otp_mmap": attr.label(
+            allow_single_file = True,
+            doc = "The OTP memory mapping file.",
+        ),
+        "top_secret_cfg": attr.label(
+            allow_single_file = True,
+            default = "//hw/top:secrets",
+            doc = "The secret configuration file.",
+        ),
+        "otp_data_perm": attr.label(
+            default = "//util/design/data:data_perm",
+            doc = "The OTP data permutation configuration.",
+        ),
+        "_tool": attr.label(
+            default = "//util/design:gen-flash-img",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -519,6 +519,30 @@ opentitan_test = rv_rule(
             allow_single_file = True,
             doc = "OTP image override for this test",
         ),
+        "flash0_info0": attr.label(
+            allow_files = True,
+            doc = "Flash bank 0 info partition 0 image override for this test",
+        ),
+        "flash0_info1": attr.label(
+            allow_files = True,
+            doc = "Flash bank 0 info partition 1 image override for this test",
+        ),
+        "flash0_info2": attr.label(
+            allow_files = True,
+            doc = "Flash bank 0 info partition 2 image override for this test",
+        ),
+        "flash1_info0": attr.label(
+            allow_files = True,
+            doc = "Flash bank 1 info partition 0 image override for this test",
+        ),
+        "flash1_info1": attr.label(
+            allow_files = True,
+            doc = "Flash bank 1 info partition 1 image override for this test",
+        ),
+        "flash1_info2": attr.label(
+            allow_files = True,
+            doc = "Flash bank 1 info partition 2 image override for this test",
+        ),
         "bitstream": attr.label(
             allow_single_file = True,
             cfg = _testing_bitstream,

--- a/rules/opentitan/exec_env.bzl
+++ b/rules/opentitan/exec_env.bzl
@@ -19,6 +19,12 @@ _FIELDS = {
     "manifest": ("file.manifest", False),
     "rom": ("attr.rom", False),
     "rom_ext": ("attr.rom_ext", False),
+    "flash0_info0": ("attr.flash0_info0", False),
+    "flash0_info1": ("attr.flash0_info1", False),
+    "flash0_info2": ("attr.flash0_info2", False),
+    "flash1_info0": ("attr.flash1_info0", False),
+    "flash1_info1": ("attr.flash1_info1", False),
+    "flash1_info2": ("attr.flash1_info2", False),
     "otp": ("file.otp", False),
     "mmi": ("file.mmi", False),
     "base_bitstream": ("file.base_bitstream", False),
@@ -150,6 +156,36 @@ def exec_env_common_attrs(**kwargs):
             default = kwargs.get("rom_ext"),
             allow_files = True,
             doc = "ROM_EXT image to use in this environment",
+        ),
+        "flash0_info0": attr.label(
+            default = kwargs.get("flash0_info0"),
+            allow_files = True,
+            doc = "Flash bank 0 info partition 0 image to use in this environment",
+        ),
+        "flash0_info1": attr.label(
+            default = kwargs.get("flash0_info1"),
+            allow_files = True,
+            doc = "Flash bank 0 info partition 1 image to use in this environment",
+        ),
+        "flash0_info2": attr.label(
+            default = kwargs.get("flash0_info2"),
+            allow_files = True,
+            doc = "Flash bank 0 info partition 2 image to use in this environment",
+        ),
+        "flash1_info0": attr.label(
+            default = kwargs.get("flash1_info0"),
+            allow_files = True,
+            doc = "Flash bank 1 info partition 0 image to use in this environment",
+        ),
+        "flash1_info1": attr.label(
+            default = kwargs.get("flash1_info1"),
+            allow_files = True,
+            doc = "Flash bank 1 info partition 1 image to use in this environment",
+        ),
+        "flash1_info2": attr.label(
+            default = kwargs.get("flash1_info2"),
+            allow_files = True,
+            doc = "Flash bank 1 info partition 2 image to use in this environment",
         ),
         "slot_spec": attr.string_dict(
             default = kwargs.get("slot_spec", {}),
@@ -390,6 +426,19 @@ def common_test_setup(ctx, exec_env, firmware):
 
     rom_ext = get_fallback(ctx, "attr.rom_ext", exec_env)
     update_file_attr(ctx, "rom_ext", rom_ext, exec_env, data_files, param, action_param)
+
+    flash0_info0 = get_fallback(ctx, "attr.flash0_info0", exec_env)
+    update_file_attr(ctx, "flash0_info0", flash0_info0, exec_env, data_files, param, action_param)
+    flash0_info1 = get_fallback(ctx, "attr.flash0_info1", exec_env)
+    update_file_attr(ctx, "flash0_info1", flash0_info1, exec_env, data_files, param, action_param)
+    flash0_info2 = get_fallback(ctx, "attr.flash0_info2", exec_env)
+    update_file_attr(ctx, "flash0_info2", flash0_info2, exec_env, data_files, param, action_param)
+    flash1_info0 = get_fallback(ctx, "attr.flash1_info0", exec_env)
+    update_file_attr(ctx, "flash1_info0", flash1_info0, exec_env, data_files, param, action_param)
+    flash1_info1 = get_fallback(ctx, "attr.flash1_info1", exec_env)
+    update_file_attr(ctx, "flash1_info1", flash1_info1, exec_env, data_files, param, action_param)
+    flash1_info2 = get_fallback(ctx, "attr.flash1_info2", exec_env)
+    update_file_attr(ctx, "flash1_info2", flash1_info2, exec_env, data_files, param, action_param)
 
     # Add the binaries built by the test or added to the test.
     update_file_provider("firmware", firmware, data_files, param, action_param)

--- a/rules/opentitan/splice.bzl
+++ b/rules/opentitan/splice.bzl
@@ -17,21 +17,22 @@ DEFAULTS = struct(
     env = "//hw/bitstream/universal:none",
 )
 
-def gen_vivado_mem_file(ctx, name, src, tool, swap_nibbles = True):
-    update = ctx.actions.declare_file("{}.update.mem".format(name))
+def gen_vivado_mem_file(ctx, name, src, tool, bram_type = "rom", bram_size = 1024, swap_nibbles = True):
+    data = ctx.actions.declare_file("{}.update.mem".format(name))
+    intg = ctx.actions.declare_file("{}.intg.update.mem".format(name))
     args = ctx.actions.args()
     if swap_nibbles:
         args.add("--swap-nibbles")
-    args.add_all([src, update])
+    args.add_all([bram_type, src, data, intg, "--bram-size", str(bram_size)])
     ctx.actions.run(
         mnemonic = "GenVivadoImage",
-        outputs = [update],
+        outputs = [data, intg],
         inputs = [src],
         arguments = [args],
         executable = tool,
         use_default_shell_env = True,
     )
-    return update
+    return data, intg
 
 def vivado_updatemem(ctx, name, src, instance, mmi, update, debug = False):
     spliced = ctx.actions.declare_file("{}.bit".format(name))
@@ -111,6 +112,47 @@ def _bitstream_splice_impl(ctx):
     if ctx.attr.skip:
         return [DefaultInfo(files = depset([src]))]
 
+    # Splice in flash images if we have them either in attrs or the exec_env.
+    for bank in range(2):
+        for partition in range(3):
+            bram = "flash{}_info{}".format(bank, partition)
+            if not hasattr(ctx.attr, bram) or getattr(ctx.attr, bram).label.name == "none":
+                flash = getattr(exec_env, bram)
+            else:
+                flash = getattr(ctx.file, bram)
+            if flash:
+                flash = get_one_binary_file(flash, field = "vmem", providers = [exec_env.provider])
+
+                data, intg = gen_vivado_mem_file(
+                    ctx = ctx,
+                    name = "{}-{}".format(ctx.label.name, bram),
+                    bram_type = "flash",
+                    # A parition contains ten 2 KiB pages, each containing 256
+                    # 8-byte words.
+                    bram_size = 10 * 256,
+                    src = flash,
+                    tool = tc.tools.gen_mem_image,
+                    swap_nibbles = ctx.attr.swap_nibbles,
+                )
+                src = vivado_updatemem(
+                    ctx = ctx,
+                    name = "{}-{}_data".format(ctx.label.name, bram),
+                    src = src,
+                    instance = bram + "_data",
+                    mmi = get_fallback(ctx, "file.mmi", exec_env),
+                    update = data,
+                    debug = ctx.attr.debug,
+                )
+                src = vivado_updatemem(
+                    ctx = ctx,
+                    name = "{}-{}_intg".format(ctx.label.name, bram),
+                    src = src,
+                    instance = bram + "_intg",
+                    mmi = get_fallback(ctx, "file.mmi", exec_env),
+                    update = intg,
+                    debug = ctx.attr.debug,
+                )
+
     # Splice in a ROM image if we have one either in attrs or the exec_env.
     if not ctx.attr.rom or ctx.attr.rom.label.name == "none":
         rom = exec_env.rom
@@ -118,9 +160,10 @@ def _bitstream_splice_impl(ctx):
         rom = ctx.attr.rom
     if rom and rom.label.name != "none":
         rom = get_one_binary_file(rom, field = "rom", providers = [exec_env.provider])
-        mem = gen_vivado_mem_file(
+        mem, _ = gen_vivado_mem_file(
             ctx = ctx,
             name = "{}-rom".format(ctx.label.name),
+            bram_type = "rom",
             src = rom,
             tool = tc.tools.gen_mem_image,
             swap_nibbles = ctx.attr.swap_nibbles,
@@ -141,9 +184,10 @@ def _bitstream_splice_impl(ctx):
     else:
         otp = ctx.file.otp
     if otp:
-        mem = gen_vivado_mem_file(
+        mem, _ = gen_vivado_mem_file(
             ctx = ctx,
             name = "{}-otp".format(ctx.label.name),
+            bram_type = "otp",
             src = otp,
             tool = tc.tools.gen_mem_image,
             swap_nibbles = ctx.attr.swap_nibbles,
@@ -173,6 +217,12 @@ bitstream_splice_ = rule(
         "otp": attr.label(allow_single_file = True, doc = "The OTP image to splice into the bitstream"),
         "mmi": attr.label(allow_single_file = True, doc = "The meminfo file"),
         "rom": attr.label(doc = "The ROM image to splice into the bitstream"),
+        "flash0_info0": attr.label(doc = "Flash bank 0 info region 0 image to splice into the bitstream"),
+        "flash0_info1": attr.label(doc = "Flash bank 0 info region 1 image to splice into the bitstream"),
+        "flash0_info2": attr.label(doc = "Flash bank 0 info region 2 image to splice into the bitstream"),
+        "flash1_info0": attr.label(doc = "Flash bank 1 info region 0 image to splice into the bitstream"),
+        "flash1_info1": attr.label(doc = "Flash bank 1 info region 1 image to splice into the bitstream"),
+        "flash1_info2": attr.label(doc = "Flash bank 1 info region 2 image to splice into the bitstream"),
         "exec_env": attr.label(providers = [[ExecEnvInfo], [DefaultInfo]], mandatory = True, doc = "The exec_env to splice for"),
         "swap_nibbles": attr.bool(default = True, doc = "Swap nybbles while preparing the memory image"),
         "debug": attr.bool(default = False, doc = "Emit debug info while updating"),

--- a/rules/opentitan/util.bzl
+++ b/rules/opentitan/util.bzl
@@ -69,7 +69,7 @@ def get_files(attrs):
             print("No DefaultInfo in ", attr)
     return files
 
-def assemble_for_test(ctx, name, spec, data_files, opentitantool):
+def assemble_for_test(ctx, name, spec, data_files, opentitantool, size = 1048576):
     """Assemble a set of images into a flash binary for testing.
 
     Args:
@@ -91,6 +91,7 @@ def assemble_for_test(ctx, name, spec, data_files, opentitantool):
             "image",
             "assemble",
             "--mirror=false",
+            "--size={}".format(size),
             "--output={}".format(image.path),
         ] + spec,
         executable = opentitantool,


### PR DESCRIPTION
This is a working PR to add support for generating and splicing `info_flash` images into FPGA bitstreams.