### PR TITLE
[base] mark mem* operations as nonnull 

### DIFF
--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -448,6 +448,12 @@ extern "C++" {
 #define OT_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 
 /**
+ * Marks all pointer parameters as non-null so the compiler warns (`-Wnonnull`)
+ * when a NULL/0 argument is passed.
+ */
+#define OT_NONNULL __attribute__((nonnull))
+
+/**
  * Attribute for weak functions that can be overridden, e.g., ISRs.
  */
 #define OT_WEAK __attribute__((weak))

--- a/sw/device/lib/base/memory.c
+++ b/sw/device/lib/base/memory.c
@@ -60,9 +60,6 @@ static uint32_t repeat_byte_to_u32(uint8_t byte) {
 
 void *OT_PREFIX_IF_NOT_RV32(memcpy)(void *restrict dest,
                                     const void *restrict src, size_t len) {
-  if (dest == NULL || src == NULL) {
-    return dest;
-  }
   unsigned char *dest8 = (unsigned char *)dest;
   const unsigned char *src8 = (const unsigned char *)src;
   size_t body_offset, tail_offset;

--- a/sw/device/lib/base/memory.h
+++ b/sw/device/lib/base/memory.h
@@ -188,6 +188,7 @@ inline void write_64(uint64_t value, void *ptr) {
  * @param len the number of bytes to copy.
  * @return the value of `dest`.
  */
+OT_NONNULL
 void *OT_PREFIX_IF_NOT_RV32(memcpy)(void *OT_RESTRICT dest,
                                     const void *OT_RESTRICT src, size_t len);
 
@@ -204,6 +205,7 @@ void *OT_PREFIX_IF_NOT_RV32(memcpy)(void *OT_RESTRICT dest,
  * @param len the number of bytes to write.
  * @return the value of `dest`.
  */
+OT_NONNULL
 void *OT_PREFIX_IF_NOT_RV32(memset)(void *dest, int value, size_t len);
 
 /**
@@ -222,6 +224,7 @@ void *OT_PREFIX_IF_NOT_RV32(memset)(void *dest, int value, size_t len);
  * contingencies of `lhs == rhs`, `lhs > rhs`, and `lhs < rhs` (as buffers, not
  * pointers), respectively.
  */
+OT_NONNULL
 int OT_PREFIX_IF_NOT_RV32(memcmp)(const void *lhs, const void *rhs, size_t len);
 
 /**
@@ -241,6 +244,7 @@ int OT_PREFIX_IF_NOT_RV32(memcmp)(const void *lhs, const void *rhs, size_t len);
  * contingencies of `lhs == rhs`, `lhs > rhs`, and `lhs < rhs` (as buffers, not
  * pointers), respectively.
  */
+OT_NONNULL
 int memrcmp(const void *lhs, const void *rhs, size_t len);
 
 /**
@@ -260,6 +264,7 @@ int memrcmp(const void *lhs, const void *rhs, size_t len);
  * @param len the length of the region, in bytes.
  * @return a pointer to the found value, or NULL.
  */
+OT_NONNULL
 void *OT_PREFIX_IF_NOT_RV32(memchr)(const void *ptr, int value, size_t len);
 
 /**
@@ -273,6 +278,7 @@ void *OT_PREFIX_IF_NOT_RV32(memchr)(const void *ptr, int value, size_t len);
  * @param len the length of the region, in bytes.
  * @return a pointer to the found value, or NULL.
  */
+OT_NONNULL
 void *OT_PREFIX_IF_NOT_RV32(memrchr)(const void *ptr, int value, size_t len);
 
 #ifdef __cplusplus

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
@@ -667,8 +667,6 @@ status_t cryptolib_fi_p256_ecdh_impl(
   uint32_t private_keyblob[kPentestP256MaskedPrivateKeyWords * 2];
   memset(private_keyblob, 0, sizeof(private_keyblob));
   memcpy(private_keyblob, uj_input.private_key, P256_CMD_BYTES);
-  memcpy(private_keyblob + kPentestP256MaskedPrivateKeyWords, 0,
-         P256_CMD_BYTES);
   otcrypto_blinded_key_t private_key = {
       .config =
           {
@@ -893,8 +891,6 @@ status_t cryptolib_fi_p384_ecdh_impl(
   uint32_t private_keyblob[kPentestP384MaskedPrivateKeyWords * 2];
   memset(private_keyblob, 0, sizeof(private_keyblob));
   memcpy(private_keyblob, uj_input.private_key, P384_CMD_BYTES);
-  memcpy(private_keyblob + kPentestP384MaskedPrivateKeyWords, 0,
-         P384_CMD_BYTES);
   otcrypto_blinded_key_t private_key = {
       .config =
           {


### PR DESCRIPTION
- Depends on #232 as this would have flagged that bug

Annotate memcpy/memset/memcmp/memrcmp/memchr/memrchr with
`__attribute__((nonnull))` via a new `OT_NONNULL` macro, so the compiler
rejects null pointer arguments at compile time under
-Wnonnull (already on via -Wall -Werror). This catches bugs like the
invalid ECDH keyblob zeroing fixed in the previous commits.

Also remove memcpy's "if (dest == NULL || src == NULL)
return dest;" guard. It conflicted with the nonnull attribute.
That check hides bugs instead of serving a real purpose.
