### PR TITLE
[rtl,prim] Clean up some lint

### DIFF
--- a/hw/ip/prim/rtl/prim_gf_mult.sv
+++ b/hw/ip/prim/rtl/prim_gf_mult.sv
@@ -90,7 +90,7 @@ module prim_gf_mult #(
   assign first = cnt == 0;
 
   if (StagesPerCycle == Width) begin : gen_all_combo
-
+    logic unused_ins = ^{clk_i, rst_ni, req_i};
     assign ack_o = 1'b1;
     assign cnt = '0;
     assign prod_q = '0;

--- a/hw/ip/prim/rtl/prim_sha2_compression.sv
+++ b/hw/ip/prim/rtl/prim_sha2_compression.sv
@@ -299,7 +299,7 @@ module prim_sha2_compression import prim_sha2_pkg::*;
          ((digest_mode_flag_q == SHA2_384) || (digest_mode_flag_q == SHA2_512)))) begin
         round_d = '0;
       end else begin
-        round_d = round_q + 1;
+        round_d = round_q + RndWidth512'(1);
       end
     end
   end


### PR DESCRIPTION
Deal with unused inputs in prim_gf_mult.
Fix rhs to lhs width mismatch.