### PR TITLE
[ci] Fix lsb_release output issue in DVSim CI setup

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -155,7 +155,7 @@ runs:
         # Inject the OS version into a parameter used in the action key computation to
         # avoid collisions between different operating systems in the caches.
         # See #14695 for more information.
-        echo "build --remote_default_exec_properties=OSVersion=\"$(lsb_release -ds)\"" >> ~/.bazelrc
+        echo "build --remote_default_exec_properties=OSVersion=\"$(lsb_release -is)_$(lsb_release -rs)\"" >> ~/.bazelrc
 
         if ${{ github.event_name != 'pull_request' }}; then
           echo "Will upload to the cache." >&2


### PR DESCRIPTION
This PR adds a prior fix by @rtorok-zr for DV CI to Pavona, to prevent whitespace in `lsb_release -ds` output from breaking the build of `_sim_dv` tests in CI. 

This change specifically replaces the original inclusion of the output from `lsb_release -ds` into the action key computation, which can contain whitespace, with the inclusion of the outputs of `lsb_release -is` and `lsb_release -rs` joined with an underscore.