### PR TITLE
[ci,gcp] Fix project IDs for access to caches

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -127,8 +127,8 @@ runs:
       if: github.event_name != 'pull_request'
       uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
       with:
-        workload_identity_provider: projects/951672875677/locations/global/workloadIdentityPools/github-actions-pool/providers/${{ github.event.repository.name }}
-        service_account: ${{ github.event.repository.name }}-gh-actions-sa@pavona-caches-3492dd4e.iam.gserviceaccount.com
+        workload_identity_provider: projects/877782468570/locations/global/workloadIdentityPools/github-actions-pool/providers/${{ github.event.repository.name }}
+        service_account: ${{ github.event.repository.name }}-gh-actions-sa@pavona-caches-430f6d3b.iam.gserviceaccount.com
 
     # The above action creates a credential file in workspace and it doesn't provide a way to configure
     # it. This influences with a few scripts that assume clean workspace, and introduce security risk


### PR DESCRIPTION
Fixes an issue with #168, where the project identifiers for authentication to Google Cloud via Workload Identity Federation were not updated correctly, causing a crash when attempting to authenticate to GCP from the `pavona` repository context.