### PR TITLE
[acc,kmac] Fixes bugs and optimizes the eager KMAC refresh in ACC

### DIFF
--- a/hw/ip/acc/dv/accsim/sim/kmac.py
+++ b/hw/ip/acc/dv/accsim/sim/kmac.py
@@ -129,6 +129,7 @@ class KmacBlock:
         self._digest1_ready_next = False
         self._digest0_read = False
         self._digest1_read = False
+        self._pending_read = False
         self._unmasked_digest = bytes()
         self._apply_mask = False
         self._finished_digest0 = False
@@ -137,7 +138,6 @@ class KmacBlock:
         self._shift_digest_reg = False
         self._new_permutation = False
         self._digest_request_ctr = 0
-        self._skip_digest_shift_cycle = False
         self._kmac_undersized_err = False
         self._kmac_oversized_err = False
 
@@ -195,7 +195,6 @@ class KmacBlock:
         self._shift_digest_reg = False
         self._new_permutation = False
         self._digest_request_ctr = 0
-        self._skip_digest_shift_cycle = False
         self._kmac_undersized_err = False
 
     def set_configuration(self, mode: int, strength: int, msg_len: int, masked_mode: bool) -> None:
@@ -222,7 +221,8 @@ class KmacBlock:
         return self._app_intf_ready
 
     def get_done(self) -> int:
-        return int(self.digest0_ready())
+        return int((self._digest0_ready and self._digest0_read) or
+                   (self._digest1_ready and self._digest1_read))
 
     def message_done(self) -> None:
         '''Indicate that the message input is done.'''
@@ -295,6 +295,8 @@ class KmacBlock:
         # Check if there is an undersized message at this point
         digest_err = self.digest_req_err()
 
+        self._pending_read = True
+
         # If there is an undersized error we inject a "last" to the message request
         # to prevent stalling and raise an error flag to the status reg
         if digest_err and not self._kmac_undersized_err:
@@ -331,6 +333,8 @@ class KmacBlock:
         # This helper function is executed during a digest wsrr insn
         # Check if there is an undersized message at this point
         digest_err = self.digest_req_err()
+
+        self._pending_read = True
 
         # If there is an undersized error we inject a "last" to the message request
         # to prevent stalling and raise an error flag to the status reg
@@ -834,14 +838,8 @@ class KmacBlock:
                 self._digest_request_ctr = 0
                 self._digest0_ready_next = True
                 self._digest1_ready_next = True
-        elif self._new_permutation:
+        elif self._new_permutation and self._pending_read:
             if self._digest_request_ctr < self._NEW_PERMUTATION_LATENCY:
-                if self._skip_digest_shift_cycle:
-                    self._skip_digest_shift_cycle = False
-                    # model the one cycle the next permutation is faster
-                    # if we do not need to squeeze remaining bits from
-                    # the digest
-                    self._digest_request_ctr += 1
                 self._digest_request_ctr += 1
                 self._digest0_ready_next = False
                 self._digest1_ready_next = False
@@ -875,18 +873,16 @@ class KmacBlock:
                 self._leftover_digest_bytes = 0
                 self._shift_digest_reg = True
                 self._digest_request_ctr += 1
-                # For the next squeeze request, we do not have the latency
-                # for shifting the remaining bits from the state.
-                self._skip_digest_shift_cycle = True
             else:
                 if self._mode in [self._MODE_SHAKE, self. _MODE_CSHAKE]:
                     # For XOF modes, eagerly trigger a new permutation.
                     self._new_permutation = True
-                    self._digest_request_ctr += 1
                     self._leftover_digest_bytes += max(self._rate_bytes - self._read_offset, 0)
                     self._read_offset = 0
             self._digest0_ready_next = False
             self._digest1_ready_next = False
+
+        self._pending_read = False
 
         # Either step the core or check if we can start it.
         if self._core_is_busy():

--- a/hw/ip/acc/rtl/acc_alu_bignum.sv
+++ b/hw/ip/acc/rtl/acc_alu_bignum.sv
@@ -1212,6 +1212,8 @@ generate
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       kmac_app_cfg_sent <= 1'b0;
+    end else if (~kmac_app_req_o.hold) begin // Once the message is complete drop flag
+      kmac_app_cfg_sent <= 1'b0;
     end else if (kmac_cfg_active_q) begin
       if (kmac_app_rsp_i.ready) begin
         kmac_app_cfg_sent <= 1'b1;

--- a/hw/ip/acc/rtl/acc_alu_bignum.sv
+++ b/hw/ip/acc/rtl/acc_alu_bignum.sv
@@ -1624,7 +1624,11 @@ generate
   // The FIFO should not be in a flush cycle
   always_comb begin
     kmac_msg_req_err = 1'b0;
-    if ((ispr_addr_i == IsprKmacDigest0 | ispr_addr_i == IsprKmacDigest1) && kmac_app_active) begin
+    if (
+      (ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest0] |
+       ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest1]) &&
+       kmac_app_active
+    ) begin
       kmac_msg_req_err = !(kmac_msg_pending_write_o[0] | kmac_msg_pending_write_o[1]) &&
                          !(kmac_msg_fifos_valid) &&
                          !kmac_msg_fifo_flush &&

--- a/hw/ip/acc/rtl/acc_alu_bignum.sv
+++ b/hw/ip/acc/rtl/acc_alu_bignum.sv
@@ -942,21 +942,43 @@ generate
   // Consecutive reads from the same digest share are legal but will not trigger a
   // new digest to be shifted from KMAC.
 
+  // If the next eager KMAC refresh will trigger a manual run we will wait for an
+  // instruction call to read. This lowers the overhead of incorectly requesting a
+  // new digest and needing to wait for Keccak to finish before the next transaction.
+
+  logic [2:0] digest_word_idx_q, digest_word_idx_d;
+  logic reset_digest_word;
+  logic [2:0] max_digest_words;
+  logic [1:0] permutation_ctr;
+  logic incr_permutation_ctr, reset_permutation_ctr;
+  logic valid_eager;
+  logic clear_eager_digest;
+
   kmac_eager_state_e eager_state_d, eager_state_q;
 
   always_comb begin : kmac_eager_next_fsm
     // Default assignments
     eager_state_d = eager_state_q;
     kmac_digest_rd_next = 1'b0;
+    incr_permutation_ctr = 1'b0;
+    clear_eager_digest = 1'b0;
+    reset_digest_word = 1'b0;
 
     unique case (eager_state_q)
       StDigestWait: begin
         // Determine if there is a read from digest 0 or digest 1
         if (kmac_digest_valid_q && ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest0]) begin
           if (~kmac_cfg_mask_mode) begin
-            // When in unmasked mode we can immediately refresh
-            kmac_digest_rd_next = 1'b1;
-            eager_state_d = StDigestWait;
+            // When in unmasked mode we can immediately refresh unless it triggers a manual run
+            if (valid_eager) begin
+              eager_state_d = StDigestWait;
+              kmac_digest_rd_next = 1'b1;
+            end else begin
+              // Go to the StDigestEagerWait state until we explicitely request a new read
+              eager_state_d = StDigestEagerWait;
+              incr_permutation_ctr = 1'b1;
+              clear_eager_digest = 1'b1;
+            end
           end else begin
             eager_state_d = StDigestShare0;
           end
@@ -964,20 +986,116 @@ generate
           eager_state_d = StDigestShare1;
         end
       end
+
+      // We have already read from DigestShare0, now we wait for a read from DigestShare1
       StDigestShare0: begin
         if (kmac_digest_valid_q && ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest1]) begin
-          eager_state_d = StDigestWait;
-          kmac_digest_rd_next = 1'b1;
+          if (valid_eager) begin
+            eager_state_d = StDigestWait;
+            kmac_digest_rd_next = 1'b1;
+          end else begin
+              // Go to the StDigestEagerWait state until we explicitely request a new read
+            eager_state_d = StDigestEagerWait;
+            incr_permutation_ctr = 1'b1;
+            clear_eager_digest = 1'b1;
+          end
         end
       end
+
+      // We have already read from DigestShare1, now we wait for a read from DigestShare0
       StDigestShare1: begin
         if (kmac_digest_valid_q && ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest0]) begin
-          eager_state_d = StDigestWait;
+          if (valid_eager) begin
+            eager_state_d = StDigestWait;
+            kmac_digest_rd_next = 1'b1;
+          end else begin
+              // Go to the StDigestEagerWait state until we explicitely request a new read
+            eager_state_d = StDigestEagerWait;
+            incr_permutation_ctr = 1'b1;
+            clear_eager_digest = 1'b1;
+          end
+        end
+      end
+
+      // We have exhausted the Keccak state and will not request a manual run until we are
+      // guarenteed to need more
+      StDigestEagerWait: begin
+        if (ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest0]) begin
+          // Go to DigestShare0 or Wait state depending on masked configuration
+          if (~kmac_cfg_mask_mode) begin
+            eager_state_d = StDigestWait;
+          end else begin
+            eager_state_d = StDigestShare0;
+          end
+          // Trigger the next read and reset the digest word count
           kmac_digest_rd_next = 1'b1;
+          reset_digest_word = 1'b1;
+        end else if (ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest1]) begin
+          eager_state_d = StDigestShare1;
+          // Trigger the next read and reset the digest word count
+          kmac_digest_rd_next = 1'b1;
+          reset_digest_word = 1'b1;
         end
       end
       default: eager_state_d = StDigestWait;
     endcase
+  end
+
+  // Comb component of counter for the number of digest reads from the current Keccak State
+  always_comb begin
+    digest_word_idx_d = digest_word_idx_q;
+    if (kmac_app_rsp_i.done) begin
+      digest_word_idx_d = digest_word_idx_q + 1'b1;
+    end
+  end
+
+  // Flop component of counter for the number of digest reads from the current Keccak State
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) digest_word_idx_q <= '0;
+    else if (kmac_new_cfg_q || reset_digest_word) begin
+      digest_word_idx_q <= '0;
+    end else begin
+      digest_word_idx_q <= digest_word_idx_d;
+    end
+  end
+
+  // Logic to set the valid_eager signal to determine if we can eager trigger
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      valid_eager <= 1'b0;
+      reset_permutation_ctr <= 1'b0;
+    end else begin
+      // If it is the 4th permutation from KMAC there is a fifth digest word available
+      // in the KMAC output buffer before needing to trigger a manual run
+      if (digest_word_idx_d == max_digest_words && permutation_ctr == 2'h3) begin
+        valid_eager <= 1'b1;
+        reset_permutation_ctr <= 1'b0;
+      // For all other permutations we need to trigger a new manual run
+      end else if (digest_word_idx_d == max_digest_words) begin
+        valid_eager <= 1'b0;
+        reset_permutation_ctr <= 1'b0;
+      end else begin
+        // Digest word idx will only be greater when the permutation_ctr == 2'h3
+        if (digest_word_idx_d > max_digest_words) begin
+          valid_eager <= 1'b0;
+          reset_permutation_ctr <= 1'b1;
+        end else begin
+          valid_eager <= 1'b1;
+          reset_permutation_ctr <= 1'b0;
+        end
+      end
+    end
+  end
+
+  // Control the permutation index for keccak states and XOFs with ACC
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      permutation_ctr <= 2'h0;
+    end else if (reset_permutation_ctr || kmac_new_cfg_q) begin
+      permutation_ctr <= 2'h0;
+    end else if (incr_permutation_ctr) begin
+      permutation_ctr <= permutation_ctr + 1'b1;
+    end
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -994,7 +1112,7 @@ generate
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       kmac_digest_valid_q <= 1'b0;
-    end else if (kmac_digest_rd_next || kmac_new_cfg_q) begin
+    end else if (kmac_digest_rd_next || kmac_new_cfg_q || clear_eager_digest) begin
       kmac_digest_valid_q <= 1'b0;
     end else if (kmac_app_rsp_i.done) begin
       kmac_digest_valid_q <= 1'b1;
@@ -1094,6 +1212,10 @@ generate
                                     | kmac_msg_ctr_err[1];
 
   assign kmac_ispr = sec_wipe_kmac_regs_urnd_i | ispr_init_i;
+
+  always_comb begin
+    max_digest_words = kmac_pkg::compute_max_digest(kmac_cfg_keccak_strength);
+  end
 
   // We speculatively fetch the next digest but this is illegal for non XOF
   // modes. As such SHA will need to limit the speculative fetch based on strength.
@@ -1470,7 +1592,7 @@ generate
   assign kmac_app_req_o.last  = kmac_app_last;
 
   // If we request an additional digest send a next to KMAC
-  assign kmac_app_req_o.next  = kmac_digest_valid_o & kmac_digest_rd_next & kmac_next_sha;
+  assign kmac_app_req_o.next  = kmac_digest_rd_next & kmac_next_sha;
 
   // Hold will remain active for duration of transaction unless an internal error occurs
   assign kmac_app_req_o.hold  = kmac_app_active;

--- a/hw/ip/acc/rtl/acc_pkg.sv
+++ b/hw/ip/acc/rtl/acc_pkg.sv
@@ -695,7 +695,8 @@ package acc_pkg;
   typedef enum logic [StateEagerWidth-1:0] {
     StDigestWait   = 4'b1010,
     StDigestShare0 = 4'b0111,
-    StDigestShare1 = 4'b1100
+    StDigestShare1 = 4'b1100,
+    StDigestEagerWait = 4'b1001
   } kmac_eager_state_e;
 
   // Encoding generated with:

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -568,6 +568,22 @@ module kmac_app
           end
         end else begin
           st_d = StAppWait;
+          if ((AppCfg[app_id].Mode == AppConfigDynamic) && (app_i[app_id].hold == 1'b0)) begin
+            st_d = StAppEagerWait;
+          end
+        end
+      end
+
+      StAppEagerWait: begin
+        if (prim_mubi_pkg::mubi4_test_true_strict(absorbed_i) ||
+            prim_mubi_pkg::mubi4_test_true_strict(squeezing_i))
+        begin
+          digest_valid = 1'b 1;
+          st_d = StIdle;
+          cmd_o = CmdDone;
+          clr_appid = 1'b 1;
+        end else begin
+          st_d = StAppEagerWait;
         end
       end
 

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -304,22 +304,22 @@ package kmac_pkg;
     SelSw             = 6'b110101
   } app_mux_sel_e ;
 
-  // Encoding generated with:
-  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 17 -n 10 \
-  //     -s 2454278799 --language=sv
+  // Encoding generated at commit 285e653a0b using Python 3.12.3 with:
+  // $ ./util/design/sparse-fsm-encode.py --language=sv \
+  //     --seed 2454278799 --distance 3 --states 18 --bits 10
   //
   // Hamming distance histogram:
   //
   //  0: --
   //  1: --
   //  2: --
-  //  3: |||||||| (12.50%)
-  //  4: |||||||||||||||||||| (30.88%)
-  //  5: |||||||||| (15.44%)
-  //  6: ||||||||||||||| (23.53%)
-  //  7: ||||| (8.82%)
-  //  8: |||| (7.35%)
-  //  9:  (1.47%)
+  //  3: ||||||||| (13.73%)
+  //  4: |||||||||||||||||||| (28.76%)
+  //  5: ||||||||||| (16.34%)
+  //  6: ||||||||||||||| (21.57%)
+  //  7: ||||||| (11.11%)
+  //  8: ||||| (7.19%)
+  //  9:  (1.31%)
   // 10: --
   //
   // Minimum Hamming distance: 3
@@ -348,35 +348,36 @@ package kmac_pkg;
     // the kmac_mode, sha3_mode, keccak strength.
     StAppCfg = 10'b1010101101,
 
-    StAppDynamicCfg = 10'b0000111100,
+    StAppDynamicCfg = 10'b1110001011,
 
-    StAppMsg = 10'b1110001011,
+    StAppMsg = 10'b1010011000,
 
     // In StKeyOutLen, this module pushes encoded outlen to the MSG_FIFO.
     // Assume the length is 256 bit, the data will be 48'h 02_0100
-    StAppOutLen  = 10'b1010011000,
-    StAppProcess = 10'b1110110010,
-    StAppManualRun = 10'b0001101001,
-    StAppWait    = 10'b1001010000,
-    StAppShiftDigest = 10'b0110100111,
+    StAppOutLen  = 10'b1110110010,
+    StAppProcess = 10'b1001010000,
+    StAppManualRun = 10'b0010111011,
+    StAppWait    = 10'b0111011111,
+    StAppEagerWait = 10'b1110010111,
+    StAppShiftDigest = 10'b0110001100,
 
     // SW Controlled
     // If start request comes from SW first, until the operation ends, all
     // requests from KeyMgr will be discarded.
-    StSw = 10'b0010111011,
+    StSw = 10'b1011100000,
 
     // Error KeyNotValid
     // When KeyMgr operates, the secret key is not ready yet.
-    StKeyMgrErrKeyNotValid = 10'b0111011111,
+    StKeyMgrErrKeyNotValid = 10'b0010100100,
 
-    StError = 10'b1110010111,
-    StErrorAwaitSw = 10'b0110001100,
-    StErrorAwaitApp = 10'b1011100000,
-    StErrorWaitAbsorbed = 10'b0010100100,
-    StErrorServiceRejected = 10'b1101000111,
+    StError = 10'b1101000111,
+    StErrorAwaitSw = 10'b0101110110,
+    StErrorAwaitApp = 10'b0000111100,
+    StErrorWaitAbsorbed = 10'b0001101001,
+    StErrorServiceRejected = 10'b0110100111,
 
     // This state is used for terminal errors
-    StTerminalError = 10'b0101110110
+    StTerminalError = 10'b0001111010
   } st_e;
 
   // MsgWidth : 64


### PR DESCRIPTION
This PR addresses issues with the eager refresh ACC uses during transactions with KMAC, along with miscellaneous bugs.

#### Previous Eager Refresh
ACC previously requested the next digest from KMAC during XOF operations as soon as the previous digest had been read. This prevented stalls incurred by `bn.wsrr` instructions reading from the `DigestShare0` or `DigestShare1` registers. There was an issue identified where the eager refresh would occur after the previous read exhausted the Keccak state.

This forced KMAC into a manual run and an additional ~96 cycle delay. During this time if ACC ended the transaction and attempted to start a new one, the `hold` signal was dropped and reasserted before KMAC could finish its manual run and return to a wait state.

#### New Eager Refresh
ACC now tracks the Keccak state and output buffer to determine if an eager refresh will lead to a manual run or new permutation. When a `next` signal on the interface triggers a manual run, ACC will not assert it until there is an explicit attempt to read the digest using a `bn.wsrr` instruction. All other scenarios in the interface remain the same. KMAC has introduced an Eager Wait state as a safeguard, transitioning anytime `hold` is dropped during an ACC <-> KMAC transaction, forcing ACC to stall before starting the next transaction.

#### Bug Fix
Fixed an issue with undersized message error reporting due to unconditioned sampling of the ISPR address as `DigestShare0` or `DigestShare1`. Sampling is now only valid while `ispr_rd_en_i` is `1`.