### PR TITLE
[top,md] Use top generically and fix regression

### DIFF
--- a/hw/top/README.md
+++ b/hw/top/README.md
@@ -1,6 +1,6 @@
-# OpenTitan top selection
+# Top Selection
 
-The `hw/top` bazel package provides a mechanism to select the OpentTitan top for which all targets (headers, binaries, tests) are built.
+The `hw/top` bazel package provides a mechanism to select the specific top for which all targets (headers, binaries, tests) are built.
 This package also provides various bazel targets to expose hardware information about the top that could be useful for software and bazel rules.
 Finally, its provides a number of useful bazel macros that integrate with the build system to handle conditional handling of dependencies.
 
@@ -111,7 +111,7 @@ You can create your own annotations by using the macros described in the next se
 ## The `//hw/top:defs.bzl` library
 
 This bazel library provides several important definitions are macros which can be used by rule creators and users to interact with the build system.
-See the documentation in [the file](https://github.com/lowRISC/opentitan/blob/master/hw/top/defs.bzl) for more details.
+See the documentation in [the file](./defs.bzl) for more details.
 - `opentitan_if_ip(ip, obj, default)` provides a way to conditionally do something the top selected by `//hw/top` contains at least one instance of a given IP.
 For example, if we want to conditionally compile code only if the usbdev block is present, we could do:
 Example:


### PR DESCRIPTION
The bazel mechanism this implements is not specific to a ROT. Put back a regressed relative link.