### PR TITLE
[dvsim] Change logging for cssutils

### DIFF
--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -28,6 +28,7 @@ import shlex
 import subprocess
 import sys
 import textwrap
+import cssutils
 from pathlib import Path
 
 import Launcher
@@ -739,6 +740,7 @@ def main():
     elif args.verbose == "debug":
         log_level = log.DEBUG
     log.basicConfig(format=log_format, level=log_level)
+    cssutils.log.setLevel(log.DEBUG if args.verbose == "debug" else log.CRITICAL)
 
     if not os.path.exists(args.cfg):
         log.fatal("Path to config file %s appears to be invalid.", args.cfg)

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -364,9 +364,7 @@ def md_results_to_html(title, css_file, md_text, is_primary_cfg=False):
     html_text += "</html>\n"
     html_text = htmc_color_pc_cells(html_text)
     # this function converts css style to inline html style
-    html_text = transform(html_text,
-                          external_styles=css_file,
-                          cssutils_logging_level=log.ERROR)
+    html_text = transform(html_text, external_styles=css_file)
     html_text = html_text.replace(
         'width:80%',
         'box-sizing:border-box; width:80%'


### PR DESCRIPTION
CSS logging should depend on the `--verbose` flag.

The `cssutils` within `premailer` marks certain CSS3 properties as errors through its validator. Examples such as the use of `rem` or the `overflow: clip`, create a stream of error messages within the `dvsim` flow.
The properties are included inline, for which reason the pages work fine.

As disabling the validator in `cssutils` would not be ideal (we still want to see errors if they exist), and we also do not want pages that compile properly to be treated as errors, this PR sets the `cssutils` messages under the `--verbose debug` flag.