### PR TITLE
[top_darjeeling,dv] Remove rom_e2e_sigverify_mod_exp dvsim tests

### DIFF
--- a/hw/top_darjeeling/dv/chip_rom_tests.hjson
+++ b/hw/top_darjeeling/dv/chip_rom_tests.hjson
@@ -752,146 +752,6 @@
       ]
       run_timeout_mins: 120
     }
-    {
-      name: rom_e2e_sigverify_mod_exp_test_unlocked0_acc
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_test_unlocked0_acc:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=200_000_000"
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      run_timeout_mins: 480
-    }
-    {
-      name: rom_e2e_sigverify_mod_exp_test_unlocked0_sw
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_test_unlocked0_sw:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=200_000_000"
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      run_timeout_mins: 480
-    }
-    {
-      name: rom_e2e_sigverify_mod_exp_dev_acc
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_dev_acc:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=20_000_000"
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_mod_exp_dev_sw
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_dev_sw:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=20_000_000"
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_mod_exp_prod_acc
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_prod_acc:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=20_000_000"
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_mod_exp_prod_sw
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_prod_sw:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=20_000_000"
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_mod_exp_prod_end_acc
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_prod_end_acc:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=20_000_000"
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_mod_exp_prod_end_sw
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_prod_end_sw:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=20_000_000"
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_mod_exp_rma_acc
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_rma_acc:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=20_000_000"
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      run_timeout_mins: 120
-    }
-    {
-      name: rom_e2e_sigverify_mod_exp_rma_sw
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:6:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_rma_sw:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=20_000_000"
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      run_timeout_mins: 120
-    }
 
     // Life cycle transitions with production ROM.
     {
@@ -928,6 +788,7 @@
     }
 
     // ROM self hash test.
+    // TODO(moidx): Update to ROM e2e target not requiring sigverify_mod_exp dependency.
     {
       name: rom_e2e_self_hash
       uvm_test_seq: chip_sw_base_vseq
@@ -1050,21 +911,6 @@
         "rom_e2e_keymgr_init_rom_ext_meas",
         "rom_e2e_keymgr_init_rom_ext_no_meas",
         "rom_e2e_keymgr_init_rom_ext_invalid_meas",
-      ]
-    }
-    {
-      name: rom_e2e_sigverify_mod_exp
-      tests: [
-        "rom_e2e_sigverify_mod_exp_test_unlocked0_acc",
-        "rom_e2e_sigverify_mod_exp_test_unlocked0_sw",
-        "rom_e2e_sigverify_mod_exp_dev_acc",
-        "rom_e2e_sigverify_mod_exp_dev_sw",
-        "rom_e2e_sigverify_mod_exp_prod_acc",
-        "rom_e2e_sigverify_mod_exp_prod_sw",
-        "rom_e2e_sigverify_mod_exp_prod_end_acc",
-        "rom_e2e_sigverify_mod_exp_prod_end_sw",
-        "rom_e2e_sigverify_mod_exp_rma_acc",
-        "rom_e2e_sigverify_mod_exp_rma_sw",
       ]
     }
     {


### PR DESCRIPTION
This PR removes the `rom_e2e_sigverify_mod_exp` tests from `hw/top_darjeeling/dv/chip_rom_tests.hjson`. These tests are no longer supported after the system software switched from RSA to ECDSA code signings and removed its collateral. The tests were originally removed in PR: https://github.com/lowRISC/opentitan/pull/22696

The tests were tracked in #44 and have been marked as resolved.