### PR TITLE
[top_dragonfly,dv] Ported chip_sw_lc_walkthrough tests to DT

### DIFF
--- a/hw/top_dragonfly/dv/chip_dragonfly_sim_cfg.hjson
+++ b/hw/top_dragonfly/dv/chip_dragonfly_sim_cfg.hjson
@@ -734,38 +734,36 @@
       run_opts: ["+bypass_alert_ready_to_end_check=1"]
       reseed: 3
     }
-    // TODO(Pavona #43): Needs Dragonfly execution environment
-    // {
-    //   name: chip_sw_lc_walkthrough_dev
-    //   uvm_test_seq: chip_sw_lc_walkthrough_vseq
-    //   sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:6:new_rules"]
-    //   en_run_modes: ["sw_test_mode_test_rom"]
-    //   run_opts: ["+flash_program_latency=5",
-    //              "+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStDev",
-                 // The test takes long time because it will transit to RMA state
-    //              "+sw_test_timeout_ns=200_000_000"]
-    //   run_timeout_mins: 240
-    // }
-    // {
-    //   name: chip_sw_lc_walkthrough_prod
-    //   uvm_test_seq: chip_sw_lc_walkthrough_vseq
-    //   sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:6:new_rules"]
-    //   en_run_modes: ["sw_test_mode_test_rom"]
-    //   run_opts: ["+flash_program_latency=5",
-    //              "+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStProd",
-                 // The test takes long time because it will transit to RMA state
-    //              "+sw_test_timeout_ns=200_000_000"]
-    //   run_timeout_mins: 240
-    // }
-    // {
-    //   name: chip_sw_lc_walkthrough_prodend
-    //   uvm_test_seq: chip_sw_lc_walkthrough_vseq
-    //   sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:6:new_rules"]
-    //   en_run_modes: ["sw_test_mode_test_rom"]
-    //   run_opts: ["+flash_program_latency=5",
-    //              "+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStProdEnd"]
-    // }
-    // End of TODO(Pavona #43)
+    {
+      name: chip_sw_lc_walkthrough_dev
+      uvm_test_seq: chip_sw_lc_walkthrough_vseq
+      sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:6:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+flash_program_latency=5",
+                 "+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStDev",
+              // The test takes long time because it will transit to RMA state
+                 "+sw_test_timeout_ns=200_000_000"]
+      run_timeout_mins: 240
+    }
+    {
+      name: chip_sw_lc_walkthrough_prod
+      uvm_test_seq: chip_sw_lc_walkthrough_vseq
+      sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:6:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+flash_program_latency=5",
+                 "+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStProd",
+              // The test takes long time because it will transit to RMA state
+                 "+sw_test_timeout_ns=200_000_000"]
+      run_timeout_mins: 240
+    }
+    {
+      name: chip_sw_lc_walkthrough_prodend
+      uvm_test_seq: chip_sw_lc_walkthrough_vseq
+      sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:6:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+flash_program_latency=5",
+                 "+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStProdEnd"]
+    }
     {
       name: chip_sw_lc_ctrl_volatile_raw_unlock
       uvm_test_seq: chip_sw_lc_volatile_raw_unlock_vseq
@@ -784,26 +782,24 @@
         "+chip_clock_source=ChipClockSourceExternal48Mhz"]
       run_timeout_mins: 120
     }
-    // TODO(Pavona #43): Needs Dragonfly execution environment
-    // {
-    //   name: chip_sw_lc_walkthrough_rma
-    //   uvm_test_seq: chip_sw_lc_walkthrough_vseq
-    //   sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:6:new_rules"]
-    //   en_run_modes: ["sw_test_mode_test_rom"]
-    //   run_opts: ["+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStRma",
-    //              "+flash_program_latency=5",
-                 // The test takes long time because it will transit to RMA state
-    //              "+sw_test_timeout_ns=200_000_000"]
-    //   run_timeout_mins: 240
-    // }
-    // {
-    //   name: chip_sw_lc_walkthrough_testunlocks
-    //   uvm_test_seq: chip_sw_lc_walkthrough_testunlocks_vseq
-    //   sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_testunlocks_test:6:new_rules"]
-    //   en_run_modes: ["sw_test_mode_test_rom"]
-    //   run_opts: ["+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStTestUnlock7"]
-    // }
-    // End of TODO(Pavona #43)
+    {
+      name: chip_sw_lc_walkthrough_rma
+      uvm_test_seq: chip_sw_lc_walkthrough_vseq
+      sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:6:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStRma",
+                 "+flash_program_latency=5",
+              // The test takes long time because it will transit to RMA state
+                 "+sw_test_timeout_ns=200_000_000"]
+      run_timeout_mins: 240
+    }
+    {
+      name: chip_sw_lc_walkthrough_testunlocks
+      uvm_test_seq: chip_sw_lc_walkthrough_testunlocks_vseq
+      sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_testunlocks_test:6:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStTestUnlock7"]
+    }
     {
       name: chip_sw_rstmgr_sw_req
       uvm_test_seq: chip_sw_base_vseq

--- a/hw/top_dragonfly/dv/chip_dragonfly_sim_cfg.hjson
+++ b/hw/top_dragonfly/dv/chip_dragonfly_sim_cfg.hjson
@@ -690,15 +690,14 @@
     //   reseed: 1
     // }
     // End of TODO(Pavona #43)
-    // TODO(Pavona #43): Needs Dragonfly execution environment
-    // {
+    {
       // Set higher reseed value to reach all kmac_data to lc_ctrl toggle coverage.
-    //   name: chip_sw_lc_ctrl_transition
-    //   uvm_test_seq: chip_sw_lc_ctrl_transition_vseq
-    //   sw_images: ["//sw/device/tests/sim_dv:lc_ctrl_transition_test:6:new_rules"]
-    //   en_run_modes: ["sw_test_mode_test_rom"]
-    //   reseed: 15
-    // }
+      name: chip_sw_lc_ctrl_transition
+      uvm_test_seq: chip_sw_lc_ctrl_transition_vseq
+      sw_images: ["//sw/device/tests/sim_dv:lc_ctrl_transition_test:6:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      reseed: 15
+    }
 
     {
       name: chip_sw_lc_ctrl_rma_to_scrap

--- a/hw/top_dragonfly/dv/chip_dragonfly_sim_cfg.hjson
+++ b/hw/top_dragonfly/dv/chip_dragonfly_sim_cfg.hjson
@@ -607,13 +607,12 @@
       sw_images: ["//sw/device/tests:kmac_entropy_test:6:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
-    // TODO(Pavona #44): Needs sw_image Bazel target
-    // {
-    //   name: chip_sw_lc_ctrl_otp_hw_cfg
-    //   uvm_test_seq: chip_sw_base_vseq
-    //   sw_images: ["//sw/device/tests:lc_ctrl_otp_hw_cfg_test:6:new_rules"]
-    //   en_run_modes: ["sw_test_mode_test_rom"]
-    // }
+    {
+      name: chip_sw_lc_ctrl_otp_hw_cfg
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:lc_ctrl_otp_hw_cfg0_test:6:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
     // TODO(Pavona #43): Needs Dragonfly execution environment
     // {
     //   name: chip_sw_otp_ctrl_lc_signals_test_unlocked0

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2965,9 +2965,12 @@ pavona_test(
 pavona_test(
     name = "lc_ctrl_otp_hw_cfg0_test",
     srcs = ["lc_ctrl_otp_hw_cfg0_test.c"],
-    exec_env = EGRET_TEST_ENVS,
+    exec_env = dicts.add(
+        EGRET_TEST_ENVS,
+        DRAGONFLY_TEST_ENVS,
+    ),
     deps = [
-        "//hw/top_egret/sw/autogen:top_egret",
+        "//hw/top/dt",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",

--- a/sw/device/tests/lc_ctrl_otp_hw_cfg0_test.c
+++ b/sw/device/tests/lc_ctrl_otp_hw_cfg0_test.c
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,8 +15,6 @@
 #include "sw/device/lib/testing/otp_ctrl_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
-
-#include "hw/top_egret/sw/autogen/top_egret.h"
 
 static dif_otp_ctrl_t otp;
 static dif_lc_ctrl_t lc;
@@ -39,12 +38,8 @@ static void otp_ctrl_dai_read_32(const dif_otp_ctrl_t *otp,
  */
 // TODO: needs to support other recipients besides LC_CTRL.
 bool test_main(void) {
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp));
-
-  mmio_region_t lc_reg =
-      mmio_region_from_addr(TOP_EGRET_LC_CTRL_REGS_BASE_ADDR);
-  CHECK_DIF_OK(dif_lc_ctrl_init(lc_reg, &lc));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
+  CHECK_DIF_OK(dif_lc_ctrl_init_from_dt(kDtLcCtrl, &lc));
 
   dif_otp_ctrl_config_t config = {
       .check_timeout = 100000,

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -1,4 +1,5 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -223,7 +224,7 @@ cc_library(
     hdrs = ["lc_ctrl_transition_impl.h"],
     target_compatible_with = [PAVONA_CPU],
     deps = [
-        "//hw/top_egret/sw/autogen:top_egret",
+        "//hw/top/dt",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -237,7 +238,10 @@ cc_library(
 pavona_test(
     name = "lc_ctrl_transition_test",
     srcs = ["lc_ctrl_transition_test.c"],
-    exec_env = {"//hw/top_egret:sim_dv": None},
+    exec_env = {
+        "//hw/top_dragonfly:sim_dv": None,
+        "//hw/top_egret:sim_dv": None,
+    },
     deps = [
         ":lc_ctrl_transition_impl",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -379,7 +383,10 @@ pavona_test(
 pavona_test(
     name = "clkmgr_external_clk_src_for_lc_test",
     srcs = ["clkmgr_external_clk_src_for_lc_test.c"],
-    exec_env = {"//hw/top_egret:sim_dv": None},
+    exec_env = {
+        "//hw/top_dragonfly:sim_dv": None,
+        "//hw/top_egret:sim_dv": None,
+    },
     deps = [
         ":lc_ctrl_transition_impl",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -271,9 +271,12 @@ pavona_test(
 pavona_test(
     name = "lc_walkthrough_test",
     srcs = ["lc_walkthrough_test.c"],
-    exec_env = {"//hw/top_egret:sim_dv": None},
+    exec_env = {
+        "//hw/top_dragonfly:sim_dv": None,
+        "//hw/top_egret:sim_dv": None,
+    },
     deps = [
-        "//hw/top_egret/sw/autogen:top_egret",
+        "//hw/top/dt",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:lc_ctrl",
@@ -291,9 +294,12 @@ pavona_test(
 pavona_test(
     name = "lc_walkthrough_testunlocks_test",
     srcs = ["lc_walkthrough_testunlocks_test.c"],
-    exec_env = {"//hw/top_egret:sim_dv": None},
+    exec_env = {
+        "//hw/top_dragonfly:sim_dv": None,
+        "//hw/top_egret:sim_dv": None,
+    },
     deps = [
-        "//hw/top_egret/sw/autogen:top_egret",
+        "//hw/top/dt",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:lc_ctrl",

--- a/sw/device/tests/sim_dv/lc_ctrl_transition_impl.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_transition_impl.c
@@ -1,10 +1,12 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
 #include <assert.h>
 #include <stdbool.h>
 
+#include "hw/top/dt/lc_ctrl.h"
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/mmio.h"
@@ -12,8 +14,6 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/lc_ctrl_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
-
-#include "hw/top_egret/sw/autogen/top_egret.h"
 
 #define LC_TOKEN_SIZE 16
 
@@ -65,7 +65,7 @@ bool execute_lc_ctrl_transition_test(bool use_ext_clk) {
   LOG_INFO("Start LC_CTRL transition test.");
 
   mmio_region_t lc_reg =
-      mmio_region_from_addr(TOP_EGRET_LC_CTRL_REGS_BASE_ADDR);
+      mmio_region_from_addr(dt_lc_ctrl_primary_reg_block(kDtLcCtrl));
   CHECK_DIF_OK(dif_lc_ctrl_init(lc_reg, &lc));
 
   LOG_INFO("Read and check LC state.");

--- a/sw/device/tests/sim_dv/lc_walkthrough_test.c
+++ b/sw/device/tests/sim_dv/lc_walkthrough_test.c
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,8 +13,6 @@
 #include "sw/device/lib/testing/otp_ctrl_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
-
-#include "hw/top_egret/sw/autogen/top_egret.h"
 
 #define LC_TOKEN_SIZE 16
 
@@ -156,16 +155,9 @@ static void lock_otp_secret2_partition(void) {
 bool test_main(void) {
   LOG_INFO("Start LC walkthrough %d test.", kDestState);
 
-  mmio_region_t lc_reg =
-      mmio_region_from_addr(TOP_EGRET_LC_CTRL_REGS_BASE_ADDR);
-  CHECK_DIF_OK(dif_lc_ctrl_init(lc_reg, &lc));
-
-  mmio_region_t otp_reg =
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR);
-  CHECK_DIF_OK(dif_otp_ctrl_init(otp_reg, &otp));
-
-  CHECK_DIF_OK(dif_rstmgr_init(
-      mmio_region_from_addr(TOP_EGRET_RSTMGR_AON_BASE_ADDR), &rstmgr));
+  CHECK_DIF_OK(dif_lc_ctrl_init_from_dt(kDtLcCtrl, &lc));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
+  CHECK_DIF_OK(dif_rstmgr_init_from_dt(kDtRstmgrAon, &rstmgr));
 
   LOG_INFO("Read and check LC state and count.");
   dif_lc_ctrl_state_t curr_state;

--- a/sw/device/tests/sim_dv/lc_walkthrough_testunlocks_test.c
+++ b/sw/device/tests/sim_dv/lc_walkthrough_testunlocks_test.c
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,8 +13,6 @@
 #include "sw/device/lib/testing/otp_ctrl_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
-
-#include "hw/top_egret/sw/autogen/top_egret.h"
 
 #define LC_TOKEN_SIZE 16
 
@@ -149,16 +148,9 @@ static void get_dest_state_and_cnt(dif_lc_ctrl_state_t *curr_state,
 bool test_main(void) {
   LOG_INFO("Start LC walkthrough testunlocks test.");
 
-  mmio_region_t lc_reg =
-      mmio_region_from_addr(TOP_EGRET_LC_CTRL_REGS_BASE_ADDR);
-  CHECK_DIF_OK(dif_lc_ctrl_init(lc_reg, &lc));
-
-  mmio_region_t otp_reg =
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR);
-  CHECK_DIF_OK(dif_otp_ctrl_init(otp_reg, &otp));
-
-  CHECK_DIF_OK(dif_rstmgr_init(
-      mmio_region_from_addr(TOP_EGRET_RSTMGR_AON_BASE_ADDR), &rstmgr));
+  CHECK_DIF_OK(dif_lc_ctrl_init_from_dt(kDtLcCtrl, &lc));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
+  CHECK_DIF_OK(dif_rstmgr_init_from_dt(kDtRstmgrAon, &rstmgr));
 
   LOG_INFO("Read and check LC state and count.");
   dif_lc_ctrl_state_t curr_state;


### PR DESCRIPTION
This PR ports the following chip-level testcases to Dragonfly and adds DT support. They will be marked off in #43 once merged.

- `chip_sw_lc_ctrl_transition`
- `chip_sw_lc_walkthrough_dev`
- `chip_sw_lc_walkthrough_prod`
- `chip_sw_lc_walkthrough_prodend`
- `chip_sw_lc_walkthrough_rma`
- `chip_sw_lc_walkthrough_testunlocks`

It also resolves the following testcase from #44.

- `chip_sw_lc_ctrl_otp_hw_cfg`