### PR TITLE
[ottf,console] Skip flow-control ISR for non-UART consoles

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf_console.c
+++ b/sw/device/lib/testing/test_framework/ottf_console.c
@@ -86,10 +86,11 @@ uint32_t ottf_console_get_flow_control_irqs(void) { return flow_control_irqs; }
 bool ottf_console_flow_control_isr(uint32_t *exc_info) {
   flow_control_irqs += 1;
 #ifdef OTTF_CONSOLE_HAS_UART
-  return ottf_console_uart_flow_control_isr(exc_info, &main_console);
-#else
-  return false;
+  if (main_console.type == kOttfConsoleUart) {
+    return ottf_console_uart_flow_control_isr(exc_info, &main_console);
+  }
 #endif
+  return false;
 }
 
 status_t ottf_console_flow_control(ottf_console_t *console,


### PR DESCRIPTION
Ran into this issue when trying to run ML-KEM testvectors on the CW340.

When the main console is not a UART, as in the cryptotest FPGA setup, the flow-control ISR unconditionally dispatched to the UART handler, which crashes the test firmware on the first incoming RPC:

  E00003 ottf_console_uart.c:153] CHECK-fail: console->type == kOttfConsoleUart
  I00004 status.c:43] FAIL!

Only dispatch to the UART flow-control handler when the main console is actually a UART.