### PR TITLE
[crypto,mldsa] Update mldsa-native to v1.0.0-beta2

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -570,7 +570,7 @@
     },
     "//third_party/mldsa_native:extensions.bzl%mldsa_native": {
       "general": {
-        "bzlTransitiveDigest": "y43IQO/okKME5VlC4nmk81AahbfsJIJKHSmjNWclSGM=",
+        "bzlTransitiveDigest": "vo4VHKT4sOOiVqFJl9Yb+YOpMA6gmn881cXfjDNwHMc=",
         "usagesDigest": "u4wmpsW8xRNXUJxQAEu2V94rpike0oJR5U4wylT/dU8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -580,10 +580,10 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//third_party/mldsa_native:BUILD.mldsa_native.bazel",
-              "sha256": "23bcd38bc9d91e93c39df47189d6c4e5eb7172334700579c32951ff31857b9e5",
-              "strip_prefix": "mldsa-native-421e6622f250f99da5b57660572e921c91cbfcf4",
+              "sha256": "722f0c778cfb33ad24e1877c3c9c6e169428393b863a00492c1e0a4dcea39465",
+              "strip_prefix": "mldsa-native-1.0.0-beta2",
               "urls": [
-                "https://github.com/pq-code-package/mldsa-native/archive/421e6622f250f99da5b57660572e921c91cbfcf4.tar.gz"
+                "https://github.com/pq-code-package/mldsa-native/archive/v1.0.0-beta2.tar.gz"
               ]
             }
           }

--- a/sw/device/lib/crypto/impl/mldsa/mldsa_native_config.h
+++ b/sw/device/lib/crypto/impl/mldsa/mldsa_native_config.h
@@ -198,7 +198,7 @@
 #endif
 
 /******************************************************************************
- * Name:        MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ * Name:        MLD_CONFIG_REDUCE_RAM
  *
  * Description: Set this to reduce RAM usage.
  *              This trades memory for performance.
@@ -209,9 +209,6 @@
  *              This option is useful for embedded systems with tight RAM
  *              constraints but relaxed performance requirements.
  *
- *              WARNING: This option is experimental!
- *              CBMC proofs do not currently cover this configuration option.
- *              Its scope and configuration may change at any time.
  *
  *****************************************************************************/
 #define MLD_CONFIG_REDUCE_RAM

--- a/sw/device/lib/crypto/include/mldsa.h
+++ b/sw/device/lib/crypto/include/mldsa.h
@@ -41,17 +41,17 @@ enum {
   kOtcryptoMldsa87SeedBytes = 32,
 
   // Work buffer sizes in 32-bit words
-  kOtcryptoMldsa44WorkBufferKeypairWords = 32992 / sizeof(uint32_t),
-  kOtcryptoMldsa44WorkBufferSignWords = 32448 / sizeof(uint32_t),
-  kOtcryptoMldsa44WorkBufferVerifyWords = 22464 / sizeof(uint32_t),
+  kOtcryptoMldsa44WorkBufferKeypairWords = 11584 / sizeof(uint32_t),
+  kOtcryptoMldsa44WorkBufferSignWords = 13120 / sizeof(uint32_t),
+  kOtcryptoMldsa44WorkBufferVerifyWords = 9120 / sizeof(uint32_t),
 
-  kOtcryptoMldsa65WorkBufferKeypairWords = 46304 / sizeof(uint32_t),
-  kOtcryptoMldsa65WorkBufferSignWords = 44768 / sizeof(uint32_t),
-  kOtcryptoMldsa65WorkBufferVerifyWords = 30720 / sizeof(uint32_t),
+  kOtcryptoMldsa65WorkBufferKeypairWords = 14656 / sizeof(uint32_t),
+  kOtcryptoMldsa65WorkBufferSignWords = 17248 / sizeof(uint32_t),
+  kOtcryptoMldsa65WorkBufferVerifyWords = 10208 / sizeof(uint32_t),
 
-  kOtcryptoMldsa87WorkBufferKeypairWords = 62688 / sizeof(uint32_t),
-  kOtcryptoMldsa87WorkBufferSignWords = 59104 / sizeof(uint32_t),
-  kOtcryptoMldsa87WorkBufferVerifyWords = 41216 / sizeof(uint32_t),
+  kOtcryptoMldsa87WorkBufferKeypairWords = 18752 / sizeof(uint32_t),
+  kOtcryptoMldsa87WorkBufferSignWords = 21344 / sizeof(uint32_t),
+  kOtcryptoMldsa87WorkBufferVerifyWords = 12512 / sizeof(uint32_t),
 };
 
 /**

--- a/third_party/mldsa_native/BUILD.mldsa_native.bazel
+++ b/third_party/mldsa_native/BUILD.mldsa_native.bazel
@@ -26,6 +26,8 @@ cc_library(
         "mldsa/src/poly_kl.h",
         "mldsa/src/polyvec.c",
         "mldsa/src/polyvec.h",
+        "mldsa/src/polyvec_lazy.c",
+        "mldsa/src/polyvec_lazy.h",
         "mldsa/src/reduce.h",
         "mldsa/src/rounding.h",
         "mldsa/src/sign.c",

--- a/third_party/mldsa_native/extensions.bzl
+++ b/third_party/mldsa_native/extensions.bzl
@@ -13,9 +13,9 @@ def _mldsa_native_repos():
     http_archive(
         name = "mldsa_native",
         build_file = Label("//third_party/mldsa_native:BUILD.mldsa_native.bazel"),
-        sha256 = "23bcd38bc9d91e93c39df47189d6c4e5eb7172334700579c32951ff31857b9e5",
-        strip_prefix = "mldsa-native-421e6622f250f99da5b57660572e921c91cbfcf4",
+        sha256 = "722f0c778cfb33ad24e1877c3c9c6e169428393b863a00492c1e0a4dcea39465",
+        strip_prefix = "mldsa-native-1.0.0-beta2",
         urls = [
-            "https://github.com/pq-code-package/mldsa-native/archive/421e6622f250f99da5b57660572e921c91cbfcf4.tar.gz",
+            "https://github.com/pq-code-package/mldsa-native/archive/v1.0.0-beta2.tar.gz",
         ],
     )


### PR DESCRIPTION
This commit updates mldsa-native to the most recent release. The most relevant change for the Pavona integration is that it requires much less memory now.
The REDUCE_RAM-mode is also no longer experimental and fully covered by CBMC proving type safety and memory safety.

The work buffers shrink accordingly:

| Param set | Operation | Before (B) | After (B) |
|-----------|-----------|-----------:|----------:|
| ML-DSA-44 | keypair   | 32,992     | 11,584    |
| ML-DSA-44 | sign      | 32,448     | 13,120    |
| ML-DSA-44 | verify    | 22,464     | 9,120     |
| ML-DSA-65 | keypair   | 46,304     | 14,656    |
| ML-DSA-65 | sign      | 44,768     | 17,248    |
| ML-DSA-65 | verify    | 30,720     | 10,208    |
| ML-DSA-87 | keypair   | 62,688     | 18,752    |
| ML-DSA-87 | sign      | 59,104     | 21,344    |
| ML-DSA-87 | verify    | 41,216     | 12,512    |

See the full release notes here:
https://github.com/pq-code-package/mldsa-native/releases/tag/v1.0.0-beta2