### PR TITLE
[doc,site] Use white background as default for SVGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Pavona logo](./doc/pavona-logo-lockup.svg)
+![Pavona logo](./doc/pavona-logo-lockup.svg#no-bg)
 
 [Pavona](https://pavona.org) is the open-source silicon distribution for composable secure silicon.
 

--- a/doc/security/specs/device_provisioning/README.md
+++ b/doc/security/specs/device_provisioning/README.md
@@ -106,7 +106,7 @@ The following diagram shows the physical connections between test components.
 <table>
   <tr>
      <td>
-        <img src="img_ate_setup.svg#white-bg" style="width: 800px;">
+        <img src="img_ate_setup.svg" style="width: 800px;">
      </td>
   </tr>
   <tr><td style="text-align:center;">Figure: FT Connectivity</td></tr>
@@ -167,7 +167,7 @@ flow with emphasis on the personalization process.
 <table>
   <tr>
     <td>
-      <img src="img_provisioning_overview.svg#white-bg" style="width: 900px;">
+      <img src="img_provisioning_overview.svg" style="width: 900px;">
     </td>
   </tr>
   <tr>
@@ -222,7 +222,7 @@ provisioning appliance during personalization.
 
 This section describes the personalization injection mode in detail.
 
-<img src="img_provisioning_injection.svg#white-bg" style="width: 900px;">
+<img src="img_provisioning_injection.svg" style="width: 900px;">
 
 **P0. Get device identifier**
 
@@ -401,7 +401,7 @@ This section describes the personalization self-generate mode in detail. In this
 mode, The device generates its own device secrets and the provisioning appliance
 is used to sign the endorsement certificate.
 
-<img src="img_provisioning_self_gen.svg#white-bg" style="width: 900px;">
+<img src="img_provisioning_self_gen.svg" style="width: 900px;">
 
 **PS0. Get device identifier**
 
@@ -545,7 +545,7 @@ role of the HOST.
 <table>
   <tr>
     <td>
-      <img src="img_provisioning_owner.svg#white-bg" style="width: 900px;">
+      <img src="img_provisioning_owner.svg" style="width: 900px;">
     </td>
   </tr>
   <tr>
@@ -577,7 +577,7 @@ Steps:
 <table>
   <tr>
     <td>
-      <img src="img_provisioning_owner_injection.svg#white-bg" style="width: 900px;">
+      <img src="img_provisioning_owner_injection.svg" style="width: 900px;">
     </td>
   </tr>
   <tr>
@@ -702,7 +702,7 @@ architecture:
 <table>
   <tr>
     <td>
-      <img src="img_ecies_encryption.svg#white-bg" style="width: 900px;">
+      <img src="img_ecies_encryption.svg" style="width: 900px;">
     </td>
   </tr>
   <tr>
@@ -791,7 +791,7 @@ data_enc, tag =
 <table>
   <tr>
     <td>
-      <img src="img_ecies_decryption.svg#white-bg" style="width: 900px;">
+      <img src="img_ecies_decryption.svg" style="width: 900px;">
     </td>
   </tr>
   <tr>

--- a/hw/top_dragonfly/doc/datasheet.md
+++ b/hw/top_dragonfly/doc/datasheet.md
@@ -5,7 +5,7 @@
 Dragonfly is a system-on-a-chip Secure Execution Environment, capable of serving as a root of trust (RoT) for measurement and attestation among other applications, for instantiation within a larger system.
 It can serve as the SoC root of trust, a platform root of trust, or even be integrated and leveraged for individual chiplet RoTs.
 
-![Top Level Block Diagram](top_dragonfly_block_diagram.svg)
+![Top Level Block Diagram](top_dragonfly_block_diagram.svg#no-bg)
 
 Dragonfly's block diagram shows the system configuration, including the RISC-V Ibex processor and all of the memories and comportable peripheral IPs.
 The system is split into a high speed domain (e.g. 1 GHz clock in a recent process node) and a peripheral domain (e.g. 250 MHz).

--- a/hw/top_egret/doc/datasheet.md
+++ b/hw/top_egret/doc/datasheet.md
@@ -2,7 +2,7 @@
 
 # Overview
 
-![Top Level Block Diagram](top_egret_block_diagram.svg)
+![Top Level Block Diagram](top_egret_block_diagram.svg#no-bg)
 
 The Egret chip is a low-power secure microcontroller that is designed for several use cases requiring hardware security.
 The block diagram is shown above and shows the system configuration, including the Ibex processor and all of the memories and comportable IPs.

--- a/sw/device/tests/penetrationtests/doc/README.md
+++ b/sw/device/tests/penetrationtests/doc/README.md
@@ -2,7 +2,7 @@
 
 The purpose of this framework is to perform side-channel analysis (SCA) and fault injection (FI) attacks on the FPGA as well as on the chip.
 
-![Full hardware setup](pentest_setup.png#white-bg)
+![Full hardware setup](pentest_setup.png)
 
 As shown in the block diagram, the pentest framework runs on the target and receives configuration commands by the SCA and FI framework.
 

--- a/util/dvsim/doc/design_doc.md
+++ b/util/dvsim/doc/design_doc.md
@@ -110,7 +110,7 @@ The individual tool-specific setup such as setting the environment variables `$P
 
 # Architecture
 
-![Architecture](architecture.png#white-bg)
+![Architecture](architecture.png)
 
 ### EDA tool flow steps
 

--- a/util/site/book-theme/css/general.css
+++ b/util/site/book-theme/css/general.css
@@ -257,8 +257,18 @@ sup {
     font-style: italic;
 }
 
-img[src*="#white-bg"] {
+
+/*
+ Add a white background when:
+ - Dark mode is on
+ - The image is an SVG
+ - The SVG has no fragment identifier (e.g. #no-bg)
+ - The SVG is not the Pavona logo
+*/
+.dark img[src$=".svg"]:not(#pavona-logo) {
     background-color: white;
+    padding: 2px;
+    box-sizing: border-box;
 }
 
 #pavona-logo {


### PR DESCRIPTION
This adds a white background to SVGs by default when the dark theme is selected. This improves readability of many diagrams.