### PR TITLE
[verilator] Mitigate risk of FuseSoC running local Verilator

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -31,6 +31,7 @@ libssl-dev
 libtool
 libudev-dev
 libusb-1.0-0
+libzstd-dev
 lrzsz
 lsb-release
 make

--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -82,6 +82,25 @@ def _fusesoc_build_impl(ctx):
     args.add_all(ctx.attr.systems)
     args.add_all(flags)
 
+
+    vivado_envs = dicts.add(ENV, {
+        "HOME": home_dir,
+        # Obtain the non-hermetic binary path and append Bazel's default PATH.
+        "PATH": BIN_PATHS["vivado"] + ":/bin:/usr/bin:/usr/local/bin",
+        "LD_PRELOAD": "/lib/x86_64-linux-gnu/libudev.so.1",
+    })
+    verilator_envs = {
+        # Contains the `execroot`-relative paths for verilator and C/C++
+        # compiler provided by Bazel. `fusesoc_build.py` converts these
+        # into absolute paths once the working directory is known.
+        "PATH": "/usr/bin",
+        "VERILATOR_BINARY": ctx.executable._verilator.path,
+        "VERILATOR_AR": ctx.executable._ar.path,
+        "VERILATOR_CC": ctx.executable._cc.path,
+        "VERILATOR_CXX": ctx.executable._cxx.path,
+        "VERILATOR_LIBCXX": ctx.files._libcxx[0].path,
+        "VERILATOR_INCLUDE": ctx.files._include[0].path,
+    }
     ctx.actions.run(
         mnemonic = "FuseSoC",
         outputs = outputs,
@@ -97,26 +116,7 @@ def _fusesoc_build_impl(ctx):
         arguments = [args],
         executable = ctx.executable._fusesoc,
         use_default_shell_env = False,
-        env = dicts.add(
-            # Verilator build doesn't need nonhermetic environment variables
-            ENV if ctx.attr.target == "synth" else {
-                # Contains the `execroot`-relative paths for verilator and C/C++
-                # compiler provided by Bazel. `fusesoc_build.py` converts these
-                # into absolute paths once the working directory is known.
-                "VERILATOR_BINARY": ctx.executable._verilator.path,
-                "VERILATOR_AR": ctx.executable._ar.path,
-                "VERILATOR_CC": ctx.executable._cc.path,
-                "VERILATOR_CXX": ctx.executable._cxx.path,
-                "VERILATOR_LIBCXX": ctx.files._libcxx[0].path,
-                "VERILATOR_INCLUDE": ctx.files._include[0].path,
-            },
-            {
-                "HOME": home_dir,
-                # Obtain the non-hermetic binary path and append Bazel's default PATH.
-                "PATH": (BIN_PATHS["vivado"] + ":" if ctx.attr.target == "synth" else "") + "/bin:/usr/bin:/usr/local/bin",
-                "LD_PRELOAD": "/lib/x86_64-linux-gnu/libudev.so.1",
-            },
-        ),
+        env = vivado_envs if ctx.attr.target == "synth" else verilator_envs,
     )
     return [
         DefaultInfo(

--- a/util/fusesoc_build.py
+++ b/util/fusesoc_build.py
@@ -16,7 +16,7 @@ from pathlib import Path
 if __name__ == "__main__":
     # First, ensure the calling interpreter is on the PATH first, so any
     # generators asking /usr/bin/env for python3 will use the same version.
-    path_env = os.environ["PATH"]
+    path_env = os.environ["PATH"] if "PATH" in os.environ else ""
     if path_env is not None:
         path_env = ":" + path_env
     path_env = os.path.dirname(sys.executable) + path_env


### PR DESCRIPTION
Refactors the implementation of `fusesoc_build` to eliminate `/usr/local/bin` from PATH when running FuseSoC with Verilator.

### TODO

`/usr/bin` still remains in the `PATH` when running FuseSoC with `Verilator` due to a dependency on the host `make`. The user is responsible for ensuring that `/usr/bin/verilator` does not contain an alternate undesired Verilator installation, e.g. if Verilator `4.x.X` is installed with `apt`.