### PR TITLE
[ci] Don't depend on lsb_release

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -155,7 +155,9 @@ runs:
         # Inject the OS version into a parameter used in the action key computation to
         # avoid collisions between different operating systems in the caches.
         # See #14695 for more information.
-        echo "build --remote_default_exec_properties=OSVersion=\"$(lsb_release -is)_$(lsb_release -rs)\"" >> ~/.bazelrc
+        OS_NAME=$(grep -Po '^NAME=\K.*' /etc/os-release | tr -d '"')
+        OS_VERSION=$(grep -Po '^VERSION_ID=\K.*' /etc/os-release | tr -d '"')
+        echo "build --remote_default_exec_properties=OSVersion=\"${OS_NAME}_${OS_VERSION}\"" >> ~/.bazelrc
 
         if ${{ github.event_name != 'pull_request' }}; then
           echo "Will upload to the cache." >&2

--- a/yum-requirements.txt
+++ b/yum-requirements.txt
@@ -22,7 +22,6 @@ libudev-devel
 libusbx
 make
 openssl-devel
-redhat-lsb-core
 # A requirement of the prebuilt clang toolchain.
 ncurses
 perl
@@ -31,7 +30,6 @@ python3
 python3-pip
 python3-setuptools
 python3-wheel
-srecord
 tree
 libxslt
 zlib-devel


### PR DESCRIPTION
Newer versions of RHEL/AlmaLinux do not offer `lsb_release` in a `dnf` package, so we use the more portable `/etc/os-release` to tag Bazel cache entries.