### PR TITLE
[verilator] Add libzstd-dev apt dependency for Ubuntu 22.04

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -31,6 +31,7 @@ libssl-dev
 libtool
 libudev-dev
 libusb-1.0-0
+libzstd-dev
 lrzsz
 lsb-release
 make

--- a/yum-requirements.txt
+++ b/yum-requirements.txt
@@ -20,6 +20,7 @@ libftdi
 libftdi-devel
 libudev-devel
 libusbx
+libzstd-devel
 make
 openssl-devel
 redhat-lsb-core


### PR DESCRIPTION
When following the installation instructions on a fresh Ubuntu 22.04.5 installation, the verilator build fails with: ld.lld: error: unable to find library -lzstd

After installing libzstd-dev, the verilated "Hello World" works fine. This commit adds libzstd-dev to the apt dependencies. I have tested that this also does not cause any issues on Ubuntu 24.04.

Reported by  @phamhnh.