### PR TITLE
[ci] Improve flexibility of dvsim action

### DIFF
--- a/.github/actions/dvsim/action.yml
+++ b/.github/actions/dvsim/action.yml
@@ -92,18 +92,25 @@ runs:
         git config --global user.name "dvsim bot"
       shell: bash
 
-    - name: Checkout internal dashboard for regrading
-      if: ${{ inputs.item == 'weekly' }}
-      uses: actions/checkout@v4
-      with:
-        repository: pavona/internal-dashboard
-        ssh-key: ${{ inputs.dashboard-upload-key }}
-        path: internal-dashboard
-
     - name: Run regrading mechanism
       id: regrade
       if: ${{ inputs.item == 'weekly' }}
       run: |
+        # Clone the internal dashboard, matching the CI branch if it exists there.
+        # For PRs use the source branch; otherwise the branch/tag that triggered the run.
+        CURRENT_BRANCH="${{ github.head_ref || github.ref_name }}"
+        DASHBOARD_REPO="git@github.com:pavona/internal-dashboard.git"
+        echo "CI branch: '$CURRENT_BRANCH'"
+
+        if [ -n "$CURRENT_BRANCH" ] && \
+           git ls-remote --exit-code --heads "$DASHBOARD_REPO" "refs/heads/$CURRENT_BRANCH" >/dev/null 2>&1; then
+          echo "Matching branch '$CURRENT_BRANCH' found in pavona/internal-dashboard - checking it out."
+          git clone --depth=1 --branch "$CURRENT_BRANCH" "$DASHBOARD_REPO" internal-dashboard
+        else
+          echo "No matching branch in pavona/internal-dashboard - checking out default branch."
+          git clone --depth=1 "$DASHBOARD_REPO" internal-dashboard
+        fi
+
         FLOW_DIR="internal-dashboard/all_tops_batch_weekly_sim"
         LATEST_VER=$(find "$FLOW_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort | tail -1)
         if [ -z "$LATEST_VER" ]; then

--- a/.github/actions/dvsim/action.yml
+++ b/.github/actions/dvsim/action.yml
@@ -52,6 +52,9 @@ inputs:
   public-upload-key:
     type: string
     default: ""
+  cfgs:
+    type: string
+    default: ""
 
 runs:
   using: composite
@@ -143,6 +146,10 @@ runs:
         elif [ -n "${{ inputs.reseed-source }}" ]; then
           RESEED="-rs ${{ inputs.reseed-source }}"
         fi
+        CFGS=""
+        if [ -n "${{ inputs.cfgs }}" ]; then
+          CFGS="--select-cfgs ${{ inputs.cfgs }}"
+        fi
 
         util/dvsim/dvsim.py $COVERAGE \
           ${{ inputs.hjson }} \
@@ -151,6 +158,7 @@ runs:
           -i ${{ inputs.item }} ${{ inputs.extra-dvsim-flags }} \
           ${PUBLISH_PRIVATE} \
           ${RESEED} \
+          ${CFGS} \
           || ! ${{ inputs.require-pass }}
 
         if [ -n "$PUBLISH_PUBLIC" ]; then
@@ -161,7 +169,8 @@ runs:
             ${{ inputs.hjson }} \
             -t ${{ inputs.tool }} \
             -i ${{ inputs.item }} \
-            ${PUBLISH_PUBLIC}
+            ${PUBLISH_PUBLIC} \
+            ${CFGS}
         fi
       shell: bash
 


### PR DESCRIPTION
This PR contains two commits:
- Add `cfgs` input to select the IPs / `sim_cfgs` to run from the `all_sim_cfgs.hjson`.
- Regrade seeds from the corresponding branch (if it exists). This way, internal branches are not being always graded based on the seeds from `main`.