### PR TITLE
[crypto] Add endloop markers to Ed25519 implementation

### DIFF
--- a/sw/acc/crypto/ed25519.s
+++ b/sw/acc/crypto/ed25519.s
@@ -1256,6 +1256,8 @@ ext_scmul:
 
   /* End loop. From the loop invariants, we know
        [w13:w10] = P = a * (X1, Y1, Z1, T1) */
+  endloop
+
   ret
 
 /**
@@ -1340,6 +1342,8 @@ ext_scmul_var:
     /* Shift the scalar value to prepare for the next loop iteration.
          w28 <= w28 >> 1 = a << ((i + 1) + 3) */
     bn.rshi  w28, w28, w31 >> 255
+
+  endloop
 
   ret
 
@@ -1765,6 +1769,7 @@ fe_pow_2252m3:
   loopi   5,2
     jal     x1, fe_square
     nop
+  endloop
 
   /* w22 <= w22 * w23 = a^(2^10-1) */
   jal     x1, fe_mul
@@ -1777,6 +1782,7 @@ fe_pow_2252m3:
   loopi   10,2
     jal     x1, fe_square
     nop
+  endloop
 
   /* w22 <= w22 * w23 = a^(2^20-1) */
   jal     x1, fe_mul
@@ -1787,6 +1793,7 @@ fe_pow_2252m3:
   loopi   20,2
     jal     x1, fe_square
     nop
+  endloop
 
   /* w22 <= w22 * w23 = a^(2^40-1) */
   jal     x1, fe_mul
@@ -1795,6 +1802,7 @@ fe_pow_2252m3:
   loopi   10,2
     jal     x1, fe_square
     nop
+  endloop
 
   /* w22 <= w22 * w15 = a^(2^50-1) */
   bn.mov  w23, w15
@@ -1808,6 +1816,7 @@ fe_pow_2252m3:
   loopi   50,2
     jal     x1, fe_square
     nop
+  endloop
 
   /* w22 <= w22 * w23 = a^(2^100-1) */
   jal     x1, fe_mul
@@ -1818,6 +1827,7 @@ fe_pow_2252m3:
   loopi   100,2
     jal     x1, fe_square
     nop
+  endloop
 
   /* w22 <= w22 * w23 = a^(2^200-1) */
   jal     x1, fe_mul
@@ -1826,6 +1836,7 @@ fe_pow_2252m3:
   loopi   50,2
     jal     x1, fe_square
     nop
+  endloop
 
   /* w22 <= w22 * w15 = a^(2^250-1) */
   bn.mov  w23, w15

--- a/sw/acc/crypto/field25519.s
+++ b/sw/acc/crypto/field25519.s
@@ -335,6 +335,7 @@ fe_inv:
   loopi   5,2
     jal     x1, fe_square
     nop
+  endloop
 
   /* w22 <= w22 * w23 = a^(2^10-1) */
   jal     x1, fe_mul
@@ -347,6 +348,7 @@ fe_inv:
   loopi   10,2
     jal     x1, fe_square
     nop
+  endloop
 
   /* w22 <= w22 * w23 = a^(2^20-1) */
   jal     x1, fe_mul
@@ -357,6 +359,7 @@ fe_inv:
   loopi   20,2
     jal     x1, fe_square
     nop
+  endloop
 
   /* w22 <= w22 * w23 = a^(2^40-1) */
   jal     x1, fe_mul
@@ -365,6 +368,7 @@ fe_inv:
   loopi   10,2
     jal     x1, fe_square
     nop
+  endloop
 
   /* w22 <= w22 * w15 = a^(2^50-1) */
   bn.mov  w23, w15
@@ -378,6 +382,7 @@ fe_inv:
   loopi   50,2
     jal     x1, fe_square
     nop
+  endloop
 
   /* w22 <= w22 * w23 = a^(2^100-1) */
   jal     x1, fe_mul
@@ -388,6 +393,7 @@ fe_inv:
   loopi   100,2
     jal     x1, fe_square
     nop
+  endloop
 
   /* w22 <= w22 * w23 = a^(2^200-1) */
   jal     x1, fe_mul
@@ -396,6 +402,7 @@ fe_inv:
   loopi   50,2
     jal     x1, fe_square
     nop
+  endloop
 
   /* w22 <= w22 * w15 = a^(2^250-1) */
   bn.mov  w23, w15
@@ -405,6 +412,7 @@ fe_inv:
   loopi   5,2
     jal     x1, fe_square
     nop
+  endloop
 
   /* w22 <= w22 * w14 = a^(2^255 - 2^5 + 11) = a^(2^255 - 21) = a^(p-2) */
   bn.mov  w23, w14

--- a/sw/acc/crypto/sha512_compact.s
+++ b/sw/acc/crypto/sha512_compact.s
@@ -283,9 +283,15 @@ sha512_compact:
         /* nop to prevent same final instruction in both loop bodies */
         nop
 
+        /* End of innermost loop */
+        endloop
+
 
     /* Add compressed chunk to current hash value */
     addi      x2, x0, 15
+
+    /* End of intermediate loop */
+    endloop
 
     /* H_0 <= H_0 + a */
     bn.lid    x2, 0(x17)
@@ -327,7 +333,10 @@ sha512_compact:
     bn.add   w15, w7, w15
     bn.sid    x2, 224(x17)
 
-ret
+  /* End of outermost loop */
+  endloop
+
+  ret
 
 .bss
 

--- a/sw/acc/crypto/sha512_interface.s
+++ b/sw/acc/crypto/sha512_interface.s
@@ -37,6 +37,7 @@ sha512_init:
   loopi    8, 2
     bn.lid   x20, 0(x2++)
     bn.sid   x20, 0(x3++)
+  endloop
 
   /* dmem[sha512_dptr_state] <= state */
   la       x2, sha512_dptr_state
@@ -67,6 +68,7 @@ sha512_init:
   la       x2, partial
   loopi    8, 1
     bn.sid   x3, 0(x2++)
+  endloop
 
   ret
 
@@ -238,10 +240,12 @@ sha512_final:
       bn.and   w21, w21, w30
       /* w28 <= H[i] ^ (w28 << 64) */
       bn.xor   w28, w21, w28 << 64
+    endloop
     /* w28 <= reverse_bytes(w28) */
     jal      x1, reverse_bytes
     /* dmem[dptr_result+i*32] <= w28 */
     bn.sid   x28, 0(x3++)
+  endloop
 
   ret
 
@@ -326,6 +330,7 @@ copy:
   beq      x11, x0, _copy_dst_offset_zero
   loop     x11, 1
     bn.rshi  w21, w21, w21 >> 8
+  endloop
   _copy_dst_offset_zero:
 
   /* Now shift in bytes starting from the source pointer. The number of bytes
@@ -333,10 +338,12 @@ copy:
   beq      x10, x0, _copy_src_offset_zero
   loop     x10, 1
     bn.rshi  w20, w20, w20 >> 8
+  endloop
   _copy_src_offset_zero:
   loop     x19, 2
     bn.rshi  w21, w20, w21 >> 8
     bn.rshi  w20, w20, w20 >> 8
+  endloop
 
   /* Finally, finish rotating the word until the old values of the destination
      are in their original position. */
@@ -346,6 +353,7 @@ copy:
   beq      x2, x0, _copy_no_final_bytes
   loop     x2, 1
     bn.rshi  w21, w21, w21 >> 8
+  endloop
   _copy_no_final_bytes:
 
   /* Store the result.
@@ -431,6 +439,7 @@ sha512_format_blocks:
     jal      x1, bswap64
     /* dmem[x12++] <= w28 */
     bn.sid   x28, 0(x12++)
+  endloop
 
   ret
 

--- a/sw/acc/crypto/sha512_padding.s
+++ b/sw/acc/crypto/sha512_padding.s
@@ -103,6 +103,7 @@ sha512_pad_message:
   loop    x4, 2
     sw      x0, 0(x21)
     addi    x21, x21, 4
+  endloop
 
   /* Convert the message byte-length to bit-length in-place.
        dmem[dptr_len] <= dmem[dptr_len] << 3 */
@@ -121,6 +122,7 @@ sha512_pad_message:
     jal     x1, bswap32
     sw      x23, 0(x21)
     addi    x21, x21, 4
+  endloop
 
   ret
 


### PR DESCRIPTION
This PR adds the `endloop` pseudo-instruction (see #235) to the ends of each loop in the Ed25519 ACC implementation, ensuring that the loops indeed end where suggested by indentation in the code.