### PR TITLE
[pentest] remove invalid ECDH keyblob zeroing

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
@@ -227,8 +227,6 @@ status_t cryptolib_sca_p256_ecdh_impl(
   uint32_t private_keyblob[kPentestP256MaskedPrivateKeyWords * 2];
   memset(private_keyblob, 0, sizeof(private_keyblob));
   memcpy(private_keyblob, uj_input.private_key, P256_CMD_BYTES);
-  memcpy(private_keyblob + kPentestP256MaskedPrivateKeyWords, 0,
-         P256_CMD_BYTES);
   otcrypto_blinded_key_t private_key = {
       .config =
           {
@@ -610,8 +608,6 @@ status_t cryptolib_sca_p384_ecdh_impl(
   uint32_t private_keyblob[kPentestP384MaskedPrivateKeyWords * 2];
   memset(private_keyblob, 0, sizeof(private_keyblob));
   memcpy(private_keyblob, uj_input.private_key, P384_CMD_BYTES);
-  memcpy(private_keyblob + kPentestP384MaskedPrivateKeyWords, 0,
-         P384_CMD_BYTES);
   otcrypto_blinded_key_t private_key = {
       .config =
           {


### PR DESCRIPTION
Remove the attempted zeroing of the second ECDH private-key share via memcpy(..., 0, ...). The second argument to memcpy is a source pointer, so passing 0 would read from the null address rather than write zeroes.

The full keyblob is already cleared with memset before copying the first share, so the second share remains zero-initialized without any additional operation.