### PR TITLE
[acc,mldsa] Turn ML-DSA parameter set into a runtime parameter

### DIFF
--- a/sw/acc/crypto/mldsa/BUILD
+++ b/sw/acc/crypto/mldsa/BUILD
@@ -8,128 +8,62 @@ load("//rules:acc.bzl", "acc_binary", "acc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-NAME_BY_SEC_LEVEL = {
-    2: "mldsa44",
-    3: "mldsa65",
-    5: "mldsa87",
-}
-
 acc_library(
     name = "kmac_send_msg",
-    srcs = [
-        "kmac_send_msg.s",
-    ],
+    srcs = ["kmac_send_msg.s"],
 )
 
 acc_library(
     name = "ntt",
-    srcs = [
-        "ntt.s",
-    ],
+    srcs = ["ntt.s"],
 )
 
 acc_library(
     name = "intt",
-    srcs = [
-        "intt.s",
-    ],
+    srcs = ["intt.s"],
 )
 
 acc_library(
     name = "poly_pointwise",
-    srcs = [
-        "poly_pointwise.s",
-    ],
+    srcs = ["poly_pointwise.s"],
 )
 
 acc_library(
     name = "poly_add",
-    srcs = [
-        "poly_add.s",
-    ],
+    srcs = ["poly_add.s"],
 )
 
 acc_library(
     name = "poly_sub",
-    srcs = [
-        "poly_sub.s",
-    ],
+    srcs = ["poly_sub.s"],
 )
 
-[
-    acc_library(
-        name = name + "_keypair",
-        srcs = [
-            "mldsa_keypair.s",
-        ],
-        copts = [
-            "-DDILITHIUM_MODE=" + str(sec_level),
-        ],
-    )
-    for sec_level, name in NAME_BY_SEC_LEVEL.items()
-]
+acc_library(
+    name = "keypair",
+    srcs = ["mldsa_keypair.s"],
+)
 
-[
-    acc_library(
-        name = name + "_verify",
-        srcs = [
-            "mldsa_verify.s",
-        ],
-        copts = [
-            "-DDILITHIUM_MODE=" + str(sec_level),
-        ],
-    )
-    for sec_level, name in NAME_BY_SEC_LEVEL.items()
-]
+acc_library(
+    name = "verify",
+    srcs = ["mldsa_verify.s"],
+)
 
-[
-    acc_library(
-        name = name + "_poly",
-        srcs = [
-            "poly.s",
-        ],
-        copts = [
-            "-DDILITHIUM_MODE=" + str(sec_level),
-        ],
-    )
-    for sec_level, name in NAME_BY_SEC_LEVEL.items()
-]
+acc_library(
+    name = "poly",
+    srcs = ["poly.s"],
+)
 
-[
-    acc_library(
-        name = name + "_rounding",
-        srcs = [
-            "rounding.s",
-        ],
-        copts = [
-            "-DDILITHIUM_MODE=" + str(sec_level),
-        ],
-    )
-    for sec_level, name in NAME_BY_SEC_LEVEL.items()
-]
+acc_library(
+    name = "rounding",
+    srcs = ["rounding.s"],
+)
 
-[
-    acc_library(
-        name = name + "_sign",
-        srcs = [
-            "mldsa_sign.s",
-        ],
-        copts = [
-            "-DDILITHIUM_MODE=" + str(sec_level),
-        ],
-    )
-    for sec_level, name in NAME_BY_SEC_LEVEL.items()
-]
+acc_library(
+    name = "sign",
+    srcs = ["mldsa_sign.s"],
+)
 
-[
-    acc_library(
-        name = name + "_consts",
-        srcs = [
-            "mldsa_consts.s",
-        ],
-        copts = [
-            "-DDILITHIUM_MODE=" + str(sec_level),
-        ],
-    )
-    for sec_level, name in NAME_BY_SEC_LEVEL.items()
-]
+acc_library(
+    name = "consts",
+    srcs = ["mldsa_consts.s"],
+)

--- a/sw/acc/crypto/mldsa/mldsa_consts.s
+++ b/sw/acc/crypto/mldsa/mldsa_consts.s
@@ -14,23 +14,6 @@
 
 #define Q 8380417
 
-#if DILITHIUM_MODE == 2
-#define ETA 2
-#define GAMMA1 131072
-#define GAMMA2 95232
-
-#elif DILITHIUM_MODE == 3
-#define ETA 4
-#define GAMMA1 524288
-#define GAMMA2 261888
-
-#elif DILITHIUM_MODE == 5
-#define ETA 2
-#define GAMMA1 524288
-#define GAMMA2 261888
-
-#endif
-
 .data
 
 /* Modulus for reduction */
@@ -634,16 +617,28 @@ power2round_D_preprocessed:
     .word 0xfff
 
 .balign 32
-.globl eta
-eta:
-    .word ETA
-    .word ETA
-    .word ETA
-    .word ETA
-    .word ETA
-    .word ETA
-    .word ETA
-    .word ETA
+.globl eta_2
+eta_2:
+    .word 2
+    .word 2
+    .word 2
+    .word 2
+    .word 2
+    .word 2
+    .word 2
+    .word 2
+
+.balign 32
+.globl eta_4
+eta_4:
+    .word 4
+    .word 4
+    .word 4
+    .word 4
+    .word 4
+    .word 4
+    .word 4
+    .word 4
 
 .balign 32
 .globl polyt0_pack_const
@@ -658,9 +653,8 @@ polyt0_pack_const:
     .word 0x1000
 
 .balign 32
-.globl decompose_const
-decompose_const:
-#if GAMMA2 == (Q-1)/88
+.globl decompose_const_88
+decompose_const_88:
     .word 0x00002c0b
     .word 0x00002c0b
     .word 0x00002c0b
@@ -669,40 +663,66 @@ decompose_const:
     .word 0x00002c0b
     .word 0x00002c0b
     .word 0x00002c0b
-#elif GAMMA2 == (Q-1)/32
-    .word 1025
-    .word 1025
-    .word 1025
-    .word 1025
-    .word 1025
-    .word 1025
-    .word 1025
-    .word 1025
-#endif
 
 .balign 32
-.globl gamma1_vec_const
-gamma1_vec_const:
-    .word GAMMA1
-    .word GAMMA1
-    .word GAMMA1
-    .word GAMMA1
-    .word GAMMA1
-    .word GAMMA1
-    .word GAMMA1
-    .word GAMMA1
+.globl decompose_const_32
+decompose_const_32:
+    .word 1025
+    .word 1025
+    .word 1025
+    .word 1025
+    .word 1025
+    .word 1025
+    .word 1025
+    .word 1025
 
 .balign 32
-.globl gamma2_vec_const
-gamma2_vec_const:
-    .word GAMMA2
-    .word GAMMA2
-    .word GAMMA2
-    .word GAMMA2
-    .word GAMMA2
-    .word GAMMA2
-    .word GAMMA2
-    .word GAMMA2
+.globl gamma1_vec_const_17
+gamma1_vec_const_17:
+    .word 131072
+    .word 131072
+    .word 131072
+    .word 131072
+    .word 131072
+    .word 131072
+    .word 131072
+    .word 131072
+
+.balign 32
+.globl gamma1_vec_const_19
+gamma1_vec_const_19:
+    .word 524288
+    .word 524288
+    .word 524288
+    .word 524288
+    .word 524288
+    .word 524288
+    .word 524288
+    .word 524288
+
+.balign 32
+.globl gamma2_vec_const_88
+gamma2_vec_const_88:
+    .word 95232
+    .word 95232
+    .word 95232
+    .word 95232
+    .word 95232
+    .word 95232
+    .word 95232
+    .word 95232
+
+.balign 32
+.globl gamma2_vec_const_32
+gamma2_vec_const_32:
+    .word 261888
+    .word 261888
+    .word 261888
+    .word 261888
+    .word 261888
+    .word 261888
+    .word 261888
+    .word 261888
 
 .balign 32
 .globl qm1half_const
@@ -729,9 +749,8 @@ decompose_127_const:
     .word 0x0000007f
 
 .balign 32
-.globl decompose_43_const
-decompose_43_const:
-#if GAMMA2 == (Q-1)/88
+.globl decompose_43_const_88
+decompose_43_const_88:
     .word 0x0000002b
     .word 0x0000002b
     .word 0x0000002b
@@ -740,21 +759,22 @@ decompose_43_const:
     .word 0x0000002b
     .word 0x0000002b
     .word 0x0000002b
-#elif GAMMA2 == (Q-1)/32
-    .word 0x000000f
-    .word 0x000000f
-    .word 0x000000f
-    .word 0x000000f
-    .word 0x000000f
-    .word 0x000000f
-    .word 0x000000f
-    .word 0x000000f
-#endif
 
 .balign 32
-.globl polyeta_unpack_mask
-polyeta_unpack_mask:
-#if ETA == 2
+.globl decompose_43_const_32
+decompose_43_const_32:
+    .word 0x000000f
+    .word 0x000000f
+    .word 0x000000f
+    .word 0x000000f
+    .word 0x000000f
+    .word 0x000000f
+    .word 0x000000f
+    .word 0x000000f
+
+.balign 32
+.globl polyeta_unpack_mask_eta_2
+polyeta_unpack_mask_eta_2:
     .word 0x07
     .word 0x07
     .word 0x07
@@ -763,7 +783,10 @@ polyeta_unpack_mask:
     .word 0x07
     .word 0x07
     .word 0x07
-#elif ETA == 4
+
+.balign 32
+.globl polyeta_unpack_mask_eta_4
+polyeta_unpack_mask_eta_4:
     .word 0x0f
     .word 0x0f
     .word 0x0f
@@ -772,7 +795,6 @@ polyeta_unpack_mask:
     .word 0x0f
     .word 0x0f
     .word 0x0f
-#endif
 
 .balign 32
 .globl polyt1_unpack_mask
@@ -799,9 +821,8 @@ polyt0_unpack_mask:
     .word 0x1fff
 
 .balign 32
-.globl polyz_unpack_mask
-polyz_unpack_mask:
-#if GAMMA1 == (1 << 17)
+.globl polyz_unpack_mask_17
+polyz_unpack_mask_17:
     .word 0x3ffff
     .word 0x3ffff
     .word 0x3ffff
@@ -810,7 +831,10 @@ polyz_unpack_mask:
     .word 0x3ffff
     .word 0x3ffff
     .word 0x3ffff
-#elif GAMMA1 == (1 << 19)
+
+.balign 32
+.globl polyz_unpack_mask_19
+polyz_unpack_mask_19:
     .word 0xfffff
     .word 0xfffff
     .word 0xfffff
@@ -819,7 +843,6 @@ polyz_unpack_mask:
     .word 0xfffff
     .word 0xfffff
     .word 0xfffff
-#endif
 
 .balign 32
 .globl poly_uniform_eta_205
@@ -860,3 +883,23 @@ poly_uniform_eta_5:
 .globl poly_wdr2gpr
 poly_wdr2gpr:
     .zero 32
+
+/* Mode-derived parameters. Caller (test harness or driver) writes the
+   active mode's values here before calling any mldsa entry point.
+   Layout (word offsets):
+     0  K
+     4  L
+     8  TAU
+    12  OMEGA
+    16  GAMMA1 - BETA
+    20  POLYW1_PACKEDBYTES
+    24  CRYPTO_PUBLICKEYBYTES
+    28  GAMMA2
+    32  GAMMA2 - BETA
+    36  SK_S2_OFFSET            (128 + L*POLYETA_PACKEDBYTES)
+    40  SK_T0_OFFSET            (128 + (L+K)*POLYETA_PACKEDBYTES)
+    44  CRYPTO_BYTES */
+.balign 32
+.globl mldsa_params
+mldsa_params:
+    .zero 64

--- a/sw/acc/crypto/mldsa/mldsa_keypair.s
+++ b/sw/acc/crypto/mldsa/mldsa_keypair.s
@@ -11,91 +11,17 @@
 .text
 
 #define SEEDBYTES 32
-#define CRHBYTES 64
-#define TRBYTES 64
-#define RNDBYTES 32
 #define N 256
 #define Q 8380417
 #define D 13
-#define ROOT_OF_UNITY 1753
 
-#if DILITHIUM_MODE == 2
-#define K 4
-#define L 4
-#define ETA 2
-#define TAU 39
-#define BETA 78
-#define GAMMA1 131072
-#define GAMMA2 95232
-#define OMEGA 80
-#define CTILDEBYTES 32
-
-#define POLYVECK_BYTES 4096
-#define POLYVECL_BYTES 4096
-
-#define CRYPTO_PUBLICKEYBYTES 1312
-#define CRYPTO_SECRETKEYBYTES 2560
-#define CRYPTO_BYTES 2420
-
-#elif DILITHIUM_MODE == 3
-#define K 6
-#define L 5
-#define ETA 4
-#define TAU 49
-#define BETA 196
-#define GAMMA1 524288
-#define GAMMA2 261888
-#define OMEGA 55
-#define CTILDEBYTES 48
-
-#define POLYVECK_BYTES 6144
-#define POLYVECL_BYTES 5120
-
-#define CRYPTO_PUBLICKEYBYTES 1952
-#define CRYPTO_SECRETKEYBYTES 4032
-#define CRYPTO_BYTES 3309
-
-#elif DILITHIUM_MODE == 5
-#define K 8
-#define L 7
-#define ETA 2
-#define TAU 60
-#define BETA 120
-#define GAMMA1 524288
-#define GAMMA2 261888
-#define OMEGA 75
-#define CTILDEBYTES 64
-
+/* Worst-case (ML-DSA-87) polyvec size. */
 #define POLYVECK_BYTES 8192
-#define POLYVECL_BYTES 7168
 
-#define CRYPTO_PUBLICKEYBYTES 2592
-#define CRYPTO_SECRETKEYBYTES 4896
-#define CRYPTO_BYTES 4627
-
-#endif
-
-#define POLYT1_PACKEDBYTES  320
-#define POLYT0_PACKEDBYTES  416
-#define POLYVECH_PACKEDBYTES (OMEGA + K)
-
-#if GAMMA1 == (1 << 17)
-#define POLYZ_PACKEDBYTES   576
-#elif GAMMA1 == (1 << 19)
-#define POLYZ_PACKEDBYTES   640
-#endif
-
-#if GAMMA2 == (Q-1)/88
-#define POLYW1_PACKEDBYTES  192
-#elif GAMMA2 == (Q-1)/32
-#define POLYW1_PACKEDBYTES  128
-#endif
-
-#if ETA == 2
-#define POLYETA_PACKEDBYTES  96
-#elif ETA == 4
-#define POLYETA_PACKEDBYTES 128
-#endif
+/* Offsets into the mldsa_params struct (in mldsa_consts.s). */
+#define MLDSA_PARAM_K_OFFSET 0
+#define MLDSA_PARAM_L_OFFSET 4
+#define MLDSA_PARAM_CRYPTO_PUBLICKEYBYTES_OFFSET 24
 
 /* Register aliases */
 .equ x2, sp
@@ -151,6 +77,7 @@
  * Returns: 0 on success
  *
  * @param[in]  dmem[zeta]: 32 random bytes
+ * @param[in]  dmem[mldsa_params]: active mode parameters
  * @param[out] dmem[pk]: public key
  * @param[out] dmem[sk]: secret key
  *
@@ -158,6 +85,9 @@
  */
 .globl crypto_sign_keypair
 crypto_sign_keypair:
+    la   s11, mldsa_params
+    lw   s10, MLDSA_PARAM_K_OFFSET(s11)
+
     /* Initialize a SHAKE256 operation. */
     li    a1, SEEDBYTES
     addi  a1, a1, 2 /* SEEDBYTES+2 */
@@ -171,12 +101,16 @@ crypto_sign_keypair:
     jal  x1, keccak_send_message
 
     /* Send K, L to KMAC block. */
+    la      t1, poly_wdr2gpr
     li      t0, 1
     csrrw   x0, kmac_partial_write, t0
-    bn.addi w0, w31, K
+    sw      s10, 0(t1)
+    bn.lid  x0, 0(t1)
     bn.wsrw kmac_msg, w0
     csrrw   x0, kmac_partial_write, t0
-    bn.addi w0, w31, L
+    lw      t2, MLDSA_PARAM_L_OFFSET(s11)
+    sw      t2, 0(t1)
+    bn.lid  x0, 0(t1)
     bn.wsrw kmac_msg, w0
 
     /* Squeeze into output buffers. Store rho and the key in sk. */
@@ -207,13 +141,13 @@ crypto_sign_keypair:
     /* Zero the destination buffer. */
     li t0, 31
     addi t1, s2, 0
-    LOOPI K, 3
+    LOOP s10, 3
         LOOPI 32, 1
           bn.sid t0, 0(t1++)
         nop
 
-    /* Load offset for resetting vector pointer. */
-    li s3, POLYVECK_BYTES
+    /* Load offset for resetting vector pointer (K * 1024). */
+    slli s3, s10, 10
 
     /* Initialize the nonce for matrix expansion. This value should be
          byte(i) || byte(j)
@@ -246,12 +180,14 @@ crypto_sign_keypair:
            for i in 0..k-1:
              t[i] += A[i][j] * s1j
     */
-    loopi L, 41
+    lw t0, MLDSA_PARAM_L_OFFSET(s11)
+    LOOP t0, 43
         bn.wsrw   mod, w16 /* MOD = R | Q */
         /* Sample the next polynomial from s1. */
         addi a0, s5, 0
         addi a1, s0, 0
         addi a2, s6, 0
+        addi a4, s10, 0
         jal  x1, poly_uniform_eta
         addi s6, s6, 1
         /* Start the SHAKE128 operation for poly_uniform for A[0][j]. */
@@ -265,6 +201,7 @@ crypto_sign_keypair:
         /* Pack the s1 polynomial into the secret key. */
         addi a0, s7, 0
         addi a1, s0, 0
+        addi a4, s10, 0
         jal x1, polyeta_pack
         addi s7, a0, 0
         bn.wsrw   mod, w22 /* MOD = 2*R | 2*Q */
@@ -272,7 +209,7 @@ crypto_sign_keypair:
         addi a0, s0, 0
         addi a2, s0, 0
         jal  x1, ntt
-        loopi K, 15
+        LOOP s10, 15
             /* Compute A[i][j]. */
             addi a1, s1, 0
             jal  x1, poly_uniform
@@ -305,7 +242,7 @@ crypto_sign_keypair:
     /* Inverse NTT on t=A*s1 */
     la  a0, t_polyvec
 
-    LOOPI K, 2
+    LOOP s10, 2
         jal  x1, intt
         addi a0, a0, 1024 /* Go to next input polynomial */
     bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
@@ -316,19 +253,21 @@ crypto_sign_keypair:
     la  s3, rhoprime
 
     /* Initialize the nonce for sampling s2. */
-    li s6, L
+    lw s6, MLDSA_PARAM_L_OFFSET(s11)
 
     /* This loop samples s2 and adds it to A*s1 (currently in the t buffer). */
-    LOOPI K, 14
+    LOOP s10, 16
         /* Sample the next polynomial from s2 and store in temp buffer. */
         addi a0, s3, 0
         addi a1, s0, 0
         addi a2, s6, 0
+        addi a4, s10, 0
         jal  x1, poly_uniform_eta
         addi s6, s6, 1
         /* Pack the s2 polynomial into the secret key. */
         addi a0, s7, 0
         addi a1, s0, 0
+        addi a4, s10, 0
         jal  x1, polyeta_pack
         addi s7, a0, 0
         /* t[i] += s2 */
@@ -342,7 +281,7 @@ crypto_sign_keypair:
     /* Reset t pointer for power2round loop. */
     la  s1, t_polyvec
 
-    LOOPI K, 9
+    LOOP s10, 9
         /* Split t polynomial into t0 (tmp buffer) and t1 (t buffer). */
         addi a0, s1, 0
         addi a1, s0, 0
@@ -368,22 +307,20 @@ crypto_sign_keypair:
     la  a1, t_polyvec
 
     /* Pack t1 */
-    LOOPI K, 2
+    LOOP s10, 2
         jal x1, polyt1_pack
         nop
 
     /* Hash pk */
 
     /* Initialize a SHAKE256 operation. */
-    li    a1, CRYPTO_PUBLICKEYBYTES
+    lw    a1, MLDSA_PARAM_CRYPTO_PUBLICKEYBYTES_OFFSET(s11)
     slli  t0, a1, 5
     addi  t0, t0, SHAKE256_CFG
     csrrw x0, kmac_cfg, t0
 
     /* Send the message to the Keccak core. */
-    /* Load pk pointer */
     la     a0, pk
-    /* a1 already contains CRYPTO_PUBLICKEYBYTES */
     jal  x1, keccak_send_message
 
     /* Read the digest (tr) into the secret key.

--- a/sw/acc/crypto/mldsa/mldsa_sign.s
+++ b/sw/acc/crypto/mldsa/mldsa_sign.s
@@ -17,85 +17,25 @@
 #define N 256
 #define Q 8380417
 #define D 13
-#define ROOT_OF_UNITY 1753
 
-#if DILITHIUM_MODE == 2
-#define K 4
-#define L 4
-#define ETA 2
-#define TAU 39
-#define BETA 78
-#define GAMMA1 131072
-#define GAMMA2 95232
-#define OMEGA 80
-#define CTILDEBYTES 32
-
-#define POLYVECK_BYTES 4096
-#define POLYVECL_BYTES 4096
-
-#define CRYPTO_PUBLICKEYBYTES 1312
-#define CRYPTO_SECRETKEYBYTES 2560
-#define CRYPTO_BYTES 2420
-
-#elif DILITHIUM_MODE == 3
-#define K 6
-#define L 5
-#define ETA 4
-#define TAU 49
-#define BETA 196
-#define GAMMA1 524288
-#define GAMMA2 261888
-#define OMEGA 55
-#define CTILDEBYTES 48
-
-#define POLYVECK_BYTES 6144
-#define POLYVECL_BYTES 5120
-
-#define CRYPTO_PUBLICKEYBYTES 1952
-#define CRYPTO_SECRETKEYBYTES 4032
-#define CRYPTO_BYTES 3309
-
-#elif DILITHIUM_MODE == 5
-#define K 8
-#define L 7
-#define ETA 2
-#define TAU 60
-#define BETA 120
-#define GAMMA1 524288
-#define GAMMA2 261888
-#define OMEGA 75
-#define CTILDEBYTES 64
-
+/* Worst-case (ML-DSA-87) polyvec sizes for static buffers. */
 #define POLYVECK_BYTES 8192
 #define POLYVECL_BYTES 7168
 
-#define CRYPTO_PUBLICKEYBYTES 2592
-#define CRYPTO_SECRETKEYBYTES 4896
-#define CRYPTO_BYTES 4627
+/* Offsets into the mldsa_params struct (in mldsa_consts.s). */
+#define MLDSA_PARAM_K_OFFSET 0
+#define MLDSA_PARAM_L_OFFSET 4
+#define MLDSA_PARAM_TAU_OFFSET 8
+#define MLDSA_PARAM_OMEGA_OFFSET 12
+#define MLDSA_PARAM_GAMMA1_MINUS_BETA_OFFSET 16
+#define MLDSA_PARAM_POLYW1_PACKEDBYTES_OFFSET 20
+#define MLDSA_PARAM_CRYPTO_PUBLICKEYBYTES_OFFSET 24
+#define MLDSA_PARAM_GAMMA2_OFFSET 28
+#define MLDSA_PARAM_GAMMA2_MINUS_BETA_OFFSET 32
+#define MLDSA_PARAM_SK_S2_OFFSET_OFFSET 36
+#define MLDSA_PARAM_SK_T0_OFFSET_OFFSET 40
+#define MLDSA_PARAM_CRYPTO_BYTES_OFFSET 44
 
-#endif
-
-#define POLYT1_PACKEDBYTES  320
-#define POLYT0_PACKEDBYTES  416
-#define POLYVECH_PACKEDBYTES (OMEGA + K)
-
-#if GAMMA1 == (1 << 17)
-#define POLYZ_PACKEDBYTES   576
-#elif GAMMA1 == (1 << 19)
-#define POLYZ_PACKEDBYTES   640
-#endif
-
-#if GAMMA2 == (Q-1)/88
-#define POLYW1_PACKEDBYTES  192
-#elif GAMMA2 == (Q-1)/32
-#define POLYW1_PACKEDBYTES  128
-#endif
-
-#if ETA == 2
-#define POLYETA_PACKEDBYTES  96
-#elif ETA == 4
-#define POLYETA_PACKEDBYTES 128
-#endif
 /* Register aliases */
 .equ x2, sp
 .equ x3, fp
@@ -280,13 +220,15 @@ _rej_crypto_sign_signature_internal:
     /* Initialize destination to 0. */
     li t0, 31
     addi t1, s1, 0
-    LOOPI K, 3
+    la t2, mldsa_params
+    lw t3, MLDSA_PARAM_K_OFFSET(t2)
+    LOOP t3, 3
         LOOPI 32, 1
           bn.sid t0, 0(t1++)
         nop
 
-    /* Load the constant for resetting the w pointer. */
-    li s6, POLYVECK_BYTES
+    /* Load the constant for resetting the w pointer (K * 1024). */
+    slli s6, t3, 10
 
     /* Initialize the nonce for matrix expansion. This value should be
          byte(i) || byte(j)
@@ -296,8 +238,6 @@ _rej_crypto_sign_signature_internal:
     /* Load a constant pointer to the zero wide register. */
     li s5, 31
 
-    /* Load a pointer to the vectorized gamma1. */
-    la   s7, gamma1_vec_const
 
     /* Load other pointers. */
     la   s8, y_poly
@@ -320,7 +260,9 @@ _rej_crypto_sign_signature_internal:
            for i in 0..k-1:
              w[i] += A[i][j] * yj
     */
-    loopi L, 41
+    la t2, mldsa_params
+    lw t3, MLDSA_PARAM_L_OFFSET(t2)
+    LOOP t3, 46
         /* Zero the buffer for y[j]. */
         addi  t0, s8, 0
         loopi 32, 1
@@ -329,7 +271,8 @@ _rej_crypto_sign_signature_internal:
         addi a0, s8, 0
         addi a1, s2, 0
         addi a2, s11, 0 /* y sampling nonce */
-        addi a3, s7, 0
+        la t2, mldsa_params
+        lw a4, MLDSA_PARAM_K_OFFSET(t2)
         jal  x1, poly_uniform_gamma_1
         addi s11, a2, 1 /* a2 should be preserved after execution */
         /* Start the SHAKE128 operation for poly_uniform for A[0][j]. */
@@ -345,7 +288,9 @@ _rej_crypto_sign_signature_internal:
         addi a0, s8, 0
         addi a2, s8, 0
         jal x1, ntt
-        loopi K, 15
+        la t2, mldsa_params
+        lw t3, MLDSA_PARAM_K_OFFSET(t2)
+        LOOP t3, 15
             /* Compute A[i][j]. */
             addi a1, s10, 0
             jal  x1, poly_uniform
@@ -379,7 +324,9 @@ _rej_crypto_sign_signature_internal:
     /* Inverse NTT on w */
     la  a0, w0_polyvec
 
-    LOOPI K, 2
+    la t2, mldsa_params
+    lw t3, MLDSA_PARAM_K_OFFSET(t2)
+    LOOP t3, 2
         jal x1, intt
         /* Go to next input polynomial */
         addi a0, a0, 1024
@@ -389,8 +336,10 @@ _rej_crypto_sign_signature_internal:
     /* Random oracle */
     /* Initialize a SHAKE256 operation. */
     addi  a1, x0, CRHBYTES
-    LOOPI K, 1
-        addi a1, a1, POLYW1_PACKEDBYTES
+    la t2, mldsa_params
+    lw t4, MLDSA_PARAM_POLYW1_PACKEDBYTES_OFFSET(t2)
+    LOOP t3, 1
+        add a1, a1, t4
     slli  t0, a1, 5
     addi  t0, t0, SHAKE256_CFG
     csrrw x0, KECCAK_CFG_REG, t0
@@ -409,10 +358,13 @@ _rej_crypto_sign_signature_internal:
     la  s2, dptr_sig
     lw  s2, 0(s2) /* Get *sig */
     addi s3, s2, 0 /* Save *sig. */
-#if CTILDEBYTES == 48
-    /* Use an offset of 16 to get an aligned buffer (alignment hack for CTILDE). */
+    /* For ML-DSA-65 (K=6, CTILDEBYTES=48) use an offset of 16 for alignment. */
+    la   t0, mldsa_params
+    lw   t3, MLDSA_PARAM_K_OFFSET(t0)
+    li   t2, 6
+    bne  t3, t2, _sign_skip_ctilde_align
     addi s2, s2, 16
-#endif
+_sign_skip_ctilde_align:
 
     /* This loop:
          - decomposes each polynomial w[i] into w0[i] and w1[i]
@@ -421,11 +373,13 @@ _rej_crypto_sign_signature_internal:
 
        Afterwards, the w1[i] value can be discarded, so we do not need to keep
        two w-sized polyvecs in scope at once. */
-    loopi K, 14
+    LOOP t3, 19
         /* Decompose w and store w0 in-place, w1 in tmp. */
         addi   a0, s0, 0
         addi   a1, s4, 0
         addi   a2, s0, 0
+        la t2, mldsa_params
+        lw a4, MLDSA_PARAM_K_OFFSET(t2)
         jal    x1, poly_decompose
         /* Pack w1. */
         addi   a0, s2, 0
@@ -433,7 +387,8 @@ _rej_crypto_sign_signature_internal:
         jal    x1, polyw1_pack
         /* Send packed w1 to the Keccak core. */
         addi   a0, s2, 0
-        addi   a1, x0, POLYW1_PACKEDBYTES
+        la t2, mldsa_params
+        lw a1, MLDSA_PARAM_POLYW1_PACKEDBYTES_OFFSET(t2)
         jal    x1, keccak_send_message
         /* Calculate the coefficients of w1 that are nonzero mod q, and store them. */
         addi   a0, s4, 0
@@ -450,20 +405,35 @@ _rej_crypto_sign_signature_internal:
 
     /* Get always-aligned temporary buffer. */
     la   t0, tmp_poly
-#if CTILDEBYTES == 32
-    /* Store first 32 bytes into temp buffer and signature. */
+
+    /* Pack ctilde into temp buffer and signature; layout depends on K. */
+    la   t3, mldsa_params
+    lw   t3, MLDSA_PARAM_K_OFFSET(t3)
+    li   t4, 4
+    beq  t3, t4, _sign_pack_ctilde_44
+    li   t4, 6
+    beq  t3, t4, _sign_pack_ctilde_65
+    /* ML-DSA-87 (K=8, CTILDEBYTES=64). */
     bn.sid  t1, 0(t0)
     bn.sid  t1, 0(s3)
-#elif CTILDEBYTES == 48
-    /* Store first 32 bytes into temp buffer and (unaligned) signature. */
+    bn.wsrr w8, 0xA
+    bn.sid  t1, 32(t0)
+    bn.sid  t1, 32(s3)
+    jal x0, _sign_pack_ctilde_done
+_sign_pack_ctilde_44:
+    /* ML-DSA-44 (K=4, CTILDEBYTES=32). */
+    bn.sid  t1, 0(t0)
+    bn.sid  t1, 0(s3)
+    jal x0, _sign_pack_ctilde_done
+_sign_pack_ctilde_65:
+    /* ML-DSA-65 (K=6, CTILDEBYTES=48). The signature is not aligned, so
+       copy via GPRs. */
     bn.sid  t1, 0(t0)
     LOOPI 8, 4
         lw t2, 0(t0)
         sw t2, 0(s3)
         addi t0, t0, 4
         addi s3, s3, 4
-
-    /* Read 32 more bytes and store 16 of them. */
     bn.wsrr w8, 0xA
     bn.sid  t1, 0(t0)
     LOOPI 4, 4
@@ -471,15 +441,7 @@ _rej_crypto_sign_signature_internal:
         sw t2, 0(s3)
         addi t0, t0, 4
         addi s3, s3, 4
-#elif CTILDEBYTES == 64
-    /* Store first 32 bytes into temp buffer and signature. */
-    bn.sid  t1, 0(t0)
-    bn.sid  t1, 0(s3)
-    /* Store 32 more bytes (both places). */
-    bn.wsrr w8, 0xA
-    bn.sid  t1, 32(t0)
-    bn.sid  t1, 32(s3)
-#endif
+_sign_pack_ctilde_done:
 
     /* Finish the SHAKE-256 operation. */
 
@@ -488,6 +450,10 @@ _rej_crypto_sign_signature_internal:
        for CTILDEBYTES = 48 as well */
     la   a0, c_poly
     la   a1, tmp_poly
+    la   t0, mldsa_params
+    lw   t1, MLDSA_PARAM_K_OFFSET(t0)
+    slli a2, t1, 3  /* CTILDEBYTES = K * 8 */
+    lw   a3, MLDSA_PARAM_TAU_OFFSET(t0)
     jal  x1, poly_challenge
 
     bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
@@ -504,7 +470,9 @@ _rej_crypto_sign_signature_internal:
     addi s0, s0, 128
 
     /* Reset the nonce for y and set up a constant for poly_uniform_gamma1. */
-    addi s8, s11, -L
+    la   t0, mldsa_params
+    lw   t1, MLDSA_PARAM_L_OFFSET(t0)
+    sub  s8, s11, t1
 
     /* Save some pointers. */
     la   s2, tmp_poly
@@ -512,15 +480,20 @@ _rej_crypto_sign_signature_internal:
     la   s7, c_poly
     la   s9, dptr_sig
     lw   s9, 0(s9)
-    addi s9, s9, CTILDEBYTES /* c is already packed */
-    la   s10, gamma1_vec_const
+    lw   t1, MLDSA_PARAM_K_OFFSET(t0)
+    slli t1, t1, 3      /* CTILDEBYTES = K * 8 */
+    add  s9, s9, t1     /* c is already packed */
 
     /* This loop computes z = (cp * s1) = y one element at a time, and does
-       rejection sampling on each element before packing it into the signature. */
-    .rept L
+       rejection sampling on each element before packing it into the signature.
+       Uses a regular branch-back loop so we can bail out early on rejection. */
+    li s4, 0
+_rejsmpl_loop:
         /* Unpack the next polynomial from s1. */
         addi a0, s2, 0
         addi a1, s0, 0
+        la t2, mldsa_params
+        lw a4, MLDSA_PARAM_K_OFFSET(t2)
         jal x1, polyeta_unpack
         /* Update the packed s1 pointer. */
         addi s0, a1, 0
@@ -548,7 +521,8 @@ _rej_crypto_sign_signature_internal:
         addi a0, s2, 0
         addi a1, s3, 0
         addi a2, s8, 0
-        addi a3, s10, 0
+        la t2, mldsa_params
+        lw a4, MLDSA_PARAM_K_OFFSET(t2)
         jal  x1, poly_uniform_gamma_1
 
         /* Update the nonce for y. */
@@ -561,28 +535,33 @@ _rej_crypto_sign_signature_internal:
 
         /* chknorm */
         addi a0, s2, 0
-        li   t0, GAMMA1
-        li   t1, BETA
-        sub  a1, t0, t1
+        la   t2, mldsa_params
+        lw   a1, MLDSA_PARAM_GAMMA1_MINUS_BETA_OFFSET(t2)
         jal x1, poly_chknorm
 
         bne a2, x0, _rej_crypto_sign_signature_internal
 
-        /* Speculatively pack z[i] into the signature. */
+        /* Pack z[i] into the signature. */
         addi a0, s9, 0
         addi a1, s2, 0
+        la t2, mldsa_params
+        lw a4, MLDSA_PARAM_K_OFFSET(t2)
         jal x1, polyz_pack
         /* Update the pointer to the end of the packed part. */
         addi s9, a0, 0
-    .endr
+    addi s4, s4, 1
+    la t0, mldsa_params
+    lw t1, MLDSA_PARAM_L_OFFSET(t0)
+    bne s4, t1, _rejsmpl_loop
 
     /* get *sig + CTILDEBYTES + L*POLYZ_PACKEDBYTES */
     addi a0, s9, 0
 
     /* Set hint bytes at end of signature (length omega + k) to 0. Round to
        next word boundary. */
-    li    t1, OMEGA
-    addi  t1, t1, K
+    lw    t1, MLDSA_PARAM_OMEGA_OFFSET(t0)
+    lw    t2, MLDSA_PARAM_K_OFFSET(t0)
+    add   t1, t1, t2
     addi  t1, t1, 3
     srli  t1, t1, 2
     LOOP  t1, 2
@@ -591,24 +570,12 @@ _rej_crypto_sign_signature_internal:
 
     addi a0, s9, 0
 
-    /* Load pointer to packed S2. */
+    /* Load pointers to packed S2 and T0 within sk. */
     la   s0, sk
-#if DILITHIUM_MODE == 2
-    addi s2, s0, 512
-#elif DILITHIUM_MODE == 3
-    addi s2, s0, 768
-#elif DILITHIUM_MODE == 5
-    addi s2, s0, 800
-#endif
-
-    /* Load pointer to packed T0. */
-#if DILITHIUM_MODE == 2
-    addi s0, s0, 896
-#elif DILITHIUM_MODE == 3
-    addi s0, s0, 1536
-#elif DILITHIUM_MODE == 5
-    addi s0, s0, 1568
-#endif
+    lw   t1, MLDSA_PARAM_SK_S2_OFFSET_OFFSET(t0)
+    add  s2, s0, t1
+    lw   t1, MLDSA_PARAM_SK_T0_OFFSET_OFFSET(t0)
+    add  s0, s0, t1
 
     /* Initialize some pointers for the loop. */
     la  s3, w0_polyvec
@@ -630,7 +597,9 @@ _rej_crypto_sign_signature_internal:
     li     t1, 1
     la     t0, modulus
     bn.lid t1, 0(t0)
-    LOOPI K, 6
+    la t0, mldsa_params
+    lw t1, MLDSA_PARAM_K_OFFSET(t0)
+    LOOP t1, 6
         LOOPI 32, 4
             bn.lid      x0, 0(a0)
             bn.addv.8S  w0, w0, w1
@@ -655,7 +624,9 @@ _rej_crypto_sign_signature_internal:
            reject
          make_hint(h, w0[i], w1[i]) # gets written directly into signature
      */
-    loopi K, 73
+    la t0, mldsa_params
+    lw t1, MLDSA_PARAM_K_OFFSET(t0)
+    LOOP t1, 84
         /* If there was a failure, skip to the end of the
            loop body (because of architectural loop rules, we have to complete
            all iterations). */
@@ -664,6 +635,8 @@ _rej_crypto_sign_signature_internal:
         /* Unpack the next polynomial from s2. */
         addi a0, s10, 0
         addi a1, s2, 0
+        la t0, mldsa_params
+        lw a4, MLDSA_PARAM_K_OFFSET(t0)
         jal  x1, polyeta_unpack
         addi a0, a0, -1024
 
@@ -701,9 +674,8 @@ _rej_crypto_sign_signature_internal:
 
         /* chknorm(tmp, gamma2 - beta) */
         addi a0, s10, 0
-        li   t0, GAMMA2 /* This li expands to 2 instructions */
-        addi t1, x0, BETA
-        sub  a1, t0, t1
+        la   t0, mldsa_params
+        lw   a1, MLDSA_PARAM_GAMMA2_MINUS_BETA_OFFSET(t0)
         jal  x1, poly_chknorm
 
         /* Update the continuation register. */
@@ -748,7 +720,8 @@ _rej_crypto_sign_signature_internal:
         jal  x1, poly_reduce32
 
         /* chknorm(h, gamma2) */
-        li   a1, GAMMA2 /* This li expands to 2 instructions */
+        la   t0, mldsa_params
+        lw   a1, MLDSA_PARAM_GAMMA2_OFFSET(t0)
         addi a0, s10, 0
         jal  x1, poly_chknorm
 
@@ -758,6 +731,8 @@ _rej_crypto_sign_signature_internal:
         /* h[i] = make_hint(w0[i], w1[i]) */
         addi   a0, s10, 0
         addi   a1, s3, 0
+        la     t0, mldsa_params
+        lw     a2, MLDSA_PARAM_GAMMA2_OFFSET(t0)
         bn.lid x0, 0(s5++)
         jal    x1, poly_make_hint
 
@@ -766,8 +741,9 @@ _rej_crypto_sign_signature_internal:
         add  s4, s4, a0
 
         /* If the accumulator (# nonzero coeffs in h) is > omega, reject. */
-        addi t0, x0, OMEGA
-        sub  t0, t0, s4
+        la   t0, mldsa_params
+        lw   t1, MLDSA_PARAM_OMEGA_OFFSET(t0)
+        sub  t0, t1, s4
         srli t0, t0, 31
 
         /* Update the continuation register. */
@@ -777,6 +753,8 @@ _rej_crypto_sign_signature_internal:
         addi a0, s9, 0
         addi a1, s10, 0
         addi a3, s6, 0
+        la   t0, mldsa_params
+        lw   a4, MLDSA_PARAM_OMEGA_OFFSET(t0)
         jal  x1, poly_encode_h
 
         /* Increment i. */
@@ -790,7 +768,8 @@ _rej_crypto_sign_signature_internal:
 
     /* Return success and signature length */
     li a0, 0
-    li a1, CRYPTO_BYTES
+    la t0, mldsa_params
+    lw a1, MLDSA_PARAM_CRYPTO_BYTES_OFFSET(t0)
   ret
 
 .bss
@@ -825,13 +804,7 @@ tmp_poly:
 /* w1 representative vector (K*32B). */
 .balign 32
 w1_repvec:
-#if DILITHIUM_MODE == 2
-.zero 128
-#elif DILITHIUM_MODE == 3
-.zero 192
-#elif DILITHIUM_MODE == 5
-.zero 256
-#endif
+.zero 256  /* Worst-case (ML-DSA-87, K=8): K*32 bytes. */
 
 /* w0 polynomial vector (K*1024B). */
 .balign 32

--- a/sw/acc/crypto/mldsa/mldsa_verify.s
+++ b/sw/acc/crypto/mldsa/mldsa_verify.s
@@ -13,92 +13,22 @@
 #define SEEDBYTES 32
 #define CRHBYTES 64
 #define TRBYTES 64
-#define RNDBYTES 32
 #define N 256
 #define Q 8380417
 #define D 13
-#define ROOT_OF_UNITY 1753
 
-#if DILITHIUM_MODE == 2
-#define K 4
-#define L 4
-#define ETA 2
-#define TAU 39
-#define BETA 78
-#define GAMMA1 131072
-#define GAMMA2 95232
-#define OMEGA 80
-#define CTILDEBYTES 32
-
-#define POLYVECK_BYTES 4096
-#define POLYVECL_BYTES 4096
-#define Lminus1 3
-
-#define CRYPTO_PUBLICKEYBYTES 1312
-#define CRYPTO_SECRETKEYBYTES 2560
-#define CRYPTO_BYTES 2420
-
-#elif DILITHIUM_MODE == 3
-#define K 6
-#define L 5
-#define ETA 4
-#define TAU 49
-#define BETA 196
-#define GAMMA1 524288
-#define GAMMA2 261888
-#define OMEGA 55
-#define CTILDEBYTES 48
-
-#define POLYVECK_BYTES 6144
-#define POLYVECL_BYTES 5120
-#define Lminus1 4
-
-#define CRYPTO_PUBLICKEYBYTES 1952
-#define CRYPTO_SECRETKEYBYTES 4032
-#define CRYPTO_BYTES 3309
-
-#elif DILITHIUM_MODE == 5
-#define K 8
-#define L 7
-#define ETA 2
-#define TAU 60
-#define BETA 120
-#define GAMMA1 524288
-#define GAMMA2 261888
-#define OMEGA 75
-#define CTILDEBYTES 64
-
+/* Worst-case (ML-DSA-87) polyvec sizes for static buffers. */
 #define POLYVECK_BYTES 8192
 #define POLYVECL_BYTES 7168
-#define Lminus1 6
 
-#define CRYPTO_PUBLICKEYBYTES 2592
-#define CRYPTO_SECRETKEYBYTES 4896
-#define CRYPTO_BYTES 4627
-
-#endif
-
-#define POLYT1_PACKEDBYTES  320
-#define POLYT0_PACKEDBYTES  416
-#define POLYVECH_PACKEDBYTES (OMEGA + K)
-
-#if GAMMA1 == (1 << 17)
-#define POLYZ_PACKEDBYTES   576
-#elif GAMMA1 == (1 << 19)
-#define POLYZ_PACKEDBYTES   640
-#endif
-
-#if GAMMA2 == (Q-1)/88
-#define POLYW1_PACKEDBYTES  192
-#elif GAMMA2 == (Q-1)/32
-#define POLYW1_PACKEDBYTES  128
-#endif
-
-#if ETA == 2
-#define POLYETA_PACKEDBYTES  96
-#elif ETA == 4
-#define POLYETA_PACKEDBYTES 128
-#endif
+/* Offsets into the mldsa_params struct (in mldsa_consts.s). */
+#define MLDSA_PARAM_K_OFFSET 0
+#define MLDSA_PARAM_L_OFFSET 4
+#define MLDSA_PARAM_TAU_OFFSET 8
+#define MLDSA_PARAM_OMEGA_OFFSET 12
+#define MLDSA_PARAM_GAMMA1_MINUS_BETA_OFFSET 16
+#define MLDSA_PARAM_POLYW1_PACKEDBYTES_OFFSET 20
+#define MLDSA_PARAM_CRYPTO_PUBLICKEYBYTES_OFFSET 24
 
 /* Register aliases */
 .equ x2, sp
@@ -163,12 +93,15 @@
  * @param[in] x11: byte-length of message
  * @param[in] dmem[ctx]: context value (0-256B)
  * @param[in] x12: byte-length of context
+ * @param[in] dmem[mldsa_params]: active mode parameters
  * @param[in] dmem[pk]: public key
  * @param[out] dmem[result]: 0 on success, 0xffffff on failure
  *
  */
 .globl crypto_sign_verify_internal
 crypto_sign_verify_internal:
+    la   s11, mldsa_params
+
     /* Save signature pointer. */
     la  t0, dptr_sig
     sw  a0, 0(t0)
@@ -179,35 +112,46 @@ crypto_sign_verify_internal:
 
     /* Unpack sig */
 
-    /* Unpack ctilde */
+    /* Unpack ctilde. CTILDEBYTES depends on K (= K*8 bytes). */
     la  t0, dptr_sig
     lw  t0, 0(t0)
     la  t1, ctilde
-#if DILITHIUM_MODE == 2
+    lw  t2, MLDSA_PARAM_K_OFFSET(s11)
+    li  t3, 4
+    beq t2, t3, _ctilde_unpack_44
+    li  t3, 6
+    beq t2, t3, _ctilde_unpack_65
+    /* ML-DSA-87 (K=8, CTILDEBYTES=64): two 32B copies. */
     bn.lid x0, 0(t0++)
     bn.sid x0, 0(t1++)
-#elif DILITHIUM_MODE == 3
-    /* The signature is not 32-byte aligned, so we copy using GPRs. */
+    bn.lid x0, 0(t0++)
+    bn.sid x0, 0(t1++)
+    jal x0, _ctilde_unpack_done
+_ctilde_unpack_44:
+    /* ML-DSA-44 (K=4, CTILDEBYTES=32): one 32B copy. */
+    bn.lid x0, 0(t0++)
+    bn.sid x0, 0(t1++)
+    jal x0, _ctilde_unpack_done
+_ctilde_unpack_65:
+    /* ML-DSA-65 (K=6, CTILDEBYTES=48): the signature is not 32-byte aligned,
+       so copy using GPRs. Zero-pad the remaining 16B to avoid bignum load
+       errors at the later compare. */
     LOOPI 12, 4
         lw t3, 0(t0)
         sw t3, 0(t1)
         addi t0, t0, 4
         addi t1, t1, 4
-    /* We need to set the remaining 16 bytes to 0 to avoid bignum load errors. */
     LOOPI 4, 2
         sw x0, 0(t1)
         addi t1, t1, 4
-#elif DILITHIUM_MODE == 5
-    bn.lid x0, 0(t0++)
-    bn.sid x0, 0(t1++)
-    bn.lid x0, 0(t0++)
-    bn.sid x0, 0(t1++)
-#endif
+_ctilde_unpack_done:
 
     /* Unpack z */
     addi a1, t0, 0
     la   a0, z_polyvec
-    LOOPI L, 2
+    lw   a4, MLDSA_PARAM_K_OFFSET(s11)
+    lw   t0, MLDSA_PARAM_L_OFFSET(s11)
+    LOOP t0, 2
         jal x1, polyz_unpack
         nop
 
@@ -217,18 +161,18 @@ crypto_sign_verify_internal:
     /* reduce32(z) for central representation */
     la a0, z_polyvec
     la a1, w1_polyvec
-    LOOPI L, 2
+    lw   t0, MLDSA_PARAM_L_OFFSET(s11)
+    LOOP t0, 2
         jal x1, poly_reduce32
         nop
 
     /* chknorm */
-    li   t0, GAMMA1
-    li   t1, BETA
-    sub  a1, t0, t1
+    lw   a1, MLDSA_PARAM_GAMMA1_MINUS_BETA_OFFSET(s11)   /* GAMMA1 - BETA */
     la   a0, w1_polyvec
     li   s2, 0
 
-    loopi L, 2
+    lw   t0, MLDSA_PARAM_L_OFFSET(s11)
+    LOOP t0, 2
         jal x1, poly_chknorm
         or  s2, s2, a2
     bne s2, x0, _fail_crypto_sign_verify_internal /* Raise error */
@@ -238,7 +182,7 @@ crypto_sign_verify_internal:
     la  a0, pk
 
     /* Initialize a SHAKE256 operation. */
-    li    a1, CRYPTO_PUBLICKEYBYTES /* set message length to CRYPTO_PUBLICKEYBYTES */
+    lw   a1, MLDSA_PARAM_CRYPTO_PUBLICKEYBYTES_OFFSET(s11) /* CRYPTO_PUBLICKEYBYTES */
     slli  t0, a1, 5
     addi  t0, t0, SHAKE256_CFG
     csrrw x0, KECCAK_CFG_REG, t0
@@ -298,6 +242,9 @@ crypto_sign_verify_internal:
 
     la  a0, c_poly
     la  a1, ctilde
+    lw   t0, MLDSA_PARAM_K_OFFSET(s11)
+    slli a2, t0, 3   /* CTILDEBYTES = K * 8 */
+    lw   a3, MLDSA_PARAM_TAU_OFFSET(s11)
     jal x1, poly_challenge
 
     /* Prepare modulus */
@@ -310,7 +257,8 @@ crypto_sign_verify_internal:
     la   a0, z_polyvec
     addi a2, a0, 0 /* inplace */
 
-    LOOPI L, 2
+    lw t0, MLDSA_PARAM_L_OFFSET(s11)
+    LOOP t0, 2
         jal  x1, ntt
         addi a1, a1, -1024
 
@@ -349,14 +297,15 @@ crypto_sign_verify_internal:
     /* Load destination pointer for matrix-vector multiplication. */
     la  s2, w1_polyvec
 
-    /* Load offset for resetting vector pointer. */
-    li s3, POLYVECL_BYTES
+    lw   t0, MLDSA_PARAM_L_OFFSET(s11)
+    slli s3, t0, 10
 
     /* Load pointer to rho (first 32B of public key). */
     la s5, pk
 
     /* Compute A * z, computing elements of A on the fly. */
-    loopi K, 39
+    lw a4, MLDSA_PARAM_K_OFFSET(s11)
+    LOOP a4, 43
         /* Compute A[i][0]. */
         addi a1, s1, 0
         jal  x1, poly_uniform
@@ -375,7 +324,9 @@ crypto_sign_verify_internal:
         addi a2, s2, 0
         jal  x1, poly_pointwise
         addi s0, s0, 1024
-        loopi Lminus1, 14
+        lw t0, MLDSA_PARAM_L_OFFSET(s11)
+        addi t0, t0, -1
+        LOOP t0, 14
             /* Compute A[i][j]. */
             addi a1, s1, 0
             jal  x1, poly_uniform
@@ -399,7 +350,9 @@ crypto_sign_verify_internal:
         addi s2, s2, 1024
         /* Adjust the matrix nonce to reset the column and increment the row. */
         bn.addi w23, w23, 256
-        bn.subi w23, w23, L
+        lw t0, MLDSA_PARAM_L_OFFSET(s11)
+        LOOP t0, 1
+            bn.subi w23, w23, 1
         /* Start the SHAKE128 operation for poly_uniform for A[i+1][j]. */
         csrrw     x0, kmac_cfg, s4
         bn.lid    x0, 0(s5)
@@ -411,8 +364,10 @@ crypto_sign_verify_internal:
     /* Call random oracle and verify challenge */
     /* Initialize a SHAKE256 operation. */
     li a1, CRHBYTES
-    LOOPI K, 1
-        addi a1, a1, POLYW1_PACKEDBYTES
+    lw t0, MLDSA_PARAM_POLYW1_PACKEDBYTES_OFFSET(s11)
+    lw a4, MLDSA_PARAM_K_OFFSET(s11)
+    LOOP a4, 1
+        add a1, a1, t0
     slli  t0, a1, 5
     addi  t0, t0, SHAKE256_CFG
     csrrw x0, KECCAK_CFG_REG, t0
@@ -439,7 +394,8 @@ crypto_sign_verify_internal:
     la  s1, w1_polyvec
     la  s3, tmp_poly
     la  s4, c_poly
-    loopi K, 42
+    lw  a4, MLDSA_PARAM_K_OFFSET(s11)
+    LOOP a4, 45
         /* Unpack the next polynomial from t1 and store it in temp buffer. */
         addi a0, s3, 0
         addi a1, s6, 0
@@ -473,6 +429,8 @@ crypto_sign_verify_internal:
         addi a1, s9, 0
         addi a2, s7, 0
         addi a3, s8, 0
+        lw   a5, MLDSA_PARAM_K_OFFSET(s11)
+        lw   t4, MLDSA_PARAM_OMEGA_OFFSET(s11)
         jal x1, poly_decode_h
         addi s9, a1, 0
         addi s7, a2, 0
@@ -482,6 +440,7 @@ crypto_sign_verify_internal:
         addi a0, s1, 0
         addi a1, s1, 0
         addi a2, s3, 0
+        lw   a4, MLDSA_PARAM_K_OFFSET(s11)
         jal  x1, poly_use_hint
         /* Pack the w1 polynomial (in-place). */
         addi a0, s1, 0
@@ -489,7 +448,7 @@ crypto_sign_verify_internal:
         jal  x1, polyw1_pack
         /* Send the packed w1 polynomial to the Keccak core. */
         addi a0, s1, 0
-        addi a1, x0, POLYW1_PACKEDBYTES
+        lw   a1, MLDSA_PARAM_POLYW1_PACKEDBYTES_OFFSET(s11)
         jal  x1, keccak_send_message
         addi s1, s1, 1024 /* increment *w1 */
 
@@ -520,13 +479,19 @@ crypto_sign_verify_internal:
     andi  t1, t1, 1
 
     beq t1, x0, _fail_crypto_sign_verify_internal
-#if CTILDEBYTES == 48 || CTILDEBYTES == 64
+
+    /* If CTILDEBYTES == 32 (K=4), one 32B compare suffices. */
+    lw   t1, MLDSA_PARAM_K_OFFSET(s11)
+    li   t3, 4
+    beq  t1, t3, _success_crypto_sign_verify_internal
+
     bn.wsrr w8, 0xA /* KECCAK_DIGEST */
-    /* Remove upper 16B from digest in the case of CTILDEBYTES == 48 */
-#if CTILDEBYTES == 48
+    /* Remove upper 16B from digest in the case of CTILDEBYTES == 48 (K=6). */
+    li   t3, 6
+    bne  t1, t3, _skip_mask_ctilde
     bn.rshi w8, w8, bn0 >> 128
     bn.rshi w8, bn0, w8 >> 128
-#endif
+_skip_mask_ctilde:
     bn.lid t2, 0(t0++)
 
     /* Check if c == c2 */
@@ -539,8 +504,7 @@ crypto_sign_verify_internal:
     andi  t0, t0, 1
 
     beq t0, x0, _fail_crypto_sign_verify_internal
-#endif
-    beq x0, x0, _success_crypto_sign_verify_internal
+    jal x0, _success_crypto_sign_verify_internal
 
     /* ------------------------ */
 
@@ -571,10 +535,10 @@ dptr_sig:
 mu:
 .zero 64
 
-/* ctilde intermediate value (CTILDEBYTES bytes). */
+/* ctilde intermediate value (max 64B = worst-case CTILDEBYTES for ML-DSA-87). */
 .balign 32
 ctilde:
-.zero CTILDEBYTES
+.zero 64
 
 /* Challenge polynomial (1024B). */
 .balign 32

--- a/sw/acc/crypto/mldsa/poly.s
+++ b/sw/acc/crypto/mldsa/poly.s
@@ -6,92 +6,10 @@
 
 .text
 
-#define SEEDBYTES 32
 #define CRHBYTES 64
-#define TRBYTES 64
-#define RNDBYTES 32
 #define N 256
 #define Q 8380417
 #define D 13
-#define ROOT_OF_UNITY 1753
-
-#if DILITHIUM_MODE == 2
-#define K 4
-#define L 4
-#define ETA 2
-#define TAU 39
-#define BETA 78
-#define GAMMA1 131072
-#define GAMMA2 95232
-#define OMEGA 80
-#define CTILDEBYTES 32
-
-#define POLYVECK_BYTES 4096
-#define POLYVECL_BYTES 4096
-
-#define CRYPTO_PUBLICKEYBYTES 1312
-#define CRYPTO_SECRETKEYBYTES 2560
-#define CRYPTO_BYTES 2420
-
-#elif DILITHIUM_MODE == 3
-#define K 6
-#define L 5
-#define ETA 4
-#define TAU 49
-#define BETA 196
-#define GAMMA1 524288
-#define GAMMA2 261888
-#define OMEGA 55
-#define CTILDEBYTES 48
-
-#define POLYVECK_BYTES 6144
-#define POLYVECL_BYTES 5120
-
-#define CRYPTO_PUBLICKEYBYTES 1952
-#define CRYPTO_SECRETKEYBYTES 4032
-#define CRYPTO_BYTES 3309
-
-#elif DILITHIUM_MODE == 5
-#define K 8
-#define L 7
-#define ETA 2
-#define TAU 60
-#define BETA 120
-#define GAMMA1 524288
-#define GAMMA2 261888
-#define OMEGA 75
-#define CTILDEBYTES 64
-
-#define POLYVECK_BYTES 8192
-#define POLYVECL_BYTES 7168
-
-#define CRYPTO_PUBLICKEYBYTES 2592
-#define CRYPTO_SECRETKEYBYTES 4896
-#define CRYPTO_BYTES 4627
-
-#endif
-
-#define POLYT1_PACKEDBYTES  320
-#define POLYT0_PACKEDBYTES  416
-#define POLYVECH_PACKEDBYTES (OMEGA + K)
-
-#if GAMMA1 == (1 << 17)
-#define POLYZ_PACKEDBYTES   576
-#elif GAMMA1 == (1 << 19)
-#define POLYZ_PACKEDBYTES   640
-#endif
-
-#if GAMMA2 == (Q-1)/88
-#define POLYW1_PACKEDBYTES  192
-#elif GAMMA2 == (Q-1)/32
-#define POLYW1_PACKEDBYTES  128
-#endif
-
-#if ETA == 2
-#define POLYETA_PACKEDBYTES  96
-#elif ETA == 4
-#define POLYETA_PACKEDBYTES 128
-#endif
 
 /* Register aliases */
 .equ x0, zero
@@ -253,7 +171,7 @@ _inner_polyt1_unpack:
     ret
 
 /**
- * polyz_unpack
+ * polyz_unpack_17 / polyz_unpack_19
  *
  * Unpack polynomial z with coefficients in [-(GAMMA1 - 1), GAMMA1] fitting into
  * 18 bits.
@@ -261,21 +179,28 @@ _inner_polyt1_unpack:
  * Returns: -
  *
  * @param[in]  a1: pointer to input byte array with POLYZ_PACKEDBYTES bytes
+ * @param[in]  x14: K (used by polyz_unpack dispatcher only)
  * @param[out] a0: pointer to output polynomial
  *
  * clobbered registers: a0-a1, t0-t6
  */
 .global polyz_unpack
 polyz_unpack:
-#if GAMMA1 == (1 << 17)
+    /* Dispatch on x14 (K): K==4 means GAMMA1=2^17, otherwise 2^19. */
+    li  t0, 4
+    beq x14, t0, polyz_unpack_17
+    jal x0, polyz_unpack_19
+
+.global polyz_unpack_17
+polyz_unpack_17:
      /* Load gamma1 as a vector into w4 */
     li t2, 4
-    la t3, gamma1_vec_const
+    la t3, gamma1_vec_const_17
     bn.lid t2, 0(t3)
 
     /* Load mask for zeroing the upper bits of the unpacked coefficients. */
     li t5, 5
-    la t3, polyz_unpack_mask
+    la t3, polyz_unpack_mask_17
     bn.lid t5, 0(t3)
 
     /* Setup WDR */
@@ -286,72 +211,65 @@ polyz_unpack:
     LOOPI 2, 42
         bn.lid  t6, 0(a1++)
         bn.mov  w1, w6
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_17
 
         bn.lid  t3, 0(a1++)
         bn.rshi w1, w3, w6 >> 144
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_17
 
         bn.rshi w1, bn0, w3 >> 32
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_17
 
         bn.lid  t6, 0(a1++)
         bn.rshi w1, w6, w3 >> 176
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_17
 
         bn.rshi w1, bn0, w6 >> 64
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_17
 
         bn.lid  t3, 0(a1++)
         bn.rshi w1, w3, w6 >> 208
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_17
 
         bn.rshi w1, bn0, w3 >> 96
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_17
 
         bn.lid  t6, 0(a1++)
         bn.rshi w1, w6, w3 >> 240
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_17
 
         bn.lid  t3, 0(a1++)
         bn.rshi w1, w3, w6 >> 128
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_17
 
         bn.rshi w1, bn0, w3 >> 16
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_17
 
         bn.lid  t6, 0(a1++)
         bn.rshi w1, w6, w3 >> 160
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_17
 
         bn.rshi w1, bn0, w6 >> 48
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_17
 
         bn.lid  t3, 0(a1++)
         bn.rshi w1, w3, w6 >> 192
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_17
 
         bn.rshi w1, bn0, w3 >> 80
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_17
 
         bn.lid  t6, 0(a1++)
         bn.rshi w1, w6, w3 >> 224
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_17
 
         bn.rshi w1, bn0, w6 >> 112
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_17
         nop /* Must not end on branch */
 
     ret
 
-/**
- * _inner_polyz_unpack
- *
- * Inner part of unpacking function to reduce the code size.
- * Do not call from anywhere but polyz_unpack.
- * Does not adhere to calling convention.
- */
-_inner_polyz_unpack:
+_inner_polyz_unpack_17:
     /* Unpack 8 coefficients in one go */
     loopi 8, 2
         /* Shift one coefficient into the output register, ignoring the
@@ -365,15 +283,17 @@ _inner_polyz_unpack:
     bn.subvm.8S w2, w4, w2 /* w2 <= gamma1_vec_const - w2 */
     bn.sid     t2, 0(a0++)
     ret
-#elif GAMMA1 == (1 << 19)
+
+.global polyz_unpack_19
+polyz_unpack_19:
     /* Load gamma1 as a vector into w4 */
     li t2, 4
-    la t3, gamma1_vec_const
+    la t3, gamma1_vec_const_19
     bn.lid t2, 0(t3)
 
     /* Load mask for zeroing the upper bits of the unpacked coefficients. */
     li t5, 5
-    la t3, polyz_unpack_mask
+    la t3, polyz_unpack_mask_19
     bn.lid t5, 0(t3)
 
     /* Setup WDR */
@@ -384,44 +304,37 @@ _inner_polyz_unpack:
     LOOPI 4, 22
         bn.lid  t6, 0(a1++)
         bn.mov  w1, w6
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_19
 
         bn.lid  t3, 0(a1++)
         bn.rshi w1, w3, w6 >> 160
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_19
 
         bn.rshi w1, bn0, w3 >> 64
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_19
 
         bn.lid  t6, 0(a1++)
         bn.rshi w1, w6, w3 >> 224
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_19
 
         bn.lid  t3, 0(a1++)
         bn.rshi w1, w3, w6 >> 128
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_19
 
         bn.rshi w1, bn0, w3 >> 32
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_19
 
         bn.lid  t6, 0(a1++)
         bn.rshi w1, w6, w3 >> 192
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_19
 
         bn.rshi w1, bn0, w6 >> 96
-        jal     x1, _inner_polyz_unpack
+        jal     x1, _inner_polyz_unpack_19
         nop /* Must not end on branch */
 
     ret
 
-/**
- * _inner_polyz_unpack
- *
- * Inner part of unpacking function to reduce the code size.
- * Do not call from anywhere but polyz_unpack.
- * Does not adhere to calling convention.
- */
-_inner_polyz_unpack:
+_inner_polyz_unpack_19:
     /* Unpack 8 coefficients in one go */
     loopi 8, 2
         /* Shift one coefficient into the output register, ignoring the
@@ -435,7 +348,6 @@ _inner_polyz_unpack:
     bn.subvm.8S w2, w4, w2 /* w2 <= gamma1_vec_const - w2 */
     bn.sid     t2, 0(a0++)
     ret
-#endif
 
 /**
  * poly_chknorm
@@ -526,6 +438,8 @@ poly_chknorm:
  *
  * @param[in]  a1: mu byte array containing seed of length CTILDEBYTES
  * @param[out] a0: pointer to output polynomial
+ * @param[in]  a2: CTILDEBYTES
+ * @param[in]  a3: TAU
  *
  * clobbered registers: a0-a5, t0-t4, w0-w3
  */
@@ -537,7 +451,7 @@ poly_challenge:
     /* Initialize a SHAKE256 operation. */
     addi a0, a1, 0 /* a0 <= *mu */
 
-    li    a1, CTILDEBYTES /* a1 <= CTILDEBYTES */
+    addi  a1, a2, 0 /* a1 <= CTILDEBYTES */
     slli  t0, a1, 5
     addi  t0, t0, SHAKE256_CFG
     csrrw zero, KECCAK_CFG_REG, t0
@@ -588,13 +502,14 @@ poly_challenge:
     /* a2 <= number of remaining bits in buf */
     li a2, 192
 
-    li t1, TAU
+    addi t1, a3, 0
     li a4, N
     /* a3 <= i = N-TAU */
     sub a3, a4, t1
     li t3, 1
 
-    LOOPI TAU, 25
+    /* Loop TAU times. */
+    LOOP t1, 25
     /* get address of c->coeffs[i], the current coefficient */
     slli a5, a3, 2 /* i * 4 for byte position */
     add  a5, a5, a0 /* Add the array start address: c->coeffs + i * 4 */
@@ -1296,7 +1211,7 @@ poly_uniform_mask_and_check_vectors:
 
 
 /**
- * poly_uniform_eta
+ * poly_uniform_eta_eta_2 / poly_uniform_eta_eta_4
  *
  * Returns: -
  *
@@ -1305,18 +1220,22 @@ poly_uniform_mask_and_check_vectors:
  * @param[in]     a0: pointer to rho
  * @param[in]     a2: nonce
  * @param[in]     a1: dmem pointer to polynomial
+ * @param[in]     x14: K (used by poly_uniform_eta dispatcher only)
  *
  * clobbered registers: a1, a3-a5, w8-w15, w20, t0-t6
  */
 .global poly_uniform_eta
 poly_uniform_eta:
+    /* Dispatch on x14 (K): K==6 means ETA=4, otherwise ETA=2. */
+    li  t0, 6
+    beq x14, t0, poly_uniform_eta_eta_4
+    jal x0, poly_uniform_eta_eta_2
+
+.global poly_uniform_eta_eta_2
+poly_uniform_eta_eta_2:
     /* Save nonce to memory (use poly tmp buffer). */
     la t0, poly_wdr2gpr
     sw a2, 0(t0)
-
-    /* Load a3 <= Q */
-    la t0, modulus
-    lw a3, 0(t0)
 
     /* Initialize a SHAKE256 operation. */
     addi a4, a1, 0               /* save output pointer */
@@ -1343,15 +1262,9 @@ poly_uniform_eta:
     li t6, 10
     li t3, 15
 
-    bn.movr t5, t6 /* DEBUG */
-
     /* Initialize constants */
     bn.addi w14, bn0, 0x0F
-#if ETA == 2
     bn.addi w21, bn0, 15
-#elif ETA == 4
-    bn.addi w21, bn0, 9
-#endif
     li a5, 8
     li a6, 2
 
@@ -1363,7 +1276,7 @@ poly_uniform_eta:
     li t4, 0
     bn.lid t4, 0(t6)
 
-    la t6, eta
+    la t6, eta_2
     li t4, 1
     bn.lid t4, 0(t6)
 
@@ -1372,65 +1285,176 @@ poly_uniform_eta:
     /* First squeeze */
     #define shake_reg w8
 
-_rej_eta_sample_loop:
+_rej_eta_sample_loop_eta_2:
         bn.wsrr  shake_reg, 0xA /* KECCAK_DIGEST */
 LOOPI 64, 13
-        beq a1, t0, _rej_eta_sample_loop_continue
+        beq a1, t0, _rej_eta_sample_loop_continue_eta_2
         /* Process 4 bits */
         bn.and  w9, shake_reg, w14            /* Mask out all other bits */
 
-        /* Check "t0" < {15,9} */
+        /* Check "t0" < 15 */
         bn.cmp w9, w21
         csrrs a4, 0x7C0, zero
-        /* If the MSB of t0 - {15,9} is not set, we know that t0 >= {15,9}
+        /* If the MSB of t0 - 15 is not set, we know that t0 >= 15
            and thus, we have to reject. */
         and a4, a4, a6
-        beq a4, zero, _rej_eta_sample_loop_continue
+        beq a4, zero, _rej_eta_sample_loop_continue_eta_2
 
         addi t6, t6, -1 /* Found one more valid 4-bit value */
 
         /* Put each 4-bit value into one of 32-bit words in the WDR */
         bn.rshi w20, w9, w20 >> 32
 
-        bne zero, t6, _rej_eta_sample_loop_continue
+        bne zero, t6, _rej_eta_sample_loop_continue_eta_2
 
         /* Vectorized part for arithmetic */
 
         /* "t{0,1}" indicate the variable names from the reference code */
         /* Compute "t0" = "t0" - (205 * "t0" >> 10) * 5 from reference code */
-        jal x1, _poly_uniform_eta_arithmetic
+        jal x1, _poly_uniform_eta_arithmetic_eta_2
 
         /* Store coefficient value from WDR into target polynomial */
         bn.sid t5, 0(a1++)
         li t6, 8
-_rej_eta_sample_loop_continue:
+_rej_eta_sample_loop_continue_eta_2:
         bn.rshi shake_reg, bn0, shake_reg >> 4 /* shift out the used nibble */
 
 /* Loop logic */
-    bne  a1, t0, _rej_eta_sample_loop /* Continue sampling */
+    bne  a1, t0, _rej_eta_sample_loop_eta_2 /* Continue sampling */
 
-_end_rej_eta_sample_loop:
     /* Finish the SHAKE-256 operation. */
 
     ret
 
-_poly_uniform_eta_arithmetic:
-#if ETA == 2
+
+.global poly_uniform_eta_eta_4
+poly_uniform_eta_eta_4:
+    /* Save nonce to memory (use poly tmp buffer). */
+    la t0, poly_wdr2gpr
+    sw a2, 0(t0)
+
+    /* Initialize a SHAKE256 operation. */
+    addi a4, a1, 0               /* save output pointer */
+
+    addi  a1, zero, 66 /* len(rho) + len(nonce) */
+    slli  t0, a1, 5
+    addi  t0, t0, SHAKE256_CFG
+    csrrw zero, KECCAK_CFG_REG, t0
+
+    /* Send the messages to the Keccak core. */
+    addi a1, zero, 64            /* set rho length */
+    addi a0, a0, 0
+    jal  x1, keccak_send_message /* a0 already contains the input buffer */
+    addi a1, zero, 2             /* set nonce length */
+    la   a0, poly_wdr2gpr        /* After rho, absorb nonce */
+    jal  x1, keccak_send_message
+    addi a1, a4, 0 /* move output pointer back to a1 */
+
+    /* t0 = 1024, stop address*/
+    addi t0, a1, 1024
+
+    /* Initialize constants for WDR index */
+    li t5, 9
+    li t6, 10
+    li t3, 15
+
+    /* Initialize constants */
+    bn.addi w14, bn0, 0x0F
+    bn.addi w21, bn0, 9
+    li a5, 8
+    li a6, 2
+
+    la t6, poly_uniform_eta_205
+    li t4, 12
+    bn.lid t4, 0(t6)
+
+    la t6, poly_uniform_eta_5/* Merge into one const for lane use */
+    li t4, 0
+    bn.lid t4, 0(t6)
+
+    la t6, eta_4
+    li t4, 1
+    bn.lid t4, 0(t6)
+
+    li t6, 8 /* coeffs to be collected in register */
+
+_rej_eta_sample_loop_eta_4:
+        bn.wsrr  shake_reg, 0xA /* KECCAK_DIGEST */
+LOOPI 64, 13
+        beq a1, t0, _rej_eta_sample_loop_continue_eta_4
+        /* Process 4 bits */
+        bn.and  w9, shake_reg, w14            /* Mask out all other bits */
+
+        /* Check "t0" < 9 */
+        bn.cmp w9, w21
+        csrrs a4, 0x7C0, zero
+        /* If the MSB of t0 - 9 is not set, we know that t0 >= 9
+           and thus, we have to reject. */
+        and a4, a4, a6
+        beq a4, zero, _rej_eta_sample_loop_continue_eta_4
+
+        addi t6, t6, -1 /* Found one more valid 4-bit value */
+
+        /* Put each 4-bit value into one of 32-bit words in the WDR */
+        bn.rshi w20, w9, w20 >> 32
+
+        bne zero, t6, _rej_eta_sample_loop_continue_eta_4
+
+        /* Vectorized part for arithmetic */
+
+        /* "t{0,1}" indicate the variable names from the reference code */
+        /* Compute "t0" = "t0" - (205 * "t0" >> 10) * 5 from reference code */
+        jal x1, _poly_uniform_eta_arithmetic_eta_4
+
+        /* Store coefficient value from WDR into target polynomial */
+        bn.sid t5, 0(a1++)
+        li t6, 8
+_rej_eta_sample_loop_continue_eta_4:
+        bn.rshi shake_reg, bn0, shake_reg >> 4 /* shift out the used nibble */
+
+/* Loop logic */
+    bne  a1, t0, _rej_eta_sample_loop_eta_4 /* Continue sampling */
+
+    /* Finish the SHAKE-256 operation. */
+
+    ret
+
+_poly_uniform_eta_arithmetic_eta_2:
     bn.mulv.8S.even.lo w13, w20, w12
     bn.mulv.8S.odd.lo  w13, w13, w12
     bn.shv.8S  w13, w13 >> 10
     bn.mulv.8S.even.lo w13, w13, w0
     bn.mulv.8S.odd.lo  w13, w13, w0
     bn.subv.8S w20, w20, w13
-#endif
+    bn.subvm.8S w9, w1, w20
+    ret
+
+_poly_uniform_eta_arithmetic_eta_4:
     bn.subvm.8S w9, w1, w20
     ret
 
 
 /**
- * poly_use_hint
+ * poly_use_hint_88 / poly_use_hint_32
  *
  * Use hint polynomial to correct the high bits of a polynomial.
+ *
+ * The _88 and _32 variants implement the same loop and differ only in the
+ * GAMMA2-dependent constants they load. In pseudocode, for input polynomial r:
+ *   for i = 0..255:
+ *     r0, r1 = decompose(r[i])
+ *     if hint == 0:
+ *       return r1
+ *     if r0 > 0:
+ *       return (r1 + 1) % ((q - 1) / (2 * gamma2))
+ *     else:
+ *       return (r1 - 1) % ((q - 1) / (2 * gamma2))
+ * The if/else cases are implemented with bitwise operations so that the loop
+ * can be vectorized; the code does not need to be constant-time. Hint values
+ * are assumed to be 0 or 1, and decompose output is assumed to be
+ * <= (q - 1) / (2 * gamma2) (16 or 44 depending on gamma2). The reference code
+ * calls r0, r1 "a0" and "a1", but we use r here to avoid confusion with
+ * register names.
  *
  * Returns:
  *
@@ -1439,96 +1463,117 @@ _poly_uniform_eta_arithmetic:
  * @param[in]     a0: output poly pointer
  * @param[out]    a1: input poly pointer
  * @param[out]    a2: input hint poly pointer
+ * @param[in]     x14: K (used by poly_use_hint dispatcher only)
  *
  * clobbered registers: a0-a2, t0-t1, w0-w15, w30
  */
 .global poly_use_hint
 poly_use_hint:
-    /* WDR constants for decompose */
+    /* Dispatch on x14 (K): K==4 means GAMMA2=(Q-1)/88, otherwise (Q-1)/32. */
+    li  t0, 4
+    beq x14, t0, poly_use_hint_88
+    jal x0, poly_use_hint_32
+
+.global poly_use_hint_88
+poly_use_hint_88:
     la t0, decompose_127_const
     li t1, 5
-    /* w5 <= decompose_127_const */
     bn.lid t1++, 0(t0)
 
-    la t0, decompose_const
-    /* w6 <= decompose_const */
+    la t0, decompose_const_88
     bn.lid t1++, 0(t0)
 
     la t0, reduce32_const
-    /* w7 <= reduce32_const */
     bn.lid t1++, 0(t0)
 
-    la t0, decompose_43_const
-    /* w8 <= decompose_43_const */
+    la t0, decompose_43_const_88
     bn.lid t1++, 0(t0)
 
-    la t0, gamma2_vec_const
-    /* w9 <= gamma2_vec_const */
+    la t0, gamma2_vec_const_88
     bn.lid t1++, 0(t0)
 
     la t0, qm1half_const
-    /* w10 <= qm1half_const */
     bn.lid t1++, 0(t0)
 
     la t0, modulus
-    /* w11 <= modulus */
     bn.lid t1++, 0(t0)
 
-    /* Save the value from the modulus register. */
     bn.wsrr w15, MOD
 
-    /* Construct the modulus for the hint (decompose_43_const + 1). This is
-       either (vectorized) 44 or 16, depending on the parameters. */
     bn.shv.8S w12, w5 >> 6
     bn.addv.8S w12, w12, w8
     bn.wsrw MOD, w12
 
-    /* In pseudocode, this loop implements (for input polynomial r):
-       for i = 0..255:
-         r0, r1 = decompose(r[i])
-         if hint == 0:
-           return r1
-         if r0 > 0:
-           return (r1 + 1) % ((q - 1) / (2 * gamma2))
-         else:
-           return (r1 - 1) % ((q - 1) / (2 * gamma2))
-       We implement the if/else cases using bitwise operations so that we can
-       vectorize the process, but the code does not actually need to be
-       constant-time.
-
-       The hint values are assumed to be always 0 or 1, and decompose output is
-       assumed to be <= (q - 1) / 2 * gamma2 (16 or 44 depending on gamma2).
-
-       The reference code calls r0, r1 "a0" and "a1", but we use r here to
-       avoid confusion with register names.
-    */
     LOOPI 32, 11
-      /* Load the next values from the input polynomial and decompose them.
-           w1 <= r0[i*8:(i+1)*8]
-           w2 <= r1[i*8:(i+1)*8] */
       bn.lid x0, 0(a1++)
-      jal    x1, decompose
+      jal    x1, decompose_88
 
-      /* Load the next values from the hint into w0. */
       bn.lid x0, 0(a2++)
 
-      /* w12[j] <= 1 if r0[8*i+j] < 0 or r0[8*i+j] == 0 and h == 1, otherwise 0 */
       bn.subv.8S w1, w1, w0
       bn.shv.8S w12, w1 >> 31
 
-      /* w13[j] <= 1 if h[8*i+j] == 1 and r0[8*i+j] <= 0 */
       bn.and w13, w12, w0
 
-      /* w12[j] <= 1 if h[8*i+j] == 1 and r0[8*i+j] > 0 */
       bn.xor w12, w12, w0
       bn.and w12, w12, w0
 
-      /* Compute and store the final result. */
       bn.addvm.8S w0, w2, w12
       bn.subvm.8S w0, w0, w13
       bn.sid x0, 0(a0++)
 
-    /* Restore the previous value of the MOD register. */
+    bn.wsrw MOD, w15
+
+    ret
+
+.global poly_use_hint_32
+poly_use_hint_32:
+    la t0, decompose_127_const
+    li t1, 5
+    bn.lid t1++, 0(t0)
+
+    la t0, decompose_const_32
+    bn.lid t1++, 0(t0)
+
+    la t0, reduce32_const
+    bn.lid t1++, 0(t0)
+
+    la t0, decompose_43_const_32
+    bn.lid t1++, 0(t0)
+
+    la t0, gamma2_vec_const_32
+    bn.lid t1++, 0(t0)
+
+    la t0, qm1half_const
+    bn.lid t1++, 0(t0)
+
+    la t0, modulus
+    bn.lid t1++, 0(t0)
+
+    bn.wsrr w15, MOD
+
+    bn.shv.8S w12, w5 >> 6
+    bn.addv.8S w12, w12, w8
+    bn.wsrw MOD, w12
+
+    LOOPI 32, 11
+      bn.lid x0, 0(a1++)
+      jal    x1, decompose_32
+
+      bn.lid x0, 0(a2++)
+
+      bn.subv.8S w1, w1, w0
+      bn.shv.8S w12, w1 >> 31
+
+      bn.and w13, w12, w0
+
+      bn.xor w12, w12, w0
+      bn.and w12, w12, w0
+
+      bn.addvm.8S w0, w2, w12
+      bn.subvm.8S w0, w0, w13
+      bn.sid x0, 0(a0++)
+
     bn.wsrw MOD, w15
 
     ret
@@ -1649,7 +1694,7 @@ _inner_polyt1_pack:
 
 
 /**
- * polyeta_pack
+ * polyeta_pack_eta_2 / polyeta_pack_eta_4
  *
  * Bit-pack polynomial with coefficients in [-ETA,ETA].
  *
@@ -1660,12 +1705,19 @@ _inner_polyt1_pack:
  * @param[out] a0: pointer to output byte array with at least
                    POLYETA_PACKEDBYTES bytes
  * @param[in]  a1: pointer to input polynomial
+ * @param[in]  x14: K (used by polyeta_pack dispatcher only)
  *
  * clobbered registers: a0-a1, t0-t3, w1, w2
  */
 .global polyeta_pack
 polyeta_pack:
-#if ETA == 2
+    /* Dispatch on x14 (K): K==6 means ETA=4, otherwise ETA=2. */
+    li  t0, 6
+    beq x14, t0, polyeta_pack_eta_4
+    jal x0, polyeta_pack_eta_2
+
+.global polyeta_pack_eta_2
+polyeta_pack_eta_2:
     /* Compute ETA - coeff */
     /* Setup WDRs */
     li t1, 1
@@ -1673,11 +1725,11 @@ polyeta_pack:
     li t3, 3
 
     /* Load precomputed, vectorized eta */
-    la t0, eta
+    la t0, eta_2
     bn.lid t3, 0(t0)
 
     /* 1 */
-    jal x1, _inner_polyeta_pack
+    jal x1, _inner_polyeta_pack_eta_2
 
     bn.lid t1, 0(a1++)
     /* w1 <= eta - w1 */
@@ -1696,7 +1748,7 @@ polyeta_pack:
         bn.rshi w1, bn0, w1 >> 32 /* Shift out used coefficient */
 
     /* 2 */
-    jal x1, _inner_polyeta_pack
+    jal x1, _inner_polyeta_pack_eta_2
 
     bn.lid t1, 0(a1++)
     /* w1 <= eta - w1 */
@@ -1715,18 +1767,18 @@ polyeta_pack:
         bn.rshi w1, bn0, w1 >> 32 /* Shift out used coefficient */
 
     /* 3 */
-    jal x1, _inner_polyeta_pack
+    jal x1, _inner_polyeta_pack_eta_2
     bn.sid t2, 0(a0++)
     ret
 
 /**
- * _inner_polyeta_pack
+ * _inner_polyeta_pack_eta_2
  *
  * Inner part of packing function to reduce the code size. Could be inlined.
- * Do not call from anywhere but polyeta_pack.
+ * Do not call from anywhere but polyeta_pack_eta_2.
  * Does not adhere to calling convention.
  */
-_inner_polyeta_pack:
+_inner_polyeta_pack_eta_2:
     LOOPI 10, 18
         bn.lid t1, 0(a1++)
         /* w1 <= eta - w1 */
@@ -1736,7 +1788,9 @@ _inner_polyeta_pack:
             bn.rshi w1, bn0, w1 >> 32 /* Shift out used coefficient */
         .endr
     ret
-#else
+
+.global polyeta_pack_eta_4
+polyeta_pack_eta_4:
     /* Compute ETA - coeff */
     /* Setup WDRs */
     li t1, 1
@@ -1744,28 +1798,28 @@ _inner_polyeta_pack:
     li t3, 3
 
     /* Load precomputed, vectorized eta */
-    la t0, eta
+    la t0, eta_4
     bn.lid t3, 0(t0)
 
     /* Each WDR can hold 256/4 coefficients. So do this 4x */
-    jal x1, _inner_polyeta_pack
+    jal x1, _inner_polyeta_pack_eta_4
     bn.sid t2, 0(a0++)
-    jal x1, _inner_polyeta_pack
+    jal x1, _inner_polyeta_pack_eta_4
     bn.sid t2, 0(a0++)
-    jal x1, _inner_polyeta_pack
+    jal x1, _inner_polyeta_pack_eta_4
     bn.sid t2, 0(a0++)
-    jal x1, _inner_polyeta_pack
+    jal x1, _inner_polyeta_pack_eta_4
     bn.sid t2, 0(a0++)
     ret
 
 /**
- * _inner_polyeta_pack
+ * _inner_polyeta_pack_eta_4
  *
  * Inner part of packing function to reduce the code size. Could be inlined.
- * Do not call from anywhere but polyeta_pack.
+ * Do not call from anywhere but polyeta_pack_eta_4.
  * Does not adhere to calling convention.
  */
-_inner_polyeta_pack:
+_inner_polyeta_pack_eta_4:
     LOOPI 8, 18
         bn.lid t1, 0(a1++)
         /* w1 <= eta - w1 */
@@ -1775,7 +1829,6 @@ _inner_polyeta_pack:
             bn.rshi w1, bn0, w1 >> 32 /* Shift out used coefficient */
         .endr
     ret
-#endif
 /**
  * polyt0_pack
  *
@@ -1941,7 +1994,7 @@ poly_nonzero_encode:
     ret
 
 /**
- * polyw1_pack
+ * polyw1_pack_88 / polyw1_pack_32
  *
  * Bit-pack polynomial w1 with coefficients fitting in 6 bits. Input
  * coefficients are assumed to be standard representatives.
@@ -1954,41 +2007,49 @@ poly_nonzero_encode:
  * @param[out] a0: pointer to output byte array with at least
                    POLYW1_PACKEDBYTES bytes
  * @param[in]  a1: pointer to input polynomial
+ * @param[in]  x14: K (used by polyw1_pack dispatcher only)
  *
  * clobbered registers: a0-a1, t0-t2
  */
 .global polyw1_pack
 polyw1_pack:
+    /* Dispatch on x14 (K): K==4 means GAMMA2=(Q-1)/88, otherwise (Q-1)/32. */
+    li  t0, 4
+    beq x14, t0, polyw1_pack_88
+    jal x0, polyw1_pack_32
+
+.global polyw1_pack_88
+polyw1_pack_88:
 
     /* Setup WDRs */
     li t1, 1
     li t2, 2
     li t4, 4
-#if GAMMA2 == (Q-1)/88
+
     LOOPI 2, 13
-        jal     x1, _inner_polyw1_pack
+        jal     x1, _inner_polyw1_pack_88
         bn.rshi w4, w2, w4 >> 192
 
 
-        jal     x1, _inner_polyw1_pack
+        jal     x1, _inner_polyw1_pack_88
         bn.rshi w4, w2, w4 >> 64
         bn.sid  t4, 0(a0++)
         bn.rshi w4, w2, bn0 >> 192
 
 
-        jal     x1, _inner_polyw1_pack
+        jal     x1, _inner_polyw1_pack_88
         bn.rshi w4, w2, w4 >> 128
         bn.sid  t4, 0(a0++)
         bn.rshi w4, w2, bn0 >> 192
 
 
-        jal     x1, _inner_polyw1_pack
+        jal     x1, _inner_polyw1_pack_88
         bn.rshi w4, w2, w4 >> 192
         bn.sid  t4, 0(a0++)
 
     ret
 
-_inner_polyw1_pack:
+_inner_polyw1_pack_88:
     LOOPI 4, 5
         bn.lid t1, 0(a1++)
         loopi 8, 2
@@ -1998,13 +2059,21 @@ _inner_polyw1_pack:
     bn.rshi w2, bn0, w2 >> 64 /* Shift the 192 bits of data to the bottom of the
                                  WDR */
     ret
-#elif GAMMA2 == (Q-1)/32
+
+.global polyw1_pack_32
+polyw1_pack_32:
+
+    /* Setup WDRs */
+    li t1, 1
+    li t2, 2
+    li t4, 4
+
     LOOPI 4, 2
-        jal     x1, _inner_polyw1_pack
+        jal     x1, _inner_polyw1_pack_32
         bn.sid t2, 0(a0++)
     ret
 
-_inner_polyw1_pack:
+_inner_polyw1_pack_32:
     LOOPI 8, 5
         bn.lid t1, 0(a1++)
         loopi 8, 2
@@ -2012,23 +2081,28 @@ _inner_polyw1_pack:
             bn.rshi w1, bn0, w1 >> 32 /* Shift out used coefficient */
         nop
     ret
-#endif
 /**
- * polyeta_unpack
+ * polyeta_unpack_eta_2 / polyeta_unpack_eta_4
  *
  * Unpack polynomial with coefficients fitting in [-ETA, ETA].
  *
  * Flags: -
  *
  * @param[in]  a1: byte array with bit-packed polynomial
+ * @param[in]  x14: K (used by polyeta_unpack dispatcher only)
  * @param[out] a0: pointer to output polynomial
  *
  * clobbered registers: a0-a1, t0-t2, w1-w2
  */
-
 .global polyeta_unpack
 polyeta_unpack:
-#if ETA == 2
+    /* Dispatch on x14 (K): K==6 means ETA=4, otherwise ETA=2. */
+    li  t0, 6
+    beq x14, t0, polyeta_unpack_eta_4
+    jal x0, polyeta_unpack_eta_2
+
+.global polyeta_unpack_eta_2
+polyeta_unpack_eta_2:
     /* Setup WDR */
     li t1, 1
     li t2, 2
@@ -2037,41 +2111,41 @@ polyeta_unpack:
     li t5, 5
 
     /* Load precomputed, vectorized eta */
-    la t0, eta
+    la t0, eta_2
     bn.lid t4, 0(t0)
     /* Load mask for zeroing the upper bits of the unpacked coefficients. */
-    la t6, polyeta_unpack_mask
+    la t6, polyeta_unpack_mask_eta_2
     bn.lid t5, 0(t6)
     li t6, 6
 
     /* Start unpacking */
     bn.lid t1, 0(a1++)
-    jal    x1, _inner_polyeta_unpack
+    jal    x1, _inner_polyeta_unpack_eta_2
 
     /* Current state: w1 = |0|0|0|w1.3 */
     bn.lid t6, 0(a1++)      /* Load new WLEN word to w2 */
     bn.or  w1, w1, w6 << 64 /* w1 = |w6.2|w6.1|w6.0|w1.3| */
-    jal    x1, _inner_polyeta_unpack /* 64-bit rest in w0.0 */
+    jal    x1, _inner_polyeta_unpack_eta_2 /* 64-bit rest in w0.0 */
 
     /* Current state: w1 = |0|0|0|w6.2 */
     bn.lid  t3, 0(a1++)       /* Load new WLEN word to w3 */
     bn.rshi w1, w3, w6 >> 128 /* w1 = |w3.1|w3.0|w6.3|w6.2 */
-    jal     x1, _inner_polyeta_unpack
+    jal     x1, _inner_polyeta_unpack_eta_2
 
     /* w1 = |0|w3.3|w3.2|w3.1 */
     bn.rshi w1, bn0, w3 >> 64
-    jal     x1, _inner_polyeta_unpack
+    jal     x1, _inner_polyeta_unpack_eta_2
 
     ret
 
 /**
- * inner_polyeta_unpack
+ * _inner_polyeta_unpack_eta_2
  *
  * Inner part of unpacking function to reduce the code size.
- * Do not call from anywhere but polyeta_unpack.
+ * Do not call from anywhere but polyeta_unpack_eta_2.
  * Does not adhere to calling convention.
  */
-_inner_polyeta_unpack:
+_inner_polyeta_unpack_eta_2:
     /* Unpack 64 coefficients in one go */
     LOOPI 8, 19
         /* This could also be done by a loop but it causes 64 cycles per
@@ -2090,7 +2164,9 @@ _inner_polyeta_unpack:
 
         bn.sid t2, 0(a0++)
     ret
-#elif ETA == 4
+
+.global polyeta_unpack_eta_4
+polyeta_unpack_eta_4:
     /* Setup WDR */
     li t1, 1
     li t2, 2
@@ -2099,36 +2175,36 @@ _inner_polyeta_unpack:
     li t5, 5
 
     /* Load precomputed, vectorized eta */
-    la t0, eta
+    la t0, eta_4
     bn.lid t4, 0(t0)
     /* Load mask for zeroing the upper bits of the unpacked coefficients. */
-    la t6, polyeta_unpack_mask
+    la t6, polyeta_unpack_mask_eta_4
     bn.lid t5, 0(t6)
     li t6, 6
 
     /* Start unpacking */
     bn.lid t1, 0(a1++)
-    jal    x1, _inner_polyeta_unpack
+    jal    x1, _inner_polyeta_unpack_eta_4
 
     bn.lid t1, 0(a1++)
-    jal    x1, _inner_polyeta_unpack
+    jal    x1, _inner_polyeta_unpack_eta_4
 
     bn.lid  t1, 0(a1++)
-    jal     x1, _inner_polyeta_unpack
+    jal     x1, _inner_polyeta_unpack_eta_4
 
     bn.lid  t1, 0(a1++)
-    jal     x1, _inner_polyeta_unpack
+    jal     x1, _inner_polyeta_unpack_eta_4
 
     ret
 
 /**
- * inner_polyeta_unpack
+ * _inner_polyeta_unpack_eta_4
  *
  * Inner part of unpacking function to reduce the code size.
- * Do not call from anywhere but polyeta_unpack.
+ * Do not call from anywhere but polyeta_unpack_eta_4.
  * Does not adhere to calling convention.
  */
-_inner_polyeta_unpack:
+_inner_polyeta_unpack_eta_4:
     /* Unpack 64 coefficients in one go */
     LOOPI 8, 19
         /* This could also be done by a loop but it causes 64 cycles per
@@ -2147,7 +2223,6 @@ _inner_polyeta_unpack:
 
         bn.sid t2, 0(a0++)
     ret
-#endif
 
 
 /**
@@ -2166,6 +2241,8 @@ _inner_polyeta_unpack:
  * @param[in]  a2: k, number of nonzero h coefficients so far
  * @param[in]  a3: i, index of this polynomial in h
  * @param[out] a4: return code (1 or 0)
+ * @param[in]  a5: K, number of polynomials in h
+ * @param[in]  t4: OMEGA
  *
  * clobbered registers: a0-a7, t0-t6
  */
@@ -2178,12 +2255,11 @@ poly_decode_h:
         bn.sid t0, 0(t1++)
 
     /* Initialize constants */
-    li t4, OMEGA
     li a7, 1
 
     /* The notation inside the comments goes in line with the reference code */
     /* Load sig[OMEGA + i] to t2 */
-    addi t2, a3, OMEGA /* i + OMEGA */
+    add  t2, a3, t4    /* i + OMEGA */
     add  t6, t2, a1    /* (sig + OMEGA + i) */
     andi a4, t6, 0x3   /* get lower two bits */
     sub  t6, t6, a4    /* set lowest two bits to 0 */
@@ -2202,6 +2278,8 @@ poly_decode_h:
     sub t3, t4, t2
     srli t3, t3, 31
     bne t3, zero, _ret1_decode_h
+
+    addi t3, a5, 0
 
     addi t5, a2, 0 /* j = k */
 
@@ -2266,8 +2344,7 @@ _loop_inner_skip_decode_h:
     addi a3, a3, 1    /* i++ */
 
     /* Check if this is the last polynomial. */
-    li   t5, K
-    bne  a3, t5, _ret0_decode_h
+    bne  a3, t3, _ret0_decode_h
 
     /* Ensure the extra indices are 0. */
 
@@ -2418,7 +2495,7 @@ _inner_polyt0_unpack:
 
 
 /**
- * poly_uniform_gamma_1
+ * poly_uniform_gamma_1_17 / poly_uniform_gamma_1_19
  *
  *  Sample polynomial with uniformly random coefficients in [-(GAMMA1 - 1),
  *  GAMMA1] by unpacking output stream of SHAKE256(seed|nonce).
@@ -2433,12 +2510,19 @@ _inner_polyt0_unpack:
  * @param[in]  a1: byte array with seed of length CRHBYTES
  * @param[in]  a2: nonce
  * @param[in]  a3: pointer to gamma1_vec_const
+ * @param[in]  x14: K (used by poly_uniform_gamma_1 dispatcher only)
  *
  * clobbered registers: a1, t0-t3, w1-w6
  */
 .global poly_uniform_gamma_1
 poly_uniform_gamma_1:
-#if GAMMA1 == (1 << 17)
+    /* Dispatch on x14 (K): K==4 means GAMMA1=2^17, otherwise 2^19. */
+    li  t0, 4
+    beq x14, t0, poly_uniform_gamma_1_17
+    jal x0, poly_uniform_gamma_1_19
+
+.global poly_uniform_gamma_1_17
+poly_uniform_gamma_1_17:
     /* copy output pointer */
     addi t1, a0, 0
 
@@ -2467,12 +2551,12 @@ poly_uniform_gamma_1:
 
     /* Load gamma1 as a vector into w4 */
     li t2, 4
-    la t3, gamma1_vec_const
+    la t3, gamma1_vec_const_17
     bn.lid t2, 0(t3)
 
     /* Load mask for zeroing the upper bits of the unpacked coefficients to w5 */
     li t2, 5
-    la t3, polyz_unpack_mask
+    la t3, polyz_unpack_mask_17
     bn.lid t2, 0(t3)
 
     /* Setup WDR */
@@ -2480,67 +2564,67 @@ poly_uniform_gamma_1:
     LOOPI 2, 42
         bn.wsrr w6, 0xA /* KECCAK_DIGEST */
         bn.mov  w1, w6
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_17
 
         bn.wsrr w3, 0xA /* KECCAK_DIGEST */
         bn.rshi w1, w3, w6 >> 144
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_17
 
         bn.rshi w1, bn0, w3 >> 32
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_17
 
         bn.wsrr w6, 0xA /* KECCAK_DIGEST */
         bn.rshi w1, w6, w3 >> 176
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_17
 
         bn.rshi w1, bn0, w6 >> 64
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_17
 
         bn.wsrr w3, 0xA /* KECCAK_DIGEST */
         bn.rshi w1, w3, w6 >> 208
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_17
 
         bn.rshi w1, bn0, w3 >> 96
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_17
 
         bn.wsrr w6, 0xA /* KECCAK_DIGEST */
         bn.rshi w1, w6, w3 >> 240
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_17
 
         bn.wsrr w3, 0xA /* KECCAK_DIGEST */
         bn.rshi w1, w3, w6 >> 128
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_17
 
         bn.rshi w1, bn0, w3 >> 16
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_17
 
         bn.wsrr w6, 0xA /* KECCAK_DIGEST */
         bn.rshi w1, w6, w3 >> 160
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_17
 
         bn.rshi w1, bn0, w6 >> 48
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_17
 
         bn.wsrr w3, 0xA /* KECCAK_DIGEST */
         bn.rshi w1, w3, w6 >> 192
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_17
 
         bn.rshi w1, bn0, w3 >> 80
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_17
 
         bn.wsrr w6, 0xA /* KECCAK_DIGEST */
         bn.rshi w1, w6, w3 >> 224
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_17
 
         bn.rshi w1, bn0, w6 >> 112
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_17
         nop /* Loop must not end on jump */
 
     /* Finish the SHAKE-256 operation. */
 
     ret
 
-_inner_poly_uniform_gamma_1:
+_inner_poly_uniform_gamma_1_17:
     /* Unpack 8 coefficients in one go */
     loopi 8, 2
         /* Shift one coefficient into the output register, ignoring the
@@ -2556,7 +2640,9 @@ _inner_poly_uniform_gamma_1:
     bn.addvm.8S w2, w0, w2
     bn.sid     t2, 0(t1++)
     ret
-#elif GAMMA1 == (1 << 19)
+
+.global poly_uniform_gamma_1_19
+poly_uniform_gamma_1_19:
     /* copy output pointer */
     addi t1, a0, 0
 
@@ -2585,12 +2671,12 @@ _inner_poly_uniform_gamma_1:
 
     /* Load gamma1 as a vector into w4 */
     li t2, 4
-    la t3, gamma1_vec_const
+    la t3, gamma1_vec_const_19
     bn.lid t2, 0(t3)
 
     /* Load mask for zeroing the upper bits of the unpacked coefficients to w5 */
     li t2, 5
-    la t3, polyz_unpack_mask
+    la t3, polyz_unpack_mask_19
     bn.lid t2, 0(t3)
 
     /* Setup WDR */
@@ -2599,39 +2685,39 @@ _inner_poly_uniform_gamma_1:
     LOOPI 4, 22
         bn.wsrr w6, 0xA /* KECCAK_DIGEST */
         bn.mov  w1, w6
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_19
 
         bn.wsrr w3, 0xA /* KECCAK_DIGEST */
         bn.rshi w1, w3, w6 >> 160
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_19
 
         bn.rshi w1, bn0, w3 >> 64
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_19
 
         bn.wsrr w6, 0xA /* KECCAK_DIGEST */
         bn.rshi w1, w6, w3 >> 224
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_19
 
         bn.wsrr w3, 0xA /* KECCAK_DIGEST */
         bn.rshi w1, w3, w6 >> 128
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_19
 
         bn.rshi w1, bn0, w3 >> 32
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_19
 
         bn.wsrr w6, 0xA /* KECCAK_DIGEST */
         bn.rshi w1, w6, w3 >> 192
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_19
 
         bn.rshi w1, bn0, w6 >> 96
-        jal     x1, _inner_poly_uniform_gamma_1
+        jal     x1, _inner_poly_uniform_gamma_1_19
         nop /* Must not end on branch */
 
     /* Finish the SHAKE-256 operation. */
 
     ret
 
-_inner_poly_uniform_gamma_1:
+_inner_poly_uniform_gamma_1_19:
     /* Unpack 8 coefficients in one go */
     loopi 8, 2
         /* Shift one coefficient into the output register, ignoring the
@@ -2647,9 +2733,8 @@ _inner_poly_uniform_gamma_1:
     bn.addvm.8S w2, w0, w2
     bn.sid     t2, 0(t1++)
     ret
-#endif
 /**
- * poly_decompose
+ * poly_decompose_88 / poly_decompose_32
  *
  *  For all coefficients c of the input polynomial, compute high and low bits
  *  c0, c1 such c mod Q = c1*ALPHA + c0 with -ALPHA/2 < c0 <= ALPHA/2 except c1
@@ -2661,55 +2746,96 @@ _inner_poly_uniform_gamma_1:
  * @param[out] a0: a0 pointer to output polynomial with coefficients c0
  * @param[out] a1: a1 pointer to output polynomial with coefficients c1
  * @param[in]  a2: *a, pointer to input polynomial
+ * @param[in]  x14: K (used by poly_decompose dispatcher only)
  *
  * clobbered registers: w0-w11, a0-a2, t0-t4
  */
 .global poly_decompose
 poly_decompose:
-    /* WDR constants for decompose */
+    /* Dispatch on x14 (K): K==4 means GAMMA2=(Q-1)/88, otherwise (Q-1)/32. */
+    li  t0, 4
+    beq x14, t0, poly_decompose_88
+    jal x0, poly_decompose_32
+
+.global poly_decompose_88
+poly_decompose_88:
     la t0, decompose_127_const
     li t1, 5
-    /* w5 <= decompose_127_const */
     bn.lid t1, 0(t0)
 
-    la t0, decompose_const
+    la t0, decompose_const_88
     li t1, 6
-    /* w6 <= decompose_const */
     bn.lid t1, 0(t0)
 
     la t0, reduce32_const
     li t1, 7
-    /* w7 <= reduce32_const */
     bn.lid t1, 0(t0)
 
-    la t0, decompose_43_const
+    la t0, decompose_43_const_88
     li t1, 8
-    /* w8 <= decompose_43_const */
     bn.lid t1, 0(t0)
 
-    la t0, gamma2_vec_const
+    la t0, gamma2_vec_const_88
     li t1, 9
-    /* w9 <= gamma2_vec_const */
     bn.lid t1, 0(t0)
 
     la t0, qm1half_const
     li t1, 10
-    /* w10 <= qm1half_const */
     bn.lid t1, 0(t0)
 
     la t0, modulus
     li t1, 11
-    /* w11 <= modulus */
     bn.lid t1, 0(t0)
 
-    /* Setup constants for WDRs */
     li t0, 0
     li t1, 1
     li t2, 2
 
     LOOPI 32, 4
         bn.lid t0, 0(a2++)
-        jal x1, decompose
+        jal x1, decompose_88
+        bn.sid t1, 0(a0++)
+        bn.sid t2, 0(a1++)
+
+    ret
+
+.global poly_decompose_32
+poly_decompose_32:
+    la t0, decompose_127_const
+    li t1, 5
+    bn.lid t1, 0(t0)
+
+    la t0, decompose_const_32
+    li t1, 6
+    bn.lid t1, 0(t0)
+
+    la t0, reduce32_const
+    li t1, 7
+    bn.lid t1, 0(t0)
+
+    la t0, decompose_43_const_32
+    li t1, 8
+    bn.lid t1, 0(t0)
+
+    la t0, gamma2_vec_const_32
+    li t1, 9
+    bn.lid t1, 0(t0)
+
+    la t0, qm1half_const
+    li t1, 10
+    bn.lid t1, 0(t0)
+
+    la t0, modulus
+    li t1, 11
+    bn.lid t1, 0(t0)
+
+    li t0, 0
+    li t1, 1
+    li t2, 2
+
+    LOOPI 32, 4
+        bn.lid t0, 0(a2++)
+        jal x1, decompose_32
         bn.sid t1, 0(a0++)
         bn.sid t2, 0(a1++)
 
@@ -2730,6 +2856,7 @@ poly_decompose:
  *
  * @param[out] a0: pointer to output hint polynomial
  * @param[in]  a1: pointer to low part of input polynomial
+ * @param[in]  a2: GAMMA2
  * @param[in]  w0: 256b representative of nonzero values in high part of polynomial
  *
  * clobbered registers: t0-t2, t5-t6, a0-a2, a4-a7
@@ -2740,7 +2867,7 @@ poly_make_hint:
     li   t4, 1
 
     /* Constants for condition checking */
-    li t6, GAMMA2
+    addi t6, a2, 0
 
     la t0, modulus
     lw a6, 0(t0)
@@ -2787,7 +2914,7 @@ _loop_end_poly_make_hint:
     ret
 
 /**
- * polyz_pack
+ * polyz_pack_17 / polyz_pack_19
  *
  * Pack polynomial z with coefficients fitting in 18 bits.
  *
@@ -2795,6 +2922,7 @@ _loop_end_poly_make_hint:
  *
  * @param[in]  w0: gamma1_vec_const
  * @param[in]  a1: pointer to input polynomial
+ * @param[in]  x14: K (used by polyz_pack dispatcher only)
  * @param[out] a0: pointer to output byte array with at least
  *                 POLYZ_PACKEDBYTES bytes
  *
@@ -2802,8 +2930,14 @@ _loop_end_poly_make_hint:
  */
 .global polyz_pack
 polyz_pack:
-#if GAMMA1 == (1 << 17)
-    la t1, gamma1_vec_const
+    /* Dispatch on x14 (K): K==4 means GAMMA1=2^17, otherwise 2^19. */
+    li  t0, 4
+    beq x14, t0, polyz_pack_17
+    jal x0, polyz_pack_19
+
+.global polyz_pack_17
+polyz_pack_17:
+    la t1, gamma1_vec_const_17
     li t3, 3
     bn.lid t3, 0(t1)
 
@@ -2812,171 +2946,171 @@ polyz_pack:
     li t4, 4
 
     /* Start packing */
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 112
     bn.sid  t4, 0(a0++)
     bn.rshi w4, w2, bn0 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 80
     bn.sid  t4, 0(a0++)
     bn.rshi w4, w2, bn0 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 48
     bn.sid  t4, 0(a0++)
     bn.rshi w4, w2, bn0 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 16
     bn.sid  t4, 0(a0++)
     bn.rshi w4, w2, bn0 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 128
     bn.sid  t4, 0(a0++)
     bn.rshi w4, w2, bn0 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 96
     bn.sid  t4, 0(a0++)
     bn.rshi w4, w2, bn0 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 64
     bn.sid  t4, 0(a0++)
     bn.rshi w4, w2, bn0 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 32
     bn.sid  t4, 0(a0++)
     bn.rshi w4, w2, bn0 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 144
     bn.sid  t4, 0(a0++)
     bn.rshi w4, w2, bn0 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 112
     bn.sid  t4, 0(a0++)
     bn.rshi w4, w2, bn0 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 80
     bn.sid  t4, 0(a0++)
     bn.rshi w4, w2, bn0 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 48
     bn.sid  t4, 0(a0++)
     bn.rshi w4, w2, bn0 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 16
     bn.sid  t4, 0(a0++)
     bn.rshi w4, w2, bn0 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 128
     bn.sid  t4, 0(a0++)
     bn.rshi w4, w2, bn0 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 96
     bn.sid  t4, 0(a0++)
     bn.rshi w4, w2, bn0 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 64
     bn.sid  t4, 0(a0++)
     bn.rshi w4, w2, bn0 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 32
     bn.sid  t4, 0(a0++)
     bn.rshi w4, w2, bn0 >> 144
 
 
-    jal     x1, _inner_polyz_pack
+    jal     x1, _inner_polyz_pack_17
     bn.rshi w4, w2, w4 >> 144
     bn.sid  t4, 0(a0++)
 
     ret
 
-_inner_polyz_pack:
+_inner_polyz_pack_17:
     bn.lid t1, 0(a1++)
     /* w1 <= eta - w1 */
     bn.subv.8S w1, w3, w1
@@ -2986,8 +3120,10 @@ _inner_polyz_pack:
     bn.rshi w2, bn0, w2 >> 112 /* Shift the 144 bits of data to the bottom of the
                                  WDR */
     ret
-#elif GAMMA1 == (1 << 19)
-    la t1, gamma1_vec_const
+
+.global polyz_pack_19
+polyz_pack_19:
+    la t1, gamma1_vec_const_19
     li t3, 3
     bn.lid t3, 0(t1)
 
@@ -2995,48 +3131,48 @@ _inner_polyz_pack:
     li t1, 1
     li t4, 4
     LOOPI 4, 25
-        jal     x1, _inner_polyz_pack
+        jal     x1, _inner_polyz_pack_19
         bn.rshi w4, w2, w4 >> 160
 
 
-        jal     x1, _inner_polyz_pack
+        jal     x1, _inner_polyz_pack_19
         bn.rshi w4, w2, w4 >> 96
         bn.sid  t4, 0(a0++)
         bn.rshi w4, w2, bn0 >> 160
 
 
-        jal     x1, _inner_polyz_pack
+        jal     x1, _inner_polyz_pack_19
         bn.rshi w4, w2, w4 >> 160
 
 
-        jal     x1, _inner_polyz_pack
+        jal     x1, _inner_polyz_pack_19
         bn.rshi w4, w2, w4 >> 32
         bn.sid  t4, 0(a0++)
         bn.rshi w4, w2, bn0 >> 160
 
 
-        jal     x1, _inner_polyz_pack
+        jal     x1, _inner_polyz_pack_19
         bn.rshi w4, w2, w4 >> 128
         bn.sid  t4, 0(a0++)
         bn.rshi w4, w2, bn0 >> 160
 
 
-        jal     x1, _inner_polyz_pack
+        jal     x1, _inner_polyz_pack_19
         bn.rshi w4, w2, w4 >> 160
 
 
-        jal     x1, _inner_polyz_pack
+        jal     x1, _inner_polyz_pack_19
         bn.rshi w4, w2, w4 >> 64
         bn.sid  t4, 0(a0++)
         bn.rshi w4, w2, bn0 >> 160
 
 
-        jal     x1, _inner_polyz_pack
+        jal     x1, _inner_polyz_pack_19
         bn.rshi w4, w2, w4 >> 160
         bn.sid  t4, 0(a0++)
 
     ret
-_inner_polyz_pack:
+_inner_polyz_pack_19:
     bn.lid t1, 0(a1++)
     /* w1 <= eta - w1 */
     bn.subv.8S w1, w3, w1
@@ -3046,7 +3182,6 @@ _inner_polyz_pack:
     bn.rshi w2, bn0, w2 >> 96 /* Shift the 96 bits of data to the bottom of the
                                  WDR */
     ret
-#endif
 
 /**
  * poly_encode_h
@@ -3058,6 +3193,7 @@ _inner_polyz_pack:
  * @param[in]  a1: pointer to input polynomial h[i]
  * @param[in]  a2: k, number of nonzero h coefficients so far
  * @param[in]  a3: i, index of this polynomial in h
+ * @param[in]  a4: OMEGA
  * @param[out] a0: pointer to the start of all signature hint bytes
  *
  * clobbered registers: a1-a2, t0-t6
@@ -3089,7 +3225,7 @@ _skip_store_poly_encode_h:
         addi t2, t2, 1
 
         /* Store the number of nonzero coefficients after h[i] at the end. */
-        addi t2, a3, OMEGA /* OMEGA + i */
+        add  t2, a3, a4   /* OMEGA + i */
         add  t2, a0, t2    /* *sig + OMEGA + i */
         andi t3, t2, 0x3   /* preserve lower 2 bits */
         and  t2, t2, t0    /* align */

--- a/sw/acc/crypto/mldsa/rounding.s
+++ b/sw/acc/crypto/mldsa/rounding.s
@@ -6,151 +6,20 @@
 
 .text
 
-#define SEEDBYTES 32
-#define CRHBYTES 64
-#define TRBYTES 64
-#define RNDBYTES 32
-#define N 256
-#define Q 8380417
-#define D 13
-#define ROOT_OF_UNITY 1753
-
-#if DILITHIUM_MODE == 2
-#define K 4
-#define L 4
-#define ETA 2
-#define TAU 39
-#define BETA 78
-#define GAMMA1 131072
-#define GAMMA2 95232
-#define OMEGA 80
-#define CTILDEBYTES 32
-
-#define POLYVECK_BYTES 4096
-#define POLYVECL_BYTES 4096
-
-#define CRYPTO_PUBLICKEYBYTES 1312
-#define CRYPTO_SECRETKEYBYTES 2560
-#define CRYPTO_BYTES 2420
-
-#elif DILITHIUM_MODE == 3
-#define K 6
-#define L 5
-#define ETA 4
-#define TAU 49
-#define BETA 196
-#define GAMMA1 524288
-#define GAMMA2 261888
-#define OMEGA 55
-#define CTILDEBYTES 48
-
-#define POLYVECK_BYTES 6144
-#define POLYVECL_BYTES 5120
-
-#define CRYPTO_PUBLICKEYBYTES 1952
-#define CRYPTO_SECRETKEYBYTES 4032
-#define CRYPTO_BYTES 3309
-
-#elif DILITHIUM_MODE == 5
-#define K 8
-#define L 7
-#define ETA 2
-#define TAU 60
-#define BETA 120
-#define GAMMA1 524288
-#define GAMMA2 261888
-#define OMEGA 75
-#define CTILDEBYTES 64
-
-#define POLYVECK_BYTES 8192
-#define POLYVECL_BYTES 7168
-
-#define CRYPTO_PUBLICKEYBYTES 2592
-#define CRYPTO_SECRETKEYBYTES 4896
-#define CRYPTO_BYTES 4627
-
-#endif
-
-#define POLYT1_PACKEDBYTES  320
-#define POLYT0_PACKEDBYTES  416
-#define POLYVECH_PACKEDBYTES (OMEGA + K)
-
-#if GAMMA1 == (1 << 17)
-#define POLYZ_PACKEDBYTES   576
-#elif GAMMA1 == (1 << 19)
-#define POLYZ_PACKEDBYTES   640
-#endif
-
-#if GAMMA2 == (Q-1)/88
-#define POLYW1_PACKEDBYTES  192
-#elif GAMMA2 == (Q-1)/32
-#define POLYW1_PACKEDBYTES  128
-#endif
-
-#if ETA == 2
-#define POLYETA_PACKEDBYTES  96
-#elif ETA == 4
-#define POLYETA_PACKEDBYTES 128
-#endif
-
-/* Register aliases */
-.equ x0, zero
-.equ x2, sp
-.equ x3, fp
-
-.equ x5, t0
-.equ x6, t1
-.equ x7, t2
-
-.equ x8, s0
-.equ x9, s1
-
-.equ x10, a0
-.equ x11, a1
-
-.equ x12, a2
-.equ x13, a3
-.equ x14, a4
-.equ x15, a5
-.equ x16, a6
-.equ x17, a7
-
-.equ x18, s2
-.equ x19, s3
-.equ x20, s4
-.equ x21, s5
-.equ x22, s6
-.equ x23, s7
-.equ x24, s8
-.equ x25, s9
-.equ x26, s10
-.equ x27, s11
-
-.equ x28, t3
-.equ x29, t4
-.equ x30, t5
-.equ x31, t6
-
 .equ w31, bn0
 
-/* Macros */
-.macro push reg
-    addi sp, sp, -4      /* Decrement stack pointer by 4 bytes */
-    sw \reg, 0(sp)      /* Store register value at the top of the stack */
-.endm
-
-.macro pop reg
-    lw \reg, 0(sp)      /* Load value from the top of the stack into register */
-    addi sp, sp, 4     /* Increment stack pointer by 4 bytes */
-.endm
-
 /**
- * decompose
+ * decompose_88 / decompose_32
  *
  * For finite field element a, compute high and low bits a0, a1 such that a
  * mod^+ Q = a1*ALPHA + a0 with -ALPHA/2 < a0 <= ALPHA/2 except if a1 =
  * (Q-1)/ALPHA where we set a1 = 0 and -ALPHA/2 <= a0 = a mod^+ Q - Q < 0.
  * Assumes a to be standard representative.
+ *
+ * Two variants are provided depending on the GAMMA2 value of the active mode:
+ *   decompose_88: GAMMA2 == (Q-1)/88   (mode 2, ML-DSA-44)
+ *   decompose_32: GAMMA2 == (Q-1)/32   (modes 3 and 5, ML-DSA-65/87)
+ * Callers select the right symbol at compile time via a #define alias.
  *
  * Returns: output element vector "a0" in w1, output element vector "a1" in w2
  *
@@ -161,14 +30,13 @@
  *
  * clobbered registers: w1-w4, w30
  */
-.global decompose
-decompose:
+.global decompose_88
+decompose_88:
     /* "a", "a{0,1}" refer to the variable names from the reference code */
 
     /* Compute "a1" */
     bn.addv.8S w2, w0, w5         /* "a" + 127 */
     bn.shv.8S  w2, w2 >> 7   /* ("a" + 127) >> 7 */
-#if GAMMA2 == (Q-1)/88
     bn.mulv.8S.even.lo w2, w2, w6         /* "a1" * 11275 */
     bn.mulv.8S.odd.lo  w2, w2, w6         /* "a1" * 11275 */
     bn.shv.8S  w4, w7 << 23  /* 1 << 23 */
@@ -179,14 +47,33 @@ decompose:
     bn.subv.8S w30, bn0, w30 /* Build mask from MSBs */
     bn.and w3, w2, w30           /* ((43 - "a1") >> 31) & "a1" */
     bn.xor w2, w2, w3            /* "a1" ^= ((43 - "a1") >> 31) & "a1" */
-#elif GAMMA2 == (Q-1)/32
+
+    /* Compute "a0" */
+    bn.mulv.8S.even.lo w4, w2, w9          /* "a1" * GAMMA2 */
+    bn.mulv.8S.odd.lo  w4, w4, w9          /* "a1" * GAMMA2 */
+    bn.shv.8S  w4, w4 << 1    /* "a1" * GAMMA2 * 2 */
+    bn.subv.8S w1, w0, w4          /* a - "a1" * GAMMA2 * 2 */
+    bn.subv.8S w4, w10, w1         /* (Q-1)/2 - "a0" */
+    bn.shv.8S  w30, w4 >> 31
+    bn.subv.8S w30, bn0, w30 /* Build mask from MSBs */
+    bn.and     w4, w11, w30        /* (((Q-1)/2 - "a0") >> 31) & Q */
+    bn.subv.8S w1, w1, w4          /* a0 -= (((Q-1)/2 - "a0") >> 31) & Q */
+
+    ret
+
+.global decompose_32
+decompose_32:
+    /* "a", "a{0,1}" refer to the variable names from the reference code */
+
+    /* Compute "a1" */
+    bn.addv.8S w2, w0, w5         /* "a" + 127 */
+    bn.shv.8S  w2, w2 >> 7   /* ("a" + 127) >> 7 */
     bn.mulv.8S.even.lo w2, w2, w6    /* "a1" * 1025 */
     bn.mulv.8S.odd.lo  w2, w2, w6    /* "a1" * 1025 */
     bn.shv.8S  w4, w7 << 21  /* 1 << 21 */
     bn.addv.8S w2, w2, w4    /* ("a1" * 1025) + (1 << 21) */
     bn.shv.8S  w2, w2 >> 22  /* (("a1" * 1025) + (1 << 21)) >> 22 */
     bn.and     w2, w2, w8    /* & 15 */
-#endif
 
     /* Compute "a0" */
     bn.mulv.8S.even.lo w4, w2, w9          /* "a1" * GAMMA2 */

--- a/sw/acc/crypto/tests/mldsa/BUILD
+++ b/sw/acc/crypto/tests/mldsa/BUILD
@@ -57,15 +57,15 @@ py_binary(
         testgen = ":mldsa_keypair_testgen",
         testgen_args = [params],
         deps = [
+            "//sw/acc/crypto/mldsa:consts",
             "//sw/acc/crypto/mldsa:intt",
+            "//sw/acc/crypto/mldsa:keypair",
             "//sw/acc/crypto/mldsa:kmac_send_msg",
-            "//sw/acc/crypto/mldsa:" + params + "_consts",
-            "//sw/acc/crypto/mldsa:" + params + "_keypair",
-            "//sw/acc/crypto/mldsa:" + params + "_poly",
-            "//sw/acc/crypto/mldsa:" + params + "_rounding",
             "//sw/acc/crypto/mldsa:ntt",
+            "//sw/acc/crypto/mldsa:poly",
             "//sw/acc/crypto/mldsa:poly_add",
             "//sw/acc/crypto/mldsa:poly_pointwise",
+            "//sw/acc/crypto/mldsa:rounding",
         ],
     )
     for i in range(NTESTS)
@@ -99,16 +99,16 @@ py_binary(
         testgen = ":mldsa_sign_testgen",
         testgen_args = [params],
         deps = [
+            "//sw/acc/crypto/mldsa:consts",
             "//sw/acc/crypto/mldsa:intt",
             "//sw/acc/crypto/mldsa:kmac_send_msg",
-            "//sw/acc/crypto/mldsa:" + params + "_consts",
-            "//sw/acc/crypto/mldsa:" + params + "_poly",
-            "//sw/acc/crypto/mldsa:" + params + "_rounding",
-            "//sw/acc/crypto/mldsa:" + params + "_sign",
             "//sw/acc/crypto/mldsa:ntt",
+            "//sw/acc/crypto/mldsa:poly",
             "//sw/acc/crypto/mldsa:poly_add",
             "//sw/acc/crypto/mldsa:poly_pointwise",
             "//sw/acc/crypto/mldsa:poly_sub",
+            "//sw/acc/crypto/mldsa:rounding",
+            "//sw/acc/crypto/mldsa:sign",
         ],
     )
     for i in range(NTESTS)
@@ -141,16 +141,16 @@ py_binary(
         testgen = ":mldsa_verify_testgen",
         testgen_args = [params],
         deps = [
+            "//sw/acc/crypto/mldsa:consts",
             "//sw/acc/crypto/mldsa:intt",
             "//sw/acc/crypto/mldsa:kmac_send_msg",
-            "//sw/acc/crypto/mldsa:" + params + "_consts",
-            "//sw/acc/crypto/mldsa:" + params + "_poly",
-            "//sw/acc/crypto/mldsa:" + params + "_rounding",
-            "//sw/acc/crypto/mldsa:" + params + "_verify",
             "//sw/acc/crypto/mldsa:ntt",
+            "//sw/acc/crypto/mldsa:poly",
             "//sw/acc/crypto/mldsa:poly_add",
             "//sw/acc/crypto/mldsa:poly_pointwise",
             "//sw/acc/crypto/mldsa:poly_sub",
+            "//sw/acc/crypto/mldsa:rounding",
+            "//sw/acc/crypto/mldsa:verify",
         ],
     )
     for i in range(NTESTS)
@@ -169,10 +169,10 @@ py_binary(
         dexp = "poly_make_hint_test.dexp",
         pqc = True,
         deps = [
+            "//sw/acc/crypto/mldsa:consts",
             "//sw/acc/crypto/mldsa:kmac_send_msg",
-            "//sw/acc/crypto/mldsa:" + params + "_consts",
-            "//sw/acc/crypto/mldsa:" + params + "_poly",
-            "//sw/acc/crypto/mldsa:" + params + "_rounding",
+            "//sw/acc/crypto/mldsa:poly",
+            "//sw/acc/crypto/mldsa:rounding",
         ],
     )
     for params in MLDSA_PARAMS
@@ -191,10 +191,10 @@ acc_sim_test(
     dexp = "poly_uniform_test.dexp",
     pqc = True,
     deps = [
+        "//sw/acc/crypto/mldsa:consts",
         "//sw/acc/crypto/mldsa:kmac_send_msg",
-        "//sw/acc/crypto/mldsa:mldsa44_consts",
-        "//sw/acc/crypto/mldsa:mldsa44_poly",
-        "//sw/acc/crypto/mldsa:mldsa44_rounding",
+        "//sw/acc/crypto/mldsa:poly",
+        "//sw/acc/crypto/mldsa:rounding",
     ],
 )
 
@@ -211,9 +211,9 @@ acc_sim_test(
     dexp = "poly_uniform_postprocess_test.dexp",
     pqc = True,
     deps = [
+        "//sw/acc/crypto/mldsa:consts",
         "//sw/acc/crypto/mldsa:kmac_send_msg",
-        "//sw/acc/crypto/mldsa:mldsa44_consts",
-        "//sw/acc/crypto/mldsa:mldsa44_poly",
-        "//sw/acc/crypto/mldsa:mldsa44_rounding",
+        "//sw/acc/crypto/mldsa:poly",
+        "//sw/acc/crypto/mldsa:rounding",
     ],
 )

--- a/sw/acc/crypto/tests/mldsa/mldsa_keypair_test.s
+++ b/sw/acc/crypto/tests/mldsa/mldsa_keypair_test.s
@@ -15,15 +15,25 @@
 
 .section .text.start
 #if DILITHIUM_MODE == 2
+    #define K 4
+    #define L 4
     #define CRYPTO_PUBLICKEYBYTES 1312
     #define CRYPTO_SECRETKEYBYTES 2560
 #elif DILITHIUM_MODE == 3
+    #define K 6
+    #define L 5
     #define CRYPTO_PUBLICKEYBYTES 1952
     #define CRYPTO_SECRETKEYBYTES 4032
 #elif DILITHIUM_MODE == 5
+    #define K 8
+    #define L 7
     #define CRYPTO_PUBLICKEYBYTES 2592
     #define CRYPTO_SECRETKEYBYTES 4896
 #endif
+
+#define MLDSA_PARAM_K_OFFSET 0
+#define MLDSA_PARAM_L_OFFSET 4
+#define MLDSA_PARAM_CRYPTO_PUBLICKEYBYTES_OFFSET 24
 
 /* Entry point. */
 .globl main
@@ -107,6 +117,15 @@ main:
   bn.rshi w2, w3, w2 >> 224
   /* Write back MOD */
   bn.wsrw 0x0, w2
+
+  /* Populate mldsa_params with the active mode's values. */
+  la    x4, mldsa_params
+  li    x5, K
+  sw    x5, MLDSA_PARAM_K_OFFSET(x4)
+  li    x5, L
+  sw    x5, MLDSA_PARAM_L_OFFSET(x4)
+  li    x5, CRYPTO_PUBLICKEYBYTES
+  sw    x5, MLDSA_PARAM_CRYPTO_PUBLICKEYBYTES_OFFSET(x4)
 
   jal x1, crypto_sign_keypair
 

--- a/sw/acc/crypto/tests/mldsa/mldsa_sign_test.s
+++ b/sw/acc/crypto/tests/mldsa/mldsa_sign_test.s
@@ -16,12 +16,58 @@
 .section .text.start
 
 #if DILITHIUM_MODE == 2
+#define K 4
+#define L 4
+#define TAU 39
+#define OMEGA 80
+#define GAMMA1_MINUS_BETA 130994
+#define POLYW1_PACKEDBYTES 192
+#define CRYPTO_PUBLICKEYBYTES 1312
+#define GAMMA2 95232
+#define GAMMA2_MINUS_BETA 95154
+#define SK_S2_OFFSET 512
+#define SK_T0_OFFSET 896
 #define CRYPTO_BYTES 2420
 #elif DILITHIUM_MODE == 3
+#define K 6
+#define L 5
+#define TAU 49
+#define OMEGA 55
+#define GAMMA1_MINUS_BETA 524092
+#define POLYW1_PACKEDBYTES 128
+#define CRYPTO_PUBLICKEYBYTES 1952
+#define GAMMA2 261888
+#define GAMMA2_MINUS_BETA 261692
+#define SK_S2_OFFSET 768
+#define SK_T0_OFFSET 1536
 #define CRYPTO_BYTES 3309
 #elif DILITHIUM_MODE == 5
+#define K 8
+#define L 7
+#define TAU 60
+#define OMEGA 75
+#define GAMMA1_MINUS_BETA 524168
+#define POLYW1_PACKEDBYTES 128
+#define CRYPTO_PUBLICKEYBYTES 2592
+#define GAMMA2 261888
+#define GAMMA2_MINUS_BETA 261768
+#define SK_S2_OFFSET 800
+#define SK_T0_OFFSET 1568
 #define CRYPTO_BYTES 4627
 #endif
+
+#define MLDSA_PARAM_K_OFFSET 0
+#define MLDSA_PARAM_L_OFFSET 4
+#define MLDSA_PARAM_TAU_OFFSET 8
+#define MLDSA_PARAM_OMEGA_OFFSET 12
+#define MLDSA_PARAM_GAMMA1_MINUS_BETA_OFFSET 16
+#define MLDSA_PARAM_POLYW1_PACKEDBYTES_OFFSET 20
+#define MLDSA_PARAM_CRYPTO_PUBLICKEYBYTES_OFFSET 24
+#define MLDSA_PARAM_GAMMA2_OFFSET 28
+#define MLDSA_PARAM_GAMMA2_MINUS_BETA_OFFSET 32
+#define MLDSA_PARAM_SK_S2_OFFSET_OFFSET 36
+#define MLDSA_PARAM_SK_T0_OFFSET_OFFSET 40
+#define MLDSA_PARAM_CRYPTO_BYTES_OFFSET 44
 
 /* Entry point. */
 .globl main
@@ -105,6 +151,33 @@ main:
   bn.rshi w2, w3, w2 >> 224
   /* Write back MOD */
   bn.wsrw 0x0, w2
+
+  /* Populate mldsa_params with the active mode's values. */
+  la    x4, mldsa_params
+  li    x5, K
+  sw    x5, MLDSA_PARAM_K_OFFSET(x4)
+  li    x5, L
+  sw    x5, MLDSA_PARAM_L_OFFSET(x4)
+  li    x5, TAU
+  sw    x5, MLDSA_PARAM_TAU_OFFSET(x4)
+  li    x5, OMEGA
+  sw    x5, MLDSA_PARAM_OMEGA_OFFSET(x4)
+  li    x5, GAMMA1_MINUS_BETA
+  sw    x5, MLDSA_PARAM_GAMMA1_MINUS_BETA_OFFSET(x4)
+  li    x5, POLYW1_PACKEDBYTES
+  sw    x5, MLDSA_PARAM_POLYW1_PACKEDBYTES_OFFSET(x4)
+  li    x5, CRYPTO_PUBLICKEYBYTES
+  sw    x5, MLDSA_PARAM_CRYPTO_PUBLICKEYBYTES_OFFSET(x4)
+  li    x5, GAMMA2
+  sw    x5, MLDSA_PARAM_GAMMA2_OFFSET(x4)
+  li    x5, GAMMA2_MINUS_BETA
+  sw    x5, MLDSA_PARAM_GAMMA2_MINUS_BETA_OFFSET(x4)
+  li    x5, SK_S2_OFFSET
+  sw    x5, MLDSA_PARAM_SK_S2_OFFSET_OFFSET(x4)
+  li    x5, SK_T0_OFFSET
+  sw    x5, MLDSA_PARAM_SK_T0_OFFSET_OFFSET(x4)
+  li    x5, CRYPTO_BYTES
+  sw    x5, MLDSA_PARAM_CRYPTO_BYTES_OFFSET(x4)
 
   /* Load parameters */
   la x10, sig

--- a/sw/acc/crypto/tests/mldsa/mldsa_verify_test.s
+++ b/sw/acc/crypto/tests/mldsa/mldsa_verify_test.s
@@ -15,11 +15,40 @@
 .section .text.start
 #if DILITHIUM_MODE == 2
     #define CRYPTO_BYTES 2420
+    #define K 4
+    #define L 4
+    #define TAU 39
+    #define OMEGA 80
+    #define GAMMA1_MINUS_BETA 130994
+    #define POLYW1_PACKEDBYTES 192
+    #define CRYPTO_PUBLICKEYBYTES 1312
 #elif DILITHIUM_MODE == 3
     #define CRYPTO_BYTES 3309
+    #define K 6
+    #define L 5
+    #define TAU 49
+    #define OMEGA 55
+    #define GAMMA1_MINUS_BETA 524092
+    #define POLYW1_PACKEDBYTES 128
+    #define CRYPTO_PUBLICKEYBYTES 1952
 #elif DILITHIUM_MODE == 5
     #define CRYPTO_BYTES 4627
+    #define K 8
+    #define L 7
+    #define TAU 60
+    #define OMEGA 75
+    #define GAMMA1_MINUS_BETA 524168
+    #define POLYW1_PACKEDBYTES 128
+    #define CRYPTO_PUBLICKEYBYTES 2592
 #endif
+
+#define MLDSA_PARAM_K_OFFSET 0
+#define MLDSA_PARAM_L_OFFSET 4
+#define MLDSA_PARAM_TAU_OFFSET 8
+#define MLDSA_PARAM_OMEGA_OFFSET 12
+#define MLDSA_PARAM_GAMMA1_MINUS_BETA_OFFSET 16
+#define MLDSA_PARAM_POLYW1_PACKEDBYTES_OFFSET 20
+#define MLDSA_PARAM_CRYPTO_PUBLICKEYBYTES_OFFSET 24
 
 /* Entry point. */
 .globl main
@@ -103,6 +132,23 @@ main:
   bn.rshi w2, w3, w2 >> 224
   /* Write back MOD */
   bn.wsrw 0x0, w2
+
+  /* Populate mldsa_params with the active mode's values. */
+  la    x4, mldsa_params
+  li    x5, K
+  sw    x5, MLDSA_PARAM_K_OFFSET(x4)
+  li    x5, L
+  sw    x5, MLDSA_PARAM_L_OFFSET(x4)
+  li    x5, TAU
+  sw    x5, MLDSA_PARAM_TAU_OFFSET(x4)
+  li    x5, OMEGA
+  sw    x5, MLDSA_PARAM_OMEGA_OFFSET(x4)
+  li    x5, GAMMA1_MINUS_BETA
+  sw    x5, MLDSA_PARAM_GAMMA1_MINUS_BETA_OFFSET(x4)
+  li    x5, POLYW1_PACKEDBYTES
+  sw    x5, MLDSA_PARAM_POLYW1_PACKEDBYTES_OFFSET(x4)
+  li    x5, CRYPTO_PUBLICKEYBYTES
+  sw    x5, MLDSA_PARAM_CRYPTO_PUBLICKEYBYTES_OFFSET(x4)
 
   /* Load parameters */
   la    x10, sig

--- a/sw/acc/crypto/tests/mldsa/poly_make_hint_test.s
+++ b/sw/acc/crypto/tests/mldsa/poly_make_hint_test.s
@@ -8,6 +8,12 @@
 
 .section .text.start
 
+#if DILITHIUM_MODE == 2
+#define GAMMA2 95232
+#else
+#define GAMMA2 261888
+#endif
+
 main:
   /* Prepare all-zero register. */
   bn.xor w31, w31, w31
@@ -15,6 +21,7 @@ main:
   /* Call poly_make_hint. */
   la     x10, result
   la     x11, low_poly
+  li     x12, GAMMA2
   la     x2, high_bits
   bn.lid x0, 0(x2)
   jal x1, poly_make_hint


### PR DESCRIPTION
In preparation of wiring the ML-DSA ACC implementation up into the cryptolib, this PR changes the implementation so that the parameter set is a runtime argument. This allows building a single binary supporting all parameter sets and operation which enabled code sharing between them.