### PR TITLE
[sw,hello_world] Split off gpio_demo from hello_world

### DIFF
--- a/release/BUILD
+++ b/release/BUILD
@@ -14,7 +14,7 @@ pkg_tar(
         "//hw:package",
         "//hw/bitstream/vivado:package",
         "//hw/top_egret/data/otp:package",
-        "//sw/device/examples/hello_world:package",
+        "//sw/device/examples/gpio_demo:package",
         "//sw/device/lib/testing/test_rom:package",
         "//sw/device/silicon_creator/rom:package",
         "//sw/host/opentitantool:package",

--- a/signing/examples/BUILD
+++ b/signing/examples/BUILD
@@ -16,7 +16,7 @@ offline_presigning_artifacts(
     name = "presigning",
     testonly = True,
     srcs = [
-        "//sw/device/examples/hello_world",
+        "//sw/device/examples/gpio_demo",
     ],
     # To sign with real keys, replace the ecdsa_key with the label of a real
     # key.

--- a/sw/device/examples/gpio_demo/BUILD
+++ b/sw/device/examples/gpio_demo/BUILD
@@ -1,0 +1,52 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules/pavona:defs.bzl", "pavona_binary")
+load("//rules:files.bzl", "exclude_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+
+package(default_visibility = ["//visibility:public"])
+
+pavona_binary(
+    name = "gpio_demo",
+    testonly = True,
+    srcs = ["gpio_demo.c"],
+    exec_env = [
+        "//hw/top_egret:fpga_cw310",
+        "//hw/top_egret:fpga_cw340",
+        "//hw/top_egret:sim_dv",
+        "//hw/top_egret:sim_verilator",
+    ],
+    deps = [
+        ":gpio_demo_lib",
+        "//sw/device/lib/base:mmio",
+    ],
+)
+
+cc_library(
+    name = "gpio_demo_lib",
+    deps = [
+        "//hw/top_egret/sw/autogen:top_egret",
+        "//sw/device/examples:demos",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/crt",
+        "//sw/device/lib/dif:gpio",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print_uart",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_start",
+        "//sw/device/lib/testing/test_framework:ottf_test_config",
+    ],
+)
+
+pkg_files(
+    name = "package",
+    testonly = True,
+    srcs = [":gpio_demo"],
+    prefix = "egret/examples",
+)

--- a/sw/device/examples/gpio_demo/README.md
+++ b/sw/device/examples/gpio_demo/README.md
@@ -1,0 +1,15 @@
+# GPIO Demo Example
+
+## Overview
+
+`gpio_demo` is a demo program used to showcase basic functionality of the system.
+The test itself does 2 main things:
+* Echo pin changes over UART.
+* Echo SPI input over UART.
+
+## GPIO Changes Over UART
+This function primarily exercises the GPIO and UART blocks.
+The test monitors changing values on the GPIO line and reports them over UART.
+
+## SPI Echo Over UART
+All data input over SPI is echoed on UART in a word-aligned fashion.

--- a/sw/device/examples/gpio_demo/gpio_demo.c
+++ b/sw/device/examples/gpio_demo/gpio_demo.c
@@ -1,0 +1,97 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/examples/demos.h"
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/dif/dif_gpio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print_uart.h"
+#include "sw/device/lib/testing/pinmux_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_test_config.h"
+
+#include "hw/top_egret/sw/autogen/top_egret.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_gpio_t gpio;
+static dif_pinmux_t pinmux;
+static dif_uart_t uart;
+
+static dif_pinmux_index_t leds[] = {
+    kTopEgretPinmuxMioOutIor10,
+    kTopEgretPinmuxMioOutIor11,
+    kTopEgretPinmuxMioOutIor12,
+    kTopEgretPinmuxMioOutIor13,
+};
+
+static dif_pinmux_index_t switches[] = {
+    kTopEgretPinmuxInselIob6,
+    kTopEgretPinmuxInselIob9,
+    kTopEgretPinmuxInselIob10,
+    kTopEgretPinmuxInselIor5,
+};
+
+void configure_pinmux(void) {
+  pinmux_testutils_init(&pinmux);
+  // Hook up some LEDs.
+  for (size_t i = 0; i < ARRAYSIZE(leds); ++i) {
+    dif_pinmux_index_t gpio = kTopEgretPinmuxOutselGpioGpio0 + i;
+    CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, leds[i], gpio));
+  }
+  // Hook up DIP switches.
+  for (size_t i = 0; i < ARRAYSIZE(switches); ++i) {
+    dif_pinmux_index_t gpio = kTopEgretPinmuxPeripheralInGpioGpio8 + i;
+    CHECK_DIF_OK(dif_pinmux_input_select(&pinmux, gpio, switches[i]));
+  }
+}
+
+void _ottf_main(void) {
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EGRET_PINMUX_AON_BASE_ADDR), &pinmux));
+  configure_pinmux();
+
+  CHECK_DIF_OK(
+      dif_uart_init(mmio_region_from_addr(TOP_EGRET_UART0_BASE_ADDR), &uart));
+
+  CHECK(kUartBaudrate <= UINT32_MAX, "kUartBaudrate must fit in uint32_t");
+  CHECK(kClockFreqPeripheralHz <= UINT32_MAX,
+        "kClockFreqPeripheralHz must fit in uint32_t");
+  CHECK_DIF_OK(dif_uart_configure(
+      &uart, (dif_uart_config_t){
+                 .baudrate = (uint32_t)kUartBaudrate,
+                 .clk_freq_hz = (uint32_t)kClockFreqPeripheralHz,
+                 .parity_enable = kDifToggleDisabled,
+                 .parity = kDifUartParityEven,
+                 .tx_enable = kDifToggleEnabled,
+                 .rx_enable = kDifToggleEnabled,
+             }));
+  base_uart_stdout(&uart);
+
+  CHECK_DIF_OK(
+      dif_gpio_init(mmio_region_from_addr(TOP_EGRET_GPIO_BASE_ADDR), &gpio));
+  // Enable GPIO: 0-3 is output; 8-11 is input.
+  CHECK_DIF_OK(dif_gpio_output_set_enabled_all(&gpio, 0xF));
+
+  demo_gpio_startup(&gpio);
+
+  // Now have UART <-> Buttons/LEDs demo
+  // all LEDs off
+  CHECK_DIF_OK(dif_gpio_write_all(&gpio, 0x0000));
+  LOG_INFO("Try out USERDIP switches 0-thru-3 on the board");
+  LOG_INFO("or type anything into the console window.");
+  LOG_INFO(
+      "The LEDs show the lower nibble of the ASCII code of the last "
+      "character.");
+
+  uint32_t gpio_state = 0;
+  while (true) {
+    busy_spin_micros(10 * 1000);  // 10 ms
+    gpio_state = demo_gpio_to_log_echo(&gpio, gpio_state);
+    demo_uart_to_uart_and_gpio_echo(&uart, &gpio);
+  }
+}

--- a/sw/device/examples/hello_world/BUILD
+++ b/sw/device/examples/hello_world/BUILD
@@ -2,57 +2,28 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules/pavona:defs.bzl", "pavona_binary")
-load("//rules:files.bzl", "exclude_files")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("//rules/pavona:defs.bzl", "pavona_test")
 
 package(default_visibility = ["//visibility:public"])
 
-pavona_binary(
+pavona_test(
     name = "hello_world",
-    testonly = True,
     srcs = ["hello_world.c"],
     copts = [
         # Disable the date-time warning only for the hello world program.
         "-Wno-date-time",
     ],
-    exec_env = [
-        "//hw/top_egret:fpga_cw310",
-        "//hw/top_egret:fpga_cw340",
-        "//hw/top_egret:sim_dv",
-        "//hw/top_egret:sim_verilator",
-        # For some reason, this target makes scafi_deprecated builds fail.
-        #"//hw/top_egret:silicon_owner_sival_rom_ext",
-    ],
+    exec_env = {
+        "//hw/top_egret:sim_dv": None,
+        "//hw/top_egret:sim_verilator": None,
+    },
     deps = [
-        ":hello_world_lib",
-        "//sw/device/lib/base:mmio",
-    ],
-)
-
-cc_library(
-    name = "hello_world_lib",
-    deps = [
-        "//hw/top_egret/sw/autogen:top_egret",
-        "//sw/device/examples:demos",
+        "//hw/top/dt",
         "//sw/device/lib/arch:device",
-        "//sw/device/lib/crt",
-        "//sw/device/lib/dif:gpio",
-        "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:uart",
-        "//sw/device/lib/runtime:hart",
-        "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:print_uart",
-        "//sw/device/lib/testing:pinmux_testutils",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_start",
         "//sw/device/lib/testing/test_framework:ottf_test_config",
     ],
-)
-
-pkg_files(
-    name = "package",
-    testonly = True,
-    srcs = [":hello_world"],
-    prefix = "egret/examples",
 )

--- a/sw/device/examples/hello_world/README.md
+++ b/sw/device/examples/hello_world/README.md
@@ -2,14 +2,5 @@
 
 ## Overview
 
-`Hello_world` is the demo program used to showcase basic functionality of the system.
-The test itself does 2 main things:
-* Echo pin changes over UART.
-* Echo SPI input over UART.
-
-## GPIO Changes Over UART
-This function primarily exercises the GPIO and UART blocks.
-The test monitors changing values on the GPIO line and reports them over UART.
-
-## SPI Echo Over UART
-All data input over SPI is echo'd on UART in a word aligned fashion.
+`hello_world` demonstrates basic system functionality by printing "Hello World!"
+over the UART and serves as an introduction to the project.

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -2,62 +2,20 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/examples/demos.h"
+#include "hw/top/dt/uart.h"
 #include "sw/device/lib/arch/device.h"
-#include "sw/device/lib/dif/dif_gpio.h"
-#include "sw/device/lib/dif/dif_pinmux.h"
-#include "sw/device/lib/dif/dif_uart.h"
-#include "sw/device/lib/runtime/hart.h"
-#include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/runtime/print_uart.h"
-#include "sw/device/lib/testing/pinmux_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 
-#include "hw/top_egret/sw/autogen/top_egret.h"
-
 OTTF_DEFINE_TEST_CONFIG();
 
-static dif_gpio_t gpio;
-static dif_pinmux_t pinmux;
-static dif_uart_t uart;
-
-static dif_pinmux_index_t leds[] = {
-    kTopEgretPinmuxMioOutIor10,
-    kTopEgretPinmuxMioOutIor11,
-    kTopEgretPinmuxMioOutIor12,
-    kTopEgretPinmuxMioOutIor13,
-};
-
-static dif_pinmux_index_t switches[] = {
-    kTopEgretPinmuxInselIob6,
-    kTopEgretPinmuxInselIob9,
-    kTopEgretPinmuxInselIob10,
-    kTopEgretPinmuxInselIor5,
-};
-
-void configure_pinmux(void) {
-  pinmux_testutils_init(&pinmux);
-  // Hook up some LEDs.
-  for (size_t i = 0; i < ARRAYSIZE(leds); ++i) {
-    dif_pinmux_index_t gpio = kTopEgretPinmuxOutselGpioGpio0 + i;
-    CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, leds[i], gpio));
-  }
-  // Hook up DIP switches.
-  for (size_t i = 0; i < ARRAYSIZE(switches); ++i) {
-    dif_pinmux_index_t gpio = kTopEgretPinmuxPeripheralInGpioGpio8 + i;
-    CHECK_DIF_OK(dif_pinmux_input_select(&pinmux, gpio, switches[i]));
-  }
-}
-
 void _ottf_main(void) {
-  CHECK_DIF_OK(dif_pinmux_init(
-      mmio_region_from_addr(TOP_EGRET_PINMUX_AON_BASE_ADDR), &pinmux));
-  configure_pinmux();
+  // Initialize the UART from the device table
+  dif_uart_t uart;
+  CHECK_DIF_OK(dif_uart_init_from_dt(kDtUart0, &uart));
 
-  CHECK_DIF_OK(
-      dif_uart_init(mmio_region_from_addr(TOP_EGRET_UART0_BASE_ADDR), &uart));
-
+  // Configure UART baud and parity
   CHECK(kUartBaudrate <= UINT32_MAX, "kUartBaudrate must fit in uint32_t");
   CHECK(kClockFreqPeripheralHz <= UINT32_MAX,
         "kClockFreqPeripheralHz must fit in uint32_t");
@@ -70,32 +28,15 @@ void _ottf_main(void) {
                  .tx_enable = kDifToggleEnabled,
                  .rx_enable = kDifToggleEnabled,
              }));
+
+  // Route LOG_INFO to this UART
   base_uart_stdout(&uart);
 
-  CHECK_DIF_OK(
-      dif_gpio_init(mmio_region_from_addr(TOP_EGRET_GPIO_BASE_ADDR), &gpio));
-  // Enable GPIO: 0-3 is output; 8-11 is input.
-  CHECK_DIF_OK(dif_gpio_output_set_enabled_all(&gpio, 0xF));
+  LOG_INFO("Hello World!");
 
   // Add DATE and TIME because I keep fooling myself with old versions
-  LOG_INFO("Hello World!");
   LOG_INFO("Built at: " __DATE__ ", " __TIME__);
 
-  demo_gpio_startup(&gpio);
-
-  // Now have UART <-> Buttons/LEDs demo
-  // all LEDs off
-  CHECK_DIF_OK(dif_gpio_write_all(&gpio, 0x0000));
-  LOG_INFO("Try out USERDIP switches 0-thru-3 on the board");
-  LOG_INFO("or type anything into the console window.");
-  LOG_INFO(
-      "The LEDs show the lower nibble of the ASCII code of the last "
-      "character.");
-
-  uint32_t gpio_state = 0;
-  while (true) {
-    busy_spin_micros(10 * 1000);  // 10 ms
-    gpio_state = demo_gpio_to_log_echo(&gpio, gpio_state);
-    demo_uart_to_uart_and_gpio_echo(&uart, &gpio);
-  }
+  // The test environment searches for this string to complete the test
+  LOG_INFO("PASS!");
 }


### PR DESCRIPTION
Make `hello_world` much simpler by having it just initialize the UART and just print "Hello World!". Rename the original `hello_world` to `gpio_demo`.

This is a recreation of #66 due to some repo shuffling.