### PR TITLE
[util,gen_system_list] Sort the tops

### DIFF
--- a/util/gen_system_list.py
+++ b/util/gen_system_list.py
@@ -87,7 +87,7 @@ def render_table(table):
 
 def make_tops_table(outfile_path=DEFAULT_OUTFILE):
     table = [TABLE_COLUMNS, ("---",) * len(TABLE_COLUMNS)]
-    for topdir in REPO_TOP.glob("hw/top_*"):
+    for topdir in sorted(REPO_TOP.glob("hw/top_*")):
         table.append((
             get_design(topdir, outfile_path),
             get_targets(topdir),


### PR DESCRIPTION
The tops must be in sorted order, otherwise the resulting table is not stable since glob will return paths in any order.