### PR TITLE
[dragonfly,chip] Fix chiplevel template, update system list

### DIFF
--- a/doc/contributing/system_list.md
+++ b/doc/contributing/system_list.md
@@ -6,8 +6,8 @@ Click on the design name to get more information about the design.
 <!-- BEGIN CMDGEN util/gen_system_list.py -->
 | Design | Targets | Description |
 | --- | --- | --- |
-| [`top_dragonfly`](../../hw/top_dragonfly/doc/datasheet.md) | asic | Dragonfly is a system-on-a-chip Secure Execution Environment, capable of serving as a root of trust (RoT) for measurement and attestation among other applications, for instantiation within a larger system. |
-| [`top_egret`](../../hw/top_egret/doc/datasheet.md) | asic, cw310, cw340 | The Egret chip is a low-power secure microcontroller that is designed for several use cases requiring hardware security. |
+| [`top_dragonfly`](../../hw/top_dragonfly/doc/datasheet.md) | verilator, asic | Dragonfly is a system-on-a-chip Secure Execution Environment, capable of serving as a root of trust (RoT) for measurement and attestation among other applications, for instantiation within a larger system. |
+| [`top_egret`](../../hw/top_egret/doc/datasheet.md) | verilator, asic, cw310, cw340 | The Egret chip is a low-power secure microcontroller that is designed for several use cases requiring hardware security. |
 | [`top_scafi_deprecated`](../../hw/top_scafi_deprecated/README.md) | cw305 | This is an experimental top intended for SCA/FI activities. |
 
 <!-- END CMDGEN -->

--- a/hw/top_dragonfly/rtl/autogen/chip_dragonfly_asic.sv
+++ b/hw/top_dragonfly/rtl/autogen/chip_dragonfly_asic.sv
@@ -118,22 +118,6 @@ module chip_dragonfly_asic #(
 
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{
-    tck_idx:           TckPadIdx,
-    tms_idx:           TmsPadIdx,
-    trst_idx:          TrstNPadIdx,
-    tdi_idx:           TdiPadIdx,
-    tdo_idx:           TdoPadIdx,
-    tap_strap0_idx:    Tap0PadIdx,
-    tap_strap1_idx:    Tap1PadIdx,
-    dft_strap0_idx:    Dft0PadIdx,
-    dft_strap1_idx:    Dft1PadIdx,
-    // TODO: check whether there is a better way to pass these USB-specific params
-    // The use of these indexes is gated behind a parameter, but to synthesize they
-    // need to exist even if the code-path is never used (pinmux.sv:UsbWkupModuleEn).
-    // Hence, set to zero.
-    usb_dp_idx:        0,
-    usb_dn_idx:        0,
-    usb_sense_idx:     0,
     // Pad types for attribute WARL behavior
     dio_pad_type: {
       BidirStd, // DIO soc_proxy_soc_gpo
@@ -1239,8 +1223,6 @@ module chip_dragonfly_asic #(
   assign unused_pwr_clamp = base_ast_pwr.pwr_clamp;
 
 
-  prim_mubi_pkg::mubi4_t ast_init_done;
-
   ast #(
     .Ast2PadOutWidth(ast_pkg::Ast2PadOutWidth),
     .Pad2AstInWidth(ast_pkg::Pad2AstInWidth)
@@ -1260,7 +1242,7 @@ module chip_dragonfly_asic #(
     .tl_i                  ( base_ast_bus ),
     .tl_o                  ( ast_base_bus ),
     // init done indication
-    .ast_init_done_o       ( ast_init_done ),
+    .ast_init_done_o       ( ),
     // buffered clocks & resets
     .clk_ast_tlul_i (clkmgr_aon_clocks.clk_io_infra),
     .clk_ast_alert_i (clkmgr_aon_clocks.clk_io_secure),

--- a/hw/top_dragonfly/templates/chiplevel.sv.tpl
+++ b/hw/top_dragonfly/templates/chiplevel.sv.tpl
@@ -122,22 +122,6 @@ module chip_${top["name"]}_${target["name"]} #(
 
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{
-    tck_idx:           TckPadIdx,
-    tms_idx:           TmsPadIdx,
-    trst_idx:          TrstNPadIdx,
-    tdi_idx:           TdiPadIdx,
-    tdo_idx:           TdoPadIdx,
-    tap_strap0_idx:    Tap0PadIdx,
-    tap_strap1_idx:    Tap1PadIdx,
-    dft_strap0_idx:    Dft0PadIdx,
-    dft_strap1_idx:    Dft1PadIdx,
-    // TODO: check whether there is a better way to pass these USB-specific params
-    // The use of these indexes is gated behind a parameter, but to synthesize they
-    // need to exist even if the code-path is never used (pinmux.sv:UsbWkupModuleEn).
-    // Hence, set to zero.
-    usb_dp_idx:        0,
-    usb_dn_idx:        0,
-    usb_sense_idx:     0,
     // Pad types for attribute WARL behavior
     dio_pad_type: {
 <%
@@ -564,8 +548,6 @@ module chip_${top["name"]}_${target["name"]} #(
 
 % endif
 
-  prim_mubi_pkg::mubi4_t ast_init_done;
-
   ast #(
     .Ast2PadOutWidth(ast_pkg::Ast2PadOutWidth),
     .Pad2AstInWidth(ast_pkg::Pad2AstInWidth)
@@ -598,7 +580,7 @@ module chip_${top["name"]}_${target["name"]} #(
     .tl_i                  ( base_ast_bus ),
     .tl_o                  ( ast_base_bus ),
     // init done indication
-    .ast_init_done_o       ( ast_init_done ),
+    .ast_init_done_o       ( ),
     // buffered clocks & resets
     % for port, clk in ast["clock_connections"].items():
     .${port} (${clk}),

--- a/util/gen_system_list.py
+++ b/util/gen_system_list.py
@@ -49,14 +49,14 @@ def get_design(topdir, outfile_path):
 
 def get_targets(topdir):
     top_cfg = topdir / "data" / f"{topdir.name}.hjson"
-    corefile = topdir / f"{topdir.name}.core"
+    topname = topdir.name.removeprefix("top_")
+    verilator_file = topdir / f"chip_{topname}_verilator.core"
 
-    if corefile.is_file():
-        sim_tools = []
-        if "sim_verilator" in corefile.read_text():
-            sim_tools.append("verilator")  # only one known sim target
-        sim_targets = ", ".join(sim_tools)
+    sim_targets = ""
+    if verilator_file.is_file():
+        sim_targets = "verilator"  # only one known sim target
 
+    hw_targets = ""
     if top_cfg.is_file():
         top_data = hjson.loads(top_cfg.read_text())
         target_names = [t["name"] for t in top_data["targets"]]


### PR DESCRIPTION
A prior commit inadvertently brought back the pinmux configuration, so get rid of that (and an otherwise unused ast_init_done signal). This seems to get the dragonfly chip-level DV tests back up and compiling.

Also, while regenerating with `make -C hw top_and_cmdgen`, gen_system_list caught some old directories which caused an error in util/gen_system_list.py. It also seems that the detection of the verilator target is better done by simply checking for the existence of `chip_[top]_verilator.core`, so do that instead of searching for "sim_verilator" (searching for "verilator" alone is fraught because of the various Verilator-based linting targets).