### PR TITLE
[acc,util] Emit .option exact to stop assembler branch relaxation

### DIFF
--- a/hw/ip/acc/util/acc_as.py
+++ b/hw/ip/acc/util/acc_as.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 # Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192).
@@ -648,6 +649,12 @@ class Transformer:
         #    0: Waiting for statement
         #    1: Waiting for body of statement (directive or instruction)
         self.state = 0
+
+        # Emit instructions exactly as written: ACC does not support the
+        # relaxed sequences (e.g. an out-of-range conditional branch becoming
+        # an inverted branch plus jal) that the assembler may otherwise
+        # substitute. Out-of-range branches become errors instead.
+        out_handle.write('.option exact\n')
 
         # Write .file and .line directives to tell the assembler where the code
         # came from.


### PR DESCRIPTION
clang's integrated assembler treats RISC-V conditional branches as relaxable: any beq/bne/... whose target it cannot prove to be within the +-4 KiB branch range (in particular, branches to symbols defined in another object) is silently rewritten into an inverted branch plus a jal.

This rewriting changes the emitted instruction count behind our back, which is a real hazard for ACC hardware loops: loop/loopi encode the body size in instructions, so if a conditional branch inside a loop body is expanded to two instructions, the hardware's loop-end address no longer matches the body the programmer wrote and execution silently goes wrong. It also makes any conditional branch a variable-size fragment until layout, so expressions like `. - label` spanning a branch no longer evaluate as absolute at parse time; this showed up in https://github.com/pavona/pavona/pull/239, where the loop-body size check that the endloop marker emits could not be placed after a loop body containing a beq. Finally, rsa.s, rsa_keygen.s, p256_verify.s, p256_ecdsa_sca.s, p384_verify.s and p384_ecdsa_sca.s all already contained such silently doubled branches (to external symbols).

Emit `.option exact` in the preamble of every translated file to disable the relaxation: branches are now emitted exactly as written.

`.option exact` is supported since LLVM 21.