### PR TITLE
[bazel,doc] Fix Bazel documentation build error

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,6 +14,7 @@ exports_files([
 filegroup(
     name = "doc_files",
     srcs = [
+        "CONTRIBUTING.md",
         "README.md",
         "//doc:doc_files",
         "//hw:doc_files",


### PR DESCRIPTION
Bazel was unable to find CONTRIBUTING.md in the repo root due to it not being listed as a source. Will fix some test failures on CI.