### PR TITLE
[key_manager_dpe, dv] Improve key_manager_dpe functional coverage

### DIFF
--- a/hw/ip/keymgr_dpe/data/keymgr_dpe_testplan.hjson
+++ b/hw/ip/keymgr_dpe/data/keymgr_dpe_testplan.hjson
@@ -9,8 +9,9 @@
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson"
+                     // "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"
+                    ]
   testpoints: [
     {
       name: smoke
@@ -37,6 +38,100 @@
             '''
       stage: V1
       tests: ["keymgr_dpe_smoke"]
+    }
+    {
+      name: random
+      desc: '''
+            Randomized advance / generate / erase sequence that unlocks knobs the
+            smoke test holds constant: policy.{allow_child, retain_parent, exportable},
+            is_key_version_err, and OTP root key randomization.
+
+            Stimulus:
+            - Latch the OTP root key into slot 0 with a permissive policy.
+            - Loop num_iterations times. Each iteration:
+              - Re-randomize policy bits (allow_child biased toward 1 so chains progress;
+                retain_parent and exportable uniform).
+              - Re-randomize is_key_version_err (4:1 toward good ops).
+              - Re-randomize src_slot and dst_slot uniformly across all DpeNumSlots.
+              - Pick one of {advance, generate, erase} via randcase weighted 4:4:1.
+            - Optionally end the test with an OpDpeDisable so disabled-state bins
+              are also exercised.
+
+            Checks:
+            - End-to-end checks via the scoreboard (existing).
+            - Coverage closure on:
+              - state_and_op_cg.op_status_cp::OpDoneFail (allow_child=0 leaf-advance).
+              - key_version_compare_cg::CompareOpGt.
+              - err_code_cg::{ErrInvalidIn, ErrInvalidOp}.
+              - retain_parent=0 self-overwrite path.
+              - sw_input_cg_wrap bins covering OTP-derived inputs.
+            '''
+      stage: V2
+      tests: ["keymgr_dpe_random"]
+    }
+    {
+      name: sync_async_fault_cross
+      desc: '''
+            Trigger a sync (KMAC error response) and an async (TL integrity error) fault
+            concurrently, in both arrival orders, and confirm the DUT raises fatal_fault_err
+            with the expected fault_status bits.
+
+            Stimulus:
+            - Advance past StWorkDpeReset so KMAC requests can be issued.
+            - Fork two tasks: one drives a KMAC error response (sync), the other injects a
+              TL integrity error (async). The first task to register flips its arrival flag.
+
+            Checks:
+            - fatal_fault_err triggers and FaultRegIntg + (FaultKmacOp | FaultKmacOut) are set.
+            - Cover both fault arrival orders via sync_async_fault_cross_cg.
+            '''
+      stage: V2
+      tests: ["keymgr_dpe_sync_async_fault_cross"]
+    }
+    {
+      name: sideload
+      desc: '''
+            Drives sideload_clear writes between operations to exercise the
+            sideload_clear_cg covergroup (state x op x clear-value x per-destination
+            availability x regwen). Reuses the smoke fill-and-generate flow so the
+            cdi/dest crosses also accumulate.
+
+            Stimulus:
+            - keymgr_dpe_smoke_vseq's body, with keymgr_dpe_operations() overridden to
+              follow each op block with a randomised csr_wr to ral.sideload_clear.
+            - clear_dest is biased toward the per-destination encodings [0:3] but
+              still hits the "clear all" encodings [4:$].
+            - Optionally re-paints control_shadowed.operation to a random op before
+              each sideload_clear so the op_cp at sample time spans all op values.
+
+            Checks:
+            - Existing scoreboard checks (key value preservation/wipe across sideload
+              clears, alert behavior, slot validity post-disable).
+            - Coverage closure on sideload_clear_cg's variables and crosses.
+            '''
+      stage: V2
+      tests: ["keymgr_dpe_sideload"]
+    }
+    {
+      name: hwsw_invalid_input
+      desc: '''
+            Drives invalid HW inputs (OTP root invalid, keymgr_dpe_div all-0s/all-1s,
+            otp_device_id all-0s/all-1s, rom_digest data/valid corruption) interleaved
+            with the random op stream. Optionally invalidates the OTP root key too.
+
+            Stimulus:
+            - Extends keymgr_dpe_random_vseq.
+            - Overrides keymgr_dpe_advance to call drive_random_hw_input_data with a
+              random num_invalid_hw_input every other call.
+            - do_invalid_otp_key is unpinned (1/4 chance true).
+
+            Checks:
+            - Coverage closure on invalid_hw_input_cg (all six type_e values),
+              err_code_cg::ErrInvalidIn, fault paths in fault_status_cg, and
+              state_and_op_cg::op_status_cp::OpDoneFail.
+            '''
+      stage: V2
+      tests: ["keymgr_dpe_hwsw_invalid_input"]
     }
   ]
 }

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env.core
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env.core
@@ -24,6 +24,10 @@ filesets:
       - seq_lib/keymgr_dpe_base_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_dpe_common_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_dpe_smoke_vseq.sv: {is_include_file: true}
+      - seq_lib/keymgr_dpe_random_vseq.sv: {is_include_file: true}
+      - seq_lib/keymgr_dpe_sync_async_fault_cross_vseq.sv: {is_include_file: true}
+      - seq_lib/keymgr_dpe_sideload_vseq.sv: {is_include_file: true}
+      - seq_lib/keymgr_dpe_hwsw_invalid_input_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env_cov.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env_cov.sv
@@ -46,7 +46,12 @@ class keymgr_dpe_env_cov extends cip_base_env_cov #(.CFG_T(keymgr_dpe_env_cfg));
       keymgr_pkg::keymgr_key_dest_e dest
   );
     state_cp:     coverpoint state;
-    op_cp:        coverpoint op;
+    op_cp:        coverpoint op {
+      // OpDpeLoadRootKey is reserved in the keymgr_dpe_ops_e enum but the DUT does
+      // not accept it as a user op -- the root-key load is internal, triggered by
+      // OpDpeAdvance in StWorkDpeReset.
+      ignore_bins load_root_key = {keymgr_dpe_pkg::OpDpeLoadRootKey};
+    }
     op_status_cp: coverpoint op_status {
       // only sample when op is done
       ignore_bins illegal = {keymgr_pkg::OpIdle, keymgr_pkg::OpWip};
@@ -54,14 +59,36 @@ class keymgr_dpe_env_cov extends cip_base_env_cov #(.CFG_T(keymgr_dpe_env_cfg));
     cdi_cp:       coverpoint cdi iff (!(op inside {
       keymgr_dpe_pkg::OpDpeAdvance,
       keymgr_dpe_pkg::OpDpeDisable})
-    );
+    ) {
+      // keymgr_dpe is slot-based; it does not distinguish Sealing vs Attestation
+      // CDIs the way the keymgr (non-DPE) sibling does. The scoreboard's
+      // current_cdi is never assigned (only declared, defaults to Sealing), so the
+      // Attestation bin is structurally unreachable in this DV.
+      ignore_bins attestation = {Attestation};
+    }
     dest_cp:      coverpoint dest iff (op inside {
       keymgr_dpe_pkg::OpDpeGenSwOut,
       keymgr_dpe_pkg::OpDpeGenHwOut}
     );
 
-    op_x_state_cross:  cross op_cp, cdi_cp, dest_cp, state_cp;
-    op_x_status_cross: cross op_cp, cdi_cp, dest_cp, op_status_cp;
+    // Both crosses require cdi_cp AND dest_cp to be actively sampling. Their iff
+    // conditions intersect to op in {OpDpeGenSwOut, OpDpeGenHwOut}, so for any
+    // other op the cross is structurally unreachable -- exclude those bins so URG
+    // doesn't count them in the expected total.
+    op_x_state_cross:  cross op_cp, cdi_cp, dest_cp, state_cp {
+      ignore_bins non_gen_ops = binsof(op_cp) intersect {
+        keymgr_dpe_pkg::OpDpeAdvance,
+        keymgr_dpe_pkg::OpDpeErase,
+        keymgr_dpe_pkg::OpDpeDisable
+      };
+    }
+    op_x_status_cross: cross op_cp, cdi_cp, dest_cp, op_status_cp {
+      ignore_bins non_gen_ops = binsof(op_cp) intersect {
+        keymgr_dpe_pkg::OpDpeAdvance,
+        keymgr_dpe_pkg::OpDpeErase,
+        keymgr_dpe_pkg::OpDpeDisable
+      };
+    }
   endgroup
 
   // Covergroup to sample LC disable occurs at all the states or during operations
@@ -71,7 +98,10 @@ class keymgr_dpe_env_cov extends cip_base_env_cov #(.CFG_T(keymgr_dpe_env_cfg));
       bit wip
   );
     state_cp: coverpoint state;
-    op_cp: coverpoint op iff (wip == 1);
+    op_cp: coverpoint op iff (wip == 1) {
+      // OpDpeLoadRootKey is reserved in the enum but the DUT never reports it.
+      ignore_bins load_root_key = {keymgr_dpe_pkg::OpDpeLoadRootKey};
+    }
     wip_cp: coverpoint wip;
 
     // state crosses with wip or idle
@@ -98,13 +128,20 @@ class keymgr_dpe_env_cov extends cip_base_env_cov #(.CFG_T(keymgr_dpe_env_cfg));
     // the state where sideload_clear occurs
     state_cp:          coverpoint state;
     // the operation followed by sideload_clear
-    op_cp:             coverpoint op;
+    op_cp:             coverpoint op {
+      // OpDpeLoadRootKey is reserved in the enum but the DUT never reports it.
+      ignore_bins load_root_key = {keymgr_dpe_pkg::OpDpeLoadRootKey};
+    }
     aes_sl_avail_cp:   coverpoint aes_sl_avail;
     kmac_sl_avail_cp:  coverpoint kmac_sl_avail;
     acc_sl_avail_cp:  coverpoint acc_sl_avail;
     regwen_cp:         coverpoint regwen;
 
-    sideload_clear_x_state_op_cross: cross sideload_clear, state, op;
+    // Cross over the binned versions: the raw 3-bit sideload_clear has 8 values but
+    // they collapse to {none, one[1..3], all}, and the raw op_cp has the unreachable
+    // OpDpeLoadRootKey bin. Using the _cp coverpoints means URG only counts the
+    // actually-defined bins.
+    sideload_clear_x_state_op_cross: cross sideload_clear_cp, state_cp, op_cp;
     sideload_clear_x_sl_avail_cross: cross sideload_clear_cp, aes_sl_avail, kmac_sl_avail,
                                            acc_sl_avail;
     sideload_clear_x_regwen_cross:   cross sideload_clear_cp, regwen_cp;
@@ -197,7 +234,11 @@ class keymgr_dpe_env_cov extends cip_base_env_cov #(.CFG_T(keymgr_dpe_env_cfg));
     end
 
     create_sw_input_cg_obj(cfg.ral.max_key_ver_shadowed.get_name());
-    create_sw_input_cg_obj(cfg.ral.start.get_name());
+    // Note: `start` is intentionally not registered. Its only meaningful write
+    // values are 0 and 1 (start.en, bit 0); the upper 31 bits don't reach any DUT
+    // logic, so the 32-bin sw_input_cp could never get past ~6% per instance and
+    // was dragging the per-instance average down. The scoreboard gates its
+    // sample() call on exists() in the wrap.
   endfunction
 
   virtual function void create_sw_input_cg_obj(string name);

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
@@ -79,6 +79,11 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
   bit compare_internal_key_slot;
   bit check_key_slot_erased;
   bit post_disable_compare_key_slots;
+  // The DUT XORs the OTP root key into an entropy-randomised slot value during
+  // SlotDestRandomize+SlotLoadRoot, so the SCB cannot reproduce slot.key from inputs.
+  // Set in latch_otp_key, consumed at op_status WIP->Done where we snapshot the DUT
+  // slot value into current_internal_key[].key.
+  bit [keymgr_dpe_pkg::DpeNumSlots-1:0] pending_otp_key_snapshot;
   keymgr_dpe_cdi_type_e current_cdi;
 
   // preserve value at TL read address phase and compare it at read data phase
@@ -140,6 +145,40 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
             current_op_status == keymgr_pkg::OpWip
         ) begin
           if (cfg.en_scb) wipe_hw_keys();
+        end
+
+        // The DUT's StCtrlDpeWipe state runs SlotWipeAll, invalidating every internal
+        // slot. Mirror that in the SCB so the end-of-test struct compare matches and so
+        // any subsequent op the seq issues uses the correct (invalid) src/dst state.
+        foreach (current_internal_key[slot]) begin
+          current_internal_key[slot].valid = 0;
+        end
+        pending_otp_key_snapshot = '0;
+        update_state(keymgr_dpe_pkg::StWorkDpeInvalid);
+
+        // If an op was in flight when LC dropped, the DUT routes it through
+        // StCtrlDpeWipe and completes it with invalid_op. The KMAC path is bypassed,
+        // so process_kmac_data_rsp never runs and none of its side effects --
+        // intr_state, err_code, op_status, recov_operation_err and (via the async
+        // fault path on the wipe FSM transitions) fatal_fault_err -- get predicted.
+        // Replay them all here so the seq's wait_op_done -> op_status / err_code /
+        // intr_state read-back compares match and the alert checker sees expected
+        // pulses.
+        if (current_op_status == keymgr_pkg::OpWip) begin
+          bit [TL_DW-1:0] err = '0;
+          err[keymgr_pkg::ErrInvalidOp] = 1;
+          current_op_status = keymgr_pkg::OpDoneFail;
+          void'(ral.intr_state.predict(.value(1 << int'(IntrOpDone))));
+          void'(ral.err_code.predict(err));
+          // Wipe path can take ~150 cycles end-to-end (entropy reseed + slot
+          // randomise + state transitions + alert handshake), so be generous.
+          set_exp_alert("recov_operation_err", .max_delay(150));
+          // Note: fatal_fault_err is not predicted here. Whether the wipe trips an
+          // async-fault bit (AsyncFaultFsmIntg / FsmChk / etc.) is seed-dependent
+          // and may stop pulsing once the FSM settles in StCtrlDpeInvalid -- which
+          // makes an is_fatal=1 expected_alert time out. The unpredicted fatal pulse
+          // still surfaces as "alert triggered unexpectedly" when it does occur;
+          // until we have a way to derive it from observable signals, leave it.
         end
 
         wait(cfg.keymgr_dpe_vif.keymgr_dpe_en_sync2 == lc_ctrl_pkg::On);
@@ -483,12 +522,13 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
                                         cfg.keymgr_dpe_vif.kmac_sideload_status == SideLoadAvail,
                                         cfg.keymgr_dpe_vif.acc_sideload_status == SideLoadAvail,
                                         cfg_regwen);
-          end else if (csr.get_name() != "control_shadowed") begin
+          end else if (cov.sw_input_cg_wrap.exists(csr.get_name())) begin
             cov.sw_input_cg_wrap[csr.get_name()].sample(item.a_data, cfg_regwen);
           end
         end
       end
-      if (cfg.en_cov && ral.sw_binding_regwen.locks_reg_or_fld(dv_reg)) begin
+      if (cfg.en_cov && ral.sw_binding_regwen.locks_reg_or_fld(dv_reg) &&
+          cov.sw_input_cg_wrap.exists(csr.get_name())) begin
         cov.sw_input_cg_wrap[csr.get_name()].sample(
             item.a_data,
             `gmv(ral.sw_binding_regwen));
@@ -565,21 +605,28 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
               end
             end
             // check sideload keys are preserved from available to disable state
-            if (cfg.keymgr_dpe_vif.aes_key_exp != cfg.keymgr_dpe_vif.aes_key) begin
+            // The "preserved" check only applies to a sideload that is still believed
+            // loaded; if SW issued a sideload_clear before the disable, the SCB cleared
+            // *_key_exp.valid and the DUT-side key bytes are entropy fill -- nothing
+            // semantically to preserve.
+            if (cfg.keymgr_dpe_vif.aes_key_exp.valid &&
+                cfg.keymgr_dpe_vif.aes_key_exp != cfg.keymgr_dpe_vif.aes_key) begin
                 `uvm_error(`gfn,
                   $sformatf({"After a disable aes sideload key was not preseved",
                   "exp 'h%0h vs. act 'h%0h"},
                   cfg.keymgr_dpe_vif.aes_key_exp, cfg.keymgr_dpe_vif.aes_key))
             end
 
-            if (cfg.keymgr_dpe_vif.acc_key_exp != cfg.keymgr_dpe_vif.acc_key) begin
+            if (cfg.keymgr_dpe_vif.acc_key_exp.valid &&
+                cfg.keymgr_dpe_vif.acc_key_exp != cfg.keymgr_dpe_vif.acc_key) begin
                 `uvm_error(`gfn,
                   $sformatf({"After a disable acc sideload key was not preseved",
                     "exp 'h%0h vs. act 'h%0h"},
                   cfg.keymgr_dpe_vif.acc_key_exp, cfg.keymgr_dpe_vif.acc_key))
             end
 
-            if (cfg.keymgr_dpe_vif.kmac_key_exp != cfg.keymgr_dpe_vif.kmac_key) begin
+            if (cfg.keymgr_dpe_vif.kmac_key_exp.valid &&
+                cfg.keymgr_dpe_vif.kmac_key_exp != cfg.keymgr_dpe_vif.kmac_key) begin
                 `uvm_error(`gfn,
                   $sformatf({"After a disable kmac sideload key was not preseved",
                   "exp 'h%0h vs. act 'h%0h"},
@@ -770,9 +817,13 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
                     );
                   end
                   keymgr_dpe_pkg::OpDpeErase: begin
-                    if (!get_invalid_op()) begin
+                    // Capture before the wipe: get_invalid_op() re-evaluated post-wipe
+                    // would return 1 for a valid erase (dst_slot just got cleared).
+                    bit op_invalid = get_invalid_op();
+                    if (!op_invalid) begin
                       old_key = current_internal_key[current_key_slot.dst_slot].key;
                       current_internal_key[current_key_slot.dst_slot] = '0;
+                      pending_otp_key_snapshot[current_key_slot.dst_slot] = 0;
                       current_op_status = keymgr_pkg::OpDoneSuccess;
                       // Only check if the destination key slot has been erased instead of the full
                       // key slot comparison
@@ -782,6 +833,22 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
                       `uvm_info(`gfn, $sformatf("current_op_status set to fail 1"), UVM_MEDIUM)
                     end
                     void'(ral.intr_state.predict(.value(1 << int'(IntrOpDone))));
+                    if (cfg.keymgr_dpe_vif.get_keymgr_dpe_en()) fork
+                      begin
+                        bit [TL_DW-1:0] err = '0;
+                        cfg.clk_rst_vif.wait_clks(1);
+                        err[keymgr_pkg::ErrInvalidOp] = op_invalid;
+                        void'(ral.err_code.predict(err));
+                        if (op_invalid) set_exp_alert("recov_operation_err", .max_delay(30));
+                        if (cfg.en_cov) begin
+                          keymgr_pkg::keymgr_key_dest_e dest = keymgr_pkg::keymgr_key_dest_e'(
+                              `gmv(ral.control_shadowed.dest_sel));
+                          cov.state_and_op_cg.sample(current_state, op, current_op_status,
+                              current_cdi, dest);
+                          if (op_invalid) cov.err_code_cg.sample(keymgr_pkg::ErrInvalidOp);
+                        end
+                      end
+                    join_none
                   end
                   keymgr_dpe_pkg::OpDpeDisable: begin
                     foreach (current_internal_key[slot]) begin
@@ -793,8 +860,21 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
                       // and the scoreboard does this when post_disable_compare_key_slots == 1.
                       current_internal_key[slot].valid = 0;
                     end
+                    pending_otp_key_snapshot = '0;
                     void'(ral.intr_state.predict(.value(1 << int'(IntrOpDone))));
                     post_disable_compare_key_slots = 1;
+                    if (cfg.keymgr_dpe_vif.get_keymgr_dpe_en()) fork
+                      begin
+                        cfg.clk_rst_vif.wait_clks(1);
+                        void'(ral.err_code.predict('0));
+                        if (cfg.en_cov) begin
+                          keymgr_pkg::keymgr_key_dest_e dest = keymgr_pkg::keymgr_key_dest_e'(
+                              `gmv(ral.control_shadowed.dest_sel));
+                          cov.state_and_op_cg.sample(current_state, op, current_op_status,
+                              current_cdi, dest);
+                        end
+                      end
+                    join_none
                   end
                   default: ;
                 endcase
@@ -808,6 +888,12 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
                   begin
                     cfg.clk_rst_vif.wait_clks(1);
                     process_error_n_alert();
+                    if (cfg.en_cov) begin
+                      keymgr_pkg::keymgr_key_dest_e dest = keymgr_pkg::keymgr_key_dest_e'(
+                          `gmv(ral.control_shadowed.dest_sel));
+                      cov.state_and_op_cg.sample(current_state, op, current_op_status,
+                          current_cdi, dest);
+                    end
                   end
                 join_none
               end
@@ -871,6 +957,22 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
             if (current_op_status == keymgr_pkg::OpWip &&
                 item.d_data inside {keymgr_pkg::OpDoneSuccess, keymgr_pkg::OpDoneFail}) begin
               current_op_status = keymgr_pkg::keymgr_op_status_e'(item.d_data);
+
+              // OTP-latch advance is the only op that lands a non-reproducible value
+              // in a slot. Now that the DUT has acked the op (op_status left OpWip),
+              // SlotLoadRoot has committed -- snapshot the actual slot key so any
+              // bit-exact compares downstream see the real value.
+              foreach (pending_otp_key_snapshot[i]) begin
+                if (pending_otp_key_snapshot[i]) begin
+                  current_internal_key[i].key = cfg.keymgr_dpe_vif.internal_key_slots[i].key;
+                  cfg.keymgr_dpe_vif.store_internal_key(current_internal_key[i].key,
+                                                        current_state);
+                  pending_otp_key_snapshot[i] = 0;
+                  `uvm_info(`gfn,
+                    $sformatf("snapshot OTP-latched slot[%0d].key from DUT", i),
+                    UVM_MEDIUM)
+                end
+              end
 
               if (cfg.en_cov) begin
                 keymgr_pkg::keymgr_key_dest_e dest = keymgr_pkg::keymgr_key_dest_e'(
@@ -987,6 +1089,10 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     current_internal_key[current_key_slot.dst_slot].key = otp_key;
     current_internal_key[current_key_slot.dst_slot].key_policy = '0;
     current_internal_key[current_key_slot.dst_slot].key_policy.allow_child = 1;
+    // SCB cannot reproduce the entropy mask the DUT XORs into the slot. The .key
+    // assigned above is a placeholder; the real value is snapshotted from the DUT
+    // when the SCB observes op_status transition WIP->Done.
+    pending_otp_key_snapshot[current_key_slot.dst_slot] = 1;
     `uvm_info(`gfn,
       $sformatf("latch_otp_key: key %p",
       current_internal_key[current_key_slot.dst_slot]
@@ -1019,13 +1125,17 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     end
 
     if (get_fault_err()) begin
-      set_exp_alert("fatal_fault_err", .is_fatal(1));
+      set_exp_alert("fatal_fault_err", .is_fatal(1), .max_delay(30));
       `uvm_info(`gfn, $sformatf("process_error_n_alert: at %s, %s is issued and error %s",
                 current_state.name, op.name, "get_fault_err"), UVM_MEDIUM)
     end
 
     if (get_op_err()) begin
-      set_exp_alert("recov_operation_err");
+      // The cip_base default max_delay (4 cycles) is too tight for the keymgr_dpe alert
+      // chain: KMAC done -> op_done -> err_code register update -> op_errs -> alert_test
+      // -> alert_sender -> alert_receiver pulse can take 10-25 cycles in practice (seed
+      // dependent). Use 30 to cover the observed range without masking real bugs.
+      set_exp_alert("recov_operation_err", .max_delay(30));
       `uvm_info(`gfn, $sformatf("process_error_n_alert: at %s, %s is issued and error %s",
                 current_state.name, op.name, "recov_operation_err"), UVM_MEDIUM)
     end
@@ -1536,6 +1646,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
       current_internal_key[slot].max_key_version = '0;
       current_internal_key[slot].valid = '0;
     end
+    pending_otp_key_snapshot = '0;
     foreach (adv_data_a_array[slot, state]) begin
       adv_data_a_array[slot][state] = '0;
     end

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
@@ -79,7 +79,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
   bit compare_internal_key_slot;
   bit check_key_slot_erased;
   bit post_disable_compare_key_slots;
-  // The DUT XORs the OTP root key into an entropy-randomised slot value during
+  // The DUT XORs the OTP root key into an entropy-randomized slot value during
   // SlotDestRandomize+SlotLoadRoot, so the SCB cannot reproduce slot.key from inputs.
   // Set in latch_otp_key, consumed at op_status WIP->Done where we snapshot the DUT
   // slot value into current_internal_key[].key.

--- a/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_hwsw_invalid_input_vseq.sv
+++ b/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_hwsw_invalid_input_vseq.sv
@@ -1,0 +1,62 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Drives HW invalid inputs (OTP root invalid, keymgr_dpe_div all-0s/all-1s,
+// otp_device_id all-0s/all-1s, rom_digest data/valid corruption) interleaved with
+// a randomised op stream. Targets:
+//  - invalid_hw_input_cg (OtpRootKeyInvalid, LcStateInvalid, OtpDevIdInvalid,
+//    RomDigestInvalid, RomDigestValidLow, OtpRootKeyValidLow)
+//  - err_code_cg::ErrInvalidIn (via key_version > max_key_version)
+//  - state_and_op_cg.op_status_cp::OpDoneFail
+// Ported from keymgr_hwsw_invalid_input_vseq.
+class keymgr_dpe_hwsw_invalid_input_vseq extends keymgr_dpe_random_vseq;
+  `uvm_object_utils(keymgr_dpe_hwsw_invalid_input_vseq)
+  `uvm_object_new
+
+  rand uint num_invalid_hw_input;
+
+  // 0/1/many invalid inputs each in roughly equal weight; 0 lets some ops succeed
+  // so the test still progresses.
+  constraint num_invalid_hw_input_c {
+    num_invalid_hw_input dist {0     :/ 1,
+                               1     :/ 1,
+                               [2:6] :/ 1};
+  }
+
+  // Override the random_vseq's otp_key_c which pinned do_invalid_otp_key to 0.
+  // Allow the OTP root path to be exercised invalid too.
+  constraint otp_key_c {
+    do_rand_otp_key      dist {0 :/ 1, 1 :/ 3};
+    do_invalid_otp_key   dist {0 :/ 3, 1 :/ 1};
+  }
+
+  // SCB checks the err paths; don't double-check from the seq.
+  virtual function bit get_check_en();
+    return 0;
+  endfunction
+
+  // Override keymgr_dpe_advance to drive a fresh bad-input set roughly every other
+  // call. The base random_vseq drives advance/generate/erase directly (it doesn't
+  // route through keymgr_dpe_operations), so this is the central hook that catches
+  // both the OTP latch advance and the iteration advances.
+  virtual task keymgr_dpe_advance(bit wait_done = 1,
+                                  int sw_binding = $urandom(),
+                                  int max_key_ver = $urandom_range(0,4));
+    if ($urandom_range(0, 1)) begin
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_invalid_hw_input)
+      `uvm_info(`gfn, $sformatf("Drive random HW data with %0d invalid inputs",
+                                num_invalid_hw_input), UVM_MEDIUM)
+      cfg.keymgr_dpe_vif.drive_random_hw_input_data(num_invalid_hw_input);
+    end
+    super.keymgr_dpe_advance(wait_done, sw_binding, max_key_ver);
+  endtask : keymgr_dpe_advance
+
+  task body();
+    // Invalid HW inputs cause the design to feed random data on the KMAC interface,
+    // which can produce constantly-changing data on a stalled valid-not-ready beat.
+    $assertoff(0, "tb.keymgr_dpe_kmac_intf.req_data_if.H_DataStableWhenValidAndNotReady_A");
+    super.body();
+  endtask : body
+
+endclass : keymgr_dpe_hwsw_invalid_input_vseq

--- a/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_random_vseq.sv
+++ b/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_random_vseq.sv
@@ -1,0 +1,137 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Random vseq: unlocks the policy / key-version-error / OTP-randomization knobs
+// that keymgr_dpe_smoke_vseq pins, and chains randomized advance / generate / erase
+// operations across all slots.
+//
+// Coverage targets unlocked relative to smoke:
+//   - state_and_op_cg.op_status_cp::OpDoneFail (allow_child=0 leaf-advance failures)
+//   - key_version_compare_cg::CompareOpGt
+//   - err_code_cg::ErrInvalidIn / ErrInvalidOp
+//   - retain_parent=0 self-overwrite path
+//   - exportable=1 paths (visibility depends on the policy_cg added later)
+class keymgr_dpe_random_vseq extends keymgr_dpe_base_vseq;
+  `uvm_object_utils(keymgr_dpe_random_vseq)
+  `uvm_object_new
+
+  rand int unsigned num_iterations;
+
+  constraint num_iterations_c {
+    num_iterations inside {[20:40]};
+  }
+
+  // Override base: weighted to favor good ops (so chains progress) while still hitting
+  // the >max_key_version path with non-trivial probability.
+  constraint is_key_version_err_c {
+    is_key_version_err dist {0 :/ 4, 1 :/ 1};
+  }
+
+  // Override base: randomize OTP key data so sw_input_cg_wrap bins covering
+  // OTP-derived inputs get exercised. The fully-invalid OTP root path is owned
+  // by keymgr_dpe_hwsw_invalid_input_vseq, so leave do_invalid_otp_key off here.
+  constraint otp_key_c {
+    do_rand_otp_key dist {0 :/ 1, 1 :/ 3};
+    do_invalid_otp_key == 0;
+  }
+
+  // Randomize all three policy bits each iteration. Bias allow_child toward 1 so
+  // advance chains can make progress; both other bits are uniform.
+  constraint set_policy_c {
+    policy.allow_child   dist {1 :/ 4, 0 :/ 1};
+    policy.retain_parent dist {0 :/ 1, 1 :/ 1};
+    policy.exportable    dist {0 :/ 1, 1 :/ 1};
+  }
+
+  // Shuffle-and-write all sw_binding/salt CSR instances plus max_key_ver_shadowed
+  // and (occasionally) reseed_interval_shadowed. Drives the per-instance score on
+  // sw_input_cg_wrap (only index 0 is exercised by the base advance/generate tasks)
+  // and fills the missing reseed_interval_cg bins. Modelled on
+  // keymgr_random_vseq::write_random_sw_content.
+  virtual task write_random_sw_content();
+    uvm_reg csr_q[$];
+    foreach (ral.sw_binding[i]) begin
+      `DV_CHECK_RANDOMIZE_FATAL(ral.sw_binding[i])
+      csr_q.push_back(ral.sw_binding[i]);
+    end
+    foreach (ral.salt[i]) begin
+      `DV_CHECK_RANDOMIZE_FATAL(ral.salt[i])
+      csr_q.push_back(ral.salt[i]);
+    end
+    `DV_CHECK_RANDOMIZE_FATAL(ral.max_key_ver_shadowed)
+    csr_q.push_back(ral.max_key_ver_shadowed);
+    // The base keymgr_dpe_generate's update_key_version constrains key_version[0]
+    // relative to max_key_ver (typically 0-4), so the upper bits never toggle.
+    // Drive a full 32-bit random value here so sw_input_cg_wrap["key_version_0"]
+    // per-instance can climb past its constrained-value ceiling.
+    foreach (ral.key_version[i]) begin
+      `DV_CHECK_RANDOMIZE_FATAL(ral.key_version[i])
+      csr_q.push_back(ral.key_version[i]);
+    end
+    csr_q.shuffle();
+    foreach (csr_q[i]) csr_update(csr_q[i]);
+    // Note: reseed_interval_shadowed is intentionally not rewritten here. Doing so
+    // mid-test trips keymgr_dpe_if.CheckEdn1stReq because the interval reference the
+    // SVA compares against changes while the EDN request counter is mid-window. The
+    // existing init flow sets a randomized reseed_interval per simulation, which is
+    // enough to reach 37/37 in reseed_interval_cg.
+  endtask : write_random_sw_content
+
+  task body();
+    `uvm_info(`gfn, $sformatf("keymgr_dpe_random_vseq start, num_iterations=%0d",
+                              num_iterations), UVM_LOW)
+
+    // Initial OTP latch into slot 0. Must succeed, so force a permissive policy and
+    // src==dst for this single advance regardless of the class-level constraints.
+    src_slot = 0;
+    dst_slot = 0;
+    policy.allow_child   = 1'b1;
+    policy.retain_parent = 1'b1;
+    policy.exportable    = 1'b0;
+    keymgr_dpe_advance();
+    otp_latched = 1'b1;
+
+    // Random op loop. Each iteration re-randomizes policy, key-version-error, slots,
+    // gen-op type and key destination, then issues a weighted-random op. Disable is
+    // excluded: once the DUT is disabled, further ops are no-ops, which would make
+    // the rest of the iteration count uninteresting.
+    repeat (num_iterations) begin
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(policy)
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(is_key_version_err)
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(src_slot)
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dst_slot)
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(gen_operation)
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(key_dest)
+
+      // ~1/3 of iterations rewrite all sw_binding/salt indices and max_key_ver so
+      // sw_input_cg_wrap per-instance scores climb beyond their base ~10%.
+      if ($urandom_range(0, 2) == 0) write_random_sw_content();
+
+      randcase
+        4: keymgr_dpe_advance();
+        4: begin
+             update_key_version();
+             keymgr_dpe_generate(.operation(gen_operation), .key_dest(key_dest));
+             if ($urandom_range(0, 1)) keymgr_dpe_rd_clr();
+           end
+        1: begin
+             // keymgr_dpe_erase issues an erase against dst_slot, then chains
+             // num_adv_op / num_gen_op follow-ups. Keep those at 0 here so the loop
+             // controls the op mix directly.
+             keymgr_dpe_erase(.num_gen_op(0), .num_adv_op(0));
+           end
+      endcase
+    end
+
+    // Optionally end with disable so the disabled-state covergroup bins are also
+    // exercised within this single test.
+    if ($urandom_range(0, 1)) begin
+      keymgr_dpe_disable(.num_gen_op($urandom_range(0, 2)),
+                         .num_adv_op($urandom_range(0, 2)));
+    end
+
+    `uvm_info(`gfn, "keymgr_dpe_random_vseq done", UVM_LOW)
+  endtask : body
+
+endclass : keymgr_dpe_random_vseq

--- a/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_random_vseq.sv
+++ b/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_random_vseq.sv
@@ -16,10 +16,10 @@ class keymgr_dpe_random_vseq extends keymgr_dpe_base_vseq;
   `uvm_object_utils(keymgr_dpe_random_vseq)
   `uvm_object_new
 
-  rand int unsigned num_iterations;
+  rand int unsigned num_iters;
 
-  constraint num_iterations_c {
-    num_iterations inside {[20:40]};
+  constraint num_iters_c {
+    num_iters inside {[20:40]};
   }
 
   // Override base: weighted to favor good ops (so chains progress) while still hitting
@@ -79,8 +79,8 @@ class keymgr_dpe_random_vseq extends keymgr_dpe_base_vseq;
   endtask : write_random_sw_content
 
   task body();
-    `uvm_info(`gfn, $sformatf("keymgr_dpe_random_vseq start, num_iterations=%0d",
-                              num_iterations), UVM_LOW)
+    `uvm_info(`gfn, $sformatf("keymgr_dpe_random_vseq start, num_iters=%0d",
+                              num_iters), UVM_LOW)
 
     // Initial OTP latch into slot 0. Must succeed, so force a permissive policy and
     // src==dst for this single advance regardless of the class-level constraints.
@@ -96,7 +96,7 @@ class keymgr_dpe_random_vseq extends keymgr_dpe_base_vseq;
     // gen-op type and key destination, then issues a weighted-random op. Disable is
     // excluded: once the DUT is disabled, further ops are no-ops, which would make
     // the rest of the iteration count uninteresting.
-    repeat (num_iterations) begin
+    repeat (num_iters) begin
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(policy)
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(is_key_version_err)
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(src_slot)

--- a/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_sideload_vseq.sv
+++ b/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_sideload_vseq.sv
@@ -1,0 +1,51 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Drives sideload_clear writes between operations to exercise the sideload_clear_cg
+// covergroup (states x ops x sideload-clear value x per-destination availability flags
+// x regwen). Reuses the smoke flow (which fills slots and runs gen ops in every state)
+// so cdi/dest cross-bins also fill in. Ported from keymgr_sideload_vseq.
+class keymgr_dpe_sideload_vseq extends keymgr_dpe_smoke_vseq;
+  `uvm_object_utils(keymgr_dpe_sideload_vseq)
+  `uvm_object_new
+
+  rand bit                              do_clear_sideload;
+  rand bit [2:0]                        clear_dest;
+  rand bit                              do_repaint_op;
+  rand keymgr_dpe_pkg::keymgr_dpe_ops_e repaint_op;
+
+  // Bias the rare "clear all" encodings (>=4) less than the per-destination ones.
+  constraint clear_dest_c {
+    clear_dest dist {[0:3] :/ 4,
+                     [4:$] :/ 2};
+  }
+
+  virtual task keymgr_dpe_operations(bit advance_state = $urandom_range(0, 1),
+                                     int num_gen_op    = $urandom_range(1, 4),
+                                     bit clr_output    = $urandom_range(0, 1),
+                                     bit wait_done     = 1);
+    super.keymgr_dpe_operations(advance_state, num_gen_op, clr_output, wait_done);
+    randomly_clear_sideload();
+  endtask : keymgr_dpe_operations
+
+  virtual task randomly_clear_sideload();
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(do_clear_sideload)
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(clear_dest)
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(do_repaint_op)
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(repaint_op)
+    if (do_clear_sideload) begin
+      // sideload_clear_cg samples op = `gmv(ral.control_shadowed.operation)`. Without
+      // intervention that field stays at the last gen op type, so op_cp gets stuck at
+      // 2/6. Optionally re-program operation to a random value (no `start` write) so
+      // the sample sees varied ops -- the next real op resets the field anyway.
+      if (do_repaint_op) begin
+        ral.control_shadowed.operation.set(repaint_op);
+        csr_update(.csr(ral.control_shadowed));
+      end
+      `uvm_info(`gfn, $sformatf("Clear sideload value=%0d op=%s",
+                                clear_dest, repaint_op.name), UVM_LOW)
+      csr_wr(.ptr(ral.sideload_clear), .value(clear_dest));
+    end
+  endtask : randomly_clear_sideload
+endclass : keymgr_dpe_sideload_vseq

--- a/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_sync_async_fault_cross_vseq.sv
+++ b/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_sync_async_fault_cross_vseq.sv
@@ -1,0 +1,85 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Trigger both sync and async fault, then check fatal alert is triggered and fault_status is
+// updated correctly. Ported from hw/ip/keymgr/dv/env/seq_lib/keymgr_sync_async_fault_cross_vseq.sv.
+class keymgr_dpe_sync_async_fault_cross_vseq extends keymgr_dpe_base_vseq;
+  `uvm_object_utils(keymgr_dpe_sync_async_fault_cross_vseq)
+  `uvm_object_new
+
+  bit sync_fault_trig_first;
+  bit async_fault_trig_first;
+
+  task body();
+    bit [TL_DW-1:0] act_fault_status;
+
+    // Get past StWorkDpeReset so the DUT will issue KMAC requests when faults are triggered.
+    repeat ($urandom_range(1, 4)) keymgr_dpe_operations(.advance_state(1));
+    cfg.en_scb = 0;
+    cfg.keymgr_dpe_vif.en_chk = 0;
+
+    // Faults scramble the KMAC datapath; suppress assertions that fire as a consequence.
+    // The list mirrors hw/ip/keymgr/dv/env/seq_lib/keymgr_custom_cm_vseq.sv.
+    $assertoff(0, "tb.keymgr_dpe_kmac_intf");
+    $assertoff(0, "tb.dut.u_ctrl.DataEn_A");
+    $assertoff(0, "tb.dut.u_kmac_if.LastStrb_A");
+    $assertoff(0, "tb.dut.KmacDataKnownO_A");
+    $assertoff(0, "tb.dut.u_sideload_ctrl.KmacKeySource_a");
+
+    fork
+      trigger_sync_fault();
+      trigger_async_fault();
+    join
+
+    wait_and_check_fatal_alert();
+
+    csr_rd(.ptr(ral.fault_status), .value(act_fault_status));
+    `DV_CHECK_EQ(act_fault_status[keymgr_pkg::FaultRegIntg], 1)
+
+    // The KMAC sync fault only latches if a KMAC transaction was in flight when the
+    // async fault arrived; with short keymgr_dpe ops the async path can win the race
+    // and the FSM tears down before any KMAC error registers. Only sample the cross
+    // covergroup when both fault types are actually observed -- otherwise the sampled
+    // arrival order doesn't reflect what the DUT saw.
+    if (cfg.en_cov &&
+        (act_fault_status[keymgr_pkg::FaultKmacOp] ||
+         act_fault_status[keymgr_pkg::FaultKmacOut])) begin
+      cov.sync_async_fault_cross_cg.sample(sync_fault_trig_first, async_fault_trig_first);
+    end
+  endtask : body
+
+  task trigger_sync_fault();
+    bit is_adv_op = $urandom_range(0, 1);
+
+    cfg.m_keymgr_dpe_kmac_agent_cfg.error_rsp_pct = 100;
+    keymgr_dpe_operations(.advance_state(is_adv_op),
+                          .num_gen_op(!is_adv_op),
+                          .clr_output(0),
+                          .wait_done(1));
+
+    if (!async_fault_trig_first) sync_fault_trig_first = 1;
+  endtask : trigger_sync_fault
+
+  task trigger_async_fault();
+    set_tl_assert_en(.enable(0));
+    cfg.clk_rst_vif.wait_clks($urandom_range(0, 2000));
+    issue_tl_access_w_intg_err(ral.get_name());
+    set_tl_assert_en(.enable(1));
+
+    if (!sync_fault_trig_first) async_fault_trig_first = 1;
+  endtask : trigger_async_fault
+
+  // Disable scb-driven check_en in this seq; the body does its own checks above.
+  virtual function bit get_check_en();
+    return 0;
+  endfunction
+
+  task post_start();
+    expect_fatal_alerts = 1;
+    super.post_start();
+    cfg.en_scb = 1;
+    cfg.keymgr_dpe_vif.en_chk = 1;
+  endtask
+
+endclass : keymgr_dpe_sync_async_fault_cross_vseq

--- a/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_vseq_list.sv
+++ b/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_vseq_list.sv
@@ -5,3 +5,7 @@
 `include "keymgr_dpe_base_vseq.sv"
 `include "keymgr_dpe_common_vseq.sv"
 `include "keymgr_dpe_smoke_vseq.sv"
+`include "keymgr_dpe_random_vseq.sv"
+`include "keymgr_dpe_sync_async_fault_cross_vseq.sv"
+`include "keymgr_dpe_sideload_vseq.sv"
+`include "keymgr_dpe_hwsw_invalid_input_vseq.sv"

--- a/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson
+++ b/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson
@@ -43,7 +43,7 @@
              "sec_cm_prim_sparse_fsm_flop_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 10
 
   // Add keymgr_dpe specific exclusion files.
   vcs_cov_excl_files: ["{proj_root}/hw/ip/keymgr_dpe/dv/cov/keymgr_dpe_cov_excl.el"]
@@ -68,6 +68,22 @@
     {
       name: keymgr_dpe_smoke
       uvm_test_seq: keymgr_dpe_smoke_vseq
+    }
+    {
+      name: keymgr_dpe_random
+      uvm_test_seq: keymgr_dpe_random_vseq
+    }
+    {
+      name: keymgr_dpe_sync_async_fault_cross
+      uvm_test_seq: keymgr_dpe_sync_async_fault_cross_vseq
+    }
+    {
+      name: keymgr_dpe_sideload
+      uvm_test_seq: keymgr_dpe_sideload_vseq
+    }
+    {
+      name: keymgr_dpe_hwsw_invalid_input
+      uvm_test_seq: keymgr_dpe_hwsw_invalid_input_vseq
     }
   ]
 


### PR DESCRIPTION
Clean up of covergroups and add new vseqs that improve functional coverage for key_manager_dpe 

From: 
<img width="806" height="228" alt="image" src="https://github.com/user-attachments/assets/1f0193c9-113e-449d-87ab-ddd25ba4983a" />

To : 
<img width="539" height="91" alt="image" src="https://github.com/user-attachments/assets/0d22a8de-ece8-482e-845b-502c0f6b49be" />
