### PR TITLE
[acc] Minor improvements to information-flow checker

### DIFF
--- a/hw/ip/acc/util/check_const_time.py
+++ b/hw/ip/acc/util/check_const_time.py
@@ -12,6 +12,7 @@ from shared.control_flow import program_control_graph, subroutine_control_graph
 from shared.decode import decode_elf
 from shared.information_flow_analysis import (get_program_iflow,
                                               get_subroutine_iflow,
+                                              parse_information_flow_node,
                                               stringify_control_deps)
 
 
@@ -43,15 +44,26 @@ def main() -> int:
               'in the form "reg:value", e.g. x3:5. Only GPRs are accepted as '
               'required constants.'))
     parser.add_argument(
-        '--secrets',
+        '--secret',
         nargs='+',
         type=str,
         required=False,
         help=('Initial secret information-flow nodes. If not provided, '
-              'assume everything is secret; check that the subroutine or '
-              'program has only one possible control-flow path regardless '
-              'of input.'))
+              'assume everything is secret unless --public is specified; '
+              'check that the subroutine or program has only one possible '
+              'control-flow path regardless of input.'))
+    parser.add_argument(
+        '--public',
+        nargs='+',
+        type=str,
+        required=False,
+        help=('Initially NOT secret information-flow nodes. If specified, '
+              'assume everything else is secret. Cannot be specified at the '
+              'same time as --secret.'))
     args = parser.parse_args()
+
+    # Load the program.
+    program = decode_elf(args.elf)
 
     # Parse initial constants.
     if args.constants is None:
@@ -62,6 +74,21 @@ def main() -> int:
                              'program; use --subroutine to analyze a specific '
                              'subroutine.')
         constants = parse_required_constants(args.constants)
+
+    if args.secret and args.public:
+        raise ValueError('Cannot specify --secret and --public together.')
+
+    # Parse the secrets as information-flow nodes.
+    secret_nodes = set()
+    if args.secret:
+        for secret in args.secret:
+            secret_nodes.add(parse_information_flow_node(secret))
+
+    # Parse the public values as information-flow nodes.
+    public_nodes = set()
+    if args.public:
+        for public in args.public:
+            public_nodes.add(parse_information_flow_node(public))
 
     # Compute control graph and get all nodes that influence control flow.
     program = decode_elf(args.elf)
@@ -83,21 +110,27 @@ def main() -> int:
                                                                   subroutine, {})
             control_deps_ignore.update(control_deps_ignore_temp)
 
-    if args.secrets is None:
-        if args.verbose:
-            print(
-                'No specific secrets provided; checking that {} has only one '
-                'control-flow path'.format(to_analyze))
-        secret_control_deps = control_deps
+    if args.secret is None:
+        if args.public is not None:
+            secret_control_deps = {
+                node: pcs
+                for node, pcs in control_deps.items()
+                if node not in public_nodes}
+        else:
+            if args.verbose:
+                print(
+                    'No specific secrets provided; checking that {} has only one '
+                    'control-flow path'.format(to_analyze))
+            secret_control_deps = control_deps
     else:
         if args.verbose:
             print('Analyzing {} with initial secrets {} and initial constants {}'.format(
-                to_analyze, args.secrets, constants))
+                to_analyze, args.secret, constants))
         # If secrets were provided, only show the ways in which those specific
         # nodes could influence control flow.
         secret_control_deps = {
             node: pcs
-            for node, pcs in control_deps.items() if node in args.secrets
+            for node, pcs in control_deps.items() if node in args.secret
         }
 
     secret_control_deps_filt = {k: v for k, v in secret_control_deps.items()

--- a/hw/ip/acc/util/check_const_time.py
+++ b/hw/ip/acc/util/check_const_time.py
@@ -91,7 +91,6 @@ def main() -> int:
             public_nodes.add(parse_information_flow_node(public))
 
     # Compute control graph and get all nodes that influence control flow.
-    program = decode_elf(args.elf)
     if args.subroutine is None:
         graph = program_control_graph(program)
         to_analyze = 'entire program'
@@ -130,7 +129,7 @@ def main() -> int:
         # nodes could influence control flow.
         secret_control_deps = {
             node: pcs
-            for node, pcs in control_deps.items() if node in args.secret
+            for node, pcs in control_deps.items() if node in secret_nodes
         }
 
     secret_control_deps_filt = {k: v for k, v in secret_control_deps.items()

--- a/hw/ip/acc/util/shared/constants.py
+++ b/hw/ip/acc/util/shared/constants.py
@@ -180,11 +180,15 @@ def parse_required_constants(constants: List[str]) -> Dict[str, int]:
             raise ValueError(
                 f'Cannot parse required constant {token}: {reg} is not a '
                 'valid GPR name.')
-        if not value.isnumeric():
+        try:
+            if value.startswith('0x'):
+                value = int(value, 16)
+            else:
+                value = int(value)
+        except ValueError:
             raise ValueError(
                 f'Cannot parse required constant {token}: {value} is not a '
                 'recognized numeric value.')
-        value = int(value)
         if value < 0 or value > GPR_MAX:
             raise ValueError(
                 f'Cannot parse required constant {token}: {value} is out of '

--- a/hw/ip/acc/util/shared/constants.py
+++ b/hw/ip/acc/util/shared/constants.py
@@ -181,10 +181,7 @@ def parse_required_constants(constants: List[str]) -> Dict[str, int]:
                 f'Cannot parse required constant {token}: {reg} is not a '
                 'valid GPR name.')
         try:
-            if value.startswith('0x'):
-                value = int(value, 16)
-            else:
-                value = int(value)
+            value = int(value, 0)
         except ValueError:
             raise ValueError(
                 f'Cannot parse required constant {token}: {value} is not a '

--- a/hw/ip/acc/util/shared/control_flow.py
+++ b/hw/ip/acc/util/shared/control_flow.py
@@ -27,6 +27,9 @@ class ControlLoc:
     def pretty(self) -> str:
         return '{:#x}'.format(self.pc)
 
+    def __repr__(self) -> str:
+        return 'ControlLoc({:#x})'.format(self.pc)
+
 
 class ImemEnd(ControlLoc):
     '''Represents the end of instruction memory.'''
@@ -40,6 +43,9 @@ class ImemEnd(ControlLoc):
 
     def pretty(self) -> str:
         return '<imem end>'
+
+    def __repr__(self) -> str:
+        return 'ImemEnd()'
 
 
 class Ret(ControlLoc):
@@ -55,6 +61,9 @@ class Ret(ControlLoc):
     def pretty(self) -> str:
         return 'RET'
 
+    def __repr__(self) -> str:
+        return 'Ret()'
+
 
 class Ecall(ControlLoc):
     '''Represents program termination as a result of an ecall.'''
@@ -68,6 +77,9 @@ class Ecall(ControlLoc):
 
     def pretty(self) -> str:
         return 'ECALL'
+
+    def __repr__(self) -> str:
+        return 'Ecall()'
 
 
 class LoopStart(ControlLoc):
@@ -90,6 +102,9 @@ class LoopStart(ControlLoc):
         return '<loop from {:#x}-{:#x}>'.format(self.loop_start_pc,
                                                 self.loop_end_pc)
 
+    def __repr__(self) -> str:
+        return 'LoopStart({:#x}-{:#x})'.format(self.loop_start_pc, self.loop_end_pc)
+
 
 class Cycle(ControlLoc):
     '''Represents a control flow that loops back to a previous PC.
@@ -107,6 +122,9 @@ class Cycle(ControlLoc):
     def pretty(self) -> str:
         return '<cycle: back to {:#x}>'.format(self.pc)
 
+    def __repr__(self) -> str:
+        return 'Cycle({:#x})'.format(self.pc)
+
 
 class LoopEnd(Cycle):
     '''Represents the end of a loop (looping back to the start).
@@ -121,6 +139,10 @@ class LoopEnd(Cycle):
     def pretty(self) -> str:
         return '<loop end: back to {:#x}>'.format(
             self.loop_start.loop_start_pc)
+
+    def __repr__(self) -> str:
+        return 'LoopEnd({:#x}-{:#x})'.format(
+            self.loop_start.loop_start_pc, self.loop_start.loop_end_pc)
 
 
 class ControlGraph:

--- a/hw/ip/acc/util/shared/information_flow.py
+++ b/hw/ip/acc/util/shared/information_flow.py
@@ -15,8 +15,9 @@ from serialize.parse_helpers import check_keys, check_list, check_str
 from .operand import Operand, RegOperandType
 
 FLAG_NAMES = ['c', 'm', 'l', 'z']
-SPECIAL_REG_NAMES = ['mod', 'acc', 'acch']
-READONLY = ['x0']
+
+# Registers that can be involved in information flow without being an operand
+SPECIAL_REG_NAMES = ['mod', 'acc', 'acch', 'kmac_core', 'rnd', 'urnd']
 
 
 class InformationFlowGraph:
@@ -683,7 +684,7 @@ class InsnInformationFlowRule:
         flow = {}
         for node in self.flows_to:
             dest = node.evaluate(op_vals, constant_regs)
-            if dest in READONLY:
+            if dest in ['x0']:
                 # No information will actually flow to this node, because it is
                 # not writeable; skip.
                 continue

--- a/hw/ip/acc/util/shared/information_flow_analysis.py
+++ b/hw/ip/acc/util/shared/information_flow_analysis.py
@@ -4,6 +4,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+import re
 from copy import deepcopy
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -12,7 +13,7 @@ from .constants import ConstantContext, get_op_val_str
 from .control_flow import (ControlLoc, ControlGraph, Cycle, Ecall, ImemEnd,
                            LoopStart, Ret)
 from .decode import ACCProgram
-from .information_flow import InformationFlowGraph
+from .information_flow import InformationFlowGraph, SPECIAL_REG_NAMES
 from .insn_yaml import Insn
 
 # Calls to _get_iflow return results in the form of a tuple with entries:
@@ -685,3 +686,24 @@ def stringify_control_deps(program: ACCProgram,
             pc_strings.append('{} at PC {:#x}'.format(insn.mnemonic, pc))
         out.append('{} (via {})'.format(node, ', '.join(pc_strings)))
     return out
+
+
+def parse_information_flow_node(x: str) -> str:
+    '''Parse a named information-flow node.
+
+    Accepts:
+    - register names e.g. "x20", "w1"
+    - special strings like "dmem" and "mod"
+    '''
+    if x == 'dmem':
+        return x
+    if x in SPECIAL_REG_NAMES:
+        return x
+    # try to match as a register
+    m = re.match(r'[wx]([0-9]+)', x)
+    if m is None:
+        raise ValueError(f'Malformatted node: {x}')
+    idx = int(m.group(1))
+    if not 0 <= idx < 32:
+        raise ValueError(f'Invalid register index: {x}')
+    return x

--- a/hw/ip/acc/util/shared/information_flow_analysis.py
+++ b/hw/ip/acc/util/shared/information_flow_analysis.py
@@ -100,9 +100,10 @@ def _build_iflow_insn(
         if const not in constants:
             raise ValueError(
                 'Could not construct information flow because {} is '
-                'not a known constant at PC {:#x}: {}'
-                '\nKnown constants: {}'
-                '\nIf the register is in fact a constant, you may '
+                'not a known constant at PC {:#x}:'
+                '\n{}'
+                '\n\nKnown constants: {}'
+                '\n\nIf the register is in fact a constant, you may '
                 'need to add constant-tracking support for more '
                 'instructions.'.format(const, pc,
                                        insn.disassemble(pc, op_vals),
@@ -428,6 +429,29 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
 
         # Set the next edges to the instruction after the jump returns
         edges = [ControlLoc(section.end + 4)]
+    elif last_insn.mnemonic in ['bne', 'beq']:
+        grs1 = get_op_val_str(last_insn, last_op_vals, 'grs1')
+        grs2 = get_op_val_str(last_insn, last_op_vals, 'grs2')
+        if grs1 in constants and grs2 in constants:
+            # if both arguments are known constants, we can remove the other branch
+            ops_equal = constants.get(grs1) == constants.get(grs2)
+            if last_insn.mnemonic == 'beq':
+                branch_taken = ops_equal
+            else:
+                assert last_insn.mnemonic == 'bne'
+                branch_taken = not ops_equal
+
+            # filter for only the chosen branch (should always leave exactly 1 option)
+            dest = last_op_vals['offset']
+            if branch_taken:
+                edges = [e for e in edges if e.pc == dest]
+            else:
+                edges = [e for e in edges if e.pc != dest]
+            assert len(edges) == 1
+
+            # update used_constants to reflect that we read the branch constants
+            used_constant_nodes = iflow.sources_for_any([grs1, grs2])
+            used_constants.update(used_constant_nodes)
     else:
         # Update the constants to include the last instruction
         constants.update_insn(last_insn, last_op_vals)

--- a/rules/acc.bzl
+++ b/rules/acc.bzl
@@ -303,8 +303,10 @@ def _acc_consttime_test_impl(ctx):
         script_content += " --subroutine {}".format(ctx.attr.subroutine)
     if ctx.attr.ignore:
         script_content += " --ignore {}".format(" ".join(ctx.attr.ignore))
-    if ctx.attr.secrets:
-        script_content += " --secrets {}".format(" ".join(ctx.attr.secrets))
+    if ctx.attr.secret:
+        script_content += " --secret {}".format(" ".join(ctx.attr.secret))
+    if ctx.attr.public:
+        script_content += " --public {}".format(" ".join(ctx.attr.public))
     if ctx.attr.initial_constants:
         script_content += " --constants {}".format(" ".join(ctx.attr.initial_constants))
     ctx.actions.write(
@@ -589,7 +591,8 @@ acc_consttime_test = rule(
         "deps": attr.label_list(providers = [OutputGroupInfo]),
         "subroutine": attr.string(),
         "ignore": attr.string_list(),
-        "secrets": attr.string_list(),
+        "secret": attr.string_list(),
+        "public": attr.string_list(),
         "initial_constants": attr.string_list(),
         "_checker": attr.label(
             default = "//hw/ip/acc/util:check_const_time",

--- a/sw/acc/crypto/tests/BUILD
+++ b/sw/acc/crypto/tests/BUILD
@@ -175,7 +175,7 @@ acc_consttime_test(
     name = "div_consttime",
     # All secrets are stored in DMEM; timing is permitted to depend on the
     # number of limbs.
-    secrets = ["dmem"],
+    secret = ["dmem"],
     subroutine = "div",
     deps = [
         ":div_small_test",
@@ -197,7 +197,7 @@ acc_consttime_test(
     name = "mod_consttime",
     # All secrets are stored in DMEM; timing is permitted to depend on the
     # number of limbs.
-    secrets = ["dmem"],
+    secret = ["dmem"],
     subroutine = "mod",
     deps = [
         ":mod_test",
@@ -264,7 +264,7 @@ acc_sim_test(
 acc_consttime_test(
     name = "gcd_consttime",
     # All inputs are in DMEM; no registers are secret.
-    secrets = ["dmem"],
+    secret = ["dmem"],
     subroutine = "gcd",
     deps = [
         ":gcd_small_test",
@@ -288,7 +288,7 @@ acc_sim_test(
 acc_consttime_test(
     name = "lcm_consttime",
     # All inputs are in DMEM; no registers are secret.
-    secrets = ["dmem"],
+    secret = ["dmem"],
     subroutine = "lcm",
     deps = [
         ":lcm_test",
@@ -309,7 +309,7 @@ acc_sim_test(
 acc_consttime_test(
     name = "mul_consttime",
     # All inputs are in DMEM; no registers are secret.
-    secrets = ["dmem"],
+    secret = ["dmem"],
     subroutine = "bignum_mul",
     deps = [
         ":mul_test",
@@ -330,7 +330,7 @@ acc_sim_test(
 acc_consttime_test(
     name = "mul256_consttime",
     # All inputs are in DMEM; no registers are secret.
-    secrets = ["dmem"],
+    secret = ["dmem"],
     subroutine = "bignum_mul256",
     deps = [
         ":mul_test",
@@ -858,6 +858,7 @@ acc_sim_test(
 
 acc_consttime_test(
     name = "p384_base_mult_consttime",
+    secret = ["dmem"],
     subroutine = "p384_base_mult",
     deps = [
         ":p384_base_mult_test",
@@ -976,52 +977,64 @@ acc_sim_test(
     ],
 )
 
-# Miller-Rabin with 1024-bit primes (as in RSA-2048).
+# Miller-Rabin round with 1024-bit primes (as in RSA-2048).
 acc_consttime_test(
-    name = "miller_rabin_consttime_1024",
-    # 4 limbs, x30 = n and x31 = n -1
+    name = "test_witness_1024_consttime",
     initial_constants = [
+        # 4 limbs, x30 = n and x31 = n - 1
         "x30:4",
         "x31:3",
     ],
-    # All secrets are stored in DMEM; timing is permitted to depend on the
-    # number of limbs.
-    secrets = ["dmem"],
-    subroutine = "miller_rabin",
+    public = [
+        # zero register
+        "w31",
+        # limb counts
+        "x30",
+        "x31",
+    ],
+    subroutine = "test_witness",
     deps = [
         ":primality_test",
     ],
 )
 
-# Miller-Rabin with 1536-bit primes (as in RSA-3072).
+# Miller-Rabin round with 1536-bit primes (as in RSA-3072).
 acc_consttime_test(
-    name = "miller_rabin_consttime_1536",
-    # 6 limbs, x30 = n and x31 = n -1
+    name = "test_witness_1536_consttime",
     initial_constants = [
+        # 6 limbs, x30 = n and x31 = n - 1
         "x30:6",
         "x31:5",
     ],
-    # All secrets are stored in DMEM; timing is permitted to depend on the
-    # number of limbs.
-    secrets = ["dmem"],
-    subroutine = "miller_rabin",
+    public = [
+        # zero register
+        "w31",
+        # limb counts
+        "x30",
+        "x31",
+    ],
+    subroutine = "test_witness",
     deps = [
         ":primality_test",
     ],
 )
 
-# Miller-Rabin with 2048-bit primes (as in RSA-4096).
+# Miller-Rabin round with 2048-bit primes (as in RSA-4096).
 acc_consttime_test(
-    name = "miller_rabin_consttime_2048",
-    # 8 limbs, x30 = n and x31 = n -1
+    name = "test_witness_2048_consttime",
     initial_constants = [
+        # 8 limbs, x30 = n and x31 = n - 1
         "x30:8",
         "x31:7",
     ],
-    # All secrets are stored in DMEM; timing is permitted to depend on the
-    # number of limbs.
-    secrets = ["dmem"],
-    subroutine = "miller_rabin",
+    public = [
+        # zero register
+        "w31",
+        # limb counts
+        "x30",
+        "x31",
+    ],
+    subroutine = "test_witness",
     deps = [
         ":primality_test",
     ],
@@ -1066,14 +1079,20 @@ acc_sim_test(
 )
 
 acc_consttime_test(
-    name = "modinv_f4_consttime_test",
+    name = "modinv_f4_1024_consttime",
     initial_constants = [
         "x20:20",
         "x21:21",
+        "x30:4",
     ],
-    # All secrets are stored in DMEM; timing is permitted to depend on the
-    # number of limbs.
-    secrets = ["dmem"],
+    public = [
+        # modulus is public
+        "mod",
+        # zero register is public
+        "w31",
+        # number of limbs is public
+        "x30",
+    ],
     subroutine = "modinv_f4",
     deps = [
         ":modinv_f4_test",
@@ -1103,7 +1122,7 @@ acc_consttime_test(
     name = "relprime_f4_consttime_test",
     # All secrets are stored in DMEM; timing is permitted to depend on the
     # number of limbs.
-    secrets = ["dmem"],
+    secret = ["dmem"],
     subroutine = "relprime_f4",
     deps = [
         ":relprime_f4_test",
@@ -1612,7 +1631,7 @@ acc_consttime_test(
     name = "sha256_consttime",
     # All secrets are stored in DMEM; timing is permitted to depend on the
     # number of message chunks.
-    secrets = ["dmem"],
+    secret = ["dmem"],
     subroutine = "sha256",
     deps = [
         ":sha256_test",


### PR DESCRIPTION
This PR cherry-picks @jadephilipoom's PR from https://github.com/zerorisc/expo/pull/246. There are going to be two follow-up PRs.

Original PR description:

These were some small improvements I made along the way towards a bigger extension to the information-flow checker that I'll post as a follow-up PR; I separated these out for easier review. There's more detail in the commit messages, but in summary:

- print out control-flow nodes more nicely for debugging
- automatically resolve branches where both sides of the comparison are known constants
- allow specifying public values instead of secret values for constant-time checks, which makes it easier to ensure nothing has been forgotten