### PR TITLE
[csrng,cov] Exclude aes_cipher_core coverage

### DIFF
--- a/hw/ip/csrng/dv/cov/csrng_cover.cfg
+++ b/hw/ip/csrng/dv/cov/csrng_cover.cfg
@@ -1,0 +1,8 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+// Specific coverage configuration for CSRNG
+
+// Exclude full tree under instances of aes_cipher_core, since that is
+// more thoroughly covered by the AES block DV.
+-moduletree aes_cipher_core

--- a/hw/ip/csrng/dv/csrng_sim_cfg.hjson
+++ b/hw/ip/csrng/dv/csrng_sim_cfg.hjson
@@ -47,6 +47,13 @@
 
   xcelium_cov_refine_files: ["{proj_root}/hw/ip/csrng/dv/cov/csrng_v2s_exclusions.vRefine"]
 
+  overrides: [
+    // Override coverage config files to add our elaboration time coverage exclusions etc.
+    {
+      name: default_vcs_cov_cfg_file
+      value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{proj_root}/hw/ip/csrng/dv/cov/csrng_cover.cfg"
+    }
+  ]
   // Default UVM test and seq class name.
   uvm_test: csrng_base_test
   uvm_test_seq: csrng_base_vseq


### PR DESCRIPTION
The aes_cipher_core is more extensively exercised by the aes block level DV, and the aes embedded in csrng is constrained to use a subset of aes functionality.

This exclusion is already implemented for xcelium in file hw/ip/csrng/dv/cov/csrng_v2s_exclusions.vRefine, and this just provides a similar exclusion for VCS.
