### PR TITLE
[doc] Add introductions to Pavona hardware and software

### DIFF
--- a/doc/getting_started/intro_hardware.md
+++ b/doc/getting_started/intro_hardware.md
@@ -1,0 +1,232 @@
+# Pavona 102: Introduction to Hardware
+
+Pavona's differentiating feature is its principled modular design that makes customizing IP blocks and top-level designs effortless.
+
+Pavona 101 shows new users how to clone the repo, install system prerequisites, and run a basic chip-level simulation.
+This guide builds on Pavona 101 by explaining the repository and infrastructure for hardware design and development.
+After this guide, you will be able to make changes to existing top-level designs and run tests on them.
+
+## Basic setup
+
+This guide assumes you have set up your repository as described in Pavona 101\.
+Remember to source your Python virtual environment.
+
+## Repository structure
+
+Change into the pavona directory and you'll find the following files:
+
+```
+(.venv) $ cd pavona
+(.venv) pavona $ ls
+BLOCKFILE          apt-requirements.txt  python-requirements.txt
+BUILD.bazel        bazelisk.sh           quality
+CLA                bench                 release
+CONTRIBUTING.md    book.toml             rules
+LICENSE            ci                    signing
+MODULE.bazel       compile_flags.txt     sw
+MODULE.bazel.lock  doc                   third_party
+NOTICE             hw                    toolchain
+README.md          mypy.ini              util
+SUMMARY.md         pyproject.toml        yum-requirements.txt
+```
+
+We explored some of the sw/ directory last time.
+In there, you'll find:
+
+* sw/device/, which contains software that will run on a Pavona top-level design.
+This includes tests as well as the "Hello, World!" example from Pavona 101\.
+* sw/host/, which contains software that runs on the machine connected to a Pavona top-level design (the "host").
+
+The other important directory is the hw/ directory, which has several key subdirectories:
+
+* hw/ip/ contains block-level IP for the Pavona ecosystem that does not need further "templatization" (see the next section).
+* hw/ip\_templates, on the other hand, contains block-level IP that *does* need templatization
+* hw/top\_darjeeling, hw/top\_earlgrey, and hw/top\_englishbreakfast, which represent the currently supported top-level reference designs in the Pavona project.
+
+Top-level designs (or "tops") organize IP into a design suited for a particular purpose or implementation methodology.
+We briefly introduce Pavona's three top-level designs here, but refer to their individual datasheets (located in each top directory's corresponding doc/ directory) for more information.
+
+* top\_earlgrey is a full discrete root of trust design ready for tapeout.
+* top\_darjeeling is another root of trust design intended for integration within a broader SoC.
+* top\_englishbreakfast is a reduction of top\_earlgrey designed to facilitate side channel analysis and fault injection experiments.
+
+In these top-specific directories, you will also find another set of IP directories: hw/top\_\*/ip and hw/top\_\*/ip\_autogen.
+This brings us to a discussion of the three types of IP in Pavona:
+
+## Three different types of IP
+
+Pavona organizes IP in three different ways.
+The first two are simple to understand:
+
+* hw/ip contains IPs that are broadly applicable to any top and do not require customization (beyond the capabilities of SystemVerilog parameters).
+* hw/top\_\*/ip contains IP that is specific to that top and is not intended to be used by another top.
+This includes the Analog Sensor Top (AST) and crossbar IPs for both Earlgrey and Darjeeling, which are specific to their respective top.
+Darjeeling contains a proxy for communication to the wider SoC, which is not meaningful in Earlgrey.
+
+### IP collateral
+
+In each IP directory, you'll find several directories:
+
+* data/ contains the IP block Hjson, which forms the "single source of truth" for this IP block.
+It contains information about inputs, outputs, registers, interrupts, and other crucial metadata about the IP block.
+This file is used extensively in templatization and top generation.
+data/ also contains the testplan.
+* doc/ contains block-specific documentation, including a programmer's guide, theory of operation, and register map.
+* dv/ contains block-specific DV collateral, including a block-level testbench/environment and sequence library.
+* Lastly, rtl/ contains the block's design.
+
+### IP templates
+
+The third type of IP is an *IP template,* and is stored in hw/ip\_templates.
+IP templates form one of Pavona's key features: the ability to customize hardware for a specific top.
+Templated IPs can be processed with Pavona tooling (discussed later) to generate a top-specific version of that IP.
+
+SystemVerilog files in templated IPs look just like ordinary SystemVerilog files, except that they contain macros that allow arbitrary text substitution.
+Templates are indicated with a \*.tpl suffix.
+Consider this snippet of the GPIO module at hw/ip\_templates/gpio/rtl/gpio.sv.tpl:
+
+```
+// General Purpose Input/Output module
+
+`include "prim_assert.sv"
+
+module ${module_instance_name}
+  import ${module_instance_name}_pkg::*;
+  import ${module_instance_name}_reg_pkg::*;
+#(
+  parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  // Number of cycles a differential skew is tolerated on the alert signal
+  parameter int unsigned                    AlertSkewCycles           = 1,
+  parameter bit                             GpioAsHwStrapsEn          = 1,
+```
+
+Note that this module doesn't have a name that looks like "gpio".
+Instead, the syntax `${module_instance_name}` is substituted by Pavona tooling to provide the true name of this module. Templated IPs allow IP customization beyond what is capable by ordinary SystemVerilog parameterization.
+Templated IPs are also widely used to help maintain consistency between disparate parts of the code base, from hardware to software to drivers and even documentation.
+
+As part of the top generation flow, top-level designs that use IP templates in hw/ip\_templates will pass parameters to these templates, which in turn get generated and placed in hw/top\_\*/ip\_autogen.
+For example, Darjeeling uses the GPIO IP, so the Darjeeling-specific GPIO module RTL is in hw/top\_darjeeling/ip\_autogen/gpio.
+
+## Hjson, the single source of truth
+
+In Pavona, most operations start from a top-level design.
+All of the information about a top-level design is centralized in a single Hjson file stored in a top-specific directory.
+An Hjson file is just like an ordinary JSON file, except that it allows comments.
+Hjson files are the primary way of encoding metadata in Pavona.
+As such, this top-level file is often called "the single source of truth".
+
+For instance, the Darjeeling design is entirely contained in hw/top\_darjeeling/data/top\_darjeeling.hjson.
+The following snippet shows a very small number of fields:
+
+```
+{ name: "darjeeling",
+  ...
+  clocks: {
+    srcs: [
+      { name: "main", aon: "no",  freq: "1000000000" }
+      { name: "io",   aon: "no",  freq: "250000000" }
+      ...
+    ],
+  },
+  ...
+  module: [
+    { name: "uart0",
+      type: "uart",
+      clock_srcs: {clk_i: "io"},
+      clock_group: "peri",
+      ...
+      base_addr: {
+        hart: "0x30010000",
+      },
+    },
+  ...
+    { name: "gpio",
+      type: "gpio",
+      template_type: "gpio",
+      clock_srcs: {clk_i: "io"},
+      clock_group: "peri",
+      reset_connections: {rst_ni: "lc_io"},
+      base_addr: {
+        hart: "0x30000000",
+      },
+      param_decl: {
+        GpioAsHwStrapsEn: "1",
+        GpioAsyncOn: "1"
+      },
+      ipgen_params: {
+        num_inp_period_counters: 8
+      }
+      attr: "ipgen"
+    },
+...
+  ]
+}
+```
+
+Here, this snippet says that there is a 1 GHz main clock and a 250 MHz IO clock, neither of which is always-on.
+Darjeeling instantiates a UART called "uart0" (among many other modules), clocked with the slower IO clock, and on the peripheral clock domain.
+The base address for its control/status register file is at 0x30010000.
+Darjeeling also instantiates the GPIO IP template, as indicated by the "template\_type" key, with 8 input period counters (num\_inp\_period\_counters).
+
+The top-level Hjson, among other things, identifies clocks, power domains, reset domains; address spaces and memories; module instantiation and connection; as well as pin connections to and from the top-level design.
+
+## The top generation flow
+
+Pavona's Architectural Composition Engine (ACE) transforms a top-level Hjson into RTL, DV, software, documentation, and more for a top-level design.
+ACE is composed of many tools in the util/ directory whose names typically end in \*gen: topgen, ipgen, dtgen, reggen, and so forth.
+
+To run ACE, pass this invocation to the Makefile.
+(If this fails with a missing "hjson" package, remember to source your Python virtual environment, then try again.)
+
+```
+(.venv) pavona $ make -C hw top_and_cmdgen
+make: Entering directory ...
+.../util/topgen.py -t .../hw/top_darjeeling/data/top_darjeeling.hjson ... -o hw/top_darjeeling
+   ...
+(cd ...; find . -name "*.md" -print0 | \
+ xargs -0 -P 8 -I '{}' ./util/cmdgen.py -u {})
+INFO:__main__:hw/top_darjeeling/ip_autogen/clkmgr/doc/interfaces.md:L3: Updating generated content.
+INFO:__main__:hw/top_darjeeling/ip_autogen/clkmgr/doc/registers.md:L3: Updating generated content.
+INFO:__main__:hw/top_darjeeling/ip_autogen/ac_range_check/doc/interfaces.md:L3: Updating generated content.
+INFO:__main__:hw/top_darjeeling/ip_autogen/ac_range_check/doc/registers.md:L3: Updating generated content.
+  ...
+make: Leaving directory ...
+```
+
+Always run ACE by using `make -C hw top_and_cmdgen` from the top-level directory of the Pavona clone; do not invoke topgen.py directly.
+
+## Customizing your own top
+
+Customizing the top almost always starts with the top-level Hjson file.
+For example, change num\_inp\_period\_counters to zero in top\_darjeeling.hjson:
+
+```
+...
+        GpioAsyncOn: "1"
+      },
+      ipgen_params: {
+        num_inp_period_counters: 0
+      }
+      attr: "ipgen"
+...
+```
+
+ and re-run ACE by running
+
+```
+(.venv) pavona $ make -C hw top_and_cmdgen
+```
+
+You'll notice that hw/top\_darjeeling/ip\_autogen/gpio/rtl/gpio.sv is now much shorter.
+That's because the templatization removes all the code related to input period counting if there are no input period counters.
+
+Templatization in Pavona is a powerful concept; it can drastically alter hardware by removing inputs and outputs, change register layouts, and even customize DV sequences.
+
+### Adding a new module
+
+Instantiating a new module in Pavona requires filling in a new entry in the `module` list of the top-level Hjson.
+In general, you'll follow the pattern of other module instantiations in filling out the name, type, clocks, resets, and base address.
+In addition to the module entry, you'll need to add your module to the `addr_spaces` key.
+You will also need to configure the crossbar to connect to your module.
+Crossbar descriptions are located in the same data/ directory as the top-level Hjson – to add your module to the main (1 GHz) Darjeeling crossbar, you'll need to edit hw/top\_darjeeling/data/xbar\_main.hjson .
+A fuller treatment is in an upcoming document.

--- a/doc/getting_started/intro_hardware.md
+++ b/doc/getting_started/intro_hardware.md
@@ -8,8 +8,8 @@ After this guide, you will be able to make changes to existing top-level designs
 
 ## Basic setup
 
-This guide assumes you have set up your repository as described in Pavona 101.
-Remember to source your Python virtual environment.
+This guide assumes you have set up your repository as described in [Pavona 101](./README.md).
+Remember to activate your Python virtual environment.
 
 ## Repository structure
 
@@ -30,7 +30,7 @@ README.md          mypy.ini              util
 SUMMARY.md         pyproject.toml        yum-requirements.txt
 ```
 
-We explored some of the `sw/` directory in [Pavona 101](./pavona_101.md).
+We explored some of the `sw/` directory in [Pavona 101](./README.md).
 In there, you'll find:
 
 * `sw/device/`, which contains software that will run on a Pavona top-level design.
@@ -40,7 +40,7 @@ This includes tests as well as the "Hello, World!" example from Pavona 101.
 The other important directory is the `hw/` directory, which has several key subdirectories:
 
 * `hw/ip/` contains block-level IP for the Pavona ecosystem that does not need further "templatization" (see the next section).
-* `hw/ip_templates`, on the other hand, contains block-level IP that *does* need templatization
+* `hw/ip_templates`, on the other hand, contains block-level IP that *does* need templatization.
 * `hw/top_darjeeling`, `hw/top_earlgrey`, and `hw/top_englishbreakfast`, which represent the currently supported top-level reference designs in the Pavona project.
 
 Top-level designs (or "tops") organize IP into a design suited for a particular purpose or implementation methodology.
@@ -67,7 +67,7 @@ Darjeeling contains a proxy for communication to the wider SoC, which is not mea
 
 In each IP directory, you'll find several directories:
 
-* `data/` contains the IP block Hjson, which forms the "single source of truth" for this IP block.
+* `data/` contains the IP block [Hjson](https://hjson.github.io), which forms the "single source of truth" for this IP block.
 It contains information about inputs, outputs, registers, interrupts, and other crucial metadata about the IP block.
 This file is used extensively in templatization and top generation.
 `data/` also contains the testplan.
@@ -173,7 +173,7 @@ The top-level Hjson, among other things, identifies clocks, power domains, reset
 ## The top generation flow
 
 Pavona's Architectural Composition Engine (ACE) transforms a top-level Hjson into RTL, DV, software, documentation, and more for a top-level design.
-ACE is composed of many tools in the util/ directory whose names typically end in "-gen": topgen, ipgen, dtgen, reggen, and so forth.
+ACE is composed of many tools in the util/ directory whose names typically end in "gen": topgen, ipgen, dtgen, reggen, and so forth.
 
 To run ACE, pass this invocation to the Makefile.
 (If this fails with a missing "hjson" package, remember to source your Python virtual environment, then try again.)

--- a/doc/getting_started/intro_hardware.md
+++ b/doc/getting_started/intro_hardware.md
@@ -2,22 +2,22 @@
 
 Pavona's differentiating feature is its principled modular design that makes customizing IP blocks and top-level designs effortless.
 
-Pavona 101 shows new users how to clone the repo, install system prerequisites, and run a basic chip-level simulation.
+[Pavona 101](./pavona_101.md) shows new users how to clone the repo, install system prerequisites, and run a basic chip-level simulation.
 This guide builds on Pavona 101 by explaining the repository and infrastructure for hardware design and development.
 After this guide, you will be able to make changes to existing top-level designs and run tests on them.
 
 ## Basic setup
 
-This guide assumes you have set up your repository as described in Pavona 101\.
+This guide assumes you have set up your repository as described in Pavona 101.
 Remember to source your Python virtual environment.
 
 ## Repository structure
 
 Change into the pavona directory and you'll find the following files:
 
-```
-(.venv) $ cd pavona
-(.venv) pavona $ ls
+```shell
+$ cd pavona
+$ ls
 BLOCKFILE          apt-requirements.txt  python-requirements.txt
 BUILD.bazel        bazelisk.sh           quality
 CLA                bench                 release
@@ -30,27 +30,27 @@ README.md          mypy.ini              util
 SUMMARY.md         pyproject.toml        yum-requirements.txt
 ```
 
-We explored some of the sw/ directory last time.
+We explored some of the `sw/` directory in [Pavona 101](./pavona_101.md).
 In there, you'll find:
 
-* sw/device/, which contains software that will run on a Pavona top-level design.
-This includes tests as well as the "Hello, World!" example from Pavona 101\.
-* sw/host/, which contains software that runs on the machine connected to a Pavona top-level design (the "host").
+* `sw/device/`, which contains software that will run on a Pavona top-level design.
+This includes tests as well as the "Hello, World!" example from Pavona 101.
+* `sw/host/`, which contains software that runs on the machine connected to a Pavona top-level design (the "host").
 
-The other important directory is the hw/ directory, which has several key subdirectories:
+The other important directory is the `hw/` directory, which has several key subdirectories:
 
-* hw/ip/ contains block-level IP for the Pavona ecosystem that does not need further "templatization" (see the next section).
-* hw/ip\_templates, on the other hand, contains block-level IP that *does* need templatization
-* hw/top\_darjeeling, hw/top\_earlgrey, and hw/top\_englishbreakfast, which represent the currently supported top-level reference designs in the Pavona project.
+* `hw/ip/` contains block-level IP for the Pavona ecosystem that does not need further "templatization" (see the next section).
+* `hw/ip_templates`, on the other hand, contains block-level IP that *does* need templatization
+* `hw/top_darjeeling`, `hw/top_earlgrey`, and `hw/top_englishbreakfast`, which represent the currently supported top-level reference designs in the Pavona project.
 
 Top-level designs (or "tops") organize IP into a design suited for a particular purpose or implementation methodology.
-We briefly introduce Pavona's three top-level designs here, but refer to their individual datasheets (located in each top directory's corresponding doc/ directory) for more information.
+We briefly introduce Pavona's three top-level designs here, but refer to their individual datasheets (located in each top directory's corresponding `doc/` directory) for more information.
 
-* top\_earlgrey is a full discrete root of trust design ready for tapeout.
-* top\_darjeeling is another root of trust design intended for integration within a broader SoC.
-* top\_englishbreakfast is a reduction of top\_earlgrey designed to facilitate side channel analysis and fault injection experiments.
+* `top_earlgrey` is a full discrete root of trust design ready for tapeout.
+* `top_darjeeling` is another root of trust design intended for integration within a broader SoC.
+* `top_englishbreakfast` is a reduction of `top_earlgrey` designed to facilitate side channel analysis and fault injection experiments.
 
-In these top-specific directories, you will also find another set of IP directories: hw/top\_\*/ip and hw/top\_\*/ip\_autogen.
+In these top-specific directories, you will also find another set of IP directories: `hw/top_*/ip` and `hw/top_*/ip_autogen`.
 This brings us to a discussion of the three types of IP in Pavona:
 
 ## Three different types of IP
@@ -58,8 +58,8 @@ This brings us to a discussion of the three types of IP in Pavona:
 Pavona organizes IP in three different ways.
 The first two are simple to understand:
 
-* hw/ip contains IPs that are broadly applicable to any top and do not require customization (beyond the capabilities of SystemVerilog parameters).
-* hw/top\_\*/ip contains IP that is specific to that top and is not intended to be used by another top.
+* `hw/ip` contains IPs that are broadly applicable to any top and do not require customization (beyond the capabilities of SystemVerilog parameters).
+* `hw/top_*/ip` contains IP that is specific to that top and is not intended to be used by another top.
 This includes the Analog Sensor Top (AST) and crossbar IPs for both Earlgrey and Darjeeling, which are specific to their respective top.
 Darjeeling contains a proxy for communication to the wider SoC, which is not meaningful in Earlgrey.
 
@@ -67,25 +67,25 @@ Darjeeling contains a proxy for communication to the wider SoC, which is not mea
 
 In each IP directory, you'll find several directories:
 
-* data/ contains the IP block Hjson, which forms the "single source of truth" for this IP block.
+* `data/` contains the IP block Hjson, which forms the "single source of truth" for this IP block.
 It contains information about inputs, outputs, registers, interrupts, and other crucial metadata about the IP block.
 This file is used extensively in templatization and top generation.
-data/ also contains the testplan.
-* doc/ contains block-specific documentation, including a programmer's guide, theory of operation, and register map.
-* dv/ contains block-specific DV collateral, including a block-level testbench/environment and sequence library.
-* Lastly, rtl/ contains the block's design.
+`data/` also contains the testplan.
+* `doc/` contains block-specific documentation, including a programmer's guide, theory of operation, and register map.
+* `dv/` contains block-specific DV collateral, including a block-level testbench/environment and sequence library.
+* Lastly, `rtl/` contains the block's design in SystemVerilog.
 
 ### IP templates
 
-The third type of IP is an *IP template,* and is stored in hw/ip\_templates.
+The third type of IP is an *IP template,* and is stored in `hw/ip_templates`.
 IP templates form one of Pavona's key features: the ability to customize hardware for a specific top.
 Templated IPs can be processed with Pavona tooling (discussed later) to generate a top-specific version of that IP.
 
 SystemVerilog files in templated IPs look just like ordinary SystemVerilog files, except that they contain macros that allow arbitrary text substitution.
-Templates are indicated with a \*.tpl suffix.
-Consider this snippet of the GPIO module at hw/ip\_templates/gpio/rtl/gpio.sv.tpl:
+Templates are indicated with a `*.tpl` suffix.
+Consider this snippet of the GPIO module at `hw/ip_templates/gpio/rtl/gpio.sv.tpl`:
 
-```
+```systemverilog
 // General Purpose Input/Output module
 
 `include "prim_assert.sv"
@@ -104,8 +104,8 @@ Note that this module doesn't have a name that looks like "gpio".
 Instead, the syntax `${module_instance_name}` is substituted by Pavona tooling to provide the true name of this module. Templated IPs allow IP customization beyond what is capable by ordinary SystemVerilog parameterization.
 Templated IPs are also widely used to help maintain consistency between disparate parts of the code base, from hardware to software to drivers and even documentation.
 
-As part of the top generation flow, top-level designs that use IP templates in hw/ip\_templates will pass parameters to these templates, which in turn get generated and placed in hw/top\_\*/ip\_autogen.
-For example, Darjeeling uses the GPIO IP, so the Darjeeling-specific GPIO module RTL is in hw/top\_darjeeling/ip\_autogen/gpio.
+As part of the top generation flow, top-level designs that use IP templates in `hw/ip_templates` will pass parameters to these templates, which in turn get generated and placed in `hw/top_*/ip_autogen`.
+For example, Darjeeling uses the GPIO IP, so the Darjeeling-specific GPIO module RTL is in `hw/top_darjeeling/ip_autogen/gpio`.
 
 ## Hjson, the single source of truth
 
@@ -115,10 +115,10 @@ An Hjson file is just like an ordinary JSON file, except that it allows comments
 Hjson files are the primary way of encoding metadata in Pavona.
 As such, this top-level file is often called "the single source of truth".
 
-For instance, the Darjeeling design is entirely contained in hw/top\_darjeeling/data/top\_darjeeling.hjson.
+For instance, the Darjeeling design is entirely contained in `hw/top_darjeeling/data/top_darjeeling.hjson`.
 The following snippet shows a very small number of fields:
 
-```
+```json
 { name: "darjeeling",
   ...
   clocks: {
@@ -166,20 +166,20 @@ The following snippet shows a very small number of fields:
 Here, this snippet says that there is a 1 GHz main clock and a 250 MHz IO clock, neither of which is always-on.
 Darjeeling instantiates a UART called "uart0" (among many other modules), clocked with the slower IO clock, and on the peripheral clock domain.
 The base address for its control/status register file is at 0x30010000.
-Darjeeling also instantiates the GPIO IP template, as indicated by the "template\_type" key, with 8 input period counters (num\_inp\_period\_counters).
+Darjeeling also instantiates the GPIO IP template, as indicated by the "`template_type`" key, with 8 input period counters (`num_inp_period_counters`).
 
 The top-level Hjson, among other things, identifies clocks, power domains, reset domains; address spaces and memories; module instantiation and connection; as well as pin connections to and from the top-level design.
 
 ## The top generation flow
 
 Pavona's Architectural Composition Engine (ACE) transforms a top-level Hjson into RTL, DV, software, documentation, and more for a top-level design.
-ACE is composed of many tools in the util/ directory whose names typically end in \*gen: topgen, ipgen, dtgen, reggen, and so forth.
+ACE is composed of many tools in the util/ directory whose names typically end in "-gen": topgen, ipgen, dtgen, reggen, and so forth.
 
 To run ACE, pass this invocation to the Makefile.
 (If this fails with a missing "hjson" package, remember to source your Python virtual environment, then try again.)
 
-```
-(.venv) pavona $ make -C hw top_and_cmdgen
+```shell
+$ make -C hw all
 make: Entering directory ...
 .../util/topgen.py -t .../hw/top_darjeeling/data/top_darjeeling.hjson ... -o hw/top_darjeeling
    ...
@@ -193,14 +193,14 @@ INFO:__main__:hw/top_darjeeling/ip_autogen/ac_range_check/doc/registers.md:L3: U
 make: Leaving directory ...
 ```
 
-Always run ACE by using `make -C hw top_and_cmdgen` from the top-level directory of the Pavona clone; do not invoke topgen.py directly.
+Always run ACE by using `make -C hw all` from the top-level directory of the Pavona clone; do not invoke topgen.py directly.
 
 ## Customizing your own top
 
 Customizing the top almost always starts with the top-level Hjson file.
-For example, change num\_inp\_period\_counters to zero in top\_darjeeling.hjson:
+For example, change `num_inp_period_counters` to zero in `top_darjeeling.hjson`:
 
-```
+```json
 ...
         GpioAsyncOn: "1"
       },
@@ -213,11 +213,11 @@ For example, change num\_inp\_period\_counters to zero in top\_darjeeling.hjson:
 
  and re-run ACE by running
 
-```
-(.venv) pavona $ make -C hw top_and_cmdgen
+```shell
+$ make -C hw all
 ```
 
-You'll notice that hw/top\_darjeeling/ip\_autogen/gpio/rtl/gpio.sv is now much shorter.
+You'll notice that `hw/top_darjeeling/ip_autogen/gpio/rtl/gpio.sv` is now much shorter.
 That's because the templatization removes all the code related to input period counting if there are no input period counters.
 
 Templatization in Pavona is a powerful concept; it can drastically alter hardware by removing inputs and outputs, change register layouts, and even customize DV sequences.
@@ -228,5 +228,5 @@ Instantiating a new module in Pavona requires filling in a new entry in the `mod
 In general, you'll follow the pattern of other module instantiations in filling out the name, type, clocks, resets, and base address.
 In addition to the module entry, you'll need to add your module to the `addr_spaces` key.
 You will also need to configure the crossbar to connect to your module.
-Crossbar descriptions are located in the same data/ directory as the top-level Hjson – to add your module to the main (1 GHz) Darjeeling crossbar, you'll need to edit hw/top\_darjeeling/data/xbar\_main.hjson .
-A fuller treatment is in an upcoming document.
+Crossbar descriptions are located in the same `data/` directory as the top-level Hjson – to add your module to the main (1 GHz) Darjeeling crossbar, you'll need to edit `hw/top_darjeeling/data/xbar_main.hjson` .
+A document showing how to add, remove, and customize modules is coming soon.

--- a/doc/getting_started/intro_software.md
+++ b/doc/getting_started/intro_software.md
@@ -1,7 +1,7 @@
 # Pavona 103: Introduction to software
 
-In Pavona 101, you learned how to clone the repository and run a Verilator test.
-In Pavona 102, you learned how ACE creates hardware from a single source of truth.
+In [Pavona 101](./pavona_101.md), you learned how to clone the repository and run a Verilator test.
+In [Pavona 102](./intro_hardware.md), you learned how ACE creates hardware from a single source of truth.
 This guide describes software in Pavona and its relationship to the hardware it runs on.
 
 ## Bazel
@@ -11,19 +11,19 @@ While this document will introduce basic Bazel commands needed to interact with 
 
 ## The software directories
 
-Pavona software resides broadly in the sw/ directory.
+Pavona software resides broadly in the `sw/` directory.
 Here are some of the most important subdirectories:
 
-* sw/device/, which contains software that will run on the general-purpose core, such as the Ibex, of a Pavona top-level design.
+* `sw/device/`, which contains software that will run on the general-purpose core, such as the Ibex, of a Pavona top-level design.
 This directory is broken down into several other directories; some important ones are:
-  * sw/device/examples/, which includes the "Hello, World!" example from Pavona 101\.
-  * sw/device/tests/, which contains hundreds of tests, encompassing peripheral smoke tests to fuller end-to-end tests.
-  * sw/device/silicon\_creator/ and sw/device/silicon\_owner/, which contain software serving root-of-trust and similar functions.
+  * `sw/device/examples/`, which includes the "Hello, World!" example from Pavona 101.
+  * `sw/device/tests/`, which contains hundreds of tests, encompassing peripheral smoke tests to fuller end-to-end tests.
+  * `sw/device/silicon_creator/` and `sw/device/silicon_owner/`, which contain software serving root-of-trust and similar functions.
     Here, you'll find the code for the ROM and ownership transfer code.
-* sw/device/acc/, which contains software that runs on the Asymmetric Cryptography Coprocessor (ACC).
+* `sw/device/acc/`, which contains software that runs on the Asymmetric Cryptography Coprocessor (ACC).
   Most ACC software is compiled into *cryptolib*, a library of cryptographic routines.
-* sw/host/, which contains software that runs on the machine (the "host") connected to a Pavona top-level design.
-  It's worth noting that this host code is distinct from code that is used to *generate* Pavona hardware, which generally lives in util/.
+* `sw/host/`, which contains software that runs on the machine (the "host") connected to a Pavona top-level design.
+  It's worth noting that this host code is distinct from code that is used to *generate* Pavona hardware, which generally lives in `util/`.
 
 The vast majority of general-purpose device code is written in C, with some RISC-V assembly where needed.
 ACC code is written in assembly, as it uses a custom ISA (although it sufficiently resembles RISC-V to reuse most of the tooling).
@@ -37,10 +37,10 @@ For more, see the Bazel documentation and the Pavona-specific Bazel documentatio
 ### Querying what targets are available
 
 Use `bazel query` to find out what software can be built from a particular directory.
-The following command lists the targets that can be built in sw/device/tests:
+The following command lists the targets that can be built in `sw/device/tests`:
 
-```
-(.venv) pavona $ bazel query sw/device/tests:*
+```shell
+$ bazel query sw/device/tests:*
 ...
 //sw/device/tests:BUILD
 //sw/device/tests:README.md
@@ -60,8 +60,8 @@ The following command lists the targets that can be built in sw/device/tests:
 Use `bazel build` to build a particular target.
 The following command builds the mask ROM (note that this is insufficient for a test, because you need an execution environment; read further).
 
-```
-(.venv) pavona $ bazel build sw/device/silicon_creator/rom:mask_rom
+```shell
+$ bazel build sw/device/silicon_creator/rom:mask_rom
 ...
 INFO: Analyzed target //sw/device/silicon_creator/rom:mask_rom (645 packages loaded, 25678 targets configured).
 INFO: Found 1 target...
@@ -87,10 +87,10 @@ Note also that building something else tends to blow away anything you've built 
 Use `bazel test` to run a test on Pavona.
 In Pavona, the name of a test is given by the binary as well as an execution environment, described below.
 To run a test, combine the test binary name with the name of the execution environment with an underscore.
-For example, to run a UART smoketest on the sim\_verilator execution environment, run the following command:
+For example, to run a UART smoketest on the `sim_verilator` execution environment, run the following command:
 
-```
-(.venv) pavona $ bazel test sw/device/tests:uart_smoketest_sim_verilator
+```shell
+$ bazel test sw/device/tests:uart_smoketest_sim_verilator
 ...
 INFO: Found 1 test target...
 Target //sw/device/tests:uart_smoketest_sim_verilator up-to-date:
@@ -108,8 +108,9 @@ Host tools are generally run, not tested; for these, use `bazel run`.
 For instance, opentitantool is the name of the tool for interacting with Pavona devices from an external host.
 To see the help menu for opentitantool:
 
-```
-(.venv) pavona $ bazel run //sw/host/opentitantool -- help...
+```shell
+$ bazel run //sw/host/opentitantool -- help
+   ...
 INFO: Build completed successfully, 1467 total actions
 INFO: Running command line: bazel-bin/sw/host/opentitantool/opentitantool <args omitted>
 A tool for interacting with OpenTitan chips.
@@ -133,22 +134,22 @@ Execution environments also encompass any ROM or firmware that supports the soft
 Some select between a test ROM and the full ROM; others select which keys to imbue into the ROM.
 
 The available execution environments also depend on the top-level hardware design being created.
-For a full list of execution environments, see rules/pavona/defs.bzl.
+For a full list of execution environments, see `rules/pavona/defs.bzl`.
 
 A complete test run of a given test on a given hardware, then, is given by combining the name of a test and the name of an execution environment.
-For instance, if a chip-level test is called "chip\_sw\_uart\_rx\_tx", and we'd like to run it in the "sim\_verilator" execution environment, we run a test whose name is formed by combining the test name and the execution environment with an underscore:
+For instance, if a chip-level test is called `chip_sw_uart_rx_tx`, and we'd like to run it in the `sim_verilator` execution environment, we run a test whose name is formed by combining the test name and the execution environment with an underscore:
 
-```
-(.venv) pavona $ bazel test sw/device/tests:chip_sw_uart_rx_tx_sim_verilator
+```shell
+$ bazel test sw/device/tests:chip_sw_uart_rx_tx_sim_verilator
 ```
 
 ## Writing a new test
 
-To write a new device test, it's easiest to look at existing tests in the sw/device/tests/ directory.
-In addition to the C code and any headers you may create, you'll need to add an entry to sw/device/tests/BUILD so that Bazel knows about your new test.
+To write a new device test, it's easiest to look at existing tests in the `sw/device/tests/` directory.
+In addition to the C code and any headers you may create, you'll need to add an entry to `sw/device/tests/BUILD` so that Bazel knows about your new test.
 Refer to the Bazel documentation for more information about how to write BUILD files.
 
-```
+```bazel
 opentitan_test(
     name = "my_new_test",
     srcs = ["my_new_test.c"],
@@ -173,7 +174,7 @@ opentitan_test(
 In order to finish a test, your test needs to print "PASS" or "FAIL".
 This file is a minimal passing test:
 
-```
+```c
 #include "hw/top/dt/uart.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/runtime/print_uart.h"

--- a/doc/getting_started/intro_software.md
+++ b/doc/getting_started/intro_software.md
@@ -136,7 +136,7 @@ Some select between a test ROM and the full ROM; others select which keys to imb
 The available execution environments also depend on the top-level hardware design being created.
 For a full list of execution environments, see `rules/pavona/defs.bzl`.
 
-A complete test run of a given test on a given hardware, then, is given by combining the name of a test and the name of an execution environment.
+A complete test run of a given test on a given hardware is given by combining the name of a test and the name of an execution environment.
 For instance, if a chip-level test is called `chip_sw_uart_rx_tx`, and we'd like to run it in the `sim_verilator` execution environment, we run a test whose name is formed by combining the test name and the execution environment with an underscore:
 
 ```shell

--- a/doc/getting_started/intro_software.md
+++ b/doc/getting_started/intro_software.md
@@ -1,0 +1,198 @@
+# Pavona 103: Introduction to software
+
+In Pavona 101, you learned how to clone the repository and run a Verilator test.
+In Pavona 102, you learned how ACE creates hardware from a single source of truth.
+This guide describes software in Pavona and its relationship to the hardware it runs on.
+
+## Bazel
+
+Bazel is a build system that coordinates the building and testing of all software in Pavona.
+While this document will introduce basic Bazel commands needed to interact with Pavona, please refer to the Bazel documentation for a more complete user guide.
+
+## The software directories
+
+Pavona software resides broadly in the sw/ directory.
+Here are some of the most important subdirectories:
+
+* sw/device/, which contains software that will run on the general-purpose core, such as the Ibex, of a Pavona top-level design.
+This directory is broken down into several other directories; some important ones are:
+  * sw/device/examples/, which includes the "Hello, World!" example from Pavona 101\.
+  * sw/device/tests/, which contains hundreds of tests, encompassing peripheral smoke tests to fuller end-to-end tests.
+  * sw/device/silicon\_creator/ and sw/device/silicon\_owner/, which contain software serving root-of-trust and similar functions.
+    Here, you'll find the code for the ROM and ownership transfer code.
+* sw/device/acc/, which contains software that runs on the Asymmetric Cryptography Coprocessor (ACC).
+  Most ACC software is compiled into *cryptolib*, a library of cryptographic routines.
+* sw/host/, which contains software that runs on the machine (the "host") connected to a Pavona top-level design.
+  It's worth noting that this host code is distinct from code that is used to *generate* Pavona hardware, which generally lives in util/.
+
+The vast majority of general-purpose device code is written in C, with some RISC-V assembly where needed.
+ACC code is written in assembly, as it uses a custom ISA (although it sufficiently resembles RISC-V to reuse most of the tooling).
+Lastly, host software is primarily written in Rust.
+
+## Basic Bazel tasks
+
+This section describes some of the most common tasks in Bazel.
+For more, see the Bazel documentation and the Pavona-specific Bazel documentation.
+
+### Querying what targets are available
+
+Use `bazel query` to find out what software can be built from a particular directory.
+The following command lists the targets that can be built in sw/device/tests:
+
+```
+(.venv) pavona $ bazel query sw/device/tests:*
+...
+//sw/device/tests:BUILD
+//sw/device/tests:README.md
+//sw/device/tests:acc_ecdsa_op_irq_test
+//sw/device/tests:acc_ecdsa_op_irq_test.c
+//sw/device/tests:acc_ecdsa_op_irq_test_fpga_cw310_rom_with_fake_keys
+//sw/device/tests:acc_ecdsa_op_irq_test_fpga_cw310_sival_rom_ext
+//sw/device/tests:acc_ecdsa_op_irq_test_fpga_cw340_rom_with_fake_keys
+//sw/device/tests:acc_ecdsa_op_irq_test_fpga_cw340_sival_rom_ext
+//sw/device/tests:acc_ecdsa_op_irq_test_silicon_creator
+//sw/device/tests:acc_ecdsa_op_irq_test_silicon_owner_sival_rom_ext
+...
+```
+
+### Building a target
+
+Use `bazel build` to build a particular target.
+The following command builds the mask ROM (note that this is insufficient for a test, because you need an execution environment; read further).
+
+```
+(.venv) pavona $ bazel build sw/device/silicon_creator/rom:mask_rom
+...
+INFO: Analyzed target //sw/device/silicon_creator/rom:mask_rom (645 packages loaded, 25678 targets configured).
+INFO: Found 1 target...
+Target //sw/device/silicon_creator/rom:mask_rom up-to-date:
+  bazel-bin/sw/device/silicon_creator/rom/mask_rom_fpga_cw310.39.scr.vmem
+  bazel-bin/sw/device/silicon_creator/rom/mask_rom_fpga_cw310.elf
+  bazel-bin/sw/device/silicon_creator/rom/mask_rom_fpga_cw310.dis
+  bazel-bin/sw/device/silicon_creator/rom/mask_rom_fpga_cw310.map
+  bazel-bin/sw/device/silicon_creator/rom/mask_rom_fpga_cw310.32.vmem
+  bazel-bin/sw/device/silicon_creator/rom/mask_rom_fpga_cw340.39.scr.vmem
+  bazel-bin/sw/device/silicon_creator/rom/mask_rom_fpga_cw340.elf
+  bazel-bin/sw/device/silicon_creator/rom/mask_rom_fpga_cw340.dis
+  bazel-bin/sw/device/silicon_creator/rom/mask_rom_fpga_cw340.map
+  bazel-bin/sw/device/silicon_creator/rom/mask_rom_fpga_cw340.32.vmem
+...
+```
+
+Note that building the software gives you a list of paths it's built.
+Note also that building something else tends to blow away anything you've built before.
+
+### Running a Pavona test (device software)
+
+Use `bazel test` to run a test on Pavona.
+In Pavona, the name of a test is given by the binary as well as an execution environment, described below.
+To run a test, combine the test binary name with the name of the execution environment with an underscore.
+For example, to run a UART smoketest on the sim\_verilator execution environment, run the following command:
+
+```
+(.venv) pavona $ bazel test sw/device/tests:uart_smoketest_sim_verilator
+...
+INFO: Found 1 test target...
+Target //sw/device/tests:uart_smoketest_sim_verilator up-to-date:
+  bazel-bin/sw/device/tests/uart_smoketest_sim_verilator.bash
+INFO: Elapsed time: 472.684s, Critical Path: 472.17s
+INFO: 3 processes: 285 action cache hit, 3 linux-sandbox.
+INFO: Build completed successfully, 3 total actions
+//sw/device/tests:uart_smoketest_sim_verilator                           PASSED in 34.5s
+
+```
+
+### Running host software
+
+Host tools are generally run, not tested; for these, use `bazel run`.
+For instance, opentitantool is the name of the tool for interacting with Pavona devices from an external host.
+To see the help menu for opentitantool:
+
+```
+(.venv) pavona $ bazel run //sw/host/opentitantool -- help...
+INFO: Build completed successfully, 1467 total actions
+INFO: Running command line: bazel-bin/sw/host/opentitantool/opentitantool <args omitted>
+A tool for interacting with OpenTitan chips.
+
+Usage: opentitantool [OPTIONS] <COMMAND>
+
+Commands:
+  bfv          Decode a raw status. Optionally accepts an ELF file to recover the filename
+  bootstrap    Bootstrap the target device
+  console
+```
+
+## Execution environments
+
+The highest-level abstraction in the Pavona build system is the execution environment.
+An execution environment describes the hardware platform that software will run on.
+An execution environment can be Verilator, an FPGA, or even within a DV simulation (such as VCS or Xcelium).
+Execution environments are orthogonal to top-level designs – indeed, different top-level designs may have vastly different sets of execution environments.
+
+Execution environments also encompass any ROM or firmware that supports the software.
+Some select between a test ROM and the full ROM; others select which keys to imbue into the ROM.
+
+The available execution environments also depend on the top-level hardware design being created.
+For a full list of execution environments, see rules/pavona/defs.bzl.
+
+A complete test run of a given test on a given hardware, then, is given by combining the name of a test and the name of an execution environment.
+For instance, if a chip-level test is called "chip\_sw\_uart\_rx\_tx", and we'd like to run it in the "sim\_verilator" execution environment, we run a test whose name is formed by combining the test name and the execution environment with an underscore:
+
+```
+(.venv) pavona $ bazel test sw/device/tests:chip_sw_uart_rx_tx_sim_verilator
+```
+
+## Writing a new test
+
+To write a new device test, it's easiest to look at existing tests in the sw/device/tests/ directory.
+In addition to the C code and any headers you may create, you'll need to add an entry to sw/device/tests/BUILD so that Bazel knows about your new test.
+Refer to the Bazel documentation for more information about how to write BUILD files.
+
+```
+opentitan_test(
+    name = "my_new_test",
+    srcs = ["my_new_test.c"],
+    exec_env = {
+        "//hw/top_earlgrey:sim_dv": None,
+        "//hw/top_earlgrey:sim_verilator": None,
+    },
+    deps = [
+        # Some dependencies you may need
+        "//hw/top/dt",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:print_uart",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_start",
+        "//sw/device/lib/testing/test_framework:ottf_test_config",
+        # Add more here
+    ],
+)
+```
+
+In order to finish a test, your test needs to print "PASS" or "FAIL".
+This file is a minimal passing test:
+
+```
+#include "hw/top/dt/uart.h"
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/runtime/print_uart.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_test_config.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+void _ottf_main(void) {
+  // Initialize the UART from the device table
+  dif_uart_t uart;
+  CHECK_DIF_OK(dif_uart_init_from_dt(kDtUart0, &uart));
+
+  // Route LOG_INFO to this UART
+  base_uart_stdout(&uart);
+
+  LOG_INFO("Hello World!");
+
+  // The test environment searches for this string to complete the test
+  LOG_INFO("PASS!");
+}
+```

--- a/doc/getting_started/pavona_101.md
+++ b/doc/getting_started/pavona_101.md
@@ -283,8 +283,8 @@ Congratulations!
 You've just set up your system, downloaded the Pavona repository, and run a test on verilated hardware.
 There are many steps forward from here:
 
-* Pavona 102: Introduction to Hardware
-* Pavona 103: Introduction to Software
+* [Pavona 102: Introduction to Hardware](./intro_hardware.md)
+* [Pavona 103: Introduction to Software](./intro_software.md)
 * Build and run hardware on an FPGA
 * Write software
 * Run DV tests


### PR DESCRIPTION
These introductory documents show how hardware and software work in Pavona. These have URLs that depend on #147 going in first.