### PR TITLE
[dvsim] Update repo name reference

### DIFF
--- a/hw/data/common_project_cfg.hjson
+++ b/hw/data/common_project_cfg.hjson
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   project:          pavona
-  repo_server:      "github.com/pavona/pavona-staging"
+  repo_server:      "github.com/pavona/pavona"
   book:             pavona.org/book
   doc_server:       docs.pavona.org
   results_server:   reports.pavona.org


### PR DESCRIPTION
The github project name was changed yesterday from `pavona-staging` to just `pavona` so we need to update this to match.