### PR TITLE
[acc] Auto-discover in-tree LLVM toolchain in find_tool

### DIFF
--- a/hw/ip/acc/util/acc_as.py
+++ b/hw/ip/acc/util/acc_as.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 # Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192).
@@ -1245,12 +1246,8 @@ def run_c_preprocessor(out_dir: str, inputs: List[str], copts: List[str]) -> Lis
     return inputs_pre
 
 
-def run_binutils_as(other_args: List[str], inputs: List[str]) -> int:
-    '''Run binutils' as on transformed inputs
-
-    Performs no output redirection and returns the process's exit code.
-
-    '''
+def run_as(other_args: List[str], inputs: List[str]) -> int:
+    '''Assemble transformed inputs; return the exit code. Assembler is clang.'''
     as_name = find_tool('as')
 
     default_args = [
@@ -1349,7 +1346,7 @@ def main(argv: List[str]) -> int:
                 # done.
                 return 0
 
-            return run_binutils_as(transformed, other_args)
+            return run_as(transformed, other_args)
 
 
 if __name__ == '__main__':

--- a/hw/ip/acc/util/shared/toolchain.py
+++ b/hw/ip/acc/util/shared/toolchain.py
@@ -1,8 +1,42 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+import glob
 import os
+from typing import Optional
+
+
+# GNU-style tool name -> the binary the in-tree LLVM toolchain provides.
+_LLVM_TOOL_NAMES = {
+    'gcc': 'clang',
+    'as': 'clang',
+    'ld': 'ld.lld',
+    'ar': 'llvm-ar',
+    'objcopy': 'llvm-objcopy',
+    'objdump': 'llvm-objdump',
+}
+
+
+def _find_bazel_llvm_tool(tool_name: str) -> Optional[str]:
+    '''Find tool_name in the Bazel LLVM toolchain under bazel-*/external/.'''
+    llvm_name = _LLVM_TOOL_NAMES.get(tool_name)
+    if llvm_name is None:
+        return None
+
+    repo_root = os.path.dirname(os.path.abspath(__file__))
+    while not os.path.exists(os.path.join(repo_root, 'MODULE.bazel')):
+        parent = os.path.dirname(repo_root)
+        if parent == repo_root:
+            return None
+        repo_root = parent
+
+    # The repo dir carries bzlmod-version prefixes; match its stable suffix.
+    pattern = os.path.join(repo_root, 'bazel-*', 'external',
+                           '*llvm_toolchain_llvm', 'bin', llvm_name)
+    matches = sorted(glob.glob(pattern))
+    return matches[0] if matches else None
 
 
 def find_tool(tool_name: str) -> str:
@@ -15,10 +49,11 @@ def find_tool(tool_name: str) -> str:
     2. Use the path set in $TOOLCHAIN_PATH/bin/riscv32-unknown-elf-<tool_name>.
     3. Look for riscv32-unknown-elf-<tool_name> in the system PATH.
     4. Look in the default toolchain install location, /tools/riscv/bin.
+    5. Fall back to the in-tree LLVM toolchain under bazel-*/external/.
 
     For methods (1) and (2), if the expected environment variable is set but
-    the tool isn't found, an error is printed. An error is also printed if
-    neither environment variables is set and methods (3) and (4) fail.
+    the tool isn't found, an error is raised. An error is also raised if none
+    of methods (1)-(5) find the tool.
     '''
     tool_env_var = 'RV32_TOOL_' + tool_name.upper()
     configured_tool_path = os.environ.get(tool_env_var)
@@ -49,10 +84,18 @@ def find_tool(tool_name: str) -> str:
         if os.path.exists(tool_path):
             return tool_path
 
-    raise RuntimeError('Unable to find {!r} in PATH or in {!r}. Set the {!r} '
-                       'or TOOLCHAIN_PATH environment variable if you '
-                       'installed your RISC-V toolchain in an alternate '
-                       'location. (Hint: if you installed the toolchain via '
-                       'Bazel, this is likely '
-                       '\'bazel-pavona/external/lowrisc_rv32imcb_files/\' )'
-                       .format(expanded, default_location, tool_env_var))
+    # Fall back to the in-tree LLVM toolchain, so standalone runs need no setup.
+    llvm_tool_path = _find_bazel_llvm_tool(tool_name)
+    if llvm_tool_path is not None:
+        return llvm_tool_path
+
+    llvm_name = _LLVM_TOOL_NAMES.get(tool_name, expanded)
+    raise RuntimeError(
+        'Unable to find the {!r} tool. The ACC tools use the in-tree LLVM '
+        'toolchain, materialised by Bazel under bazel-*/external/, but {!r} '
+        'was not found there (nor {!r} on PATH or in {!r}). Run any Bazel '
+        'build once to fetch it (e.g. \'./bazelisk.sh build //hw/ip/acc/...\'), '
+        'then retry, or set {!r} to the tool directly (RV32_TOOL_GCC/AS must '
+        'be clang, RV32_TOOL_LD must be ld.lld).'
+        .format(tool_name, llvm_name, expanded, default_location,
+                tool_env_var))

--- a/util/acc_build.py
+++ b/util/acc_build.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 """Build software running on ACC
@@ -46,6 +47,7 @@ from typing import List, Optional, Tuple
 
 import acc_as
 import acc_ld
+from shared.toolchain import find_tool
 from elftools.elf.elffile import ELFFile, SymbolTableSection  # type: ignore
 
 
@@ -122,13 +124,12 @@ def call_acc_ld(src_files: List[Path], out_file: Path,
 
 
 def call_rv32_objcopy(args: List[str]):
-    rv32_tool_objcopy = os.environ.get('RV32_TOOL_OBJCOPY',
-                                       'riscv32-unknown-elf-objcopy')
+    rv32_tool_objcopy = os.environ.get('RV32_TOOL_OBJCOPY') or find_tool('objcopy')
     run_cmd([rv32_tool_objcopy] + args)
 
 
 def call_rv32_ar(args: List[str]):
-    rv32_tool_ar = os.environ.get('RV32_TOOL_AR', 'riscv32-unknown-elf-ar')
+    rv32_tool_ar = os.environ.get('RV32_TOOL_AR') or find_tool('ar')
     run_cmd([rv32_tool_ar] + args)
 
 


### PR DESCRIPTION
It was reported by @phamhnh that when trying to run `acc_as.py` directly, one gets this unhelpful and wrong error message:
```
Unable to find 'riscv32-unknown-elf-gcc' in PATH or in '/tools/riscv/bin'. Set the 'RV32_TOOL_GCC' or TOOLCHAIN_PATH environment variable if you installed your RISC-V toolchain in an alternate location. (Hint: if you installed the toolchain via Bazel, this is likely 'bazel-pavona/external/lowrisc_rv32imcb_files/' )
```

The toolchain now actually lives under `bazel-pavona/external/toolchains_llvm++llvm+llvm_toolchain_llvm/bin/`, but I believe we can just auto-discover it.

This PR fixes the erorr message, and also makes `acc_as.py` auto-dicover the toolchain installed via bazel.