### PR TITLE
[dvsim] Fixes to reseed issues

### DIFF
--- a/util/dvsim/CfgFactory.py
+++ b/util/dvsim/CfgFactory.py
@@ -106,8 +106,11 @@ def reseed_source(graded_reseeds: dict, seed_index: dict, default_reseed: int):
             key = (candidate, graded_reseeds["name"], variant)
             if key in seed_index:
                 hit = True
-                hjson_test["reseed"] = seed_index[key]["reseed"]
-                hjson_test["seeds"] = seed_index[key]["seeds"]
+                entry = seed_index[key]
+                if "reseed" in entry:
+                    hjson_test["reseed"] = entry["reseed"]
+                if "seeds" in entry:
+                    hjson_test["seeds"] = entry["seeds"]
                 break  # Assume one match per test
 
     if "reseed" in graded_reseeds.keys() and hit:

--- a/util/dvsim/modes.py
+++ b/util/dvsim/modes.py
@@ -105,14 +105,13 @@ class Mode:
                 continue
 
             # If the attribute wouldn't otherwise merge, but it's a reseed
-            # value, (as introduced by the --reseed-source) it with the
-            # lesser of the two.
+            # value (as introduced by the --reseed-source), it should always go with
+            # the corresponding sourced attribute.
             if attr == "reseed":
                 log.warn(f"For merging reseed value of {mode.name} "
                          f"(reseed={mode_attr_val}) into {self.name} "
-                         f"(reseed={self_attr_val}), selecting the smaller "
-                         "value.")
-                setattr(self, attr, min(mode_attr_val, self_attr_val))
+                         f"(reseed={self_attr_val}), selecting the default value.")
+                setattr(self, attr, self_attr_val)
                 continue
 
             # If we get to here then neither value is the default value and


### PR DESCRIPTION
This PR contains two commits:
- The first one is so that we can address #86.
- The second one is to address a small issue: not specifying either `seeds` or `reseeds` in a sourced file results in a `KeyError` that forces the user to specify both. This fix makes it more flexible (you don't have to specify both).