### PR TITLE
[ci] Raise ACC smoke test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
     needs: quick_lint
     runs-on:
       group: pavona-basic
-    timeout-minutes: 20
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
With the hermetic toolchain setup and toolchain builds, the total run time sometimes runs into the 20-minute timeout.