### PR TITLE
[ipgen] Include argument for removing top references

### DIFF
--- a/hw/ip_templates/pwrmgr/doc/programmers_guide.md.tpl
+++ b/hw/ip_templates/pwrmgr/doc/programmers_guide.md.tpl
@@ -5,7 +5,7 @@ The following proposes one method for how this can be done.
 
 Assume first the system has the power states described [above](theory_of_operation.md#supported-low-power-modes).
 
-## Programmer Sequence for Entering Low Power
+${"##"} Programmer Sequence for Entering Low Power
 
 1. Disable interrupt handling.
 2. Mask all interrupt sources that should not prevent low power entry.
@@ -22,7 +22,7 @@ Assume first the system has the power states described [above](theory_of_operati
 Note that entering low power mode requires that pwrmgr's `pwr_cpu_i.core_sleeping` input be at logic high long enough to be sampled.
 A wait-for-interrupt instruction does not guarantee entry into low power, since the CPU could immediately resume execution in some cases.
 
-### Possible Exits
+${"###"} Possible Exits
 
 Once low power is initiated, the system may exit due to several reasons.
 1. Graceful low power exit - This exit occurs when some source in the system gracefully wakes up the power manager.
@@ -45,24 +45,28 @@ To check the exit condition, software can follow these steps:
 2. Check [`WAKE_INFO`](registers.md#wake_info) to get the condition.
   - If no bits are set, then this was a fast fall through, where low power entry was not attempted.
 
-## Programmer Sequence for Exiting Low Power
+${"##"} Programmer Sequence for Exiting Low Power
 
 There are two separate cases for low power exit.
 One is exiting from deep sleep, and the other is exiting from normal sleep.
 
-### Exiting from Deep Sleep
+${"###"} Exiting from Deep Sleep
 
 When exiting from deep sleep, the system begins execution in ROM.
 
 1. Complete normal preparation steps.
+% if not no_top:
 2. Check reset cause in [rstmgr](../../rstmgr/README.md)
+% else:
+2. Check reset cause in rstmgr
+% endif
 3. Re-enable modules that have powered down.
 4. Disable wakeup recording through [`WAKE_INFO_CAPTURE_DIS`](registers.md#wake_info_capture_dis).
 5. Check which source woke up the system through [`WAKE_INFO`](registers.md#wake_info).
 6. Take appropriate steps to handle the wake and resume normal operation.
 7. Once wake is handled, clear the wake indication in [`WAKE_INFO`](registers.md#wake_info).
 
-### Exiting from Normal Sleep
+${"###"} Exiting from Normal Sleep
 
 The handling for fall-through and abort are similar to normal sleep exit.
 Since in these scenarios the system was not reset, software continues executing the instruction after the wait-for-interrupt invocation.
@@ -74,6 +78,6 @@ Since in these scenarios the system was not reset, software continues executing 
 5. Re-enable interrupts for normal operation and wakeup handling.
 6. Once wake is handled, clear the wake indication in [`WAKE_INFO`](registers.md#wake_info).
 
-## Device Interface Functions (DIFs)
+${"##"} Device Interface Functions (DIFs)
 
 - [Device Interface Functions](../../../../../sw/device/lib/dif/dif_pwrmgr.h)

--- a/hw/ip_templates/pwrmgr/doc/theory_of_operation.md.tpl
+++ b/hw/ip_templates/pwrmgr/doc/theory_of_operation.md.tpl
@@ -7,14 +7,14 @@ The power manager performs the following functions:
 - Sequence various power up activities such as OTP sensing, life cycle initiation and releasing software to execute.
 
 
-## Block Diagram
+${"##"} Block Diagram
 
 See the below high level block diagram that illustrates the connections between the power manager and various system components.
 Blocks outlined with a solid magenta line are always on; while blocks outlined with a dashed magenta line are a mix of components that are and those that are not.
 
 ![Power Manager Connectivity Diagram](../doc/pwrmgr_connectivity.svg)
 
-## Overall Sequencing
+${"##"} Overall Sequencing
 
 The power manager contains two state machines.
 One operates on the always-on slow clock (this clock is always running and usually measured in KHz) and is responsible for turning faster clocks on and off and managing the power domains.
@@ -37,12 +37,16 @@ Note, most of the states are transitional states, and only the following state c
 The slow FSM `Low Power` and fast FSM `Active` states specifically are concepts useful when examining [reset handling](#reset-request-handling).
 
 
-## Slow Clock Domain FSM
+${"##"} Slow Clock Domain FSM
 
 The slow clock domain FSM (referred to as the slow FSM from here on) resets to the Reset state.
 This state is released by `por_rst_n`, which is supplied from the reset controller.
 The `por_rst_n` signal is released when the reset controller detects the root power domains (`vcaon_pok` from AST) of the system are ready.
+% if not no_top:
 Please see the [ast](../../../ip/ast/README.md) for more details.
+% else:
+Please see the ast for more details.
+% endif
 
 The slow FSM requests the AST to power up the main domain and high speed clocks.
 Once those steps are done, it requests the [fast FSM](#fast-clock-domain-fsm) to begin operation.
@@ -53,7 +57,7 @@ When a power down request is received, the slow FSM turns off AST clocks and pow
 This means the clocks and power are not always turned off, but are rather controlled by software configurations in [`CONTROL`](registers.md#control) prior to low power entry .
 Once these steps are complete, the slow FSM transitions to a low power state and awaits a wake request, which can come either as an actual wakeup, or a reset event (for example always on watchdog expiration).
 
-#### Sparse FSM
+${"####"} Sparse FSM
 
 Since the slow FSM is sparsely encoded, it is possible for the FSM to end up in an undefined state if attacked.
 When this occurs, the slow FSM sends an `invalid` indication to the fast FSM and forcibly powers off and clamps everything.
@@ -64,7 +68,7 @@ The slow FSM does not recover from this state until the system is reset by POR.
 Unlike [escalation resets](#escalation-reset-request), the system does not self reset.
 Instead the system goes into a terminal non-responsive state where a user or host must directly intervene by toggling the power or asserting an external reset input.
 
-## Fast Clock Domain FSM
+${"##"} Fast Clock Domain FSM
 
 The fast clock domain FSM (referred to as fast FSM from here on) resets to `Low Power` state and waits for a power-up request from the slow FSM.
 
@@ -96,7 +100,7 @@ If none of these exception cases are matched for low power entry, the fast FSM t
 For reset requests, fall through and aborts are not checked and the system simply resets directly.
 Note in this scenario the slow FSM is not requested to take over.
 
-#### Sparse FSM
+${"####"} Sparse FSM
 
 Since the fast FSM is sparsely encoded, it is possible for the FSM to end up in an undefined state if attacked.
 When this occurs, the fast FSM forcibly disables all clocks and holds the system in reset.
@@ -104,7 +108,7 @@ When this occurs, the fast FSM forcibly disables all clocks and holds the system
 The fast FSM does not recover from this state until the system is reset by POR.
 
 
-### ROM Integrity Checks
+${"###"} ROM Integrity Checks
 
 The power manager coordinates the [start up ROM check](../../../../ip/rom_ctrl/README.md#the-startup-rom-check) with `rom_ctrl`.
 
@@ -117,7 +121,7 @@ If the device is not in one of the test states, the `good` signal is used to det
 If `good` is true, ROM execution is allowed.
 If `good` is false, ROM execution is disallowed.
 
-### Fall Through Handling
+${"###"} Fall Through Handling
 
 A low power entry fall through occurs when some condition occurs that immediately de-assert the entry conditions right after the software requests it.
 
@@ -128,12 +132,12 @@ The fall through handle is specifically catered to the latter category.
 For a normal low power entry, the fast FSM first checks that the low power entry conditions are still true.
 If the entry conditions are no longer true, the fast FSM "falls through" the entry handling and returns the system to active state, thus terminating the entry process.
 
-### Abort Handling
+${"###"} Abort Handling
 
 If the entry conditions are still true, the fast FSM then checks there are no ongoing non-volatile activities from `otp_ctrl`, `lc_ctrl` and `flash_ctrl` (if they re part of the system).
 If any module is active, the fast FSM "aborts" entry handling and returns the system to active state, thus terminating the entry process.
 
-## Reset Request Handling
+${"##"} Reset Request Handling
 
 There are 4 reset requests in the system
 - peripheral requested reset such as watchdog.
@@ -152,13 +156,13 @@ When a reset request is received during fast FSM `Active` state, the fast FSM as
 The normal power-up process described [above](#fast-clock-domain-fsm) is then followed to release the resets.
 Note in this case, the slow FSM is "not activated" and remains in its `Idle` state.
 
-### Power Manager Internal Reset Requests
+${"###"} Power Manager Internal Reset Requests
 
 In additional to external requests, the power manager maintains 2 internal reset requests:
 * Escalation reset request
 * Main power domain unstable reset request
 
-#### Escalation Reset Request
+${"####"} Escalation Reset Request
 
 Alert escalation resets in general behave similarly to peripheral requested resets.
 However, peripheral resets are always handled gracefully and follow the normal FSM transition.
@@ -169,7 +173,7 @@ As a result, upon alert escalation, the power manager makes a best case effort t
 This may not always be possible if the escalation happens while the FSM is in an invalid state.
 In this scenario, the pwrmgr keeps everything powered off and silenced and requests escalation handling if the system ever wakes up.
 
-#### Escalation Clock Timeout
+${"####"} Escalation Clock Timeout
 
 Under normal behavior, the power manager can receive escalation requests from the system and handle them [appropriately](#escalation-reset-request).
 However, if the escalation clock or reset are non-functional for any reason, the escalation request would not be serviced.
@@ -181,7 +185,7 @@ If the request / acknowledge interface does not respond within 128 power manager
 When this happens, the power manager creates a local escalation request that behaves identically to the global escalation request.
 
 
-#### Main Power Unstable Reset Requests
+${"####"} Main Power Unstable Reset Requests
 If the main power ever becomes unstable (the power okay indication is low even though it is powered on), the power manager requests an internal reset.
 This reset behaves similarly to the escalation reset and transitions directly into reset handling.
 
@@ -190,13 +194,13 @@ As a result of this, the main power unstable checks are valid only during states
 This includes any state where power manager has requested the power to be turned on.
 
 
-### Reset Requests Received During Other States
+${"###"} Reset Requests Received During Other States
 
 All other states in the slow / fast FSM are considered transitional states.
 Resets are not observed in other states because the system will always be transitioning towards one of the steady states (the system is in the process of powering down or powering up).
 Once a steady state is reached, reset requests are then observed and processed.
 
-### Reset Recording
+${"###"} Reset Recording
 
 There are two ways in which the device is reset:
 - The reset requests mentioned in [reset handling](#reset-request-handling)
@@ -227,7 +231,7 @@ If reset requests arrive slightly ahead of a low power entry request, then power
 Ultimately when control is returned to software, it may see two reset reasons and must handle them accordingly.
 
 
-## Wakeup Recording
+${"##"} Wakeup Recording
 
 Similar to [reset handling](#reset-request-handling), wakeup signals are only observed during slow FSM `Low Power`; however their recording is continuous until explicitly disabled by software.
 
@@ -236,16 +240,20 @@ This ensures wakeup events are not missed until software has set up the appropri
 Recording needs clocks to be active, and during low power they are usually not.
 For this reason, it is important for wakeups to be level and remain active until software clears them.
 
-The software is also able to enable recording during `Active` state if it chooses to do so.  The recording enables are OR’d together for hardware purposes.
+The software is also able to enable recording during `Active` state if it chooses to do so.  The recording enables are OR'd together for hardware purposes.
 
 
-## Flash Handling
+${"##"} Flash Handling
 For the section below, flash macro refers to the proprietary flash storage supplied by a vendor.
 `flash_ctrl`, on the other hand, refers to the open source controller that manages access to the flash macro.
 
-### Power-Up Handling
+${"###"} Power-Up Handling
 
+% if not no_top:
 The [AST](../../../ip/ast/README.md) automatically takes the flash macro out of power down state as part of the power manager's power up request.
+% else:
+The AST automatically takes the flash macro out of power down state as part of the power manager's power up request.
+% endif
 
 Once flash macro is powered up and ready, an indication is sent to the `flash_ctrl`.
 
@@ -255,7 +263,7 @@ This involves the following steps:
 *   Poll `flash_ctrl` register to ensure flash macro has powered up and completed internal initialization.
 *   Initialize `flash_ctrl` seed reading and scrambling.
 
-### Power-Down Handling
+${"###"} Power-Down Handling
 
 Before the device enters low power, the pwrmgr first checks to ensure there are no ongoing transactions to the flash macro.
 When the device enters deep sleep, the flash macro is automatically put into power down mode by the AST.
@@ -263,7 +271,7 @@ The AST places the flash macro into power down through direct signaling between 
 
 When the device exits low power state, it is the responsibility of the boot ROM to poll for flash macro and `flash_ctrl` power-up complete similar to the above section.
 
-### Flash Brownout Handling
+${"###"} Flash Brownout Handling
 
 When the external supply of the device dips below a certain threshold during a non-volatile flash macro operation (program or erase), the flash macro requires the operation to terminate in a pre-defined manner.
 This sequence will be exclusively handled by the AST.
@@ -272,12 +280,12 @@ The power manager is unaware of the difference between POR and flash brownout.
 Because of this, the software also cannot distinguish between these two reset causes.
 
 
-## Supported Low Power Modes
+${"##"} Supported Low Power Modes
 
 This section details the various low power modes supported.
 
 
-### Deep Sleep or Standby
+${"###"} Deep Sleep or Standby
 
 This is the lowest power mode of the device (outside of full power down or device held in reset).
 During this state:
@@ -285,10 +293,10 @@ During this state:
 *   All clocks other than the always-on slow clock are turned off at the source.
 *   All non-always-on digital domains are powered off.
 *   I/O power domains may or may not be off.
-    *   The state of the IO power domain has no impact on the digital core’s power budget, e.g. the IO power being off does not cause the accompanying digital logic in pads or elsewhere to leak more.
+    *   The state of the IO power domain has no impact on the digital core's power budget, e.g. the IO power being off does not cause the accompanying digital logic in pads or elsewhere to leak more.
 
 
-### Normal Sleep
+${"###"} Normal Sleep
 
 This is a fast low power mode of the device that trades-off power consumption for resume latency.
 During this state:
@@ -297,9 +305,9 @@ During this state:
 *   All power domains are kept on for fast resume.
 *   Sensor countermeasures can be opportunistically on.
 *   I/O power domains may or may not be off.
-    *   The state of the IO power domain has no impact on the digital core’s power budget, e.g. the IO power being off does not cause the accompanying digital logic in pads or elsewhere to leak more.
+    *   The state of the IO power domain has no impact on the digital core's power budget, e.g. the IO power being off does not cause the accompanying digital logic in pads or elsewhere to leak more.
 
-## Debug
+${"##"} Debug
 
 When performing TAP debug, it is important for the debugging software to prevent the system from going to low power.
 If the system enters low power during live debug, the debug session will be broken.

--- a/hw/top_dragonfly/ip_autogen/pwrmgr/doc/theory_of_operation.md
+++ b/hw/top_dragonfly/ip_autogen/pwrmgr/doc/theory_of_operation.md
@@ -236,7 +236,7 @@ This ensures wakeup events are not missed until software has set up the appropri
 Recording needs clocks to be active, and during low power they are usually not.
 For this reason, it is important for wakeups to be level and remain active until software clears them.
 
-The software is also able to enable recording during `Active` state if it chooses to do so.  The recording enables are OR’d together for hardware purposes.
+The software is also able to enable recording during `Active` state if it chooses to do so.  The recording enables are OR'd together for hardware purposes.
 
 
 ## Flash Handling
@@ -285,7 +285,7 @@ During this state:
 *   All clocks other than the always-on slow clock are turned off at the source.
 *   All non-always-on digital domains are powered off.
 *   I/O power domains may or may not be off.
-    *   The state of the IO power domain has no impact on the digital core’s power budget, e.g. the IO power being off does not cause the accompanying digital logic in pads or elsewhere to leak more.
+    *   The state of the IO power domain has no impact on the digital core's power budget, e.g. the IO power being off does not cause the accompanying digital logic in pads or elsewhere to leak more.
 
 
 ### Normal Sleep
@@ -297,7 +297,7 @@ During this state:
 *   All power domains are kept on for fast resume.
 *   Sensor countermeasures can be opportunistically on.
 *   I/O power domains may or may not be off.
-    *   The state of the IO power domain has no impact on the digital core’s power budget, e.g. the IO power being off does not cause the accompanying digital logic in pads or elsewhere to leak more.
+    *   The state of the IO power domain has no impact on the digital core's power budget, e.g. the IO power being off does not cause the accompanying digital logic in pads or elsewhere to leak more.
 
 ## Debug
 

--- a/hw/top_egret/ip_autogen/pwrmgr/doc/theory_of_operation.md
+++ b/hw/top_egret/ip_autogen/pwrmgr/doc/theory_of_operation.md
@@ -236,7 +236,7 @@ This ensures wakeup events are not missed until software has set up the appropri
 Recording needs clocks to be active, and during low power they are usually not.
 For this reason, it is important for wakeups to be level and remain active until software clears them.
 
-The software is also able to enable recording during `Active` state if it chooses to do so.  The recording enables are OR’d together for hardware purposes.
+The software is also able to enable recording during `Active` state if it chooses to do so.  The recording enables are OR'd together for hardware purposes.
 
 
 ## Flash Handling
@@ -285,7 +285,7 @@ During this state:
 *   All clocks other than the always-on slow clock are turned off at the source.
 *   All non-always-on digital domains are powered off.
 *   I/O power domains may or may not be off.
-    *   The state of the IO power domain has no impact on the digital core’s power budget, e.g. the IO power being off does not cause the accompanying digital logic in pads or elsewhere to leak more.
+    *   The state of the IO power domain has no impact on the digital core's power budget, e.g. the IO power being off does not cause the accompanying digital logic in pads or elsewhere to leak more.
 
 
 ### Normal Sleep
@@ -297,7 +297,7 @@ During this state:
 *   All power domains are kept on for fast resume.
 *   Sensor countermeasures can be opportunistically on.
 *   I/O power domains may or may not be off.
-    *   The state of the IO power domain has no impact on the digital core’s power budget, e.g. the IO power being off does not cause the accompanying digital logic in pads or elsewhere to leak more.
+    *   The state of the IO power domain has no impact on the digital core's power budget, e.g. the IO power being off does not cause the accompanying digital logic in pads or elsewhere to leak more.
 
 ## Debug
 

--- a/hw/top_scafi_deprecated/ip_autogen/pwrmgr/doc/theory_of_operation.md
+++ b/hw/top_scafi_deprecated/ip_autogen/pwrmgr/doc/theory_of_operation.md
@@ -236,7 +236,7 @@ This ensures wakeup events are not missed until software has set up the appropri
 Recording needs clocks to be active, and during low power they are usually not.
 For this reason, it is important for wakeups to be level and remain active until software clears them.
 
-The software is also able to enable recording during `Active` state if it chooses to do so.  The recording enables are OR’d together for hardware purposes.
+The software is also able to enable recording during `Active` state if it chooses to do so.  The recording enables are OR'd together for hardware purposes.
 
 
 ## Flash Handling
@@ -285,7 +285,7 @@ During this state:
 *   All clocks other than the always-on slow clock are turned off at the source.
 *   All non-always-on digital domains are powered off.
 *   I/O power domains may or may not be off.
-    *   The state of the IO power domain has no impact on the digital core’s power budget, e.g. the IO power being off does not cause the accompanying digital logic in pads or elsewhere to leak more.
+    *   The state of the IO power domain has no impact on the digital core's power budget, e.g. the IO power being off does not cause the accompanying digital logic in pads or elsewhere to leak more.
 
 
 ### Normal Sleep
@@ -297,7 +297,7 @@ During this state:
 *   All power domains are kept on for fast resume.
 *   Sensor countermeasures can be opportunistically on.
 *   I/O power domains may or may not be off.
-    *   The state of the IO power domain has no impact on the digital core’s power budget, e.g. the IO power being off does not cause the accompanying digital logic in pads or elsewhere to leak more.
+    *   The state of the IO power domain has no impact on the digital core's power budget, e.g. the IO power being off does not cause the accompanying digital logic in pads or elsewhere to leak more.
 
 ## Debug
 

--- a/util/ipgen.py
+++ b/util/ipgen.py
@@ -45,7 +45,7 @@ def action_generate(ip_template: IpTemplate, args: argparse.Namespace) -> None:
     # Render the IP template into an IP block.
     try:
         renderer = IpBlockRenderer(ip_template, ip_config)
-        renderer.render(output_path, overwrite_output_dir)
+        renderer.render(output_path, overwrite_output_dir, args.no_top)
     except TemplateRenderError as e:
         logging.error(e.verbose_str())
         sys.exit(1)
@@ -89,6 +89,11 @@ def main() -> int:
         type=Path,
         required=True,
         help='IP template directory',
+    )
+    parent_parser.add_argument(
+        '--no-top',
+        help="Generate standalone IP without top-specific references",
+        action="store_true"
     )
 
     subparsers = parser.add_subparsers(

--- a/util/ipgen/README.md
+++ b/util/ipgen/README.md
@@ -178,8 +178,8 @@ actions:
 <!-- BEGIN CMDGEN util/selfdoc.py quote:util/ipgen.py generate --help -->
 ```
 $ util/ipgen.py generate --help
-usage: ipgen.py generate [-h] [--verbose] -C TEMPLATE_DIR -o OUTDIR [--force]
-                         --config-file CONFIG_FILE
+usage: ipgen.py generate [-h] [--verbose] -C TEMPLATE_DIR [--no-top] -o OUTDIR
+                         [--force] --config-file CONFIG_FILE
 
 Generate an IP block from an IP template
 
@@ -188,6 +188,7 @@ options:
   --verbose             More info messages
   -C TEMPLATE_DIR, --template-dir TEMPLATE_DIR
                         IP template directory
+  --no-top              Generate standalone IP without top-specific references
   -o OUTDIR, --outdir OUTDIR
                         output directory for the resulting IP block
   --force, -f           overwrite the output directory, if it exists
@@ -201,8 +202,8 @@ options:
 <!-- BEGIN CMDGEN util/selfdoc.py quote:util/ipgen.py generate --help -->
 ```
 $ util/ipgen.py generate --help
-usage: ipgen.py generate [-h] [--verbose] -C TEMPLATE_DIR -o OUTDIR [--force]
-                         --config-file CONFIG_FILE
+usage: ipgen.py generate [-h] [--verbose] -C TEMPLATE_DIR [--no-top] -o OUTDIR
+                         [--force] --config-file CONFIG_FILE
 
 Generate an IP block from an IP template
 
@@ -211,6 +212,7 @@ options:
   --verbose             More info messages
   -C TEMPLATE_DIR, --template-dir TEMPLATE_DIR
                         IP template directory
+  --no-top              Generate standalone IP without top-specific references
   -o OUTDIR, --outdir OUTDIR
                         output directory for the resulting IP block
   --force, -f           overwrite the output directory, if it exists

--- a/util/ipgen/renderer.py
+++ b/util/ipgen/renderer.py
@@ -47,7 +47,7 @@ class IpTemplateRendererBase:
                 raise KeyError(f"No parameter named {name!r} exists.")
 
     def get_template_parameter_values(
-            self) -> Dict[str, Union[str, int, object]]:
+            self, no_top: bool) -> Dict[str, Union[str, int, object]]:
         """ Get a typed mapping of all template parameters and their values.
         """
         ret = {}
@@ -83,6 +83,7 @@ class IpTemplateRendererBase:
 
             ret[name] = val_typed
 
+        ret['no_top'] = no_top
         return ret
 
     def _get_mako_template_lookup(self) -> MakoTemplateLookup:
@@ -159,7 +160,7 @@ class IpTemplateRendererBase:
                                                 rewritten_vlnv))
         return rewritten_vlnv
 
-    def _render_mako_template_to_str(self, template_filepath: Path) -> str:
+    def _render_mako_template_to_str(self, template_filepath: Path, no_top: bool) -> str:
         """ Render a template and return the rendered text. """
 
         lookup = self._get_mako_template_lookup()
@@ -175,7 +176,7 @@ class IpTemplateRendererBase:
         tpl_args = {
             "instance_name": self.ip_config.instance_name,  # type: ignore
             **helper_funcs,  # type: ignore
-            **self.get_template_parameter_values()  # type: ignore
+            **self.get_template_parameter_values(no_top)  # type: ignore
         }
         try:
             return template.render(**tpl_args)
@@ -183,10 +184,10 @@ class IpTemplateRendererBase:
             raise TemplateRenderError(
                 "Unable to render template: " +
                 mako_exceptions.text_error_template().render(),
-                self.get_template_parameter_values()) from None
+                self.get_template_parameter_values(no_top)) from None
 
     def _render_mako_template_to_file(self, template_filepath: Path,
-                                      outdir_path: Path) -> None:
+                                      outdir_path: Path, no_top: bool) -> None:
         """ Render a file template into a file in outdir_path.
 
         The name of the output file matches the file name of the template file,
@@ -197,7 +198,7 @@ class IpTemplateRendererBase:
 
         outfile_name = self._filename_without_tpl_suffix(template_filepath)
 
-        rendered_str = self._render_mako_template_to_str(template_filepath)
+        rendered_str = self._render_mako_template_to_str(template_filepath, no_top)
         try:
             with open(outdir_path / outfile_name, 'w') as f:
                 f.write(rendered_str)
@@ -233,7 +234,7 @@ class IpDescriptionOnlyRenderer(IpTemplateRendererBase):
         hjson_tpl_path = (self.ip_template.template_path / 'data' /
                           f'{self.ip_template.name}.hjson.tpl')
         if hjson_tpl_path.is_file():
-            return self._render_mako_template_to_str(hjson_tpl_path)
+            return self._render_mako_template_to_str(hjson_tpl_path, False)
 
         raise TemplateRenderError(
             f"No IP description template at {hjson_tpl_path}")
@@ -292,7 +293,7 @@ class IpBlockRenderer(IpTemplateRendererBase):
                        'Please remove it manually.')
                 raise TemplateRenderError(msg).with_traceback(e.__traceback__)
 
-    def render(self, output_dir: Path, overwrite_output_dir: bool) -> None:
+    def render(self, output_dir: Path, overwrite_output_dir: bool, no_top: bool) -> None:
         """ Render the IP template into output_dir.
 
         Generates the IP directory in a staging area and atomically moves it
@@ -338,7 +339,7 @@ class IpBlockRenderer(IpTemplateRendererBase):
                 outdir_path = staging_dir / template_filepath_rel.parent
 
                 self._render_mako_template_to_file(template_filepath,
-                                                   outdir_path)
+                                                   outdir_path, no_top)
         except Exception:
             shutil.rmtree(staging_dir, ignore_errors=True)
             raise

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -168,7 +168,7 @@ def ipgen_render(template_name: str, topname: str, params: ParamsT,
     try:
         renderer = IpBlockRenderer(ip_template, ip_config)
         renderer.render(out_path / "ip_autogen" / module_name,
-                        overwrite_output_dir=True)
+                        overwrite_output_dir=True, no_top=False)
     except TemplateRenderError as e:
         log.error(e.verbose_str())
         sys.exit(1)


### PR DESCRIPTION
This commit includes a new flag `--no-top` that can be passed to ipgen to generate IP files without having references that are top-dependent (e.g. references in README.md files to other IPs that would exist in a top, like AST).