### PR TITLE
[df,rom] Backport second-stage ROM for integrated tops

### DIFF
--- a/sw/device/silicon_creator/lib/epmp_state.c
+++ b/sw/device/silicon_creator/lib/epmp_state.c
@@ -15,6 +15,7 @@ OT_WEAK epmp_state_t epmp_state;
 /**
  * Extern declarations of inline functions.
  */
+extern void epmp_state_unconfigure(uint32_t entry);
 extern void epmp_state_configure_tor(uint32_t entry, epmp_region_t region,
                                      epmp_perm_t perm);
 extern void epmp_state_configure_na4(uint32_t entry, epmp_region_t region,

--- a/sw/device/silicon_creator/lib/epmp_state.h
+++ b/sw/device/silicon_creator/lib/epmp_state.h
@@ -171,6 +171,21 @@ typedef struct epmp_state {
 extern epmp_state_t epmp_state;
 
 /**
+ * Un-configure the given PMP entry in state.
+ *
+ * @param entry The index of the entry to update.
+ */
+inline void epmp_state_unconfigure(uint32_t entry) {
+  // Set configuration register.
+  bitfield_field32_t field = {.mask = 0xff, .index = (entry % 4) * 8};
+  epmp_state.pmpcfg[entry / 4] =
+      bitfield_field32_write(epmp_state.pmpcfg[entry / 4], field, 0);
+
+  // Set address registers.
+  epmp_state.pmpaddr[entry] = 0;
+}
+
+/**
  * Configure the given PMP entry in state using the Top-Of-Range addressing
  * mode.
  *

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -765,3 +765,125 @@ pavona_binary(
         ":base_rom_lib",
     ],
 )
+
+cc_library(
+    name = "second_rom_common",
+    srcs = [
+        "second_rom.c",
+        "second_rom.h",
+    ],
+    deps = [
+        ":second_rom_epmp",
+        ":sigverify_keys_ecdsa_p256",
+        ":sigverify_keys_spx",
+        "//hw/top:aon_timer_c_regs",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:csr",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:stdasm",
+        "//sw/device/lib/crt",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/silicon_creator/lib:acc_boot_services",
+        "//sw/device/silicon_creator/lib:cfi",
+        "//sw/device/silicon_creator/lib:dbg_print",
+        "//sw/device/silicon_creator/lib:epmp_state",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:irq_asm",
+        "//sw/device/silicon_creator/lib:manifest",
+        "//sw/device/silicon_creator/lib:shutdown",
+        "//sw/device/silicon_creator/lib/base:chip",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+        "//sw/device/silicon_creator/lib/base:static_critical",
+        "//sw/device/silicon_creator/lib/drivers:alert",
+        "//sw/device/silicon_creator/lib/drivers:ast",
+        "//sw/device/silicon_creator/lib/drivers:ibex",
+        "//sw/device/silicon_creator/lib/drivers:keymgr_dpe",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/drivers:otp",
+        "//sw/device/silicon_creator/lib/drivers:pinmux",
+        "//sw/device/silicon_creator/lib/drivers:pwrmgr",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/drivers:rnd",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+        "//sw/device/silicon_creator/lib/drivers:uart",
+        "//sw/device/silicon_creator/lib/drivers:watchdog",
+        "//sw/device/silicon_creator/lib/sigverify",
+    ],
+)
+
+cc_library(
+    name = "second_rom_lib",
+    srcs = ["second_rom_start.S"],
+    target_compatible_with = [PAVONA_CPU],
+    deps = [
+        ":second_rom_common",
+        ":second_rom_epmp",
+        "//hw/top:aon_timer_c_regs",
+        "//hw/top:ast_c_regs",
+        "//hw/top:clkmgr_c_regs",
+        "//hw/top:csrng_c_regs",
+        "//hw/top:edn_c_regs",
+        "//hw/top:gpio_c_regs",
+        "//hw/top:lc_ctrl_c_regs",
+        "//hw/top:otp_ctrl_c_regs",
+        "//hw/top:pinmux_c_regs",
+        "//hw/top:pwrmgr_c_regs",
+        "//hw/top:rv_core_ibex_c_regs",
+        "//hw/top:sram_ctrl_c_regs",
+        "//hw/top_dragonfly/sw/autogen:top_dragonfly",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:multibits",
+        "//sw/device/silicon_creator/lib/base:chip",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "second_rom_epmp",
+    srcs = [
+        "second_rom_epmp.c",
+        "second_rom_epmp_init.S",
+    ],
+    hdrs = ["second_rom_epmp.h"],
+    target_compatible_with = [PAVONA_CPU],
+    deps = [
+        "//hw/top_dragonfly/sw/autogen:top_dragonfly",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:csr",
+        "//sw/device/lib/base:memory",
+        "//sw/device/silicon_creator/lib:dbg_print",
+        "//sw/device/silicon_creator/lib:epmp_state",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+    ],
+)
+
+ld_library(
+    name = "second_rom_linker_script",
+    script = "second_rom.ld",
+    deps = [
+        "//hw/top_dragonfly/sw/autogen:top_dragonfly_memory",
+        "//sw/device:info_sections",
+        "//sw/device/silicon_creator/lib/base:static_critical_sections",
+    ],
+)
+
+pavona_binary(
+    name = "second_rom",
+    exec_env = [
+        "//hw/top_dragonfly:sim_dv_base",
+        "//hw/top_dragonfly:sim_verilator_base",
+    ],
+    kind = "rom",
+    linker_script = ":second_rom_linker_script",
+    rom_scramble_mode = "second-rom",
+    transitive_features = [
+        "use_lld",
+        "lto",
+        "minsize",
+    ],
+    deps = [
+        ":second_rom_lib",
+    ],
+)

--- a/sw/device/silicon_creator/rom/second_rom.c
+++ b/sw/device/silicon_creator/rom/second_rom.c
@@ -1,0 +1,289 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/rom/second_rom.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/stdasm.h"
+#include "sw/device/silicon_creator/lib/base/boot_measurements.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
+#include "sw/device/silicon_creator/lib/base/static_critical_version.h"
+#include "sw/device/silicon_creator/lib/cfi.h"
+#include "sw/device/silicon_creator/lib/dbg_print.h"
+#include "sw/device/silicon_creator/lib/drivers/alert.h"
+#include "sw/device/silicon_creator/lib/drivers/ast.h"
+#include "sw/device/silicon_creator/lib/drivers/ibex.h"
+#include "sw/device/silicon_creator/lib/drivers/keymgr_dpe.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/drivers/otp.h"
+#include "sw/device/silicon_creator/lib/drivers/pinmux.h"
+#include "sw/device/silicon_creator/lib/drivers/pwrmgr.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#include "sw/device/silicon_creator/lib/drivers/rnd.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+#include "sw/device/silicon_creator/lib/drivers/uart.h"
+#include "sw/device/silicon_creator/lib/drivers/watchdog.h"
+#include "sw/device/silicon_creator/lib/epmp_state.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/shutdown.h"
+#include "sw/device/silicon_creator/lib/sigverify/sigverify.h"
+#include "sw/device/silicon_creator/rom/second_rom_epmp.h"
+#include "sw/device/silicon_creator/rom/sigverify_keys_ecdsa_p256.h"
+#include "sw/device/silicon_creator/rom/sigverify_keys_spx.h"
+
+#include "hw/top/otp_ctrl_regs.h"
+#include "hw/top_dragonfly/sw/autogen/top_dragonfly.h"
+
+/**
+ * Type alias for the ROM_EXT entry point.
+ *
+ * The entry point address obtained from the ROM_EXT manifest must be cast to a
+ * pointer to this type before being called.
+ */
+typedef void rom_ext_entry_point(void);
+
+/**
+ * Table of forward branch Control Flow Integrity (CFI) counters.
+ *
+ * Columns: Name, Initital Value.
+ *
+ * Each counter is indexed by Name. The Initial Value is used to initialize the
+ * counters with unique values with a good hamming distance. The values are
+ * restricted to 11-bit to be able use immediate load instructions.
+
+ * Encoding generated with
+ * $ ./util/design/sparse-fsm-encode.py -d 6 -m 6 -n 11 \
+ *     -s 1630646358 --language=c
+ *
+ * Minimum Hamming distance: 6
+ * Maximum Hamming distance: 8
+ * Minimum Hamming weight: 5
+ * Maximum Hamming weight: 8
+ */
+// clang-format off
+#define ROM_CFI_FUNC_COUNTERS_TABLE(X) \
+  X(kCfiRomMain,         0x14b) \
+  X(kCfiRomInit,         0x7dc) \
+  X(kCfiRomVerify,       0x5a7) \
+  X(kCfiRomTryBoot,      0x235) \
+  X(kCfiRomPreBootCheck, 0x43a) \
+  X(kCfiRomBoot,         0x2e2)
+// clang-format on
+
+// Define counters and constant values required by the CFI counter macros.
+CFI_DEFINE_COUNTERS(rom_counters, ROM_CFI_FUNC_COUNTERS_TABLE);
+
+// Life cycle state of the chip.
+lifecycle_state_t lc_state = (lifecycle_state_t)0;
+
+OT_ALWAYS_INLINE
+OT_WARN_UNUSED_RESULT
+static rom_error_t rom_irq_error(void) {
+  uint32_t mcause;
+  CSR_READ(CSR_REG_MCAUSE, &mcause);
+  // Shuffle the mcause bits into the uppermost byte of the word and report
+  // the cause as kErrorInterrupt.
+  // Based on the ibex verilog, it appears that the most significant bit
+  // indicates whether the cause is an exception (0) or external interrupt (1),
+  // and the 5 least significant bits indicate which exception/interrupt.
+  //
+  // Preserve the MSB and shift the 7 LSBs into the upper byte.
+  // (we preserve 7 instead of 5 because the verilog hardcodes the unused bits
+  // as zero and those would be the next bits used should the number of
+  // interrupt causes increase).
+  mcause = (mcause & 0x80000000) | ((mcause & 0x7f) << 24);
+  return kErrorInterrupt + mcause;
+}
+
+/**
+ * Performs once-per-boot initialization of ROM modules and peripherals.
+ */
+OT_WARN_UNUSED_RESULT
+static rom_error_t rom_init(void) {
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomInit, 1);
+
+  dbg_printf("Starting 2nd stage ROM\r\n");
+
+  // Reset MMIO counters
+  sec_mmio_next_stage_init();
+
+  // Set static_critical region format version.
+  static_critical_version = kStaticCriticalVersion1;
+
+  lc_state = lifecycle_state_get();
+
+  // Re-initialize the watchdog timer.
+  watchdog_init(lc_state);
+  SEC_MMIO_WRITE_INCREMENT(kWatchdogSecMmioInit);
+
+  // Update in-memory copy of the ePMP register configuration.
+  second_rom_epmp_state_init(lc_state);
+  HARDENED_RETURN_IF_ERROR(epmp_state_check());
+
+  // Check that AST is in the expected state.
+  HARDENED_RETURN_IF_ERROR(ast_check(lc_state));
+
+  // This function is a NOP unless ROM is built for an fpga.
+  device_fpga_version_print();
+
+  sec_mmio_check_values(rnd_uint32());
+  sec_mmio_check_counters(/*expected_check_count=*/1);
+
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomInit, 2);
+  return kErrorOk;
+}
+
+/* These symbols are defined in
+ * `sw/device/silicon_creator/rom/second_rom.ld`, and describes the
+ * location of the flash header.
+ */
+extern char _rom_ext_virtual_start[];
+extern char _rom_ext_virtual_size[];
+/**
+ * Compute the virtual address corresponding to the physical address `lma_addr`.
+ *
+ * @param manifest Pointer to the current manifest.
+ * @param lma_addr Load address or physical address.
+ * @return the computed virtual address.
+ */
+OT_WARN_UNUSED_RESULT
+static inline uintptr_t rom_ext_vma_get(const manifest_t *manifest,
+                                        uintptr_t lma_addr) {
+  return (lma_addr - (uintptr_t)manifest + (uintptr_t)_rom_ext_virtual_start);
+}
+
+/**
+ * Performs consistency checks before booting a ROM_EXT.
+ *
+ * All of the checks in this function are expected to pass and any failures
+ * result in shutdown.
+ */
+static void rom_pre_boot_check(void) {
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomPreBootCheck, 1);
+
+  // Check the alert_handler configuration.
+  SHUTDOWN_IF_ERROR(alert_config_check(lc_state));
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomPreBootCheck, 2);
+
+  // Check cached life cycle state against the value reported by hardware.
+  lifecycle_state_t lc_state_check = lifecycle_state_get();
+  if (launder32(lc_state_check) != lc_state) {
+    HARDENED_TRAP();
+  }
+  HARDENED_CHECK_EQ(lc_state_check, lc_state);
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomPreBootCheck, 3);
+
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomPreBootCheck, 4);
+
+  // Check the ePMP state
+  SHUTDOWN_IF_ERROR(epmp_state_check());
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomPreBootCheck, 5);
+
+  // Check the cpuctrl CSR.
+  uint32_t cpuctrl_csr;
+  uint32_t cpuctrl_otp =
+      otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_CPUCTRL_OFFSET);
+  CSR_READ(CSR_REG_CPUCTRL, &cpuctrl_csr);
+  // We only mask the 8th bit (`ic_scr_key_valid`) to include exception flags
+  // (bits 6 and 7) in the check.
+  cpuctrl_csr = bitfield_bit32_write(cpuctrl_csr, 8, false);
+  if (launder32(cpuctrl_csr) != cpuctrl_otp) {
+    HARDENED_TRAP();
+  }
+  HARDENED_CHECK_EQ(cpuctrl_csr, cpuctrl_otp);
+  // Check rstmgr alert and cpu info collection configuration.
+  SHUTDOWN_IF_ERROR(
+      rstmgr_info_en_check(retention_sram_get()->creator.reset_reasons));
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomPreBootCheck, 6);
+
+  sec_mmio_check_counters(/*expected_check_count=*/2);
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomPreBootCheck, 7);
+}
+
+/* Function that alerts to the UART we are waiting for a JTAG bootstrap, and
+ * then busy waits to allow it to occur. This function never returns because we
+ * expect the host performing the bootstrap to reset the chip afterwards.
+ */
+void wait_for_jtag_bootstrap(void) {
+  dbg_printf("No valid ECDSA key found in CTN. Waiting for JTAG bootstrap.\n");
+  while (true) {
+  }
+}
+
+/**
+ * Attempts to boot ROM_EXT.
+ *
+ * @return Result of the last attempt.
+ */
+OT_WARN_UNUSED_RESULT
+static rom_error_t rom_try_boot(void) {
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomTryBoot, 1);
+  CFI_FUNC_COUNTER_PREPCALL(rom_counters, kCfiRomTryBoot, 2,
+                            kCfiRomPreBootCheck);
+  rom_pre_boot_check();
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomTryBoot, 4);
+  CFI_FUNC_COUNTER_CHECK(rom_counters, kCfiRomPreBootCheck, 8);
+
+  uintptr_t rom_ext_lma = TOP_DRAGONFLY_SOC_PROXY_RAM_CTN_BASE_ADDR;
+
+  // TODO: Load ROM extension from flash, through SPI host,
+  //       at rom_ext_lma (shared SRAM).
+
+  // TODO: Verify ROM extension.
+
+  // TODO: Remap the ROM ext virtual region to shared SRAM.
+  // Use a reserved remapper, that must not be used by ROM patches.
+  // HARDENED_RETURN_IF_ERROR(
+  //    ibex_addr_remap_set(1, (uintptr_t)_rom_ext_virtual_start, rom_ext_lma,
+  //                        (size_t)_rom_ext_virtual_size));
+  HARDENED_RETURN_IF_ERROR(epmp_state_check());
+
+  // TODO: Do not hardcode the start and end offset for the ePMP region.
+  second_rom_epmp_unlock_rom_ext(
+      text_region,
+      (epmp_region_t){.start = rom_ext_lma,
+                      .end = rom_ext_lma + (uintptr_t)_rom_ext_virtual_size});
+
+  dbg_printf("Jumping to ROM_EXT entry point at 0x%x\r\n",
+             (unsigned)entry_point);
+  ((rom_ext_entry_point *)entry_point)();
+
+  return kErrorRomBootFailed;
+}
+
+void second_rom_main(void) {
+  CFI_FUNC_COUNTER_INIT(rom_counters, kCfiRomMain);
+
+  CFI_FUNC_COUNTER_PREPCALL(rom_counters, kCfiRomMain, 1, kCfiRomInit);
+  SHUTDOWN_IF_ERROR(rom_init());
+  CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomMain, 3);
+  CFI_FUNC_COUNTER_CHECK(rom_counters, kCfiRomInit, 3);
+
+  // `rom_try_boot` will not return unless there is an error.
+  CFI_FUNC_COUNTER_PREPCALL(rom_counters, kCfiRomMain, 4, kCfiRomTryBoot);
+  shutdown_finalize(rom_try_boot());
+}
+
+void rom_interrupt_handler(void) {
+  register rom_error_t error asm("a0") = rom_irq_error();
+  asm volatile("tail shutdown_finalize;" ::"r"(error));
+  OT_UNREACHABLE();
+}
+
+// We only need a single handler for all ROM interrupts, but we want to
+// keep distinct symbols to make writing tests easier.  In the ROM,
+// alias all interrupt handler symbols to the single handler.
+OT_ALIAS("rom_interrupt_handler")
+noreturn void rom_exception_handler(void);
+
+OT_ALIAS("rom_interrupt_handler")
+noreturn void rom_nmi_handler(void);

--- a/sw/device/silicon_creator/rom/second_rom.c
+++ b/sw/device/silicon_creator/rom/second_rom.c
@@ -14,6 +14,7 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/stdasm.h"
+#include "sw/device/silicon_creator/lib/acc_boot_services.h"
 #include "sw/device/silicon_creator/lib/base/boot_measurements.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/base/static_critical_version.h"
@@ -34,6 +35,7 @@
 #include "sw/device/silicon_creator/lib/drivers/watchdog.h"
 #include "sw/device/silicon_creator/lib/epmp_state.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/manifest.h"
 #include "sw/device/silicon_creator/lib/shutdown.h"
 #include "sw/device/silicon_creator/lib/sigverify/sigverify.h"
 #include "sw/device/silicon_creator/rom/second_rom_epmp.h"
@@ -84,6 +86,10 @@ CFI_DEFINE_COUNTERS(rom_counters, ROM_CFI_FUNC_COUNTERS_TABLE);
 
 // Life cycle state of the chip.
 lifecycle_state_t lc_state = (lifecycle_state_t)0;
+// Boot data from flash.
+boot_data_t boot_data = {0};
+// First stage (ROM-->ROM_EXT) secure boot keys loaded from OTP.
+static sigverify_otp_key_ctx_t sigverify_ctx;
 
 OT_ALWAYS_INLINE
 OT_WARN_UNUSED_RESULT
@@ -234,20 +240,95 @@ static rom_error_t rom_try_boot(void) {
   CFI_FUNC_COUNTER_CHECK(rom_counters, kCfiRomPreBootCheck, 8);
 
   uintptr_t rom_ext_lma = TOP_DRAGONFLY_SOC_PROXY_RAM_CTN_BASE_ADDR;
+  const manifest_t *manifest = (const manifest_t *)rom_ext_lma;
 
-  // TODO: Load ROM extension from flash, through SPI host,
-  //       at rom_ext_lma (shared SRAM).
-
-  // TODO: Verify ROM extension.
-
-  // TODO: Remap the ROM ext virtual region to shared SRAM.
-  // Use a reserved remapper, that must not be used by ROM patches.
-  // HARDENED_RETURN_IF_ERROR(
-  //    ibex_addr_remap_set(1, (uintptr_t)_rom_ext_virtual_start, rom_ext_lma,
-  //                        (size_t)_rom_ext_virtual_size));
   HARDENED_RETURN_IF_ERROR(epmp_state_check());
 
-  // TODO: Do not hardcode the start and end offset for the ePMP region.
+  // Load secure boot keys from OTP into RAM.
+  HARDENED_RETURN_IF_ERROR(sigverify_otp_keys_init(&sigverify_ctx));
+
+  // Load ACC boot services app.
+  //
+  // This will be reused by later boot stages.
+  HARDENED_RETURN_IF_ERROR(acc_boot_app_load());
+
+  // ECDSA key.
+  const ecdsa_p256_public_key_t *ecdsa_key = NULL;
+  rom_error_t err = sigverify_ecdsa_p256_key_get(
+      &sigverify_ctx,
+      sigverify_ecdsa_p256_key_id_get(&manifest->ecdsa_public_key), lc_state,
+      &ecdsa_key);
+  if (err != kErrorOk) {
+    HARDENED_CHECK_NE(err, kErrorOk);
+    switch (launder32(lc_state)) {
+      case kLcStateProd:
+        // No JTAG bootstrap available in PROD.
+        HARDENED_CHECK_EQ(lc_state, kLcStateProd);
+        return err;
+      case kLcStateProdEnd:
+        // No JTAG bootstrap available in PROD_END.
+        HARDENED_CHECK_EQ(lc_state, kLcStateProdEnd);
+        return err;
+      case kLcStateTest:
+        HARDENED_CHECK_EQ(lc_state, kLcStateTest);
+        wait_for_jtag_bootstrap();
+        OT_UNREACHABLE();
+      case kLcStateDev:
+        HARDENED_CHECK_EQ(lc_state, kLcStateDev);
+        wait_for_jtag_bootstrap();
+        OT_UNREACHABLE();
+      case kLcStateRma:
+        HARDENED_CHECK_EQ(lc_state, kLcStateRma);
+        wait_for_jtag_bootstrap();
+        OT_UNREACHABLE();
+      default:
+        HARDENED_TRAP();
+        OT_UNREACHABLE();
+    }
+  }
+
+  // Measure ROM_EXT and portions of manifest via SHA256 digest.
+  hmac_sha256_init();
+
+  // Add manifest usage constraints to the measurement.
+  manifest_usage_constraints_t usage_constraints_from_hw;
+  sigverify_usage_constraints_get(manifest->usage_constraints.selector_bits,
+                                  &usage_constraints_from_hw);
+  hmac_sha256_update(&usage_constraints_from_hw,
+                     sizeof(usage_constraints_from_hw));
+
+  // Add remaining part of manifest / ROM_EXT image to the measurement.
+  manifest_digest_region_t digest_region = manifest_digest_region_get(manifest);
+  hmac_sha256_update(digest_region.start, digest_region.length);
+  hmac_sha256_process();
+  hmac_digest_t act_digest;
+  hmac_sha256_final(&act_digest);
+
+  // Actually verify the manifest / ROM_EXT
+  uint32_t flash_exec = 0;
+  HARDENED_RETURN_IF_ERROR(sigverify_ecdsa_p256_verify(
+      &manifest->ecdsa_signature, ecdsa_key, &act_digest, &flash_exec));
+
+  // Set up virtual addressing for ROM_EXT.
+  if (manifest->address_translation != kHardenedBoolTrue) {
+    return kErrorRomBootFailed;
+  }
+  HARDENED_CHECK_EQ(manifest->address_translation, kHardenedBoolTrue);
+  epmp_region_t text_region = manifest_code_region_get(manifest);
+  uintptr_t entry_point = manifest_entry_point_get(manifest);
+  HARDENED_CHECK_EQ(manifest->address_translation, kHardenedBoolTrue);
+  ibex_addr_remap_set(0, (uintptr_t)_rom_ext_virtual_start, (uintptr_t)manifest,
+                      (size_t)_rom_ext_virtual_size);
+  SEC_MMIO_WRITE_INCREMENT(kAddressTranslationSecMmioConfigure);
+
+  // Move the ROM_EXT execution section from the load address to the virtual
+  // address.
+  text_region.start = rom_ext_vma_get(manifest, text_region.start);
+  text_region.end = rom_ext_vma_get(manifest, text_region.end);
+  entry_point = rom_ext_vma_get(manifest, entry_point);
+
+  // Unlock read-only for the whole rom_ext virtual memory.
+  HARDENED_RETURN_IF_ERROR(epmp_state_check());
   second_rom_epmp_unlock_rom_ext(
       text_region,
       (epmp_region_t){.start = rom_ext_lma,

--- a/sw/device/silicon_creator/rom/second_rom.c
+++ b/sw/device/silicon_creator/rom/second_rom.c
@@ -310,29 +310,31 @@ static rom_error_t rom_try_boot(void) {
       &manifest->ecdsa_signature, ecdsa_key, &act_digest, &flash_exec));
 
   // Set up virtual addressing for ROM_EXT.
-  if (manifest->address_translation != kHardenedBoolTrue) {
-    return kErrorRomBootFailed;
-  }
-  HARDENED_CHECK_EQ(manifest->address_translation, kHardenedBoolTrue);
   epmp_region_t text_region = manifest_code_region_get(manifest);
   uintptr_t entry_point = manifest_entry_point_get(manifest);
-  HARDENED_CHECK_EQ(manifest->address_translation, kHardenedBoolTrue);
-  ibex_addr_remap_set(0, (uintptr_t)_rom_ext_virtual_start, (uintptr_t)manifest,
-                      (size_t)_rom_ext_virtual_size);
-  SEC_MMIO_WRITE_INCREMENT(kAddressTranslationSecMmioConfigure);
 
-  // Move the ROM_EXT execution section from the load address to the virtual
-  // address.
-  text_region.start = rom_ext_vma_get(manifest, text_region.start);
-  text_region.end = rom_ext_vma_get(manifest, text_region.end);
-  entry_point = rom_ext_vma_get(manifest, entry_point);
+  // Enable address translation if it is enabled in the manifest.
+  if (manifest->address_translation == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(manifest->address_translation, kHardenedBoolTrue);
+    ibex_addr_remap_set(0, (uintptr_t)_rom_ext_virtual_start,
+                        (uintptr_t)manifest, (size_t)_rom_ext_virtual_size);
+    SEC_MMIO_WRITE_INCREMENT(kAddressTranslationSecMmioConfigure);
+    // Move the ROM_EXT execution section from the load address to the virtual
+    // address.
+    text_region.start = rom_ext_vma_get(manifest, text_region.start);
+    text_region.end = rom_ext_vma_get(manifest, text_region.end);
+    entry_point = rom_ext_vma_get(manifest, entry_point);
+  } else {
+    HARDENED_CHECK_EQ(manifest->address_translation, kHardenedBoolFalse);
+  }
 
-  // Unlock read-only for the whole rom_ext virtual memory.
+  // Unlock read-only for the whole rom_ext [virtual] memory.
   HARDENED_RETURN_IF_ERROR(epmp_state_check());
   second_rom_epmp_unlock_rom_ext(
       text_region,
       (epmp_region_t){.start = rom_ext_lma,
-                      .end = rom_ext_lma + (uintptr_t)_rom_ext_virtual_size});
+                      .end = rom_ext_lma + (uintptr_t)_rom_ext_virtual_size},
+      manifest->address_translation);
 
   dbg_printf("Jumping to ROM_EXT entry point at 0x%x\r\n",
              (unsigned)entry_point);

--- a/sw/device/silicon_creator/rom/second_rom.h
+++ b/sw/device/silicon_creator/rom/second_rom.h
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_SECOND_ROM_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_SECOND_ROM_H_
+
+#include <stdnoreturn.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Denotes functions that have to use the interrupt handler ABI.
+ *
+ * These must be 4-byte aligned. Note that they don't use the `interrupt`
+ * attribute since ROM handlers shut down the chip instead of returning like
+ * regular handlers.
+ */
+#define ROM_INTERRUPT_HANDLER_ABI __attribute__((aligned(4)))
+
+/**
+ * Denotes functions that have to be near the interrupt vector, because they
+ * are jumped to from it.
+ */
+#define ROM_VECTOR_FUNCTION __attribute__((section(".crt")))
+
+/**
+ * The first assembly procedure executed by the ROM (defined in
+ * `rom.S`).
+ *
+ * This procedure does not obey the standard RISC-V calling convention, so it
+ * must not be called from other C code.
+ */
+ROM_VECTOR_FUNCTION
+noreturn void _second_rom_start_boot(void);
+
+/**
+ * The first C function executed by the ROM (defined in `rom.c`)
+ */
+noreturn void second_rom_main(void);
+
+/**
+ * ROM hardware exception handler.
+ */
+ROM_VECTOR_FUNCTION
+ROM_INTERRUPT_HANDLER_ABI
+noreturn void second_rom_interrupt_handler(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_SECOND_ROM_H_

--- a/sw/device/silicon_creator/rom/second_rom.ld
+++ b/sw/device/silicon_creator/rom/second_rom.ld
@@ -1,0 +1,192 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Linker script for an OpenTitan ROM.
+ *
+ * Portions of this file are Ibex-specific.
+ */
+
+OUTPUT_ARCH(riscv)
+
+/**
+ * Indicate that there are no dynamic libraries, whatsoever.
+ */
+__DYNAMIC = 0;
+
+INCLUDE hw/top_dragonfly/sw/autogen/top_dragonfly_memory.ld
+
+/**
+ * The Second ROM boot address, which indicates the location of the initial
+ * interrupt vector.
+ */
+_second_rom_boot_address = ORIGIN(rom1);
+
+/**
+ * Symbols to be used in the setup of the address translation for ROM_EXT.
+ */
+_rom_ext_virtual_start = ORIGIN(rom_ext_virtual);
+_rom_ext_virtual_size = LENGTH(rom_ext_virtual);
+ASSERT((_rom_ext_virtual_size <= (LENGTH(ram_ctn))),
+  "Error: rom ext is bigger than slot.");
+
+/* DV Log offset (has to be different to other boot stages). */
+_dv_log_offset = 0x0;
+
+/**
+ * This symbol is used as a jump target when an error is detected by the
+ * hardened shadow call stack implementation. We set it to 0 which will
+ * trigger an instruction access exception.
+ *
+ * If a compiler without hardened shadow call stack support is used this
+ * symbol will be ignored.
+ */
+__abi_shutdown$ = 0x0;
+
+/**
+ * Physical Memory Protection (PMP) encoded address register values.
+ *
+ * Some addresses required for PMP entries are known only at link time.
+ * These addresses are encoded here so that no calculations need to be
+ * performed at runtime.
+ *
+ * See The RISC-V Instruction Set Manual Volume II: Privileged Architecture
+ * for more information about PMP address register encodings.
+ */
+_epmp_second_text_tor_lo = _text_start / 4;
+_epmp_second_text_tor_hi = _text_end / 4;
+
+ENTRY(_second_rom_start_boot);
+
+/**
+ * NOTE: We have to align each section to word boundaries as our current
+ * s19->slm conversion scripts are not able to handle non-word aligned sections.
+ */
+SECTIONS {
+  /**
+   * Ibex interrupt vector. See rom_init.S for more information.
+   *
+   * This has to be set up at the boot address, so that execution jumps to the
+   * reset handler correctly.
+   */
+  .vectors _second_rom_boot_address : ALIGN(256) {
+    _text_start = .;
+    KEEP(*(.vectors))
+  } > rom1
+
+  /**
+   * C runtime (CRT) section, containing program initialization code.
+   *
+   * This is a separate section to `.text` so that the jumps inside `.vectors`
+   * will fit into the instruction encoding.
+   */
+  .crt : ALIGN(4) {
+    /* Pad with zeros. */
+    FILL(0x0000)
+    KEEP(*(.crt))
+    /* .crt must fit in the ePMP RX region at reset. */
+    ASSERT(
+        SIZEOF(.vectors) + SIZEOF(.crt) <= _epmp_reset_rx_size,
+        "Error: .crt overflows reset ePMP region");
+    . = MAX(., _epmp_reset_rx_size - SIZEOF(.vectors));
+  } > rom1
+
+  /**
+   * Standard text section, containing program code.
+   */
+  .text : ALIGN(4) {
+    *(.text)
+    *(.text.*)
+
+
+    /* Ensure section end is word-aligned. */
+    . = ALIGN(4);
+  } > rom1
+
+  /**
+   * Shutdown text section, containing shutdown function(s).
+   *
+   * This must be the last executable section in the ROM.
+   */
+  .shutdown : ALIGN(4) {
+    *(.shutdown)
+    *(.shutdown.*)
+
+    /* Ensure section end is word-aligned. */
+    . = ALIGN(4);
+    _text_end = .;
+  } > rom1
+
+  /**
+   * Read-only data section, containing all large compile-time constants, like
+   * strings.
+   */
+  .rodata : ALIGN(4) {
+    /* Small read-only data comes before regular read-only data for the same
+     * reasons as in the data section */
+    *(.srodata)
+    *(.srodata.*)
+    *(.rodata)
+    *(.rodata.*)
+  } > rom1
+
+  /**
+   * Critical static data that is accessible by both the ROM and the ROM
+   * extension.
+   */
+  INCLUDE sw/device/silicon_creator/lib/base/static_critical.ld
+
+  /**
+   * OpenTitan ROM does not have a mutable `.data` section.
+   */
+  .data (NOLOAD) : {
+    *(.sdata)
+    *(.sdata.*)
+    *(.data)
+    *(.data.*)
+
+    /* Tests are an exception to the rule that .data must be empty */
+    ASSERT(
+        (DEFINED(rom_test) ? 0 : SIZEOF(.data)) == 0,
+        "Error: .data section must be empty");
+  } > ram_main
+
+  /**
+   * Standard BSS section. This will be zeroed at runtime by the CRT.
+   */
+  .bss : ALIGN(4) {
+    _bss_start = .;
+
+    /* This will get loaded into `gp`, and the linker will use that register for
+     * accessing data within [-2048,2047] of `__global_pointer$`.
+     *
+     * This is much cheaper (for small data) than materializing the
+     * address and loading from that (which will take one extra instruction).
+     */
+    __global_pointer$ = . + 2048;
+
+    /* Small BSS should come before regular BSS. This helps to ensure small
+     * globals are within 2048 bytes of the value of `gp`, making their accesses
+     * hopefully only take one instruction. */
+    *(.sbss)
+    *(.sbss.*)
+    *(.bss)
+    *(.bss.*)
+
+    /* Ensure section end is word-aligned. */
+    . = ALIGN(4);
+    _bss_end = .;
+  } > ram_main
+
+  /**
+   * Immutable chip_info data, containing build-time-recorded information.
+   *
+   * This is the last thing in rom.
+   */
+  .chip_info _rom1_chip_info_start : ALIGN(4) {
+    KEEP(*(.chip_info))
+  } > rom1
+
+  INCLUDE sw/device/info_sections.ld
+}

--- a/sw/device/silicon_creator/rom/second_rom_epmp.c
+++ b/sw/device/silicon_creator/rom/second_rom_epmp.c
@@ -1,0 +1,140 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/rom/second_rom_epmp.h"
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/base/memory.h"
+
+#include "hw/top_dragonfly/sw/autogen/top_dragonfly.h"
+
+// Symbols defined in linker script.
+extern char _text_start[];             // Start of executable code.
+extern char _text_end[];               // End of executable code.
+extern char _rom_ext_virtual_start[];  // Start of ROM_EXT (VMA)
+extern char _rom_ext_virtual_size[];   // Size of ROM_EXT (VMA)
+
+// Note: Hardcoding these values since the way we generate this range is not
+// very robust at the moment. See
+// https://github.com/lowRISC/opentitan/issues/14345 and
+// https://github.com/lowRISC/opentitan/issues/14336.
+static_assert(TOP_DRAGONFLY_MMIO_BASE_ADDR == 0x21100000,
+              "MMIO region changed, update ePMP configuration if needed");
+static_assert(TOP_DRAGONFLY_MMIO_SIZE_BYTES == 0xF501000,
+              "MMIO region changed, update ePMP configuration if needed");
+
+static_assert(TOP_DRAGONFLY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR >=
+                      TOP_DRAGONFLY_MMIO_BASE_ADDR &&
+                  TOP_DRAGONFLY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR +
+                          TOP_DRAGONFLY_SRAM_CTRL_RET_AON_RAM_SIZE_BYTES <=
+                      TOP_DRAGONFLY_MMIO_BASE_ADDR +
+                          TOP_DRAGONFLY_MMIO_SIZE_BYTES,
+              "Retention SRAM must be in the MMIO address space.");
+
+void second_rom_epmp_state_init(lifecycle_state_t lc_state) {
+  // Bring in-memory copy in line with the changes done in second_rom_start.S
+  //
+  // Note that the ePMP registers and their in-memory copy are carried over
+  // from the Base ROM.
+  const epmp_region_t second_rom_text = {.start = (uintptr_t)_text_start,
+                                         .end = (uintptr_t)_text_end};
+  epmp_state_unconfigure(0);
+  epmp_state_unconfigure(1);
+  epmp_state_unconfigure(2);
+  epmp_state_configure_tor(5, second_rom_text, kEpmpPermLockedReadExecute);
+
+  // Open Mailbox RAM and CTN and update Debug ROM access.
+  const epmp_region_t ram_mbox = {
+      .start = TOP_DRAGONFLY_SRAM_CTRL_MBOX_RAM_BASE_ADDR,
+      .end = TOP_DRAGONFLY_SRAM_CTRL_MBOX_RAM_BASE_ADDR +
+             TOP_DRAGONFLY_SRAM_CTRL_MBOX_RAM_SIZE_BYTES};
+  const epmp_region_t ctn = {.start = TOP_DRAGONFLY_SOC_PROXY_CTN_BASE_ADDR,
+                             .end = TOP_DRAGONFLY_SOC_PROXY_CTN_BASE_ADDR +
+                                    TOP_DRAGONFLY_SOC_PROXY_CTN_SIZE_BYTES};
+  const epmp_region_t debug_rom = {.start = TOP_DRAGONFLY_RV_DM_MEM_BASE_ADDR,
+                                   .end = TOP_DRAGONFLY_RV_DM_MEM_BASE_ADDR +
+                                          TOP_DRAGONFLY_RV_DM_MEM_SIZE_BYTES};
+  epmp_perm_t debug_rom_access = kEpmpPermLockedNoAccess;
+  switch (launder32(lc_state)) {
+    case kLcStateTest:
+      HARDENED_CHECK_EQ(lc_state, kLcStateTest);
+      debug_rom_access = kEpmpPermLockedReadWriteExecute;
+      break;
+    case kLcStateDev:
+      HARDENED_CHECK_EQ(lc_state, kLcStateDev);
+      debug_rom_access = kEpmpPermLockedReadWriteExecute;
+      break;
+    case kLcStateProd:
+      HARDENED_CHECK_EQ(lc_state, kLcStateProd);
+      debug_rom_access = kEpmpPermLockedNoAccess;
+      break;
+    case kLcStateProdEnd:
+      HARDENED_CHECK_EQ(lc_state, kLcStateProdEnd);
+      debug_rom_access = kEpmpPermLockedNoAccess;
+      break;
+    case kLcStateRma:
+      HARDENED_CHECK_EQ(lc_state, kLcStateRma);
+      debug_rom_access = kEpmpPermLockedReadWriteExecute;
+      break;
+    default:
+      HARDENED_TRAP();
+  }
+  // Update the hardware configuration (CSRs).
+  //
+  //            32           24             16             8             0
+  //             +-------------+-------------+-------------+-------------+
+  // `pmpcfg2` = | `pmp11cfg`  | `pmp10cfg`  | `pmp9cfg`   | `pmp8cfg`   |
+  //             +-------------+-------------+-------------+-------------+
+  // `pmpcfg3` = | `pmp15cfg`  | `pmp14cfg`  | `pmp13cfg`  | `pmp12cfg`  |
+  //             +-------------+-------------+-------------+-------------+
+  CSR_WRITE(CSR_REG_PMPADDR9,
+            ram_mbox.start >> 2 | (ram_mbox.end - ram_mbox.start - 1) >> 3);
+  CSR_WRITE(CSR_REG_PMPADDR10, ctn.start >> 2 | (ctn.end - ctn.start - 1) >> 3);
+  CSR_WRITE(CSR_REG_PMPADDR13,
+            debug_rom.start >> 2 | (debug_rom.end - debug_rom.start - 1) >> 3);
+  CSR_CLEAR_BITS(CSR_REG_PMPCFG2, 0xffff << 8);
+  CSR_SET_BITS(CSR_REG_PMPCFG2,
+               ((kEpmpModeNapot | kEpmpPermLockedReadWrite) << 8) |
+                   ((kEpmpModeNapot | kEpmpPermLockedReadWrite) << 16));
+  CSR_CLEAR_BITS(CSR_REG_PMPCFG3, 0xff << 8);
+  CSR_SET_BITS(CSR_REG_PMPCFG3, (kEpmpModeNapot | debug_rom_access) << 8);
+  // Update in-memory copy of ePMP register state
+  epmp_state_configure_napot(9, ram_mbox, kEpmpPermLockedReadWrite);
+  epmp_state_configure_napot(10, ctn, kEpmpPermLockedReadWrite);
+  epmp_state_configure_napot(13, debug_rom, debug_rom_access);
+}
+
+void second_rom_epmp_unlock_rom_ext(epmp_region_t rom_ext_text,
+                                    epmp_region_t rom_ext_lma) {
+  const epmp_region_t rom_ext_vma = {.start = (uintptr_t)_rom_ext_virtual_start,
+                                     .end = (uintptr_t)_rom_ext_virtual_start +
+                                            (uintptr_t)_rom_ext_virtual_size};
+  // Make sure rom_ext_text is a subset of rom_ext_vma
+  HARDENED_CHECK_GE(rom_ext_text.start, rom_ext_vma.start);
+  HARDENED_CHECK_LE(rom_ext_text.end, rom_ext_vma.end);
+  // Update the hardware configuration (CSRs).
+  //
+  //            32          24          16           8           0
+  //             +-----------+-----------+-----------+-----------+
+  // `pmpcfg0` = | `pmp3cfg` | `pmp2cfg` | `pmp1cfg` | `pmp0cfg` |
+  //             +-----------+-----------+-----------+-----------+
+  CSR_WRITE(CSR_REG_PMPADDR0, rom_ext_text.start >> 2);
+  CSR_WRITE(CSR_REG_PMPADDR1, rom_ext_text.end >> 2);
+  CSR_WRITE(
+      CSR_REG_PMPADDR2,
+      rom_ext_vma.start >> 2 | (rom_ext_vma.end - rom_ext_vma.start - 1) >> 3);
+  CSR_WRITE(
+      CSR_REG_PMPADDR3,
+      rom_ext_lma.start >> 2 | (rom_ext_lma.end - rom_ext_lma.start - 1) >> 3);
+  CSR_CLEAR_BITS(CSR_REG_PMPCFG0, 0xffffffff);
+  CSR_SET_BITS(CSR_REG_PMPCFG0,
+               ((kEpmpModeNapot | kEpmpPermLockedReadOnly) << 24) |
+                   ((kEpmpModeNapot | kEpmpPermLockedReadOnly) << 16) |
+                   ((kEpmpModeTor | kEpmpPermLockedReadExecute) << 8));
+  // Update the in-memory copy of ePMP register state.
+  epmp_state_configure_tor(1, rom_ext_text, kEpmpPermLockedReadExecute);
+  epmp_state_configure_napot(2, rom_ext_vma, kEpmpPermLockedReadOnly);
+  epmp_state_configure_napot(3, rom_ext_lma, kEpmpPermLockedReadOnly);
+}

--- a/sw/device/silicon_creator/rom/second_rom_epmp.c
+++ b/sw/device/silicon_creator/rom/second_rom_epmp.c
@@ -107,13 +107,19 @@ void second_rom_epmp_state_init(lifecycle_state_t lc_state) {
 }
 
 void second_rom_epmp_unlock_rom_ext(epmp_region_t rom_ext_text,
-                                    epmp_region_t rom_ext_lma) {
+                                    epmp_region_t rom_ext_lma,
+                                    hardened_bool_t address_translation) {
   const epmp_region_t rom_ext_vma = {.start = (uintptr_t)_rom_ext_virtual_start,
                                      .end = (uintptr_t)_rom_ext_virtual_start +
                                             (uintptr_t)_rom_ext_virtual_size};
-  // Make sure rom_ext_text is a subset of rom_ext_vma
-  HARDENED_CHECK_GE(rom_ext_text.start, rom_ext_vma.start);
-  HARDENED_CHECK_LE(rom_ext_text.end, rom_ext_vma.end);
+  if (address_translation == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(address_translation, kHardenedBoolTrue);
+    // Make sure rom_ext_text is a subset of rom_ext_vma
+    HARDENED_CHECK_GE(rom_ext_text.start, rom_ext_vma.start);
+    HARDENED_CHECK_LE(rom_ext_text.end, rom_ext_vma.end);
+  } else {
+    HARDENED_CHECK_EQ(address_translation, kHardenedBoolFalse);
+  }
   // Update the hardware configuration (CSRs).
   //
   //            32          24          16           8           0

--- a/sw/device/silicon_creator/rom/second_rom_epmp.h
+++ b/sw/device/silicon_creator/rom/second_rom_epmp.h
@@ -1,0 +1,79 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_SECOND_ROM_EPMP_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_SECOND_ROM_EPMP_H_
+
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/epmp_state.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * ROM enhanced Physical Memory Protection (ePMP) library.
+ *
+ * The ePMP configuration is managed in two parts:
+ *
+ *   1. The actual hardware configuration held in CSRs
+ *   2. The in-memory copy of register values in `epmp_state_t` that is used
+ *      to verify the CSRs
+ *
+ * Every time the hardware configuration is updated the in-memory copy
+ * must also be updated. The hardware configuration is usually interacted
+ * with directly using the CSR library or assembly whereas the in-memory
+ * copy of the state should normally be modified using configuration functions
+ * from the silicon creator ePMP library.
+ *
+ * This separation of concerns allows the hardware configuration to be
+ * updated efficiently as needed (including before the C runtime is
+ * initialized) with the in-memory copy of the state used to double check the
+ * configuration as required.
+ */
+
+/**
+ * Initialise the ePMP in-memory copy of the register state to reflect the
+ * hardware configuration expected at entry to the ROM C code.
+ *
+ * The actual hardware configuration is performed separately, either by reset
+ * logic or in assembly. This code must be kept in sync with any changes
+ * to the hardware configuration.
+ *
+ * @param lc_state The current lifecycle state to check for debug enable.
+ */
+void second_rom_epmp_state_init(lifecycle_state_t lc_state);
+
+/**
+ * Unlocks the provided ROM_EXT image regions.
+ *
+ * ROM_EXT is loaded into rom_ext_lma region (i.e. CTN RAM) and it is expected
+ * that a remap has been configured from there to rom_ext_virtual region.
+ *
+ * This function will configure the following PMP rules:
+ * - rom_ext_text region: read-execute
+ * - rom_ext_virtual region: read-only
+ * - rom_ext_lma region: read-only
+ * It will also ensure that rom_ext_text region is contained into
+ * rom_ext_virtual region.
+ *
+ * The provided ePMP state is also updated to reflect the changes made to the
+ * hardware configuration.
+ * The physical region size must be power of 2 as this function uses NAPOT
+ * (Naturally-Aligned-Power-Of-Two) addressing mode.
+ *
+ * @param rom_ext_text Region in the ROM_EXT image to receive read-execute
+ *                     permission (VMA).
+ * @param rom_ext_lma Region in the ROM_EXT image to receive read-only
+ *                     permission (LMA).
+ */
+void second_rom_epmp_unlock_rom_ext(epmp_region_t rom_ext_text,
+                                    epmp_region_t rom_ext_lma);
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_SECOND_ROM_EPMP_H_

--- a/sw/device/silicon_creator/rom/second_rom_epmp.h
+++ b/sw/device/silicon_creator/rom/second_rom_epmp.h
@@ -71,7 +71,8 @@ void second_rom_epmp_state_init(lifecycle_state_t lc_state);
  *                     permission (LMA).
  */
 void second_rom_epmp_unlock_rom_ext(epmp_region_t rom_ext_text,
-                                    epmp_region_t rom_ext_lma);
+                                    epmp_region_t rom_ext_lma,
+                                    hardened_bool_t address_translation);
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/silicon_creator/rom/second_rom_epmp_init.S
+++ b/sw/device/silicon_creator/rom/second_rom_epmp_init.S
@@ -1,0 +1,109 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/epmp_defs.h"
+
+#include "hw/top_dragonfly/sw/autogen/top_dragonfly_memory.h"
+
+/**
+ * Helper macro to move v into the correct position to set the pmp{N*4+i}cfg
+ * field in the pmpcfg{N} register.
+ *
+ * Example: set value for pmp5cfg which is a field of pmpcfg1.
+ *
+ *   li   t0, CFG_INDEX(5 % 4, v)
+ *   csrw pmpcfg1, t0
+ */
+#define CFG_INDEX(i, v) ((v) << ((i)*8))
+
+/**
+ * Encode address for Top-Of-Range addressing mode.
+ */
+#define TOR(addr) ((addr) >> 2)
+
+/**
+ * Encode address and length for Naturally-Aligned-Power-Of-Two addressing
+ * mode.
+ */
+#define NAPOT(addr, len) (((addr) >> 2) | (((len) - 1) >> 3))
+
+// -----------------------------------------------------------------------------
+
+  /**
+   * The "ax" flag below is necessary to ensure that this section
+   * is allocated space in ROM by the linker.
+   */
+  .section .crt, "ax", @progbits
+
+  /**
+   * Configure the CPU's Enhanced Physical Memory Protection (ePMP) feature.
+   *
+   * This function follows the standard ILP32 calling convention but does not
+   * require a valid stack pointer, thread pointer or global pointer.
+   *
+   * May clobber temporary registers (t0-t6).
+   */
+  .balign 4
+  .global rom_epmp_init
+  .type rom_epmp_init, @function
+rom_epmp_init:
+  // Pre-encoded addresses defined in linker script.
+  .extern _epmp_text_tor_lo
+  .extern _epmp_text_tor_hi
+  .extern _epmp_stack_guard_na4
+
+  // Setup PMP address registers.
+
+  // ROM TEXT
+  la   t0, _epmp_text_tor_lo
+  csrw pmpaddr0, t0
+  la   t0, _epmp_text_tor_hi
+  csrw pmpaddr1, t0
+
+  // ROM
+  li   t0, NAPOT(TOP_DRAGONFLY_ROM_CTRL0_ROM_BASE_ADDR, TOP_DRAGONFLY_ROM_CTRL0_ROM_SIZE_BYTES)
+  csrw pmpaddr2, t0
+
+  // ROM_EXT TEXT (configured after signature verification)
+  csrw pmpaddr3, zero // ROM_EXT TEXT low
+  csrw pmpaddr4, zero // ROM_EXT TEXT high
+
+  // This used to be the eFLASH region. However, since Dragonfly does not have an eFLASH,
+  // we execute out of the shared CTN SRAM.
+  li   t0, NAPOT(TOP_DRAGONFLY_SOC_PROXY_RAM_CTN_BASE_ADDR, TOP_DRAGONFLY_SOC_PROXY_RAM_CTN_SIZE_BYTES)
+  csrw pmpaddr5, t0
+
+  // MMIO
+  li   t0, TOR(TOP_DRAGONFLY_MMIO_BASE_ADDR)
+  csrw pmpaddr10, t0
+  li   t0, TOR(TOP_DRAGONFLY_MMIO_BASE_ADDR + TOP_DRAGONFLY_MMIO_SIZE_BYTES)
+  csrw pmpaddr11, t0
+
+  // Debug ROM
+  li   t0, NAPOT(TOP_DRAGONFLY_RV_DM_MEM_BASE_ADDR, TOP_DRAGONFLY_RV_DM_MEM_SIZE_BYTES)
+  csrw pmpaddr13, t0
+
+  // Stack guard
+  la   t0, _epmp_stack_guard_na4
+  csrw pmpaddr14, t0
+
+  // RAM
+  li   t0, NAPOT(TOP_DRAGONFLY_SRAM_CTRL_MAIN_RAM_BASE_ADDR, TOP_DRAGONFLY_SRAM_CTRL_MAIN_RAM_SIZE_BYTES)
+  csrw pmpaddr15, t0
+
+  // Set PMP configuration registers.
+  li   t0, CFG_INDEX(1  % 4, EPMP_CFG_A_TOR   | EPMP_CFG_LRX) | /* ROM TEXT    */ \
+           CFG_INDEX(2  % 4, EPMP_CFG_A_NAPOT | EPMP_CFG_LR)    /* ROM         */
+  li   t1, CFG_INDEX(5  % 4, EPMP_CFG_A_NAPOT | EPMP_CFG_LR)    /* eFLASH      */
+  li   t2, CFG_INDEX(11 % 4, EPMP_CFG_A_TOR   | EPMP_CFG_LRW)   /* MMIO        */
+  li   t3, CFG_INDEX(13 % 4, EPMP_CFG_A_NAPOT | EPMP_CFG_LRWX)| /* Debug ROM   */ \
+           CFG_INDEX(14 % 4, EPMP_CFG_A_NA4   | EPMP_CFG_L)   | /* Stack Guard */ \
+           CFG_INDEX(15 % 4, EPMP_CFG_A_NAPOT | EPMP_CFG_LRW)   /* RAM         */
+  csrw pmpcfg0, t0
+  csrw pmpcfg1, t1
+  csrw pmpcfg2, t2
+  csrw pmpcfg3, t3
+
+  ret
+  .size rom_epmp_init, .-rom_epmp_init

--- a/sw/device/silicon_creator/rom/second_rom_start.S
+++ b/sw/device/silicon_creator/rom/second_rom_start.S
@@ -1,0 +1,234 @@
+// Copyright lowRISC contributors.
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hw/top_dragonfly/sw/autogen/top_dragonfly_memory.h"
+#include "sw/device/lib/base/hardened_asm.h"
+#include "sw/device/lib/base/multibits_asm.h"
+#include "sw/device/silicon_creator/lib/base/chip.h"
+#include "hw/top/aon_timer_regs.h"
+#include "hw/top/ast_regs.h"
+#include "hw/top/clkmgr_regs.h"
+#include "hw/top/csrng_regs.h"
+#include "hw/top/edn_regs.h"
+#include "hw/top/gpio_regs.h"
+#include "hw/top/lc_ctrl_regs.h"
+#include "hw/top/otp_ctrl_regs.h"
+#include "hw/top/pinmux_regs.h"
+#include "hw/top/pwrmgr_regs.h"
+#include "hw/top/rv_core_ibex_regs.h"
+#include "hw/top/sram_ctrl_regs.h"
+
+// This macro defines convenience labels for tests that use a debugger.
+#define LABEL_FOR_TEST(kName_) .local kName_ ; kName_: ;
+
+.equ UNIMP, 0xc0001073
+.extern _epmp_second_text_tor_lo
+.extern _epmp_second_text_tor_hi
+/**
+ * ROM interrupt vectors.
+ */
+
+  // Push ROM interrupt vector options.
+  .option push
+
+  // Disable RISC-V instruction compression: we need all instructions to
+  // be exactly word wide in the interrupt vector.
+  .option norvc
+
+  // Disable RISC-V linker relaxation, as it can compress instructions at
+  // link-time, which we also really don't want.
+  .option norelax
+
+  /**
+   * Initial RISC-V vectored exception/interrupt handlers.
+   *
+   * After reset, all interrupts are disabled. Only exceptions (interrupt 0) and
+   * non-maskable interrupts (interrupt 31) are possible. For simplicity,
+   * however, we just set all interrupt handlers to the same exception handler.
+   *
+   * Since the C runtime is not initialized immediately after reset, the initial
+   * interrupt vector must only call functions written in assembly. Once the C
+   * runtime is intialized, the interrupt vector should be replaced.
+   *
+   * If the hardware is operating correctly, the assembly interrupt handlers
+   * should never be called.
+   *
+   * Note that the Ibex reset handler (entry point) immediately follows this
+   * interrupt vector and can be thought of as an extra entry.
+   *
+   * More information about Ibex's interrupts can be found here:
+   *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
+   */
+  .section .vectors, "ax"
+  .balignl 256, UNIMP
+  .global _rom_interrupt_vector_asm
+  .type _rom_interrupt_vector_asm, @function
+_rom_interrupt_vector_asm:
+  // Each jump instruction must be exactly 4 bytes in order to ensure that the
+  // entries are properly located.
+  .rept 32
+  j _asm_exception_handler
+  .endr
+
+  // Second ROM entry point
+  j _second_rom_start_boot
+  .size _rom_interrupt_vector_asm, .-_rom_interrupt_vector_asm
+
+// -----------------------------------------------------------------------------
+
+  /**
+   * Post C runtime initialization RISC-V vectored exception/interrupt handlers.
+   */
+  .balignl 256, UNIMP
+  .global _rom_interrupt_vector_c
+  .type _rom_interrupt_vector_c, @function
+_rom_interrupt_vector_c:
+  // Entry 0: exception handler.
+  j rom_exception_handler
+
+  // Entries 1-30: interrupt handlers.
+  .rept 30
+  j rom_interrupt_handler
+  .endr
+
+  // Entry 31: non-maskable interrupt handler.
+  j rom_nmi_handler
+  .size _rom_interrupt_vector_c, .-_rom_interrupt_vector_c
+
+  // Pop ROM interrupt vector options.
+  //
+  // Re-enable compressed instructions, linker relaxation.
+  .option pop
+
+  /**
+   * ROM shadow stack.
+   */
+  .section .bss
+  .balignl 4, UNIMP
+  .global _rom_shadow_stack
+  .type _rom_shadow_stack, @object
+_rom_shadow_stack:
+  .zero 256 * 4
+  .size _rom_shadow_stack, .-_rom_shadow_stack
+
+// -----------------------------------------------------------------------------
+
+/**
+ * ROM runtime initialization code.
+ */
+
+  // NOTE: The "ax" flag below is necessary to ensure that this section
+  // is allocated executable space in ROM by the linker.
+  .section .crt, "ax"
+
+  // Linker relaxations are disabled until `gp` is set below, because otherwise
+  // some sequences may be turned into `gp`-relative sequences, which is
+  // incorrect when `gp` is not initialized.
+  .option push
+  .option norelax
+
+  /**
+   * Entry point after base ROM.
+   */
+  .balignl 4, UNIMP
+  .global _second_rom_start_boot
+  .type _second_rom_start_boot, @function
+_second_rom_start_boot:
+  // Set up the global pointer and re-enable linker relaxations.
+  la gp, __global_pointer$
+  .option pop
+
+.L_clean_device_state:
+  /**
+   * Clean Device State Part 1 (Please refer to `boot.md` section "Cleaning Device
+   * State").
+   */
+
+  // Zero all writable registers except for `gp` (`x3`) since it's already initialized.
+  li x1,  0x0
+  li x2,  0x0
+  li x4,  0x0
+  li x5,  0x0
+  li x6,  0x0
+  li x7,  0x0
+  li x8,  0x0
+  li x9,  0x0
+  li x10, 0x0
+  li x11, 0x0
+  li x12, 0x0
+  li x13, 0x0
+  li x14, 0x0
+  li x15, 0x0
+  li x16, 0x0
+  li x17, 0x0
+  li x18, 0x0
+  li x19, 0x0
+  li x20, 0x0
+  li x21, 0x0
+  li x22, 0x0
+  li x23, 0x0
+  li x24, 0x0
+  li x25, 0x0
+  li x26, 0x0
+  li x27, 0x0
+  li x28, 0x0
+  li x29, 0x0
+  li x30, 0x0
+  li x31, 0x0
+
+  // 2nd stage PMP setting
+  // Reset ROM0 slots
+  li   t0, 0
+  csrw pmpaddr0, t0
+  csrw pmpaddr1, t0
+  csrw pmpaddr2, t0
+  csrw pmpcfg0, t0
+  // Update end of text region for ROM1
+  la   t0, _epmp_second_text_tor_hi
+  csrw pmpaddr5, t0
+
+  /**
+   * Setup C Runtime
+   */
+
+  // Initialize the `.bss` section.
+  la   a0, _bss_start
+  la   a1, _bss_end
+  call crt_section_clear
+
+  // Set up stack pointer.
+  //
+  // In RISC-V, the stack grows downwards, so we load the address of the highest
+  // word in the stack into sp.
+  //
+  // If an exception fires, the handler is conventionally only allowed to clobber
+  // memory at addresses below `sp`.
+  la sp, _stack_end
+
+  // Set up shadow stack pointer.
+  //
+  // The shadow stack, unlike the regular stack, grows upwards.
+  la x18, _rom_shadow_stack
+
+
+  // Set exception/interrupt handlers.
+  //
+  // Now that the C runtime is initialized it is safe to use C functions as
+  // exception/interrupt handlers.
+  //
+  // Note: the increment just sets the low bits to 0b01 which is the vectored
+  // mode setting.
+  la   t0, (_rom_interrupt_vector_c + 1)
+  csrw mtvec, t0
+
+  /**
+   * Jump to C Code
+   */
+  tail second_rom_main
+  unimp
+  unimp
+  unimp
+  unimp
+  .size _second_rom_start_boot, .-_second_rom_start_boot


### PR DESCRIPTION
This PR backports the second-stage ROM for integrated top-level designs, which was originally developed primary by @sameo on the `integrated-dev` branch.

Also included are a few new features that were not present in the original implementation:
- A sigverify toolchain for verifying ROM_EXT by @pqcfox 
- An update to the ePMP setup step that enables the ROM to work on `exec_env`s where Ibex virtual addressing is disabled.