### PR TITLE
[crypto] Mark AES-GCM timing test working

### DIFF
--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -206,15 +206,11 @@ opentitan_test(
     fpga = fpga_params(
         timeout = "long",
         tags = [
-            "broken",  # https://github.com/lowRISC/opentitan/issues/15788
             "slow_test",
         ],
-        # [test-triage] test not constant time with icache enabled
     ),
     verilator = verilator_params(
         timeout = "long",
-        tags = ["broken"],  # https://github.com/lowRISC/opentitan/issues/15788
-        # [test-triage] test not constant time with icache enabled
     ),
     deps = [
         ":aes_gcm_testutils",


### PR DESCRIPTION
A previous commit (`231b0c36`) fixed a typo in `aes_gcm_timing_test` that caused it to fail even when the AES-GCM implementation was indeed running in constant time, but the tests themselves were left as marked broken. This commit simply removes the broken designation from the appropriate test targets.