### PR TITLE
[darjeeling,jitter] Fix clock jitter configuration

### DIFF
--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -219,23 +219,13 @@ class chip_sw_base_vseq extends chip_base_vseq;
     `uvm_info(`gfn, "cpu_init completed", UVM_MEDIUM)
   endtask
 
-  // The jitter enable mechanism is different from test_rom and rom right now.
-  // That's why below there is both a symbol overwrite and an otp backdoor load.
-  // Once test_rom and rom are consistent in this area, the symbol backdoor load
-  // can be removed.
   task config_jitter();
     bit en_jitter;
     void'($value$plusargs("en_jitter=%0d", en_jitter));
     if (en_jitter) begin
-      // enable for test_rom
-      bit [7:0] en_jitter_arr[] = {1};
-      sw_symbol_backdoor_overwrite("kJitterEnabled", en_jitter_arr, SwTypeRom);
-
-      // enable for rom
       cfg.mem_bkdr_util_h[Otp].write32(otp_ctrl_reg_pkg::CreatorSwCfgJitterEnOffset,
                                        prim_mubi_pkg::MuBi4True);
     end else begin
-      // rom blindly copies from otp, backdoor load a false value
       cfg.mem_bkdr_util_h[Otp].write32(otp_ctrl_reg_pkg::CreatorSwCfgJitterEnOffset,
                                        prim_mubi_pkg::MuBi4False);
     end

--- a/sw/device/lib/arch/device_fpga_cw340.c
+++ b/sw/device/lib/arch/device_fpga_cw340.c
@@ -54,5 +54,3 @@ const uint32_t kAstCheckPollCpuCycles =
 uintptr_t device_test_status_address(void) { return 0; }
 
 uintptr_t device_log_bypass_uart_address(void) { return 0; }
-
-const bool kJitterEnabled = false;


### PR DESCRIPTION
Update clock jitter configuration in darjeeling.
Jitter configuration is done in ROM since 2023 per lowrisc/opentitan#19615.

Addresses lowrisc/opentitan#19580