### PR TITLE
[dvsim] More changes to dvsim

### DIFF
--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -210,9 +210,6 @@
   cov_report_txt:   "{cov_report_dir}/dashboard.txt"
   cov_report_page:  "dashboard.html"
 
-  // Knowledge database
-  knowledge_db_dir_name: "kdb.elab++"
-
   // UNR related.
   // All code coverage, assert isn't supported
   cov_unr_metrics: "line+cond+fsm+tgl+branch"

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -565,8 +565,38 @@ class FlowCfg():
         subprocess.run(["git", "-C", repo_dir, "commit", "-m",
                         f"[dashboard] Update {self.name}_{test}_{self.flow} {self.timestamp}"],
                        check=True, env=env)
-        subprocess.run(["git", "-C", repo_dir, "push"], check=True, env=env)
+        subprocess.run(["git", "-C", repo_dir, "push", "origin", self.branch],
+                       check=True, env=env)
         log.info("Results published successfully.")
+
+    def check_remote_branch_exists(self, repository: str, flag: str):
+        """Verify the publish branch exists on the remote dashboard repo.
+
+        Called early in main() so we fail fast instead of running the whole
+        flow and then failing on the final push.
+        """
+        env = self._setup_ssh_env()
+        try:
+            result = subprocess.run(
+                ["git", "ls-remote", "--heads", repository, self.branch],
+                check=True, capture_output=True, text=True, env=env,
+            )
+        except FileNotFoundError:
+            log.fatal("git is not installed or not on PATH. Cannot publish results.")
+            sys.exit(1)
+        except subprocess.CalledProcessError as e:
+            log.fatal("Could not query %s for branch %r (--%s):\n%s",
+                      repository, self.branch, flag,
+                      e.stderr.strip() if e.stderr else "")
+            sys.exit(1)
+
+        if not result.stdout.strip():
+            log.fatal("Branch %r does not exist on dashboard repository %s. "
+                      "Create it there before publishing (--%s).",
+                      self.branch, repository, flag)
+            sys.exit(1)
+
+        log.info("Dashboard branch %r found on %s.", self.branch, repository)
 
     def _setup_ssh_env(self) -> dict:
         """Return an env dict with SSH configured, using passphrase or deploy key."""
@@ -605,7 +635,12 @@ class FlowCfg():
         return env
 
     def clone_or_pull(self, repository: str, local_path: str, env: dict):
-        """Clone the repo if it doesn't exist locally, otherwise pull latest."""
+        """Clone the repo if it doesn't exist locally, otherwise pull latest.
+
+        Operates on `self.branch`: we expect a matching branch on the dashboard
+        repository (verified up-front by check_remote_branch_exists).
+        """
+        branch = self.branch
         try:
             if os.path.exists(local_path):
                 result = subprocess.run(
@@ -617,11 +652,25 @@ class FlowCfg():
                     log.warning("Existing repo at %s points to %s, expected %s. Recloning.",
                                 local_path, existing_remote, repository)
                     shutil.rmtree(local_path)
-                    subprocess.run(["git", "clone", repository, local_path], check=True, env=env)
+                    subprocess.run(
+                        ["git", "clone", "-b", branch, repository, local_path],
+                        check=True, env=env)
                 else:
-                    subprocess.run(["git", "-C", local_path, "pull"], check=True, env=env)
+                    # The local clone may have been left on a different branch
+                    # by a previous run, so fetch + checkout + pull explicitly.
+                    subprocess.run(
+                        ["git", "-C", local_path, "fetch", "origin", branch],
+                        check=True, env=env)
+                    subprocess.run(
+                        ["git", "-C", local_path, "checkout", branch],
+                        check=True, env=env)
+                    subprocess.run(
+                        ["git", "-C", local_path, "pull", "origin", branch],
+                        check=True, env=env)
             else:
-                subprocess.run(["git", "clone", repository, local_path], check=True, env=env)
+                subprocess.run(
+                    ["git", "clone", "-b", branch, repository, local_path],
+                    check=True, env=env)
         except FileNotFoundError:
             log.error("git is not installed or not on PATH. Cannot publish results.")
             raise
@@ -629,7 +678,7 @@ class FlowCfg():
             log.error("Timed out trying to reach repository: %s", repository)
             raise
         except subprocess.CalledProcessError as e:
-            log.error("Git operation failed for %s:\n%s",
+            log.error("git operation failed for %s:\n%s",
                       repository, e.stderr.decode().strip() if e.stderr else "")
             raise
 

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -743,29 +743,6 @@ class FlowCfg():
             except FileNotFoundError:
                 log.warning(f"No merged coverage database found for {item.name} at {merged_src}.")
 
-        kdb_name = getattr(item, 'knowledge_db_dir_name', None)
-        if kdb_name:
-            # The knowledge DB lives somewhere under scratch_path; locate it by
-            # name rather than assuming a fixed parent directory, so the same
-            # code works for VCS (under build_dir/simv.daidir) and Xcelium
-            # (under build_dir/xcelium.d, etc.).
-            scratch = Path(item.scratch_path)
-            matches = list(scratch.rglob(kdb_name))
-            if not matches:
-                log.warning(f"Knowledge database {kdb_name} not found under {scratch}"
-                            f" for {item.name}")
-            else:
-                for kdb_src in matches:
-                    # Preserve each KDB's location relative to scratch_path so
-                    # multiple matches (e.g. one per build_mode) don't collide.
-                    build_subdir = kdb_src.parent.parent.name
-                    kdb_dest = Path(cov_data_dest) / build_subdir / kdb_name
-                    cp_path(kdb_src, kdb_dest)
-                    log.info(f"Copied knowledge database "
-                             f"{build_subdir}/{kdb_name} for {item.name}")
-        else:
-            log.warning(f"No knowledge database for {item.name}. Current support only for VCS.")
-
     def _strip_native_cov_link(self, html_path: Path):
         """Remove the 'Coverage Dashboard' link heading from a published report.
 

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -814,6 +814,7 @@ def main():
     # Run --publish-prev if it was provided
     if args.publish_prev is not None:
         check_ssh_git_access(args.publish_prev, "publish-prev")
+        cfg.check_remote_branch_exists(args.publish_prev, "publish-prev")
         if args.items is None:
             log.fatal("We need to know the regression to publish it! Set the regression with -i")
             sys.exit(1)
@@ -850,6 +851,7 @@ def main():
             log.fatal("--publish needs the config file to be a batch cfg")
             sys.exit(1)
         check_ssh_git_access(args.publish, "publish")
+        cfg.check_remote_branch_exists(args.publish, "publish")
 
     # Deploy the builds and runs
     if args.items:

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -677,7 +677,7 @@ def parse_args():
                       help=("Mode for publishing results. 'public' (the default) "
                             "publishes only sanitized report numbers. 'private' "
                             "additionally publishes native tool databases "
-                            "(.vdb, kdb.elab++) and rewrites the dashboard's "
+                            "(.vdb) and rewrites the dashboard's "
                             "Coverage Dashboard link to point at the native "
                             "Synopsys/Cadence reports inside the published repo. "
                             "Only meaningful with --publish or --publish-prev."))


### PR DESCRIPTION
This PR contains two commits. The first one removes the copying of KDBs as we no longer need them for analysis.
The second one creates a branch on the dashboard repository identical to the branch from which `dvsim` is being ran.

The second commit allows for the following (in my opinion, simpler) procedure for testing particular blocks. Say we want to make another IP block on a branch named `ip_block/dev` off of `main` and we want to test the coverage of that block separately from the rest with a dedicated dashboard for it. Instead of pushing to `main`, `--publish` now will push to `ip_block/dev` in the respective dashboard repository. 

The only caveat is that the branch must already exist on the dashboard repository.