### PR TITLE
[acc,mlkem] Minor fixes for ML-KEM assembly (DMEM initialization, layout assumptions)

### DIFF
--- a/sw/acc/crypto/mlkem/mlkem_decap.s
+++ b/sw/acc/crypto/mlkem/mlkem_decap.s
@@ -91,10 +91,12 @@ indcpa_dec:
    *   STACK_DEC_B + K*512    : poly v
    *   STACK_DEC_B + (K+1)*512: secret key polyvec */
   #define STACK_DEC_M_ADDR     -32
+  #define STACK_DEC_SK_ADDR    -36
   #define STACK_DEC_B        -4640
 
   /* Store parameters to stack */
   sw a3, STACK_DEC_M_ADDR(fp)
+  sw a1, STACK_DEC_SK_ADDR(fp)
 
   /*** unpack_ciphertext ***/
   li  a2, STACK_DEC_B
@@ -104,6 +106,7 @@ indcpa_dec:
   jal x1, unpack_ciphertext
 
   /*** unpack_sk ***/
+  lw  a0, STACK_DEC_SK_ADDR(fp)
   jal x1, unpack_sk
 
   bn.wsrr   w16, 0x0 /* w16 = R | Q */

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_enc.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_enc.s
@@ -436,7 +436,8 @@ pkpv:
 epp:
 .zero 2048
 
-/* Shared buffer for sp and ep (512 bytes each). */
+/* Shared buffer for sp and ep (k*512 bytes, max K=4). */
+.balign 32
 sp:
 ep:
-.zero 512
+.zero 2048

--- a/sw/acc/crypto/mlkem/mlkem_keypair.s
+++ b/sw/acc/crypto/mlkem/mlkem_keypair.s
@@ -111,6 +111,9 @@ indcpa_keypair:
   addi  a1, zero, 32
   jal   x1, keccak_send_message
   addi  a0, fp, STACK_BUF
+  /* Initialize; keccak_send_message reads a full WDR. */
+  li    t0, 31
+  bn.sid  t0, 0(a0)
   sw    x14, 0(a0)
   addi  a1, zero, 1
   jal   x1, keccak_send_message
@@ -127,6 +130,9 @@ indcpa_keypair:
   li   a3, STACK_NONCE
   add  a3, a3, fp
   li   a2, 0
+  /* Initialize; keccak_send_message reads a full WDR. */
+  li   t1, 31
+  bn.sid  t1, 0(a3)
   /* K iterations */
   LOOP x14, 6
     add  t1, fp, a5
@@ -217,6 +223,9 @@ indcpa_keypair:
   li   a3, STACK_NONCE
   add  a3, a3, fp
   addi a2, x14, 0
+  /* Initialize; keccak_send_message reads a full WDR. */
+  li   t1, 31
+  bn.sid  t1, 0(a3)
   /* K iterations */
   LOOP x14, 6
     add  t1, fp, a5

--- a/sw/acc/crypto/tests/mlkem/mlkem_decap_test.s
+++ b/sw/acc/crypto/tests/mlkem/mlkem_decap_test.s
@@ -15,7 +15,7 @@
 
 .section .text.start
 
-#define STACK_SIZE 20000
+#define STACK_SIZE 6144
 #define CRYPTO_BYTES 32
 
 #if KYBER_K == 2


### PR DESCRIPTION
In the process of testing the ML-KEM ACC implementation on FPGA, I hit a few minor issues that I fixed here.

- Depends on #214 