### PR TITLE
[ci,gcp] Re-enable bazel and bitstream caches

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -146,5 +146,5 @@ run --sandbox_explicit_pseudoterminal
 build --incompatible_strict_action_env
 
 # Bazel remote cache configuration.
-common --remote_cache=https://storage.googleapis.com/expo-bazel-cache"
+common --remote_cache=https://storage.googleapis.com/pavona-bazel-cache"
 build --remote_upload_local_results=false

--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -120,6 +120,53 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
+    # Log into Google Cloud using workload_identity_provider.
+    - id: auth
+      name: Authenticate to Google Cloud
+      # This uses secrets, so it does not work on pull requests from forks.
+      if: github.event_name != 'pull_request'
+      uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
+      with:
+        workload_identity_provider: projects/951672875677/locations/global/workloadIdentityPools/github-actions-pool/providers/${{ github.event.repository.name }}
+        service_account: ${{ github.event.repository.name }}-gh-actions-sa@expo-caches-3492dd4e.iam.gserviceaccount.com
+
+
+    # The above action creates a credential file in workspace and it doesn't provide a way to configure
+    # it. This influences with a few scripts that assume clean workspace, and introduce security risk
+    # that it may be exposed when uploading to buckets.
+    - name: Move Google credentials out from workspace
+      if: github.event_name != 'pull_request'
+      run: |
+        SOURCE=${{ steps.auth.outputs.credentials_file_path }}
+        TARGET=${{ runner.temp }}/$(basename "$SOURCE")
+        mv $SOURCE $TARGET
+        echo "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=$TARGET" >> $GITHUB_ENV
+        echo "GOOGLE_APPLICATION_CREDENTIALS=$TARGET" >> $GITHUB_ENV
+        echo "GOOGLE_GHA_CREDS_PATH=$TARGET" >> $GITHUB_ENV
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+
+    - uses: google-github-actions/setup-gcloud@v2
+      if: github.event_name != 'pull_request'
+
+    - name: Configure ~/.bazelrc
+      if: inputs.configure-bazel == 'true'
+      run: |
+        echo "common --remote_cache=https://storage.googleapis.com/expo-bazel-cache" >> ~/.bazelrc
+        # Inject the OS version into a parameter used in the action key computation to
+        # avoid collisions between different operating systems in the caches.
+        # See #14695 for more information.
+        echo "build --remote_default_exec_properties=OSVersion=\"$(lsb_release -ds)\"" >> ~/.bazelrc
+
+        if ${{ github.event_name != 'pull_request' }}; then
+          echo "Will upload to the cache." >&2
+        else
+          echo "Download from cache only." >&2
+          echo "build --remote_upload_local_results=false" >> ~/.bazelrc
+        fi
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+
     - name: Install merge-junit
       run: |
         MERGE_JUNIT_PATH="/tools/merge-junit"

--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -128,8 +128,7 @@ runs:
       uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
       with:
         workload_identity_provider: projects/951672875677/locations/global/workloadIdentityPools/github-actions-pool/providers/${{ github.event.repository.name }}
-        service_account: ${{ github.event.repository.name }}-gh-actions-sa@expo-caches-3492dd4e.iam.gserviceaccount.com
-
+        service_account: ${{ github.event.repository.name }}-gh-actions-sa@pavona-caches-3492dd4e.iam.gserviceaccount.com
 
     # The above action creates a credential file in workspace and it doesn't provide a way to configure
     # it. This influences with a few scripts that assume clean workspace, and introduce security risk
@@ -152,7 +151,7 @@ runs:
     - name: Configure ~/.bazelrc
       if: inputs.configure-bazel == 'true'
       run: |
-        echo "common --remote_cache=https://storage.googleapis.com/expo-bazel-cache" >> ~/.bazelrc
+        echo "common --remote_cache=https://storage.googleapis.com/pavona-bazel-cache" >> ~/.bazelrc
         # Inject the OS version into a parameter used in the action key computation to
         # avoid collisions between different operating systems in the caches.
         # See #14695 for more information.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,7 @@ jobs:
       top_name: earlgrey
       design_suffix: cw340
 
-  # Hyper310 FPGA jobs
+  # CW310 FPGA jobs
   execute_tests_cw310:
     name: Earlgrey CW310 Tests
     needs: chip_earlgrey_cw310

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -4,8 +4,9 @@
 
 name: Post-Merge Artifacts
 on:
-  merge_group:
-    branches: [ main ]
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -87,7 +87,7 @@ jobs:
             $PWD/build-bin/**/manifest.json
       - name: Upload bitstreams to GCP bucket
         run: |
-          BUCKET_URI=gs://expo-bitstreams/${{ github.ref_name }}
+          BUCKET_URI=gs://pavona-bitstreams/${{ github.ref_name }}
           printf "$(date -u +%Y-%m-%dT%H:%M:%S)\n${{ github.sha }}" > latest.txt
           gcloud storage cp build-bin/bitstream-cache/bitstream-cache.tar.gz $BUCKET_URI/bitstream-${{ github.sha }}.tar.gz
           gcloud storage cp latest.txt $BUCKET_URI/latest.txt

--- a/rules/bitstreams.bzl
+++ b/rules/bitstreams.bzl
@@ -110,7 +110,7 @@ bitstreams_repo = repository_rule(
     attrs = {
         "bucket_url": attr.string(
             doc = "Location of the GCP bitstream bucket.",
-            default = "https://storage.googleapis.com/expo-bitstreams/",
+            default = "https://storage.googleapis.com/pavona-bitstreams/",
         ),
         "cache": attr.string(
             doc = "Location of bitstreams cache.",

--- a/rules/scripts/bitstreams_workspace.py
+++ b/rules/scripts/bitstreams_workspace.py
@@ -29,7 +29,7 @@ MANIFEST_SCHEMA_VERSION_MAX = 3
 # Default location of the bitstreams cache.
 CACHE_DIR = '~/.cache/pavona-bitstreams'
 # Default bucket URL.
-BUCKET_URL = 'https://storage.googleapis.com/expo-bitstreams/'  # TODO: update remote cache
+BUCKET_URL = 'https://storage.googleapis.com/pavona-bitstreams/'
 # The xml document returned by the bucket is in this namespace.
 XMLNS = {'': 'http://doc.s3.amazonaws.com/2006-03-01'}
 # Manifest schema directory
@@ -60,7 +60,7 @@ parser.add_argument('--latest-update',
                     default='latest.txt',
                     help='Last time the cache was updated')
 parser.add_argument('--branch',
-                    default="master",  # TODO: update after switch to new repo
+                    default="main",
                     help='Upstream git branch to search for bitstreams.')
 parser.add_argument('--bucket-url', default=BUCKET_URL, help='GCP Bucket URL')
 parser.add_argument('--build-file',


### PR DESCRIPTION
This PR configures the repository to use the Google Cloud buckets provided by the Pavona Project for caching bazel targets and FPGA bitstreams. 

### Bitstream Cache

Bitstreams built by CI are built and uploaded to the cache when a Pull Request is merged to the `main` branch. In a local checkout, you can enable the `post-checkout` hook to automatically fetch the latest matching bitstream each time you switch branches:

```cp util/git/hooks/post-checkout` .git/hooks/```

### Bazel Remote Cache

The Bazel remote cache stores pre-built artifacts from the `main` branch of the repository, making rebuilds faster. Downloading cached builds in a local checkout is configured automatically in `.bazelrc`.