### PR TITLE
[doc] Add sitemap.xml to doxygen output

### DIFF
--- a/util/site/doxygen/Doxyfile
+++ b/util/site/doxygen/Doxyfile
@@ -99,6 +99,7 @@ GENERATE_HTML          = YES
 
 # Relative to `OUTPUT_DIRECTORY`
 HTML_OUTPUT            = "doxy/"
+SITEMAP_URL            = "https://docs.pavona.org/gen/doxy/"
 
 HTML_COLORSTYLE_HUE    = 271
 


### PR DESCRIPTION
This extends the current Doxyfile to generate a sitemap.xml file that references all generated .html files. Search engines will then be able to automatically discover all files on the docs site.