### PR TITLE
[dj,fpga] Add slot for second ROM in FPGA bitstreams

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -192,12 +192,13 @@ runs:
 
     # Setup FPGA, if requested.
     - name: FPGA setup
-      if: inputs.fpga != ''
       run: |
-         # Install dependencies
-         sudo apt install -y libudev-dev libclang-dev libftdi1-dev
-         # Add Vivado Lab binary directory to path
-         echo "/tools/Xilinx/Vivado_Lab/${{ inputs.vivado-lab-version }}/bin" >> $GITHUB_PATH
+        if command -v apt > /dev/null; then
+          # Install dependencies
+          sudo apt install -y libudev-dev libclang-dev libftdi1-dev
+        fi
+        # Add Vivado Lab binary directory to path
+        echo "/tools/Xilinx/Vivado_Lab/${{ inputs.vivado-lab-version }}/bin" >> $GITHUB_PATH
       shell: bash
     - name: Run FPGA set-pll and clear bitstream
       if: inputs.fpga == 'cw310' || inputs.fpga == 'cw340'

--- a/hw/ip/BUILD
+++ b/hw/ip/BUILD
@@ -26,6 +26,7 @@ filegroup(
         "//hw/ip/hmac:rtl_files",
         "//hw/ip/i2c:rtl_files",
         "//hw/ip/keymgr:rtl_files",
+        "//hw/ip/keymgr_dpe:rtl_files",
         "//hw/ip/kmac:rtl_files",
         "//hw/ip/lc_ctrl:rtl_files",
         "//hw/ip/mbx:rtl_files",

--- a/hw/ip/rom_ctrl/util/gen_vivado_mem_image.py
+++ b/hw/ip/rom_ctrl/util/gen_vivado_mem_image.py
@@ -73,7 +73,7 @@ class UpdatememSimulator:
         return line_groups
 
 
-def parse_otp_init_strings(init_line_groups: List[List[str]]) -> List[int]:
+def parse_otp_init_strings(otp_size: int, init_line_groups: List[List[str]]) -> List[int]:
     """Parse a sequence of 22-bit OTP words from Vivado INIT_XX lines.
 
     The data layout was determined by running a full Vivado bitstream build and
@@ -107,7 +107,7 @@ def parse_otp_init_strings(init_line_groups: List[List[str]]) -> List[int]:
             bram_scratch.append(bits)
         brams.append(bram_scratch)
 
-    for i in range(1024):
+    for i in range(otp_size):
         # Slice off the first 22 bits.
         bits = []
         for bram in brams:
@@ -125,11 +125,11 @@ def parse_otp_init_strings(init_line_groups: List[List[str]]) -> List[int]:
     return out
 
 
-def otp_words_to_updatemem_pieces(words: List[int]) -> List[str]:
+def otp_words_to_updatemem_pieces(otp_size: int, words: List[int]) -> List[str]:
     """Transform `words` into pieces of an updatemem-compatible MEM file."""
 
     assert len(words) % 4 == 0
-    assert len(words) <= 1024
+    assert len(words) <= otp_size
     mask_22_bits = (1 << 22) - 1
     assert all(word == (word & mask_22_bits) for word in words)
 
@@ -172,12 +172,12 @@ def otp_words_to_updatemem_pieces(words: List[int]) -> List[str]:
     # the real updatemem would print. We also know how to recover OTP memory
     # contents from INIT_XX strings. Composing these two functions should bring
     # us back to the original `words` input.
-    updatemem_sim = UpdatememSimulator(0x40, 22)
+    updatemem_sim = UpdatememSimulator(0x200, 22)
     for piece in mem_pieces[1:]:
         updatemem_sim.write_updatemem_hex_string(piece)
     init_lines = updatemem_sim.render_init_lines()
 
-    reconstructed = parse_otp_init_strings(init_lines)
+    reconstructed = parse_otp_init_strings(otp_size, init_lines)
     if len(reconstructed) < len(words) or reconstructed[:len(words)] != words:
         raise Exception("Generated updatemem data for OTP failed self-check")
 
@@ -203,6 +203,7 @@ def main() -> int:
     parser.add_argument('infile', type=argparse.FileType('rb'))
     parser.add_argument('outfile', type=argparse.FileType('w'))
     parser.add_argument('--swap-nibbles', dest='swap_nibbles', action='store_true')
+    parser.add_argument('--otp-size', dest='otp_size', type=int)
 
     args = parser.parse_args()
 
@@ -223,7 +224,7 @@ def main() -> int:
 
     if width == 24:
         logger.info("Generating updatemem-compatible MEM file for OTP image.")
-        updatemem_pieces = otp_words_to_updatemem_pieces(words)
+        updatemem_pieces = otp_words_to_updatemem_pieces(args.otp_size, words)
         updatemem_line = ' '.join(updatemem_pieces)
         args.outfile.write(updatemem_line + '\n')
         return 0

--- a/hw/ip/rom_ctrl/util/gen_vivado_mem_image.py
+++ b/hw/ip/rom_ctrl/util/gen_vivado_mem_image.py
@@ -184,13 +184,17 @@ def otp_words_to_updatemem_pieces(otp_size: int, words: List[int]) -> List[str]:
     return mem_pieces
 
 
-def swap_bytes(width: int, orig: int, swap_nibbles: bool) -> int:
+def swap_bytes(width: int, orig: int, swap_nibbles: bool, swap_crumbs: bool) -> int:
     num_bytes = math.ceil(width / 8)
     swapped = 0
     for i in range(num_bytes):
         byte_value = ((orig >> (i * 8)) & 0xFF)
         if swap_nibbles:
             byte_value = ((byte_value << 4) | (byte_value >> 4)) & 0xFF
+        if swap_crumbs:
+            mask_evens = 0x33333333
+            mask_odds = 0xCCCCCCCC
+            byte_value = ((byte_value & mask_evens) << 2) | ((byte_value & mask_odds) >> 2)
         swapped |= (byte_value << ((num_bytes - i - 1) * 8))
     return swapped
 
@@ -203,6 +207,7 @@ def main() -> int:
     parser.add_argument('infile', type=argparse.FileType('rb'))
     parser.add_argument('outfile', type=argparse.FileType('w'))
     parser.add_argument('--swap-nibbles', dest='swap_nibbles', action='store_true')
+    parser.add_argument('--swap-crumbs', dest='swap_crumbs', action='store_true')
     parser.add_argument('--otp-size', dest='otp_size', type=int)
 
     args = parser.parse_args()
@@ -242,7 +247,7 @@ def main() -> int:
         # Generate the address.
         addr = idx * math.ceil(width / 8)
         # Convert endianness.
-        data = swap_bytes(width, word, args.swap_nibbles)
+        data = swap_bytes(width, word, args.swap_nibbles, args.swap_crumbs)
         # Check for contiguous addresses. If any are found, omit this word's
         # address to speed up `updatemem` operation.
         toks = []

--- a/hw/ip/rom_ctrl/util/gen_vivado_mem_image_test.py
+++ b/hw/ip/rom_ctrl/util/gen_vivado_mem_image_test.py
@@ -14,13 +14,13 @@ EARLGREY_OTP_SIZE = 1024
 class TestGenVivadoMemImage(unittest.TestCase):
 
     def test_swap_bytes(self) -> None:
-        swapped = swap_bytes(39, 0x01, swap_nibbles=False)
+        swapped = swap_bytes(39, 0x01, swap_nibbles=False, swap_crumbs=False)
         self.assertEqual(swapped, 0x0100000000)
 
-        swapped = swap_bytes(39, 0x0102030405, swap_nibbles=False)
+        swapped = swap_bytes(39, 0x0102030405, swap_nibbles=False, swap_crumbs=False)
         self.assertEqual(swapped, 0x0504030201)
 
-        swapped = swap_bytes(39, 0x0102030405, swap_nibbles=True)
+        swapped = swap_bytes(39, 0x0102030405, swap_nibbles=True, swap_crumbs=False)
         self.assertEqual(swapped, 0x5040302010)
 
 

--- a/hw/ip/rom_ctrl/util/gen_vivado_mem_image_test.py
+++ b/hw/ip/rom_ctrl/util/gen_vivado_mem_image_test.py
@@ -8,6 +8,8 @@ import unittest
 from gen_vivado_mem_image import (UpdatememSimulator,
                                   otp_words_to_updatemem_pieces, swap_bytes)
 
+EARLGREY_OTP_SIZE = 1024
+
 
 class TestGenVivadoMemImage(unittest.TestCase):
 
@@ -26,7 +28,7 @@ class TestOtpWordsToUpdatememPieces(unittest.TestCase):
 
     def test_all_ones(self) -> None:
         words = [0x3fffff] * 4
-        updatemem_pieces = otp_words_to_updatemem_pieces(words)
+        updatemem_pieces = otp_words_to_updatemem_pieces(EARLGREY_OTP_SIZE, words)
         expected = ["@0"] + \
             ["FFFFFC00000"] + ["00000000000"] * 7 + \
             ["FFFFFC00000"] + ["00000000000"] * 7 + \
@@ -36,7 +38,7 @@ class TestOtpWordsToUpdatememPieces(unittest.TestCase):
 
     def test_reverses_bits(self) -> None:
         words = [0x3df00d for _ in range(4)]
-        updatemem_pieces = otp_words_to_updatemem_pieces(words)
+        updatemem_pieces = otp_words_to_updatemem_pieces(EARLGREY_OTP_SIZE, words)
         expected = ["@0"] + \
             ["B00FBC00000"] + ["00000000000"] * 7 + \
             ["B00FBC00000"] + ["00000000000"] * 7 + \
@@ -48,7 +50,7 @@ class TestOtpWordsToUpdatememPieces(unittest.TestCase):
         words = [0x3df00d, 0x2df00d, 0x1df00d, 0x0df00d] * 4 + \
                 [0x3fffff, 0x3fffff, 0x3fffff, 0x3fffff] * 3 + \
                 [0x3df00d, 0x2df00d, 0x1df00d, 0x0df00d]
-        updatemem_pieces = otp_words_to_updatemem_pieces(words)
+        updatemem_pieces = otp_words_to_updatemem_pieces(EARLGREY_OTP_SIZE, words)
 
         quadword1 = ["B00FBC00000"] + ["00000000000"] * 7 + \
             ["B00FB400000"] + ["00000000000"] * 7 + \

--- a/hw/top_darjeeling/rtl/autogen/chip_darjeeling_asic.sv
+++ b/hw/top_darjeeling/rtl/autogen/chip_darjeeling_asic.sv
@@ -95,6 +95,8 @@ module chip_darjeeling_asic #(
   inout SOC_GPO10, // Dedicated Pad for soc_proxy_soc_gpo
   inout SOC_GPO11, // Dedicated Pad for soc_proxy_soc_gpo
 
+  // Manual Pads kept off padring
+
   // Muxed Pads
   inout MIO0, // MIO Pad 0
   inout MIO1, // MIO Pad 1
@@ -116,6 +118,22 @@ module chip_darjeeling_asic #(
 
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{
+    tck_idx:           TckPadIdx,
+    tms_idx:           TmsPadIdx,
+    trst_idx:          TrstNPadIdx,
+    tdi_idx:           TdiPadIdx,
+    tdo_idx:           TdoPadIdx,
+    tap_strap0_idx:    Tap0PadIdx,
+    tap_strap1_idx:    Tap1PadIdx,
+    dft_strap0_idx:    Dft0PadIdx,
+    dft_strap1_idx:    Dft1PadIdx,
+    // TODO: check whether there is a better way to pass these USB-specific params
+    // The use of these indexes is gated behind a parameter, but to synthesize they
+    // need to exist even if the code-path is never used (pinmux.sv:UsbWkupModuleEn).
+    // Hence, set to zero.
+    usb_dp_idx:        0,
+    usb_dn_idx:        0,
+    usb_sense_idx:     0,
     // Pad types for attribute WARL behavior
     dio_pad_type: {
       BidirStd, // DIO soc_proxy_soc_gpo
@@ -1206,6 +1224,9 @@ module chip_darjeeling_asic #(
   logic [rstmgr_pkg::PowerDomains-1:0] por_n;
   assign por_n = {ast_pwst.main_pok, ast_pwst.aon_pok};
 
+  // external clock comes in at a fixed position
+  assign ext_clk = mio_in_raw[MioPadMio11];
+
   wire unused_t0, unused_t1;
   assign unused_t0 = 1'b0;
   assign unused_t1 = 1'b0;
@@ -1216,6 +1237,9 @@ module chip_darjeeling_asic #(
 
   logic unused_pwr_clamp;
   assign unused_pwr_clamp = base_ast_pwr.pwr_clamp;
+
+
+  prim_mubi_pkg::mubi4_t ast_init_done;
 
   ast #(
     .Ast2PadOutWidth(ast_pkg::Ast2PadOutWidth),
@@ -1236,7 +1260,7 @@ module chip_darjeeling_asic #(
     .tl_i                  ( base_ast_bus ),
     .tl_o                  ( ast_base_bus ),
     // init done indication
-    .ast_init_done_o       ( ),
+    .ast_init_done_o       ( ast_init_done ),
     // buffered clocks & resets
     .clk_ast_tlul_i (clkmgr_aon_clocks.clk_io_infra),
     .clk_ast_alert_i (clkmgr_aon_clocks.clk_io_secure),
@@ -1509,6 +1533,7 @@ module chip_darjeeling_asic #(
     .cfg_rsp_o(),
     .alert_o()
   );
+
 
   //////////////////////////////////
   // Manual Pad / Signal Tie-offs //

--- a/hw/top_darjeeling/rtl/usr_access_xil7series.sv
+++ b/hw/top_darjeeling/rtl/usr_access_xil7series.sv
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module usr_access_xil7series (
+  output logic [31:0] info_o
+
+);
+
+  USR_ACCESSE2 u_fpga_info (
+    .CFGCLK(),
+    .DATA(info_o),
+    .DATAVALID()
+  );
+
+endmodule // usr_access_xil7series

--- a/hw/top_darjeeling/sw/autogen/chip/top_darjeeling.rs
+++ b/hw/top_darjeeling/sw/autogen/chip/top_darjeeling.rs
@@ -19,6 +19,7 @@
 //! - Pinmux Pin/Select Names
 //! - Power Manager Wakeups
 
+#[allow(unused_imports)]
 use core::convert::TryFrom;
 
 /// Peripheral base address for uart0 in top darjeeling.

--- a/hw/top_darjeeling/sw/autogen/chip/top_darjeeling_soc_dbg.rs
+++ b/hw/top_darjeeling/sw/autogen/chip/top_darjeeling_soc_dbg.rs
@@ -17,6 +17,7 @@
 //! - PLIC Interrupt ID Names and Source Mappings
 //! - Alert ID Names and Source Mappings
 
+#[allow(unused_imports)]
 use core::convert::TryFrom;
 
 /// Peripheral base address for dmi device on lc_ctrl in top darjeeling.

--- a/hw/top_darjeeling/sw/autogen/chip/top_darjeeling_soc_mbx.rs
+++ b/hw/top_darjeeling/sw/autogen/chip/top_darjeeling_soc_mbx.rs
@@ -17,6 +17,7 @@
 //! - PLIC Interrupt ID Names and Source Mappings
 //! - Alert ID Names and Source Mappings
 
+#[allow(unused_imports)]
 use core::convert::TryFrom;
 
 /// Peripheral base address for soc device on mbx0 in top darjeeling.

--- a/hw/top_darjeeling/templates/chiplevel.sv.tpl
+++ b/hw/top_darjeeling/templates/chiplevel.sv.tpl
@@ -37,6 +37,7 @@ def get_dio_sig(pinmux: {}, pad: {}):
 maxwidth = 0
 muxed_pads = []
 dedicated_pads = []
+nopadring_pads = []
 k = 0
 for pad in pinout["pads"]:
   if pad["connection"] == "muxed":
@@ -54,7 +55,10 @@ for pad in target["pinout"]["add_pads"]:
   # we need to add their global index here.
   amended_pad = deepcopy(pad)
   amended_pad.update({"idx" : k})
-  dedicated_pads.append(pad)
+  if pad["connection"] == "manual_nopadring":
+    nopadring_pads.append(pad)
+  else:
+    dedicated_pads.append(pad)
   k += 1
 %>\
 
@@ -80,6 +84,11 @@ module chip_${top["name"]}_${target["name"]} #(
     comment = "// Manual Pad"
 %>\
   ${port_comment}${pad["port_type"]} ${pad["name"]}, ${comment}
+% endfor
+
+  // Manual Pads kept off padring
+% for pad in nopadring_pads:
+  ${port_comment}${pad["port_type"]} ${pad["name"]}, // Manual Pad kept off padring
 % endfor
 
   // Muxed Pads
@@ -113,6 +122,22 @@ module chip_${top["name"]}_${target["name"]} #(
 
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{
+    tck_idx:           TckPadIdx,
+    tms_idx:           TmsPadIdx,
+    trst_idx:          TrstNPadIdx,
+    tdi_idx:           TdiPadIdx,
+    tdo_idx:           TdoPadIdx,
+    tap_strap0_idx:    Tap0PadIdx,
+    tap_strap1_idx:    Tap1PadIdx,
+    dft_strap0_idx:    Dft0PadIdx,
+    dft_strap1_idx:    Dft1PadIdx,
+    // TODO: check whether there is a better way to pass these USB-specific params
+    // The use of these indexes is gated behind a parameter, but to synthesize they
+    // need to exist even if the code-path is never used (pinmux.sv:UsbWkupModuleEn).
+    // Hence, set to zero.
+    usb_dp_idx:        0,
+    usb_dn_idx:        0,
+    usb_sense_idx:     0,
     // Pad types for attribute WARL behavior
     dio_pad_type: {
 <%
@@ -249,15 +274,18 @@ module chip_${top["name"]}_${target["name"]} #(
 
   ast_pkg::ast_clks_t ast_base_clks;
 
+% if target["name"] == "asic":
   // AST signals needed in padring
   logic scan_rst_n;
    prim_mubi_pkg::mubi4_t scanmode;
+% endif
 
   padring #(
     // Padring specific counts may differ from pinmux config due
     // to custom, stubbed or added pads.
     .NDioPads(${len(dedicated_pads)}),
     .NMioPads(${len(muxed_pads)}),
+% if target["name"] == "asic":
     .PhysicalPads(1),
     .NIoBanks(int'(IoBankCount)),
     .DioScanRole ({
@@ -280,6 +308,7 @@ module chip_${top["name"]}_${target["name"]} #(
       ${lib.Name.from_snake_case('io_bank_' + pad["bank"]).as_camel_case()}${" " if loop.last else ","} // ${pad['name']}
 % endfor
     }),
+% endif
 \
 \
     .DioPadType ({
@@ -294,8 +323,13 @@ module chip_${top["name"]}_${target["name"]} #(
     })
   ) u_padring (
   // This is only used for scan and DFT purposes
+% if target["name"] == "asic":
     .clk_scan_i   ( ast_base_clks.clk_sys ),
     .scanmode_i   ( scanmode              ),
+% else:
+    .clk_scan_i   ( 1'b0                  ),
+    .scanmode_i   ( prim_mubi_pkg::MuBi4False ),
+% endif
     .dio_in_raw_o ( dio_in_raw ),
     // Chip IOs
     .dio_pad_io ({
@@ -482,6 +516,10 @@ module chip_${top["name"]}_${target["name"]} #(
   logic [rstmgr_pkg::PowerDomains-1:0] por_n;
   assign por_n = {ast_pwst.main_pok, ast_pwst.aon_pok};
 
+% if target["name"] == "asic":
+  // external clock comes in at a fixed position
+  assign ext_clk = mio_in_raw[MioPadMio11];
+
   wire unused_t0, unused_t1;
   assign unused_t0 = 1'b0;
   assign unused_t1 = 1'b0;
@@ -493,16 +531,64 @@ module chip_${top["name"]}_${target["name"]} #(
   logic unused_pwr_clamp;
   assign unused_pwr_clamp = base_ast_pwr.pwr_clamp;
 
+% else:
+  // TODO: Hook this up when FPGA pads are updated
+  assign ext_clk = '0;
+  assign pad2ast = '0;
+
+  logic clk_main, clk_usb_48mhz, clk_aon, rst_n, srst_n;
+  clkgen_xil7series # (
+    .AddClkBuf(0)
+  ) clkgen (
+    .clk_i(manual_in_io_clk),
+    .rst_ni(manual_in_por_n),
+    .srst_ni(srst_n),
+    .clk_main_o(clk_main),
+    .clk_48MHz_o(clk_usb_48mhz),
+    .clk_aon_o(clk_aon),
+    .rst_no(rst_n)
+  );
+
+  logic [31:0] fpga_info;
+  usr_access_xil7series u_info (
+    .info_o(fpga_info)
+  );
+
+  ast_pkg::clks_osc_byp_t clks_osc_byp;
+  assign clks_osc_byp = '{
+    usb: clk_usb_48mhz,
+    sys: clk_main,
+    io:  clk_main,
+    aon: clk_aon
+  };
+
+% endif
+
+  prim_mubi_pkg::mubi4_t ast_init_done;
+
   ast #(
     .Ast2PadOutWidth(ast_pkg::Ast2PadOutWidth),
     .Pad2AstInWidth(ast_pkg::Pad2AstInWidth)
   ) u_ast (
+% if target["name"] == "asic":
     // external POR
     .por_ni                ( manual_in_por_n ),
 
     // Direct short to PAD
     .ast2pad_t0_ao         ( unused_t0 ),
     .ast2pad_t1_ao         ( unused_t1 ),
+% else:
+    // external POR
+    .por_ni                ( rst_n ),
+
+    // clocks' oscillator bypass for FPGA
+    .clk_osc_byp_i         ( clks_osc_byp ),
+
+    // Direct short to PAD
+    .ast2pad_t0_ao         (  ),
+    .ast2pad_t1_ao         (  ),
+
+% endif
 
     // clocks and resets supplied for detection
     .sns_clks_i            ( clkmgr_aon_clocks    ),
@@ -512,7 +598,7 @@ module chip_${top["name"]}_${target["name"]} #(
     .tl_i                  ( base_ast_bus ),
     .tl_o                  ( ast_base_bus ),
     // init done indication
-    .ast_init_done_o       ( ),
+    .ast_init_done_o       ( ast_init_done ),
     // buffered clocks & resets
     % for port, clk in ast["clock_connections"].items():
     .${port} (${clk}),
@@ -786,6 +872,11 @@ module chip_${top["name"]}_${target["name"]} #(
     .alert_o()
   );
 
+###################################################################
+## ASIC                                                          ##
+###################################################################
+
+% if target["name"] == "asic":
   //////////////////////////////////
   // Manual Pad / Signal Tie-offs //
   //////////////////////////////////
@@ -963,6 +1054,7 @@ module chip_${top["name"]}_${target["name"]} #(
     // FPGA build info
     .fpga_info_i                       ( '0                         )
   );
+% endif
 
   logic unused_signals;
   assign unused_signals = ^{pwrmgr_boot_status.clk_status,

--- a/hw/top_darjeeling/util/vivado_hook_init_design_post.tcl
+++ b/hw/top_darjeeling/util/vivado_hook_init_design_post.tcl
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/hw/top_darjeeling/util/vivado_hook_opt_design_post.tcl
+++ b/hw/top_darjeeling/util/vivado_hook_opt_design_post.tcl
@@ -1,0 +1,38 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Hook to check BRAM implementation for Boot ROM. This is required for Boot ROM splicing.
+send_msg "Designcheck 2-1" INFO "Checking if Boot ROM is mapped to BRAM."
+
+set fpga_family [get_property FAMILY [get_parts [get_property PART [current_design]]]]
+
+switch ${fpga_family} {
+  kintex7 {
+    set bram_regex "BMEM.*.*"
+  }
+  kintexu {
+    set bram_regex "BLOCKRAM.*.*"
+  }
+  virtexuplus {
+    set bram_regex "BLOCKRAM.*.*"
+  }
+  default {
+    set bram_regex "BMEM.*.*"
+  }
+}
+
+if {[catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_0 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
+ && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_1 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
+ && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_2 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
+ && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_3 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
+ && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_4 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
+ && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_5 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
+ && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_6 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
+ && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_7 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
+ && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_8 && PRIMITIVE_TYPE =~ ${bram_regex} "]]\
+ && [catch [get_cells -hierarchical -filter " NAME =~  *u_rom_ctrl*u_rom*rdata_o_reg_9 && PRIMITIVE_TYPE =~ ${bram_regex} "]] } {
+  send_msg "Designcheck 2-2" INFO "BRAM implementation found for Boot ROM."
+} else {
+  send_msg "Designcheck 2-3" ERROR "BRAM implementation not found for Boot ROM."
+}

--- a/hw/top_darjeeling/util/vivado_hook_synth_design_pre.tcl
+++ b/hw/top_darjeeling/util/vivado_hook_synth_design_pre.tcl
@@ -1,0 +1,23 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Change the severity of some messages.
+
+# Abort if the boot ROM init file cannot be found. This is normally just a critical warning
+# which is easily overlooked. The bitstream can still be generated but is not functional.
+set_msg_config -id {[Synth 8-4445]} -new_severity ERROR
+
+# Abort upon inferring latches. This is normally just a warning. We want to avoid that
+# code inferring latches ends up in the repo in the first place.
+set_msg_config -id {[Synth 8-327]} -new_severity ERROR
+
+# Abort if a create_clock command fails. This typically happens if anchor points for clock
+# constraints inside the design change. The failure is normally just reported as a critical
+# warning in batch mode which is easily overlooked. The design might still work but some clocks
+# will be unconstrained which can lead to other problems later on.
+set_msg_config -id {[Vivado 12-4739]} -new_severity ERROR
+
+# Abort if pblock constraints lose their target cells. This can happen if hierarchies change and
+# the constraint doesn't get updated.
+set_msg_config -id {[Vivado 12-1433]} -new_severity ERROR

--- a/hw/top_darjeeling/util/vivado_hook_write_bitstream_pre.tcl
+++ b/hw/top_darjeeling/util/vivado_hook_write_bitstream_pre.tcl
@@ -1,1 +1,258 @@
-../../../hw/top_earlgrey/util/vivado_hook_write_bitstream_pre.tcl
+# Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+send_msg "Designcheck 1-1" INFO "Checking design"
+
+# Ensure the design meets timing
+set slack_ns [get_property SLACK [get_timing_paths -delay_type min_max]]
+send_msg "Designcheck 1-2" INFO "Slack is ${slack_ns} ns."
+
+if [expr {$slack_ns < 0}] {
+  send_msg "Designcheck 1-3" ERROR "Timing failed. Slack is ${slack_ns} ns."
+}
+
+# Enable bitstream identification via USR_ACCESS register.
+set_property BITSTREAM.CONFIG.USR_ACCESS TIMESTAMP [current_design]
+
+# Generate an MMI file for the given BRAM cells.
+#
+# Args:
+#   filename:            Path to the output file.
+#   mem_info:            Dictionary of dictionaries with following properties for each (inner) value:
+#       brams:               A list of BRAM cells.
+#       mem_type_regex:      The BRAM type regex, dividing the mem type and site, e.g. {(RAMB\d+)_(\w+)}.
+#       fake_word_width:     If non-zero, pretend that $brams covers
+#                            `fake_word_width` bits. Influences the values of the
+#                            MMI's <AddressSpace> and <DataWidth> tags.
+#       addr_end_multiplier: A coefficient applied to the address space. Influences
+#                            the values of the MMI's <AddressSpace> and
+#                            <AddressRange> tags.
+#       schema:              Either "Processor" or "MemoryArray"
+#   designtask_count:    A number used for logging with `send_msg`.
+proc generate_mmi {filename mem_infos designtask_count} {
+    send_msg "${designtask_count}-1" INFO "Dumping MMI to ${filename}"
+
+    set workroot [file dirname [info script]]
+    set filepath "${workroot}/${filename}"
+    set fileout [open $filepath "w"]
+    set part [get_property PART [current_design]]
+    puts $fileout "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    puts $fileout "<MemInfo Version=\"1\" Minor=\"1\">"
+
+    dict for {id mem_info} $mem_infos {
+        dict with mem_info {
+            if {[llen $brams] == 0} {
+                send_msg "${designtask_count}-1" INFO "Cannot make MMI for zero BRAMs"
+                continue
+            }
+
+            set fake_slice_width [expr $fake_word_width / [llen $brams]]
+
+            # Calculate the overall address space.
+            set space 0
+            set width 0
+            foreach inst [lsort -dictionary $brams] {
+                set slice_begin [get_property ram_slice_begin [get_cells $inst]]
+                set slice_end [get_property ram_slice_end [get_cells $inst]]
+                if {$slice_begin eq {} || $slice_end eq {}} {
+                    send_msg "${designtask_count}-2" ERROR "Extraction of ${filename} information failed."
+                }
+                set slice_width [expr {$slice_end - $slice_begin + 1}]
+                if {$slice_width < $fake_slice_width} {
+                    set slice_end [expr {$slice_begin + $fake_slice_width - 1}]
+                    set slice_width $fake_slice_width
+                }
+                set addr_begin [get_property ram_addr_begin [get_cells $inst]]
+                set addr_end [get_property ram_addr_end [get_cells $inst]]
+                if {$addr_begin eq {} || $addr_end eq {}} {
+                    send_msg "${designtask_count}-3" ERROR "Extraction of ${filename} MMI information failed."
+                }
+
+                # Calculate total number of bits.
+                set space [expr {$space + ($addr_end - $addr_begin + 1) * $slice_width}]
+                set width [expr {$width + $slice_width}]
+                set last_slice_width $slice_width
+            }
+            set space [expr {($space * $addr_end_multiplier / 8) - 1}]
+
+            # Generate the MMI.
+            if { $schema eq "Processor" } {
+                puts $fileout "  <Processor Endianness=\"Little\" InstPath=\"$id\">"
+                puts $fileout "    <AddressSpace Name=\"dummy_addrspace\" Begin=\"0\" End=\"$space\">"
+                puts $fileout "      <BusBlock>"
+            } else {
+                puts $fileout "  <MemoryArray InstPath=\"$id\" MemoryPrimitive=\"auto\" MemoryConfiguration=\"enabled_configuration\">"
+                # Memory type could be retrieved from the RTL_RAM_TYPE property, if desired,
+                # but we hard-code it here for now.
+                puts $fileout "    <MemoryLayout Name=\"$id\" CoreMemory_Width=\"$width\" MemoryType=\"RAM_SP\">"
+            }
+
+            foreach inst [lsort -dictionary $brams] {
+                set loc [get_property LOC [get_cells $inst]]
+                set loc_matches [regexp $mem_type_regex $loc loc_match loc_prefix loc_suffix]
+                if {$loc_matches == 0} {
+                    send_msg "${designtask_count}-4" ERROR "Extraction of ${filename} mem location failed."
+                }
+                set slice_begin [get_property ram_slice_begin [get_cells $inst]]
+                set slice_end [get_property ram_slice_end [get_cells $inst]]
+                set slice_width [expr {$slice_end - $slice_begin + 1}]
+                if {$slice_width < $fake_slice_width} {
+                    set slice_end [expr {$slice_begin + $fake_slice_width - 1}]
+                    set slice_width $fake_slice_width
+                }
+                set addr_begin [get_property ram_addr_begin [get_cells $inst]]
+                set addr_end [get_property ram_addr_end [get_cells $inst]]
+                set addr_end [expr {($addr_end + 1) * $addr_end_multiplier - 1}]
+                set bit_layout [get_property "MEM.PORTA.DATA_BIT_LAYOUT" [get_cells $inst]]
+                set read_width_a [get_property "READ_WIDTH_A" [get_cells $inst]]
+                set read_width_b [get_property "READ_WIDTH_B" [get_cells $inst]]
+                set slr_index [get_property "SLR_INDEX" [get_cells $inst]]
+                if {$schema eq "Processor"} {
+                    puts $fileout "        <BitLane MemType=\"$loc_prefix\" Placement=\"$loc_suffix\">"
+                    puts $fileout "          <DataWidth MSB=\"$slice_end\" LSB=\"$slice_begin\"/>"
+                    puts $fileout "          <AddressRange Begin=\"$addr_begin\" End=\"$addr_end\"/>"
+                    puts $fileout "          <Parity ON=\"false\" NumBits=\"0\"/>"
+                    puts $fileout "        </BitLane>"
+                } else {
+                    puts $fileout "      <BRAM MemType=\"$loc_prefix\" Placement=\"$loc_suffix\" Read_Width_A=\"$read_width_a\" Read_Width_B=\"$read_width_b\" SLR_INDEX=\"$slr_index\">"
+                    puts $fileout "        <DataWidth_PortA MSB=\"$slice_end\" LSB=\"$slice_begin\"/>"
+                    puts $fileout "        <AddressRange_PortA Begin=\"$addr_begin\" End=\"$addr_end\"/>"
+                    puts $fileout "        <BitLayout_PortA pattern=\"$bit_layout\"/>"
+                    puts $fileout "        <DataWidth_PortB MSB=\"0\" LSB=\"0\"/>"
+                    puts $fileout "        <AddressRange_PortB Begin=\"0\" End=\"0\"/>"
+                    puts $fileout "        <BitLayout_PortB pattern=\"\"/>"
+                    puts $fileout "        <Parity ON=\"false\" NumBits=\"0\"/>"
+                    puts $fileout "      </BRAM>"
+                }
+            }
+            if {$schema eq "Processor"} {
+                puts $fileout "      </BusBlock>"
+                puts $fileout "    </AddressSpace>"
+                puts $fileout "  </Processor>"
+            } else {
+                puts $fileout "    </MemoryLayout>"
+                puts $fileout "  </MemoryArray>"
+            }
+        }
+    }
+
+    puts $fileout "  <Config>"
+    puts $fileout "    <Option Name=\"Part\" Val=\"$part\"/>"
+    puts $fileout "  </Config>"
+    puts $fileout "</MemInfo>"
+    close $fileout
+    send_msg "${designtask_count}-4" INFO "MMI dumped to ${filepath}"
+}
+
+# Dump INIT_XX strings for the given BRAMs to an output file.
+#
+# In the output file, the BRAMs and their INIT_XX strings will be sorted in
+# increasing order. This proc is a time-saver because the Vivado GUI's property
+# viewer does not sort the INIT_XX strings numerically.
+#
+# Args:
+#   filename:         Where to write
+#   brams:            A list of BRAM cells.
+#   designtask_count: A number used for logging with `send_msg`.
+proc dump_init_strings {filename brams designtask_count} {
+    # For each OTP BRAM, dump all the INIT_XX strings.
+    send_msg "${designtask_count}-1" INFO "Dumping INIT_XX strings to ${filename}"
+
+    set workroot [file dirname [info script]]
+    set filepath "${workroot}/${filename}"
+    set fileout [open $filepath "w"]
+
+    foreach inst [lsort -dictionary $brams] {
+        set bram [get_cells $inst]
+
+        set loc [get_property LOC $bram]
+        puts $fileout "LOC: $loc"
+
+        set init_count 0
+        while 1 {
+            set key [format "INIT_%.2X" $init_count]
+            if { [llength [list_property $bram $key]] eq 0 } {
+                break
+            }
+            set val [get_property $key $bram]
+            puts $fileout "$key $val"
+            incr init_count
+        }
+
+        puts $fileout ""
+    }
+    close $fileout
+    send_msg "${designtask_count}-4" INFO "INIT_XX strings dumped to ${filepath}"
+}
+
+set fpga_family [get_property FAMILY [get_parts [get_property PART [current_design]]]]
+
+switch ${fpga_family} {
+  kintex7 {
+    set bram_regex "BMEM.*.*"
+  }
+  kintexu {
+    set bram_regex "BLOCKRAM.*.*"
+  }
+  virtexuplus {
+    set bram_regex "BLOCKRAM.*.*"
+  }
+  default {
+    set bram_regex "BMEM.*.*"
+  }
+}
+set mem_type_regex {(RAMB\d+)_(\w+)}
+
+set gen_mem_info {{brams mem_type_regex fake_word_width addr_end_multiplier schema} {
+  dict set mem_info brams $brams
+  dict set mem_info mem_type_regex $mem_type_regex
+  dict set mem_info fake_word_width $fake_word_width
+  dict set mem_info addr_end_multiplier $addr_end_multiplier
+  return [dict set mem_info schema $schema]
+}}
+
+# The scrambled Boot ROM is actually 39 bits wide, but we need to pretend that
+# it's 40 bits, or else we will be unable to encode our ROM data in a MEM file
+# that updatemem will understand.
+#
+# Suppose we did not pad the width, leaving it at 39 bits. Now, if we encode a
+# word as a 10-digit hex string, updatemem would splice an additional zero bit
+# into the bitstream because each hex digit is strictly 4 bits. If we wrote four
+# words at a time, as a 39-digit hex string (39*4 is nicely divisible by 4),
+# updatemem would fail to parse the hex string, saying something like "Data
+# segment starting at 0x00000000, has exceeded data limits." The longest hex
+# string it will accept is 16 digits, or 64 bits.
+#
+# A hack that works is to pretend the data width is actually 40 bits. Updatemem
+# seems to write that extra zero bit into the ether without complaint.
+set rom0_brams [split [get_cells -hierarchical -filter " PRIMITIVE_TYPE =~ ${bram_regex} && NAME =~ *u_rom_ctrl0*"] " "]
+dict set memInfo rom0 [apply $gen_mem_info $rom0_brams $mem_type_regex 40 1 "Processor"]
+set rom1_brams [split [get_cells -hierarchical -filter " PRIMITIVE_TYPE =~ ${bram_regex} && NAME =~ *u_rom_ctrl1*"] " "]
+dict set memInfo rom1 [apply $gen_mem_info $rom1_brams $mem_type_regex 40 1 "Processor"]
+
+# OTP does not require faking the word width, but it has its own quirk. It seems
+# each 22-bit OTP word is followed by 15 zero words. The MMI's <AddressSpace>
+# and <AddressRange> tags need to account for this or else updatemem will think
+# that its data input overruns the address space. The workaround is to pretend
+# the address space is 16 times larger than we would normally compute.
+set otp_brams [split [get_cells -hierarchical -filter " PRIMITIVE_TYPE =~ ${bram_regex} && NAME =~ *u_otp_macro*"] " "]
+dict set memInfo otp [apply $gen_mem_info $otp_brams $mem_type_regex 0 16 "Processor"]
+
+# The flash banks have 76-bit wide words. 64 bits are data, and 12 bits are metadata / integrity.
+for {set bank 0} {$bank < 2} {incr bank} {
+  for {set partition 0} {$partition < 3} {incr partition} {
+    set flash_info_brams [split [get_cells -hierarchical -filter " PRIMITIVE_TYPE =~ ${bram_regex} && NAME =~ *u_flash_ctrl*gen_prim_flash_banks[${bank}]*gen_info_types[${partition}].u_info_mem*gen_xpm.gen_split[0].*"] " "]
+    dict set memInfo "flash${bank}_info${partition}_data" [apply $gen_mem_info $flash_info_brams $mem_type_regex 0 1 "MemoryArray"]
+    set flash_info_brams [split [get_cells -hierarchical -filter " PRIMITIVE_TYPE =~ ${bram_regex} && NAME =~ *u_flash_ctrl*gen_prim_flash_banks[${bank}]*gen_info_types[${partition}].u_info_mem*gen_xpm.gen_split[64].*"] " "]
+    dict set memInfo "flash${bank}_info${partition}_intg" [apply $gen_mem_info $flash_info_brams $mem_type_regex 0 1 "MemoryArray"]
+  }
+}
+
+generate_mmi "memories.mmi" $memInfo 1
+
+# For debugging purposes, dump the INIT_XX strings for ROM and OTP.
+dump_init_strings "rom0_init_strings.txt" $rom0_brams 3
+dump_init_strings "rom1_init_strings.txt" $rom1_brams 4
+dump_init_strings "otp_init_strings.txt" $otp_brams 5

--- a/hw/top_darjeeling/util/vivado_hook_write_bitstream_pre.tcl
+++ b/hw/top_darjeeling/util/vivado_hook_write_bitstream_pre.tcl
@@ -1,0 +1,1 @@
+../../../hw/top_earlgrey/util/vivado_hook_write_bitstream_pre.tcl

--- a/hw/top_darjeeling/util/vivado_setup_hooks.tcl
+++ b/hw/top_darjeeling/util/vivado_setup_hooks.tcl
@@ -1,0 +1,26 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Setup hook scripts, to be called at various stages during the build process
+# See Xilinx UG 894 ("Using Tcl Scripting") for documentation.
+
+# fusesoc-generated workroot containing the Vivado project file
+set workroot [pwd]
+
+# Pre synthesize design hook
+set_property STEPS.SYNTH_DESIGN.TCL.PRE "${workroot}/vivado_hook_synth_design_pre.tcl" [get_runs synth_1]
+
+# Pre implementation (init design) post hook
+set_property STEPS.INIT_DESIGN.TCL.POST "${workroot}/vivado_hook_init_design_post.tcl" [get_runs impl_1]
+
+# Post opt design hook
+set_property STEPS.OPT_DESIGN.TCL.POST "${workroot}/vivado_hook_opt_design_post.tcl" [get_runs impl_1]
+
+# TODO: This hook is not getting called by Vivado when running through our
+# fusesoc flow (it gets called when writing a bitstream through the GUI).
+# Requires an update to edalize, see https://github.com/olofk/edalize/pull/60.
+#set_property STEPS.WRITE_BITSTREAM.TCL.PRE "${workroot}/vivado_hook_write_bitstream_pre.tcl" [get_runs impl_1]
+
+# As workaround, we use the post route design hook, which gets called.
+set_property STEPS.ROUTE_DESIGN.TCL.POST "${workroot}/vivado_hook_write_bitstream_pre.tcl" [get_runs impl_1]

--- a/hw/top_earlgrey/sw/autogen/chip/top_earlgrey.rs
+++ b/hw/top_earlgrey/sw/autogen/chip/top_earlgrey.rs
@@ -19,6 +19,7 @@
 //! - Pinmux Pin/Select Names
 //! - Power Manager Wakeups
 
+#[allow(unused_imports)]
 use core::convert::TryFrom;
 
 /// Peripheral base address for uart0 in top earlgrey.

--- a/hw/top_earlgrey/util/vivado_hook_write_bitstream_pre.tcl
+++ b/hw/top_earlgrey/util/vivado_hook_write_bitstream_pre.tcl
@@ -45,7 +45,7 @@ proc generate_mmi {filename mem_infos designtask_count} {
         dict with mem_info {
             if {[llen $brams] == 0} {
                 send_msg "${designtask_count}-1" INFO "Cannot make MMI for zero BRAMs"
-                return
+                continue
             }
 
             set fake_slice_width [expr $fake_word_width / [llen $brams]]

--- a/hw/top_englishbreakfast/sw/autogen/chip/top_englishbreakfast.rs
+++ b/hw/top_englishbreakfast/sw/autogen/chip/top_englishbreakfast.rs
@@ -19,6 +19,7 @@
 //! - Pinmux Pin/Select Names
 //! - Power Manager Wakeups
 
+#[allow(unused_imports)]
 use core::convert::TryFrom;
 
 /// Peripheral base address for uart0 in top englishbreakfast.

--- a/rules/opentitan/splice.bzl
+++ b/rules/opentitan/splice.bzl
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("//rules/opentitan:exec_env.bzl", "ExecEnvInfo")
 load("//rules/opentitan:providers.bzl", "get_one_binary_file")
 load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
@@ -17,11 +18,12 @@ DEFAULTS = struct(
     env = "//hw/bitstream/universal:none",
 )
 
-def gen_vivado_mem_file(ctx, name, src, tool, swap_nibbles = True):
+def gen_vivado_mem_file(ctx, name, src, tool, otp_size, swap_nibbles = True):
     update = ctx.actions.declare_file("{}.update.mem".format(name))
     args = ctx.actions.args()
     if swap_nibbles:
         args.add("--swap-nibbles")
+    args.add("--otp-size={}".format(otp_size))
     args.add_all([src, update])
     ctx.actions.run(
         mnemonic = "GenVivadoImage",
@@ -116,6 +118,17 @@ def _bitstream_splice_impl(ctx):
         rom = exec_env.rom
     else:
         rom = ctx.attr.rom
+
+    # OTP size in number of 2-byte words.
+    top_name = ctx.attr._top[BuildSettingInfo].value
+    if top_name == "earlgrey":
+        # Earlgrey: 2K OTP == 1024 2-byte words
+        otp_size = 1024
+    elif top_name == "darjeeling":
+        # Darjeeling: 16K OTP == 8192 2-byte words
+        otp_size = 8192
+    else:
+        fail("Top name should be 'earlgrey' or 'darjeeling' for bitstream splice; got `{}`".format(top_name))
     if rom and rom.label.name != "none":
         rom = get_one_binary_file(rom, field = "rom", providers = [exec_env.provider])
         mem = gen_vivado_mem_file(
@@ -123,6 +136,7 @@ def _bitstream_splice_impl(ctx):
             name = "{}-rom".format(ctx.label.name),
             src = rom,
             tool = tc.tools.gen_mem_image,
+            otp_size = otp_size,
             swap_nibbles = ctx.attr.swap_nibbles,
         )
         src = vivado_updatemem(
@@ -146,6 +160,7 @@ def _bitstream_splice_impl(ctx):
             name = "{}-otp".format(ctx.label.name),
             src = otp,
             tool = tc.tools.gen_mem_image,
+            otp_size = otp_size,
             swap_nibbles = ctx.attr.swap_nibbles,
         )
         src = vivado_updatemem(
@@ -177,6 +192,7 @@ bitstream_splice_ = rule(
         "swap_nibbles": attr.bool(default = True, doc = "Swap nybbles while preparing the memory image"),
         "debug": attr.bool(default = False, doc = "Emit debug info while updating"),
         "skip": attr.bool(default = False, doc = "Skip splice and do not modify the bitstream"),
+        "_top": attr.label(doc = "The hardware top-level name", default = "//hw/top"),
     },
     toolchains = [LOCALTOOLS_TOOLCHAIN],
 )

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -206,6 +206,11 @@ cc_library(
             "englishbreakfast": [],
         },
         ["HAS_RETENTION_RAM"],
+    ) + opentitan_select_top(
+        {
+            "darjeeling": ["HAS_ROM_CTRL1"],
+        },
+        [],
     ),
     target_compatible_with = [OPENTITAN_CPU],
     deps = [

--- a/sw/device/lib/testing/test_rom/test_rom.c
+++ b/sw/device/lib/testing/test_rom/test_rom.c
@@ -72,7 +72,12 @@ static const dt_otp_ctrl_t kOtpCtrlDt = kDtOtpCtrl;
  */
 extern char _rom_ext_virtual_start_address[];
 extern char _rom_ext_virtual_size[];
+#ifndef HAS_ROM_CTRL1
 extern char _manifest_address[];
+#else
+// _second_rom_address is defined in test_rom.ld.
+extern uintptr_t _second_rom_address;
+#endif
 
 /**
  * Type alias for the OTTF entry point.
@@ -87,6 +92,7 @@ static dif_rstmgr_t rstmgr;
 static dif_uart_t uart0;
 static dif_rv_core_ibex_t ibex;
 
+#ifndef HAS_ROM_CTRL1
 /**
  * Compute the virtual address corresponding to the physical address `lma_addr`.
  *
@@ -99,6 +105,7 @@ static inline uintptr_t rom_ext_vma_get(const manifest_t *manifest,
   return (lma_addr - (uintptr_t)manifest +
           (uintptr_t)_rom_ext_virtual_start_address);
 }
+#endif
 
 // `test_in_rom = True` tests can override this symbol to provide their own
 // rom tests. By default, it simply jumps into the OTTF's flash.
@@ -235,10 +242,9 @@ bool rom_test_main(void) {
   }
 #endif
 
-#ifdef OPENTITAN_IS_EARLGREY
+#ifndef HAS_ROM_CTRL1
   CHECK_DIF_OK(
       dif_flash_ctrl_set_exec_enablement(&flash_ctrl, kDifToggleEnabled));
-#endif
 
   const manifest_t *manifest = (const manifest_t *)_manifest_address;
 
@@ -269,6 +275,13 @@ bool rom_test_main(void) {
   // responsibily of the OTTF to set up its own stack, and to never return.
   LOG_INFO("Test ROM complete, jumping to flash (addr: %x)!", entry_point);
   ((ottf_entry_point *)entry_point)();
+#else
+  // Jump to second ROM.
+  uintptr_t entry_point = ((uintptr_t)&_second_rom_address);
+  LOG_INFO("Test ROM complete, jumping to second ROM (addr: 0x%x)!",
+           entry_point);
+  ((ottf_entry_point *)entry_point)();
+#endif
 
   // If the flash image returns, we should abort anyway.
   abort();

--- a/sw/device/lib/testing/test_second_rom/BUILD
+++ b/sw/device/lib/testing/test_second_rom/BUILD
@@ -1,0 +1,160 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//hw/top:defs.bzl", "opentitan_require_ip", "opentitan_require_top", "opentitan_select_top")
+load(
+    "//rules/opentitan:defs.bzl",
+    "OPENTITAN_CPU",
+    "opentitan_binary",
+    "opentitan_test",
+)
+load("//rules/opentitan:legacy.bzl", "legacy_rom_targets")
+load("//rules:files.bzl", "output_groups")
+load("//rules:linker.bzl", "ld_library")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+
+package(default_visibility = ["//visibility:public"])
+
+ld_library(
+    name = "linker_script",
+    script = "test_second_rom.ld",
+    deps = [
+        "//hw/top:top_ld",
+        "//sw/device:info_sections",
+        "//sw/device/lib/testing/test_framework:ottf_ld_top_config",
+        "//sw/device/silicon_creator/lib/base:static_critical_sections",
+    ],
+)
+
+opentitan_binary(
+    name = "test_second_rom",
+    exec_env = [
+        "//hw/top_darjeeling:sim_dv_base",
+        "//hw/top_darjeeling:sim_verilator_base",
+    ],
+    features = ["use_lld"],
+    kind = "rom",
+    linker_script = ":linker_script",
+    rom_scramble_mode = "second-rom",
+    deps = [
+        ":test_second_rom_lib",
+    ],
+)
+
+[
+    # Generate targets with `sim_dv` and `sim_verilator` suffixes as expected
+    # by dvsim.
+    alias(
+        name = "test_second_rom_{}".format(env),
+        actual = ":test_second_rom",
+    )
+    for env in [
+        "sim_dv",
+        "sim_verilator",
+    ]
+]
+
+[
+    filegroup(
+        name = "test_second_rom_{}_hashfile".format(dev),
+        srcs = [":test_second_rom"],
+        output_group = "{}_hashfile".format(dev),
+    )
+    for dev in [
+        "sim_dv",
+        "sim_verilator",
+        "fpga_cw305",
+        "fpga_cw310",
+        "fpga_cw340",
+    ]
+]
+
+cc_library(
+    name = "darjeeling_test_second_rom_lib",
+    srcs = [
+        "darjeeling_fake_driver_funcs.c",
+    ],
+)
+
+cc_library(
+    name = "test_second_rom_lib",
+    srcs = [
+        "test_second_rom.c",
+        "test_second_rom_start.S",
+    ],
+    deps = [
+        ":darjeeling_test_second_rom_lib",
+        "//hw/top:ast_c_regs",
+        "//hw/top:clkmgr_c_regs",
+        "//hw/top:csrng_c_regs",
+        "//hw/top:edn_c_regs",
+        "//hw/top:entropy_src_c_regs",
+        "//hw/top:otp_ctrl_c_regs",
+        "//hw/top:sram_ctrl_c_regs",
+        "//hw/top:top_lib",
+        "//hw/top/dt:otp_ctrl",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/crt",
+        "//sw/device/lib/dif:clkmgr",
+        "//sw/device/lib/dif:gpio",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/lib/dif:spi_device",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print_uart",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:status",
+        "//sw/device/silicon_creator/lib:chip_info",
+        "//sw/device/silicon_creator/lib:manifest",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+        "//sw/device/silicon_creator/lib/base:static_critical",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)
+
+opentitan_test(
+    name = "test_second_rom_test",
+    srcs = ["test_second_rom_test.c"],
+    exec_env = {
+        "//hw/top_darjeeling:sim_dv": None,
+        "//hw/top_darjeeling:sim_verilator": None,
+    },
+    deps = [
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+output_groups(
+    name = "pre_package",
+    testonly = True,
+    srcs = [":test_second_rom"],
+    groups = [
+        "sim_dv_elf",
+        "sim_dv_rom",
+        "sim_dv_logs",
+        "sim_dv_mapfile",
+        "sim_verilator_elf",
+        "sim_verilator_rom",
+        "sim_verilator_mapfile",
+    ],
+)
+
+pkg_files(
+    name = "package",
+    testonly = True,
+    srcs = [":pre_package"],
+    prefix = opentitan_select_top(
+        {
+            "darjeeling": "darjeeling/test_second_rom",
+        },
+        "test_second_rom",
+    ),
+)

--- a/sw/device/lib/testing/test_second_rom/darjeeling_fake_driver_funcs.c
+++ b/sw/device/lib/testing/test_second_rom/darjeeling_fake_driver_funcs.c
@@ -1,0 +1,3 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0

--- a/sw/device/lib/testing/test_second_rom/test_second_rom.c
+++ b/sw/device/lib/testing/test_second_rom/test_second_rom.c
@@ -1,0 +1,125 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hw/top/dt/soc_proxy.h"
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_gpio.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
+#include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print_uart.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/status.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
+#include "sw/device/silicon_creator/lib/chip_info.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#include "sw/device/silicon_creator/lib/manifest.h"
+
+static const dt_rv_core_ibex_t kRvCoreIbexDt = kDtRvCoreIbex;
+
+static const dt_uart_t kUart0Dt = kDtUart0;
+static dif_uart_t uart0;
+
+/* These symbols are defined in
+ * `opentitan/sw/device/lib/testing/test_second_rom/test_second_rom.ld`, and
+ * describes the location of the flash header and manifest.
+ */
+extern char _rom_ext_virtual_start_address[];
+extern char _rom_ext_virtual_size[];
+extern char _manifest_address[];
+
+/**
+ * Type alias for the OTTF entry point.
+ *
+ * The entry point address obtained from the OTTF manifest must be cast to a
+ * pointer to this type before being called.
+ */
+typedef void ottf_entry_point(void);
+
+static dif_rv_core_ibex_t ibex;
+
+/**
+ * Compute the virtual address corresponding to the physical address `lma_addr`.
+ *
+ * @param manifest Pointer to the current manifest.
+ * @param lma_addr Load address or physical address.
+ * @return the computed virtual address.
+ */
+static inline uintptr_t rom_ext_vma_get(const manifest_t *manifest,
+                                        uintptr_t lma_addr) {
+  return (lma_addr - (uintptr_t)manifest +
+          (uintptr_t)_rom_ext_virtual_start_address);
+}
+
+// `test_in_rom = True` tests can override this symbol to provide their own
+// rom tests. By default, it simply jumps into the OTTF's flash.
+OT_WEAK
+bool second_rom_test_main(void) {
+  // Setup the UART for printing messages to the console.
+  if (kDeviceType != kDeviceSimDV) {
+    CHECK_DIF_OK(dif_uart_init_from_dt(kUart0Dt, &uart0));
+    base_uart_stdout(&uart0);
+  }
+
+  // Print the chip version information
+  LOG_INFO("kChipInfo: scm_revision=%x", kChipInfo.scm_revision);
+
+  // Print the FPGA version-id.
+  // This is guaranteed to be zero on all non-FPGA implementations.
+  dif_rv_core_ibex_fpga_info_t fpga;
+  CHECK_DIF_OK(dif_rv_core_ibex_init_from_dt(kRvCoreIbexDt, &ibex));
+  CHECK_DIF_OK(dif_rv_core_ibex_read_fpga_info(&ibex, &fpga));
+  if (fpga != 0) {
+    LOG_INFO("TestSecondROM:%08x", fpga);
+  }
+
+  const manifest_t *manifest = (const manifest_t *)_manifest_address;
+
+  uintptr_t entry_point = manifest_entry_point_get(manifest);
+  // Enable address translation if manifest says to
+  if (manifest->address_translation == kHardenedBoolTrue) {
+    dif_rv_core_ibex_addr_translation_mapping_t addr_map = {
+        .matching_addr = (uintptr_t)_rom_ext_virtual_start_address,
+        .remap_addr = (uintptr_t)manifest,
+        .size = (size_t)_rom_ext_virtual_size,
+    };
+    CHECK_DIF_OK(dif_rv_core_ibex_configure_addr_translation(
+        &ibex, kDifRvCoreIbexAddrTranslationSlot_0,
+        kDifRvCoreIbexAddrTranslationDBus, addr_map));
+    CHECK_DIF_OK(dif_rv_core_ibex_configure_addr_translation(
+        &ibex, kDifRvCoreIbexAddrTranslationSlot_0,
+        kDifRvCoreIbexAddrTranslationIBus, addr_map));
+    CHECK_DIF_OK(dif_rv_core_ibex_enable_addr_translation(
+        &ibex, kDifRvCoreIbexAddrTranslationSlot_0,
+        kDifRvCoreIbexAddrTranslationDBus));
+    CHECK_DIF_OK(dif_rv_core_ibex_enable_addr_translation(
+        &ibex, kDifRvCoreIbexAddrTranslationSlot_0,
+        kDifRvCoreIbexAddrTranslationIBus));
+    entry_point = rom_ext_vma_get(manifest, entry_point);
+  }
+
+  // Jump to the OTTF in SRAM. Within the SRAM binary, it is the responsibily
+  // of the OTTF to set up its own stack, and to never return.
+  LOG_INFO("Test Second ROM complete, jumping to SRAM (addr: %x)!",
+           entry_point);
+  ((ottf_entry_point *)entry_point)();
+
+  // If the flash image returns, we should abort anyway.
+  abort();
+}
+
+void _second_rom_boot_start(void) {
+  test_status_set(kTestStatusInBootRom);
+  test_status_set(second_rom_test_main() ? kTestStatusPassed
+                                         : kTestStatusFailed);
+
+  abort();
+}

--- a/sw/device/lib/testing/test_second_rom/test_second_rom.ld
+++ b/sw/device/lib/testing/test_second_rom/test_second_rom.ld
@@ -1,4 +1,5 @@
 /* Copyright lowRISC contributors (OpenTitan project). */
+/* Copyright zeroRISC Inc. */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
@@ -20,28 +21,21 @@ INCLUDE OPENTITAN_TOP_MEMORY_LD
 #include "ottf_ld_top_config.ld"
 
 /**
- * Region aliases.
+ * Region alias. This linker script only makes sense on tops with two ROM
+ * stages.
  */
-#ifdef OPENTITAN_IS_DARJEELING
-REGION_ALIAS("test_rom", rom0)
-/**
- * Origin of the second ROM binary.
- */
-_second_rom_address = ORIGIN(rom1);
-#else
-REGION_ALIAS("test_rom", rom)
-/**
- * Location of the manifest.
- */
-_manifest_address = ORIGIN(ottf_storage);
-#endif
+REGION_ALIAS("test_second_rom", rom1)
 
 /**
  * The boot address, which indicates the location of the initial interrupt
  * vector.
  */
-_boot_address = ORIGIN(test_rom);
+_boot_address = ORIGIN(test_second_rom);
 
+/**
+ * Location of the manifest.
+ */
+_manifest_address = ORIGIN(ottf_storage);
 
 /**
  * Symbols to be used in the setup of the address translation for ROM_EXT.
@@ -52,7 +46,7 @@ ASSERT((_rom_ext_virtual_size <= (LENGTH(ottf_storage) / 2)),
   "Error: rom ext flash is bigger than slot.");
 
 _rom_digest_size = 32;
-_chip_info_start = ORIGIN(test_rom) + LENGTH(test_rom) - _rom_digest_size - _chip_info_size;
+_chip_info_start = ORIGIN(test_second_rom) + LENGTH(test_second_rom) - _rom_digest_size - _chip_info_size;
 
 /* DV Log offset (has to be different to other boot stages). */
 _dv_log_offset = 0x0;
@@ -62,7 +56,7 @@ _dv_log_offset = 0x0;
  * erroring). In reality, we don't use this information within the ROM image, as
  * we start at a fixed offset.
  */
-ENTRY(_reset_start);
+ENTRY(_start);
 
 /**
  * NOTE: We have to align each section to word boundaries as our current
@@ -70,21 +64,21 @@ ENTRY(_reset_start);
  */
 SECTIONS {
   /**
-   * Ibex interrupt vector. See test_rom_start.S for more information.
+   * Ibex interrupt vector. See test_second_rom_start.S for more information.
    *
    * This has to be set up at the boot address, so that execution jumps to the
    * reset handler correctly.
    */
   .vectors _boot_address : ALIGN(4) {
     KEEP(*(.vectors))
-  } > test_rom
+  } > test_second_rom
 
   /**
    * C runtime (CRT) section, containing program initialization code.
    */
   .crt : ALIGN(4) {
     KEEP(*(.crt))
-  } > test_rom
+  } > test_second_rom
 
   /**
    * Standard text section, containing program code.
@@ -92,7 +86,7 @@ SECTIONS {
   .text : ALIGN(4) {
     *(.text)
     *(.text.*)
-  } > test_rom
+  } > test_second_rom
 
   /**
    * Read-only data section, containing all large compile-time constants, like
@@ -105,7 +99,7 @@ SECTIONS {
     *(.srodata.*)
     *(.rodata)
     *(.rodata.*)
-  } > test_rom
+  } > test_second_rom
 
   /**
    * Critical static data that is accessible by both the ROM and the ROM
@@ -148,14 +142,14 @@ SECTIONS {
     /* This puts it in ram_main at runtime (for the VMA), but puts the section
      * into rom for load time (for the LMA). This is why `_data_init_*` uses
      * `LOADADDR`. */
-  } > ram_main AT> test_rom
+  } > ram_main AT> test_second_rom
 
   /**
    * Immutable chip_info data, containing build-time-recorded information.
    */
   .chip_info _chip_info_start : ALIGN(4) {
     KEEP(*(.chip_info))
-  } > test_rom
+  } > test_second_rom
 
   /**
    * Standard BSS section. This will be zeroed at runtime by the CRT.

--- a/sw/device/lib/testing/test_second_rom/test_second_rom_start.S
+++ b/sw/device/lib/testing/test_second_rom/test_second_rom_start.S
@@ -1,0 +1,77 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Test second ROM runtime initialization code.
+ */
+
+  // NOTE: The "ax" flag below is necessary to ensure that this section
+  // is allocated executable space in ROM by the linker.
+  .section .crt, "ax"
+
+// -----------------------------------------------------------------------------
+
+  /**
+   * Callable entry point for the boot rom.
+   *
+   * Currently, this zeroes the `.bss` section, copies initial data to
+   * `.data`, and then jumps to the program entry point.
+   */
+  .balign 4
+  .global _start
+  .type _start, @function
+_start:
+  // Zero out the `.bss` segment.
+  la   a0, _bss_start
+  la   a1, _bss_end
+  call crt_section_clear
+
+  // Initialize the `.data` segment from the `.idata` segment.
+  la   a0, _data_start
+  la   a1, _data_end
+  la   a2, _data_init_start
+  call crt_section_copy
+
+  // Clobber all temporary registers.
+  li t0, 0x0
+  li t1, 0x0
+  li t2, 0x0
+  li t3, 0x0
+  li t4, 0x0
+  li t5, 0x0
+  li t6, 0x0
+
+  // Clobber all argument registers.
+  li a0, 0x0
+  li a1, 0x0
+  li a2, 0x0
+  li a3, 0x0
+  li a4, 0x0
+  li a5, 0x0
+  li a6, 0x0
+  li a7, 0x0
+
+  // Jump into the C program entry point.
+  call _second_rom_boot_start
+
+  // Enter a wait for interrupt loop, the device should reset shortly.
+.L_wfi_loop:
+  wfi
+  j   .L_wfi_loop
+  .size _start, .-_start
+
+// -----------------------------------------------------------------------------
+
+  /**
+   * Test ROM IRQ/exception handler; loops forever.
+   */
+  .balign 4
+  .section .text
+  .global _test_rom_irq_handler
+  .type _test_rom_irq_handler, @function
+_test_rom_irq_handler:
+  wfi
+  j _test_rom_irq_handler
+  .size _test_rom_irq_handler, .-_test_rom_irq_handler

--- a/sw/device/lib/testing/test_second_rom/test_second_rom_test.c
+++ b/sw/device/lib/testing/test_second_rom/test_second_rom_test.c
@@ -1,0 +1,11 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) { return true; }

--- a/util/topgen/gen_top_docs.py
+++ b/util/topgen/gen_top_docs.py
@@ -39,6 +39,7 @@ def create_pinout_table(top, c_helper, target):
     stats['muxed'] = 0
     stats['direct'] = 0
     stats['manual'] = 0
+    stats['manual_nopadring'] = 0
 
     # get all pads for this target
     pads = top['pinout']['pads'] + target['pinout']['add_pads']

--- a/util/topgen/templates/toplevel.rs.tpl
+++ b/util/topgen/templates/toplevel.rs.tpl
@@ -62,6 +62,7 @@ ${helper.file_header.render()}
 //! - Power Manager Wakeups
 % endif
 
+#[allow(unused_imports)]
 use core::convert::TryFrom;
 % for (inst_name, if_name), region in helper.devices(addr_space):
 <%

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -906,7 +906,7 @@ def check_implementation_targets(top: ConfigT, prefix: str) -> int:
             known_pad_names.update({pad['name']: 1})
 
         for pad in target['pinout']['add_pads']:
-            error += check_pad(top, pad, known_pad_names, ['manual'],
+            error += check_pad(top, pad, known_pad_names, ['manual', 'manual_nopadring'],
                                prefix + ' Additional Pad')
 
     return error


### PR DESCRIPTION
This PR updates the build tooling for Darjeeling FPGA bitstreams to make Vivado provision separate splice-able regions for `rom_ctrl0` and `rom_ctrl1`.

To retain the property that the bitstream with nothing spliced runs through the test ROM and then jumps to CTN RAM, this PR creates a `test_second_rom` as the default payload for `rom_ctrl1`. This binary performs no dedicated chip setup and is simply a passthrough to CTN.

On Xilinx FPGAs, the `rom1` BRAM region is built using a very strange bit order. For the lack of a better term, it is "crumb endian", i.e. in addition to swapping the nibbles within a byte as is done with `rom0`, we also have to swap the order of the bit-pairs within each nibble. In other words, this is equivalent to writing the bits in reverse order and then swapping the even and odd bits.