### PR TITLE
[topgen,ctn] Generate constants for CTN SRAM

### DIFF
--- a/hw/top_dragonfly/sw/autogen/chip/top_dragonfly.rs
+++ b/hw/top_dragonfly/sw/autogen/chip/top_dragonfly.rs
@@ -686,6 +686,12 @@ pub const SOC_PROXY_CTN_BASE_ADDR: usize = 0x40000000;
 /// Memory size for ctn memory on soc_proxy in top dragonfly.
 pub const SOC_PROXY_CTN_SIZE_BYTES: usize = 0x80000000;
 
+/// Memory base address for ram_ctn in top dragonfly.
+pub const SOC_PROXY_RAM_CTN_BASE_ADDR: usize = 0x41000000;
+
+/// Memory size for ram_ctn in top dragonfly.
+pub const SOC_PROXY_RAM_CTN_SIZE_BYTES: usize = 0x100000;
+
 /// Memory base address for ram memory on sram_ctrl_ret_aon in top dragonfly.
 pub const SRAM_CTRL_RET_AON_RAM_BASE_ADDR: usize = 0x30600000;
 

--- a/hw/top_dragonfly/sw/autogen/top_dragonfly.h
+++ b/hw/top_dragonfly/sw/autogen/top_dragonfly.h
@@ -888,6 +888,16 @@ extern "C" {
 #define TOP_DRAGONFLY_SOC_PROXY_CTN_SIZE_BYTES 0x80000000u
 
 /**
+ * Memory base address for ram_ctn in top dragonfly.
+ */
+#define TOP_DRAGONFLY_SOC_PROXY_RAM_CTN_BASE_ADDR 0x41000000u
+
+/**
+ * Memory size for ram_ctn in top dragonfly.
+ */
+#define TOP_DRAGONFLY_SOC_PROXY_RAM_CTN_SIZE_BYTES 0x100000u
+
+/**
  * Memory base address for ram memory on sram_ctrl_ret_aon in top dragonfly.
  */
 #define TOP_DRAGONFLY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR 0x30600000u

--- a/hw/top_dragonfly/sw/autogen/top_dragonfly_memory.h
+++ b/hw/top_dragonfly/sw/autogen/top_dragonfly_memory.h
@@ -36,6 +36,16 @@
 #define TOP_DRAGONFLY_SOC_PROXY_CTN_SIZE_BYTES 0x80000000
 
 /**
+ * Memory base for for ram_ctn in top dragonfly.
+ */
+#define TOP_DRAGONFLY_SOC_PROXY_RAM_CTN_BASE_ADDR 0x41000000
+
+/**
+ * Memory size for ram_ctn in top dragonfly.
+ */
+#define TOP_DRAGONFLY_SOC_PROXY_RAM_CTN_SIZE_BYTES 0x100000
+
+/**
  * Memory base for ram memory on sram_ctrl_ret_aon in top dragonfly.
  */
 #define TOP_DRAGONFLY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR 0x30600000

--- a/hw/top_dragonfly/sw/autogen/top_dragonfly_memory.ld
+++ b/hw/top_dragonfly/sw/autogen/top_dragonfly_memory.ld
@@ -20,6 +20,7 @@ MEMORY {
   ram_mbox(rwx) : ORIGIN = 0x11000000, LENGTH = 0x1000
   rom0(rx) : ORIGIN = 0x00008000, LENGTH = 0x8000
   rom1(rx) : ORIGIN = 0x00020000, LENGTH = 0x10000
+  ram_ctn(rwx) : ORIGIN = 0x40000000 + 0x01000000, LENGTH = 0x00100000
   rom_ext_virtual(rx) : ORIGIN = 0x90000000, LENGTH = 0x80000
   owner_virtual(rx) : ORIGIN = 0xa0000000, LENGTH = 0x80000
 }

--- a/util/topgen/templates/toplevel.h.tpl
+++ b/util/topgen/templates/toplevel.h.tpl
@@ -127,6 +127,28 @@ extern "C" {
  */
 #define ${size_bytes_name} ${hex_size_bytes}
 
+## TODO: we need a more holistic approach to declare memories and IPs sitting in the
+## CTN address space. For now, we create the base and offset for the CTN SRAM with this workaround.
+% if inst_name == "soc_proxy" and if_name == "ctn":
+<%
+    hex_base_addr = "0x{:X}u".format(region.base_addr + 0x01000000)
+    hex_size_bytes = "0x{:X}u".format(0x00100000)
+
+    base_addr_name = region.base_addr_name().as_c_define().replace('CTN', 'RAM_CTN')
+    size_bytes_name = region.size_bytes_name().as_c_define().replace('CTN', 'RAM_CTN')
+
+%>\
+/**
+ * Memory base address for ram_ctn in top ${top["name"]}.
+ */
+#define ${base_addr_name} ${hex_base_addr}
+
+/**
+ * Memory size for ram_ctn in top ${top["name"]}.
+ */
+#define ${size_bytes_name} ${hex_size_bytes}
+
+% endif
 % endfor
 % if has_plic:
 

--- a/util/topgen/templates/toplevel.rs.tpl
+++ b/util/topgen/templates/toplevel.rs.tpl
@@ -104,6 +104,24 @@ pub const ${base_addr_name}: usize = ${hex_base_addr};
 
 /// Memory size for ${if_name} memory on ${inst_name} in top ${top["name"]}.
 pub const ${size_bytes_name}: usize = ${hex_size_bytes};
+## TODO: we need a more holistic approach to declare memories and IPs sitting in the
+## CTN address space. For now, we create the base and offset for the CTN SRAM with this workaround.
+% if inst_name == "soc_proxy" and if_name == "ctn":
+<%
+    hex_base_addr = "0x{:X}".format(region.base_addr + 0x01000000)
+    hex_size_bytes = "0x{:X}".format(0x00100000)
+
+    base_addr_name = region.base_addr_name(short=True).as_c_define().replace('CTN', 'RAM_CTN')
+    size_bytes_name = region.size_bytes_name(short=True).as_c_define().replace('CTN', 'RAM_CTN')
+
+%>\
+
+/// Memory base address for ram_ctn in top ${top["name"]}.
+pub const ${base_addr_name}: usize = ${hex_base_addr};
+
+/// Memory size for ram_ctn in top ${top["name"]}.
+pub const ${size_bytes_name}: usize = ${hex_size_bytes};
+% endif
 % endfor
 % if has_plic:
 

--- a/util/topgen/templates/toplevel_memory.h.tpl
+++ b/util/topgen/templates/toplevel_memory.h.tpl
@@ -48,6 +48,28 @@ header_suffix = (top["name"] + addr_space_suffix).upper()
  */
 #define ${size_bytes_name} ${hex_size_bytes}
 
+## TODO: we need a more holistic approach to declare memories and IPs sitting in the
+## CTN address space. For now, we create the base and offset for the CTN SRAM with this workaround.
+% if inst_name == "soc_proxy" and if_name == "ctn":
+<%
+    hex_base_addr = "0x{:X}".format(region.base_addr + 0x01000000)
+    hex_size_bytes = "0x{:X}".format(0x00100000)
+
+    base_addr_name = region.base_addr_name().as_c_define().replace('CTN', 'RAM_CTN')
+    size_bytes_name = region.size_bytes_name().as_c_define().replace('CTN', 'RAM_CTN')
+
+%>\
+/**
+ * Memory base for for ram_ctn in top ${top["name"]}.
+ */
+#define ${base_addr_name} ${hex_base_addr}
+
+/**
+ * Memory size for ram_ctn in top ${top["name"]}.
+ */
+#define ${size_bytes_name} ${hex_size_bytes}
+
+% endif
 % endfor
 
 % for (inst_name, if_name), region in helper.devices(addr_space):

--- a/util/topgen/templates/toplevel_memory.ld.tpl
+++ b/util/topgen/templates/toplevel_memory.ld.tpl
@@ -71,6 +71,17 @@ MEMORY {
     % endfor
   % endif
 % endfor
+## TODO: need to find a more holistic way to define memories on the wrapper CTN crossbar.
+## At the moment, the topgen tooling is only aware of the CTN address space as a whole.
+% for m in top["module"]:
+  % if "memory" in m:
+    % for key, mem in m["memory"].items():
+      % if mem["label"] == "ctn":
+  ram_ctn(${flags(mem)}) : ORIGIN = ${m["base_addrs"][key][addr_space]} + 0x01000000, LENGTH = 0x00100000
+      % endif
+    % endfor
+  % endif
+% endfor
   rom_ext_virtual(rx) : ORIGIN = 0x90000000, LENGTH = ${get_virtual_memory_size(top)}
   owner_virtual(rx) : ORIGIN = 0xa0000000, LENGTH = ${get_virtual_memory_size(top)}
 }


### PR DESCRIPTION
This adds CTN SRAM memory base and size constants to the toplevel headers, ingested by ROM for instance.

This is a cherry-pick of https://github.com/lowRISC/opentitan/commit/642e62c5f41434b347d932ea4fa1dc8407d6489a

We do not yet have a mechanism to specify memory regions that are outside of the system that the hart has direct access to (e.g. the CTN memory space reachable via the CTN egress port).

This is needed for backporting the ROM for integrated tops, see PR #222 