### PR TITLE
[sim_cfg,doc] Fix batch sim_cfg names in docs and code

### DIFF
--- a/.github/ISSUE_TEMPLATE/test-triage.yml
+++ b/.github/ISSUE_TEMPLATE/test-triage.yml
@@ -33,7 +33,7 @@ body:
       value: |
         - GitHub Revision: HASH_VALUE
         - dvsim invocation command to reproduce the failure, inclusive of build and run seeds:
-          ./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_sim_cfg.hjson -i TEST_NAME --build-seed BUILD_SEED --fixed-seed FAILING_SEED --waves fsdb
+          ./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_earlgrey_sim_cfg.hjson -i TEST_NAME --build-seed BUILD_SEED --fixed-seed FAILING_SEED --waves fsdb
         - Kokoro build number if applicable
     validations:
       required: true

--- a/ci/scripts/check_dv_sw_images.sh
+++ b/ci/scripts/check_dv_sw_images.sh
@@ -7,6 +7,6 @@
 set -e
 
 ./ci/scripts/check_dv_sw_images.py \
-    hw/top_earlgrey/dv/chip_sim_cfg.hjson \
+    hw/top_earlgrey/dv/chip_earlgrey_sim_cfg.hjson \
     hw/top_earlgrey/dv/chip_rom_tests.hjson \
     hw/top_earlgrey/dv/chip_smoketests.hjson

--- a/hw/top_darjeeling/dv/chip_rom_tests.hjson
+++ b/hw/top_darjeeling/dv/chip_rom_tests.hjson
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   # This auxiliary chip sim cfg specification focuses on chip level rom functional tests.
-  # Please see chip_sim_cfg.hjson for full setup details.
+  # Please see chip_darjeeling_sim_cfg.hjson for full setup details.
 
   # Note: Please maintain alphabetical order.
   tests: [

--- a/hw/top_darjeeling/dv/chip_smoketests.hjson
+++ b/hw/top_darjeeling/dv/chip_smoketests.hjson
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   # This auxiliary chip sim cfg specification focuses on chip level smoke tests.
-  # Please see chip_sim_cfg.hjson for full setup details.
+  # Please see chip_darjeeling_sim_cfg.hjson for full setup details.
 
   # Note: Please maintain alphabetical order.
   tests: [

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_random_power_glitch_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_random_power_glitch_vseq.sv
@@ -57,7 +57,7 @@ class chip_sw_random_power_glitch_vseq extends chip_sw_base_vseq;
     repeat (NumRound) begin
       // The timeout for this test needs to be larger than 30_000_000, otherwise certain seeds
       // like:
-      // ./util/dvsim/dvsim.py hw/top_darjeeling/dv/chip_sim_cfg.hjson -i \
+      // ./util/dvsim/dvsim.py hw/top_darjeeling/dv/chip_darjeeling_sim_cfg.hjson -i \
       //   chip_sw_pwrmgr_random_sleep_power_glitch_reset --build-seed 4232114340 \
       //   --fixed-seed 2369106033 --verbosity m
       // will fail.

--- a/hw/top_darjeeling/dv/partner_chip_sim_cfg_sample.hjson
+++ b/hw/top_darjeeling/dv/partner_chip_sim_cfg_sample.hjson
@@ -7,8 +7,8 @@
 // existing infrastructure with `dvsim` can be reused with very minimal changes
 // to run simulations on a modified design.
 {
-  // Import the chip_sim_cfg.hjson to run the chip level simulations.
-  import_cfgs: ["{proj_root}/hw/{top_chip}/dv/chip_sim_cfg.hjson"]
+  // Import the chip_darjeeling_sim_cfg.hjson to run the chip level simulations.
+  import_cfgs: ["{proj_root}/hw/{top_chip}/dv/chip_darjeeling_sim_cfg.hjson"]
 
   // Pass the fileset_partner flag to FuseSoC to swap the open source files
   // with partner implementations.

--- a/hw/top_earlgrey/dv/BUILD
+++ b/hw/top_earlgrey/dv/BUILD
@@ -7,8 +7,8 @@ package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "config",
     srcs = [
+        "chip_earlgrey_sim_cfg.hjson",
         "chip_rom_tests.hjson",
-        "chip_sim_cfg.hjson",
         "chip_smoketests.hjson",
     ],
 )

--- a/hw/top_earlgrey/dv/README.md
+++ b/hw/top_earlgrey/dv/README.md
@@ -126,7 +126,7 @@ DV simulations for `top_earlgrey` are run with the [`dvsim`]() tool.
 Please take a look at the link for detailed information on the usage, capabilities, features and known issues.
 The basic UART transmit and receive test can be run with the following command:
 ```console
-$ ./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_sim_cfg.hjson -i chip_sw_uart_tx_rx
+$ ./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_earlgrey_sim_cfg.hjson -i chip_sw_uart_tx_rx
 ```
 For a list of available tests  to run, please see the 'Tests' column in the [testplan](#testplan) below.
 

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   # This auxiliary chip sim cfg specification focuses on chip level rom functional tests.
-  # Please see chip_sim_cfg.hjson for full setup details.
+  # Please see chip_earlgrey_sim_cfg.hjson for full setup details.
 
   # Note: Please maintain alphabetical order.
   tests: [

--- a/hw/top_earlgrey/dv/chip_smoketests.hjson
+++ b/hw/top_earlgrey/dv/chip_smoketests.hjson
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   # This auxiliary chip sim cfg specification focuses on chip level smoke tests.
-  # Please see chip_sim_cfg.hjson for full setup details.
+  # Please see chip_earlgrey_sim_cfg.hjson for full setup details.
 
   # Note: Please maintain alphabetical order.
   tests: [

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_random_power_glitch_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_random_power_glitch_vseq.sv
@@ -57,7 +57,7 @@ class chip_sw_random_power_glitch_vseq extends chip_sw_base_vseq;
     repeat (NumRound) begin
       // The timeout for this test needs to be larger than 30_000_000, otherwise certain seeds
       // like:
-      // ./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_sim_cfg.hjson -i \
+      // ./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_earlgrey_sim_cfg.hjson -i \
       //   chip_sw_pwrmgr_random_sleep_power_glitch_reset --build-seed 4232114340 \
       //   --fixed-seed 2369106033 --verbosity m
       // will fail.

--- a/hw/top_earlgrey/dv/partner_chip_sim_cfg_sample.hjson
+++ b/hw/top_earlgrey/dv/partner_chip_sim_cfg_sample.hjson
@@ -7,8 +7,8 @@
 // existing infrastructure with `dvsim` can be reused with very minimal changes
 // to run simulations on a modified design.
 {
-  // Import the chip_sim_cfg.hjson to run the chip level simulations.
-  import_cfgs: ["{proj_root}/hw/top_earlgrey/dv/chip_sim_cfg.hjson"]
+  // Import the chip_earlgrey_sim_cfg.hjson to run the chip level simulations.
+  import_cfgs: ["{proj_root}/hw/top_earlgrey/dv/chip_earlgrey_sim_cfg.hjson"]
 
   // Pass the fileset_partner flag to FuseSoC to swap the open source files
   // with partner implementations.


### PR DESCRIPTION
Split off from hotfix made in #54. Fixes some failing tests run with Bazel.