### PR TITLE
[doc,mdbook] Fix lack of images in tooling docs

### DIFF
--- a/.mdbookignore
+++ b/.mdbookignore
@@ -5,3 +5,4 @@
 !sw/
 !site/
 !doc/
+!util/


### PR DESCRIPTION
Currently, the mdbook documentation fails to render images within the tooling docs because the `util/` directory is being ignored by mdbook. This PR fixes this.