### PR TITLE
[ci] Reintegrate `Build Documentation` CI job with PR checks

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -2,11 +2,10 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Build Documentation
+name: Upload Documentation
 on:
-  pull_request:
   merge_group:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:
@@ -19,27 +18,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build_docs:
-    name: Build documentation
-    runs-on:
-      group: pavona-basic
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Bitstream cache requires all commits.
-      - name: Prepare environment
-        uses: ./.github/actions/prepare-env
-        with:
-          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
-      - name: Build documentation
-        run: util/site/build-docs.sh build
-      - name: Upload files as artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: docs
-          path: build-site/
-          overwrite: true
-
   upload_docs:
     name: Upload documentation
     if: ${{ github.event_name != 'pull_request' && github.ref_name == 'master' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,27 @@ jobs:
           cargo deny --all-features --manifest-path third_party/rust/Cargo.toml check licenses
           cargo deny --all-features --manifest-path third_party/tock/Cargo.toml check licenses
 
+  build_docs:
+    name: Build documentation
+    runs-on:
+      group: pavona-basic
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Bitstream cache requires all commits.
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
+      - name: Build documentation
+        run: util/site/build-docs.sh build
+      - name: Upload files as artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: docs
+          path: build-site/
+          overwrite: true
+
   verible_lint:
     name: Verible lint
     permissions:


### PR DESCRIPTION
This PR migrates the `Build Documentation` CI job back to the standard set of per-PR checks, rather than running it as a separate workflow.