### PR TITLE
[acc,dv] Set RV32_TOOL_GCC to hermetic Clang

### DIFF
--- a/hw/ip/acc/dv/uvm/get-toolchain-paths.sh
+++ b/hw/ip/acc/dv/uvm/get-toolchain-paths.sh
@@ -28,3 +28,4 @@ RV32_TOOL_AS=$(${BAZEL_CMD} query \
   --output location | cut -f1 -d:)
 export RV32_TOOL_LD
 export RV32_TOOL_AS
+export RV32_TOOL_GCC=${RV32_TOOL_AS}


### PR DESCRIPTION
acc_as tries to find a host RISC-V GCC, but we need to get the Clang brought in by llvm_toolchain.

This PR resolves many of the build errors coming up from `hw/ip/acc/util/shared/toolchain.py` which asks for RV32_TOOL_GCC while building ACC binaries for DVSim.