### PR TITLE
[acc,masking] Add first-order masked ML-DSA key generation and signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
     name: Run ACC crypto tests
     needs: quick_lint
     runs-on:
-      group: pavona-basic
+      group: pavona-large
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -269,10 +269,10 @@ jobs:
         uses: ./.github/actions/prepare-env
       - name: Execute tests
         run: |
-          # Limit local number of test jobs to 4 to prevent memory contention
+          # Limit local number of test jobs to 8 to prevent memory contention
           # from timing out tests.
           ./bazelisk.sh test --test_output=errors --test_tag_filters=-nightly \
-            --local_test_jobs=4 --test_timeout=3600 //sw/acc/crypto/...
+            --local_test_jobs=8 --test_timeout=3600 //sw/acc/crypto/...
 
   verilator_egret:
     name: Egret Verilator Tests

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -361,6 +361,9 @@ use_repo(mldsa_native, "mldsa_native")
 verilator = use_extension("//third_party/verilator:extensions.bzl", "verilator")
 use_repo(verilator, "verilator")
 
+mldsa_sign_bench = use_extension("//third_party/mldsa_sign_bench:extensions.bzl", "mldsa_sign_bench")
+use_repo(mldsa_sign_bench, "mldsa_sign_bench")
+
 # Hooks:
 # Extension for linking in externally managed test and provisioning customizations
 # for both secure/non-secure manufacturer domains.

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -597,6 +597,35 @@
         ]
       }
     },
+    "//third_party/mldsa_sign_bench:extensions.bzl%mldsa_sign_bench": {
+      "general": {
+        "bzlTransitiveDigest": "bFNwq0bki64bJUE5MfdzXQstV+ZepyA8d+auPkqfRfg=",
+        "usagesDigest": "Zk6mfFh205HxlADIH+B6TBA1faj2JWGhSUi9Wtspe50=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "mldsa_sign_bench": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/mldsa_sign_bench:BUILD.mldsa_sign_bench.bazel",
+              "sha256": "adfc61b35a64df8d43c67ac6c2b190a6344115f9f12ff357af56f1d57b08ff8b",
+              "strip_prefix": "mldsa-sign-bench-66da53064d4323c024fcd15e423c2afc28b2ecf4",
+              "urls": [
+                "https://github.com/zerorisc/mldsa-sign-bench/archive/66da53064d4323c024fcd15e423c2afc28b2ecf4.tar.gz"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "//third_party/mlkem_native:extensions.bzl%mlkem_native": {
       "general": {
         "bzlTransitiveDigest": "+2ghk+QRreE0onX/A+/ajAnK7A+W+dNmLuCN1U9KERk=",

--- a/hw/ip/acc/util/acc_as.py
+++ b/hw/ip/acc/util/acc_as.py
@@ -654,7 +654,7 @@ class Transformer:
         # (body_label, mnemonic, bodysize_expr) that the matching endloop pops.
         # loop_id makes the body labels unique.
         self.loop_id = 0
-        self.loop_stack = []  # type: List[Tuple[str, str, Optional[str]]]
+        self.loop_stack = []  # type: List[Tuple[int, str, Optional[str]]]
 
         # Strings that should be spat out verbatim
         self.acc = []   # type: List[str]
@@ -809,7 +809,8 @@ class Transformer:
                    op_to_expr: Dict[str, Optional[str]]) -> None:
         '''Emit a body-start label after a loop/loopi and record the frame.'''
         self.loop_id += 1
-        label = '.L__acc_loopbody_{}_{}'.format(self.in_idx, self.loop_id)
+        # Numeric local label: redefinable, so it works inside .rept/.macro.
+        label = (self.in_idx + 1) * 1000000 + self.loop_id
         self.out_handle.write(f'{label}:\n')
         self.loop_stack.append((label, insn.mnemonic, op_to_expr.get('bodysize')))
 
@@ -820,7 +821,7 @@ class Transformer:
                                .format(self.in_path, self.line_number))
         label, mnem, bodysize = self.loop_stack.pop()
         self.out_handle.write(
-            f'.if (. - {label}) != (({bodysize}) * 4)\n'
+            f'.if (. - {label}b) != (({bodysize}) * 4)\n'
             f'.error "{mnem}: loop body size does not match declared '
             f'bodysize ({bodysize})"\n'
             '.endif\n')

--- a/rules/acc.bzl
+++ b/rules/acc.bzl
@@ -268,9 +268,17 @@ def _acc_autogen_sim_test_impl(ctx):
     exp = ctx.actions.declare_file(ctx.attr.name + ".exp")
     dexp = ctx.actions.declare_file(ctx.attr.name + ".dexp")
     args = ["-s", str(ctx.attr.seed)] + ctx.attr.testgen_args + [data.path, exp.path, dexp.path]
+    if ctx.attr.nshares != 0:
+        args += ["-n", str(ctx.attr.nshares)]
+    if ctx.attr.scheme != -1:
+        args += ["--scheme", str(ctx.attr.scheme)]
+    inputs = [ctx.executable.testgen]
+    if ctx.file.vectors != None:
+        args += ["--from-vector", ctx.file.vectors.path, "--index", str(ctx.attr.vector_index)]
+        inputs.append(ctx.file.vectors)
     ctx.actions.run(
         outputs = [data, exp, dexp],
-        inputs = [ctx.executable.testgen],
+        inputs = inputs,
         arguments = args,
         executable = ctx.executable.testgen,
     )
@@ -553,6 +561,10 @@ acc_autogen_sim_test = rv_rule(
             cfg = "exec",
         ),
         "seed": attr.int(mandatory = True),
+        "scheme": attr.int(mandatory = False, default = -1),
+        "nshares": attr.int(mandatory = False),
+        "vectors": attr.label(allow_single_file = True, mandatory = False),
+        "vector_index": attr.int(mandatory = False),
         "_acc_as": attr.label(
             default = "//hw/ip/acc/util:acc_as",
             executable = True,

--- a/sw/acc/crypto/mldsa/BUILD
+++ b/sw/acc/crypto/mldsa/BUILD
@@ -71,6 +71,20 @@ acc_library(
 
 [
     acc_library(
+        name = name + "_keypair_masked_2shares",
+        srcs = [
+            "mldsa_keypair.s",
+        ],
+        copts = [
+            "-DDILITHIUM_MODE=" + str(sec_level),
+            "-DNSHARES=2",
+        ],
+    )
+    for sec_level, name in NAME_BY_SEC_LEVEL.items()
+]
+
+[
+    acc_library(
         name = name + "_verify",
         srcs = [
             "mldsa_verify.s",
@@ -121,6 +135,23 @@ acc_library(
     for sec_level, name in NAME_BY_SEC_LEVEL.items()
 ]
 
+NSHARES = [2]
+
+[
+    acc_library(
+        name = name + "_sign_masked_" + str(nshares) + "shares",
+        srcs = [
+            "mldsa_sign_masked.s",
+        ],
+        copts = [
+            "-DDILITHIUM_MODE=" + str(sec_level),
+            "-DNSHARES=" + str(nshares),
+        ],
+    )
+    for nshares in NSHARES
+    for sec_level, name in NAME_BY_SEC_LEVEL.items()
+]
+
 [
     acc_library(
         name = name + "_consts",
@@ -129,6 +160,20 @@ acc_library(
         ],
         copts = [
             "-DDILITHIUM_MODE=" + str(sec_level),
+        ],
+    )
+    for sec_level, name in NAME_BY_SEC_LEVEL.items()
+]
+
+[
+    acc_library(
+        name = name + "_consts_masked",
+        srcs = [
+            "mldsa_consts.s",
+        ],
+        copts = [
+            "-DDILITHIUM_MODE=" + str(sec_level),
+            "-DNSHARES=2",
         ],
     )
     for sec_level, name in NAME_BY_SEC_LEVEL.items()

--- a/sw/acc/crypto/mldsa/gadgets/BUILD
+++ b/sw/acc/crypto/mldsa/gadgets/BUILD
@@ -1,0 +1,224 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:acc.bzl", "acc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+acc_library(
+    name = "secunmask_modq",
+    srcs = [
+        "secunmask_modq.s",
+    ],
+)
+
+acc_library(
+    name = "secleq",
+    srcs = [
+        "secleq.s",
+    ],
+)
+
+acc_library(
+    name = "seccompress",
+    srcs = [
+        "seccompress.s",
+    ],
+)
+
+acc_library(
+    name = "secboundcheck_mldsa",
+    srcs = [
+        "secboundcheck.s",
+    ],
+)
+
+acc_library(
+    name = "secand_cs20",
+    srcs = [
+        "secand_cs20.s",
+    ],
+)
+
+# Drop-in d=2 specialization of secand_cs20
+acc_library(
+    name = "secand_cs20_d2",
+    srcs = [
+        "secand_cs20_d2.s",
+    ],
+)
+
+acc_library(
+    name = "secfulladder_bc22",
+    srcs = [
+        "secfulladder_bc22.s",
+    ],
+)
+
+# d=2 specialization of secfulladder_bc22.s
+acc_library(
+    name = "secfulladder_bc22_d2",
+    srcs = [
+        "secfulladder_bc22_d2.s",
+    ],
+)
+
+acc_library(
+    name = "secadd_bc22",
+    srcs = [
+        "secadd_bc22.s",
+    ],
+)
+
+acc_library(
+    name = "secadd_bc22_immd_d1",
+    srcs = [
+        "secadd_bc22_immd_d1.s",
+    ],
+)
+
+acc_library(
+    name = "secadd_bc22_immd_d2",
+    srcs = [
+        "secadd_bc22_immd_d2.s",
+    ],
+)
+
+acc_library(
+    name = "secaddmodq_bc22_mldsa",
+    srcs = [
+        "secaddmodq_bc22.s",
+    ],
+)
+
+acc_library(
+    name = "secadd_constant_bmsk_mldsa",
+    srcs = [
+        "secadd_constant_bmsk_mldsa.s",
+    ],
+)
+
+acc_library(
+    name = "seca2bmodq_bc22_mldsa",
+    srcs = [
+        "seca2bmodq_bc22.s",
+    ],
+)
+
+acc_library(
+    name = "secb2amodq_bc22_mldsa",
+    srcs = [
+        "secb2amodq_bc22.s",
+    ],
+)
+
+acc_library(
+    name = "secb2amodq_eta",
+    srcs = [
+        "secb2amodq_eta.s",
+    ],
+)
+
+acc_library(
+    name = "poly_rej_samp_bitsliced_mldsa",
+    srcs = [
+        "poly_rej_samp_bitsliced.s",
+    ],
+)
+
+acc_library(
+    name = "poly_rej_samp_bitsliced_mldsa_test",
+    srcs = [
+        "poly_rej_samp_bitsliced.s",
+    ],
+    copts = [
+        "-DTEST=1",
+    ],
+)
+
+# Shared scratchpad buffer for the masking gadgets.
+acc_library(
+    name = "scratch",
+    srcs = [
+        "scratch.s",
+    ],
+)
+
+acc_library(
+    name = "bitslice_mldsa",
+    srcs = [
+        "bitslice.s",
+    ],
+)
+
+# k=32 variant: emits all 32 bit-stripes (vs the default 23).  Used by
+# seccompress so it can transpose y_i with the bottom 24 rounding bits
+# intact, then SecAdd mod 2^32.
+acc_library(
+    name = "bitslice_mldsa_k32",
+    srcs = [
+        "bitslice.s",
+    ],
+    copts = [
+        "-DBITSLICE_KBITS=32",
+    ],
+)
+
+acc_library(
+    name = "unbitslice_mldsa",
+    srcs = [
+        "unbitslice.s",
+    ],
+)
+
+[
+    acc_library(
+        name = "masked_poly_uniform_gamma1_" + name,
+        srcs = [
+            "masked_poly_uniform_gamma1.s",
+        ],
+        copts = [
+            "-DDILITHIUM_MODE=" + str(sec_level),
+        ],
+    )
+    for sec_level, name in {
+        2: "mldsa44",
+        3: "mldsa65",
+        5: "mldsa87",
+    }.items()
+]
+
+[
+    acc_library(
+        name = "masked_poly_uniform_eta_" + name,
+        srcs = [
+            "masked_poly_uniform_eta.s",
+        ],
+        copts = [
+            "-DETA=" + str(eta),
+        ],
+    )
+    for name, eta in {
+        "mldsa44": 2,
+        "mldsa65": 4,
+        "mldsa87": 2,
+    }.items()
+]
+
+[
+    acc_library(
+        name = "secdecompose_" + name,
+        srcs = [
+            "secdecompose.s",
+        ],
+        copts = [
+            "-DDILITHIUM_MODE=" + str(sec_level),
+        ],
+    )
+    for sec_level, name in {
+        2: "mldsa44",
+        3: "mldsa65",
+        5: "mldsa87",
+    }.items()
+]

--- a/sw/acc/crypto/mldsa/gadgets/bitslice.s
+++ b/sw/acc/crypto/mldsa/gadgets/bitslice.s
@@ -1,0 +1,515 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x1,  ra
+.equ x2,  sp
+.equ x5,  t0
+.equ x6,  t1
+.equ x10, a0
+.equ x11, a1
+.equ x13, a3
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+
+/* BITSLICE_KBITS: how many bit-stripes to emit (23 for Dilithium q_bits,
+ * 32 for seccompress). */
+#ifndef BITSLICE_KBITS
+  #define BITSLICE_KBITS 23
+#endif
+
+#if   BITSLICE_KBITS == 23
+  #define BITSLICE_B0_CNT 8
+  #define BITSLICE_B1_CNT 8
+  #define BITSLICE_B2_CNT 7
+  #define BITSLICE_B3_CNT 0
+  #define BITSLICE_SYM    bitslice
+#elif BITSLICE_KBITS == 32
+  #define BITSLICE_B0_CNT 8
+  #define BITSLICE_B1_CNT 8
+  #define BITSLICE_B2_CNT 8
+  #define BITSLICE_B3_CNT 8
+  #define BITSLICE_SYM    bitslice_k32
+#else
+  #error "bitslice: BITSLICE_KBITS must be 23 or 32"
+#endif
+
+#define KBITS BITSLICE_KBITS
+
+/* Mask registers (built once, held across the gadget):
+ *   w20..w24 = butterfly masks for j=16/8/4/2/1
+ *   w25 = j=4 stripe (lanes 0-3)
+ *   w26 = j=2 stripe (lanes {0,1,4,5})
+ *   w27 = j=1 stripe (lanes {0,2,4,6})
+ */
+
+/*
+ * Name: bitslice (ML-DSA, compile-time BITSLICE_KBITS)
+ *
+ * Transpose 256 canonical 32-bit coefficients into BITSLICE_KBITS
+ * bitsliced WDRs (output WDR j's lane i = bit j of coefficient i).
+ * Upper (32 - BITSLICE_KBITS) bits of each input coef are dropped.
+ *
+ * @param[in]       a0: ptr_out, dmem pointer to output (KBITS WDRs at stride a2)
+ * @param[in]       a1: ptr_in,  dmem pointer to input  (32 * 32 = 1024 B)
+ * @param[in]       a2: stride,  output WDR stride in bytes (32 for contiguous)
+ * @param[in]  w31: all-zero
+ *
+ * clobbered registers: x5, x10, x13, x28 to x30, w0 to w27
+ * clobbered flag groups: FG0
+ */
+.globl BITSLICE_SYM
+BITSLICE_SYM:
+    la   a3, scratch
+
+    bn.not    w6,  w31
+    bn.shv.8S w20, w6  >> 16
+    bn.shv.8S w4,  w20 << 8
+    bn.xor    w21, w20, w4
+    bn.shv.8S w4,  w21 << 4
+    bn.xor    w22, w21, w4
+    bn.shv.8S w4,  w22 << 2
+    bn.xor    w23, w22, w4
+    bn.shv.8S w4,  w23 << 1
+    bn.xor    w24, w23, w4
+    bn.rshi   w25, w31, w6  >> 128
+    bn.rshi   w4,  w31, w6  >> 192
+    bn.rshi   w5,  w4,  w31 >> 128
+    bn.or     w26, w4,  w5
+    bn.rshi   w4,  w31, w6  >> 224
+    bn.rshi   w5,  w4,  w31 >> 192
+    bn.or     w4,  w4,  w5
+    bn.rshi   w5,  w4,  w31 >> 128
+    bn.or     w27, w4,  w5
+
+    /* === Phase 1: 8 groups of 32-coef bit transpose. === */
+    addi t3, a1, 0
+    addi t4, a3, 0
+    li   t5, 8
+
+    loop t5, 161
+        li   t0, 0
+        loopi 4, 2
+            bn.lid t0, 0(t3++)
+            addi   t0, t0, 1
+
+        /* Stage j=16 (cross-WDR). */
+        bn.shv.8S w4, w0 >> 16
+        bn.xor    w4, w2, w4
+        bn.and    w4, w4, w20
+        bn.xor    w2, w2, w4
+        bn.shv.8S w4, w4 << 16
+        bn.xor    w0, w0, w4
+
+        bn.shv.8S w4, w1 >> 16
+        bn.xor    w4, w3, w4
+        bn.and    w4, w4, w20
+        bn.xor    w3, w3, w4
+        bn.shv.8S w4, w4 << 16
+        bn.xor    w1, w1, w4
+
+        /* Stage j=8 (cross-WDR). */
+        bn.shv.8S w4, w0 >> 8
+        bn.xor    w4, w1, w4
+        bn.and    w4, w4, w21
+        bn.xor    w1, w1, w4
+        bn.shv.8S w4, w4 << 8
+        bn.xor    w0, w0, w4
+
+        bn.shv.8S w4, w2 >> 8
+        bn.xor    w4, w3, w4
+        bn.and    w4, w4, w21
+        bn.xor    w3, w3, w4
+        bn.shv.8S w4, w4 << 8
+        bn.xor    w2, w2, w4
+
+        /* Stage j=4 (intra-WDR). */
+        bn.rshi   w6, w31, w0 >> 128
+        bn.shv.8S w4, w0 >> 4
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w22
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 4
+        bn.xor    w0, w0, w4
+        bn.rshi   w6, w6, w31 >> 128
+        bn.and    w0, w0, w25
+        bn.or     w0, w0, w6
+
+        bn.rshi   w6, w31, w1 >> 128
+        bn.shv.8S w4, w1 >> 4
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w22
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 4
+        bn.xor    w1, w1, w4
+        bn.rshi   w6, w6, w31 >> 128
+        bn.and    w1, w1, w25
+        bn.or     w1, w1, w6
+
+        bn.rshi   w6, w31, w2 >> 128
+        bn.shv.8S w4, w2 >> 4
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w22
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 4
+        bn.xor    w2, w2, w4
+        bn.rshi   w6, w6, w31 >> 128
+        bn.and    w2, w2, w25
+        bn.or     w2, w2, w6
+
+        bn.rshi   w6, w31, w3 >> 128
+        bn.shv.8S w4, w3 >> 4
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w22
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 4
+        bn.xor    w3, w3, w4
+        bn.rshi   w6, w6, w31 >> 128
+        bn.and    w3, w3, w25
+        bn.or     w3, w3, w6
+
+        /* Stage j=2 (intra-WDR). */
+        bn.and    w5, w0, w26
+        bn.rshi   w6, w31, w0 >> 64
+        bn.and    w6, w6, w26
+        bn.shv.8S w4, w5 >> 2
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w23
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 2
+        bn.xor    w5, w5, w4
+        bn.rshi   w6, w6, w31 >> 192
+        bn.or     w0, w5, w6
+
+        bn.and    w5, w1, w26
+        bn.rshi   w6, w31, w1 >> 64
+        bn.and    w6, w6, w26
+        bn.shv.8S w4, w5 >> 2
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w23
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 2
+        bn.xor    w5, w5, w4
+        bn.rshi   w6, w6, w31 >> 192
+        bn.or     w1, w5, w6
+
+        bn.and    w5, w2, w26
+        bn.rshi   w6, w31, w2 >> 64
+        bn.and    w6, w6, w26
+        bn.shv.8S w4, w5 >> 2
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w23
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 2
+        bn.xor    w5, w5, w4
+        bn.rshi   w6, w6, w31 >> 192
+        bn.or     w2, w5, w6
+
+        bn.and    w5, w3, w26
+        bn.rshi   w6, w31, w3 >> 64
+        bn.and    w6, w6, w26
+        bn.shv.8S w4, w5 >> 2
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w23
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 2
+        bn.xor    w5, w5, w4
+        bn.rshi   w6, w6, w31 >> 192
+        bn.or     w3, w5, w6
+
+        /* Stage j=1 (intra-WDR). */
+        bn.and    w5, w0, w27
+        bn.rshi   w6, w31, w0 >> 32
+        bn.and    w6, w6, w27
+        bn.shv.8S w4, w5 >> 1
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w24
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 1
+        bn.xor    w5, w5, w4
+        bn.rshi   w6, w6, w31 >> 224
+        bn.or     w0, w5, w6
+
+        bn.and    w5, w1, w27
+        bn.rshi   w6, w31, w1 >> 32
+        bn.and    w6, w6, w27
+        bn.shv.8S w4, w5 >> 1
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w24
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 1
+        bn.xor    w5, w5, w4
+        bn.rshi   w6, w6, w31 >> 224
+        bn.or     w1, w5, w6
+
+        bn.and    w5, w2, w27
+        bn.rshi   w6, w31, w2 >> 32
+        bn.and    w6, w6, w27
+        bn.shv.8S w4, w5 >> 1
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w24
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 1
+        bn.xor    w5, w5, w4
+        bn.rshi   w6, w6, w31 >> 224
+        bn.or     w2, w5, w6
+
+        bn.and    w5, w3, w27
+        bn.rshi   w6, w31, w3 >> 32
+        bn.and    w6, w6, w27
+        bn.shv.8S w4, w5 >> 1
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w24
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 1
+        bn.xor    w5, w5, w4
+        bn.rshi   w6, w6, w31 >> 224
+        bn.or     w3, w5, w6
+
+        li   t0, 0
+        loopi 4, 2
+            bn.sid t0, 0(t4++)
+            addi   t0, t0, 1
+        nop
+
+    /* === Phase 2: gather blocks at stride 128 from scratch+q*32, 8x8-transpose,
+     * emit BITSLICE_B{q}_CNT WDRs each. === */
+
+    /* --- q=0 --- */
+    addi t3, a3, 0
+    li   t0, 0
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+
+    bn.trn1.8S w8,  w0, w1
+    bn.trn2.8S w9,  w0, w1
+    bn.trn1.8S w10, w2, w3
+    bn.trn2.8S w11, w2, w3
+    bn.trn1.8S w12, w4, w5
+    bn.trn2.8S w13, w4, w5
+    bn.trn1.8S w14, w6, w7
+    bn.trn2.8S w15, w6, w7
+    bn.trn1.4D w0,  w8,  w10
+    bn.trn2.4D w2,  w8,  w10
+    bn.trn1.4D w1,  w9,  w11
+    bn.trn2.4D w3,  w9,  w11
+    bn.trn1.4D w4,  w12, w14
+    bn.trn2.4D w6,  w12, w14
+    bn.trn1.4D w5,  w13, w15
+    bn.trn2.4D w7,  w13, w15
+    bn.trn1.2Q w16, w0, w4
+    bn.trn2.2Q w20, w0, w4
+    bn.trn1.2Q w17, w1, w5
+    bn.trn2.2Q w21, w1, w5
+    bn.trn1.2Q w18, w2, w6
+    bn.trn2.2Q w22, w2, w6
+    bn.trn1.2Q w19, w3, w7
+    bn.trn2.2Q w23, w3, w7
+
+    li   t0, 16
+    loopi BITSLICE_B0_CNT, 3
+        bn.sid t0, 0(a0)
+        add    a0, a0, a2
+        addi   t0, t0, 1
+
+#if BITSLICE_B1_CNT > 0
+    /* --- q=1 --- */
+    addi t3, a3, 32
+    li   t0, 0
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+
+    bn.trn1.8S w8,  w0, w1
+    bn.trn2.8S w9,  w0, w1
+    bn.trn1.8S w10, w2, w3
+    bn.trn2.8S w11, w2, w3
+    bn.trn1.8S w12, w4, w5
+    bn.trn2.8S w13, w4, w5
+    bn.trn1.8S w14, w6, w7
+    bn.trn2.8S w15, w6, w7
+    bn.trn1.4D w0,  w8,  w10
+    bn.trn2.4D w2,  w8,  w10
+    bn.trn1.4D w1,  w9,  w11
+    bn.trn2.4D w3,  w9,  w11
+    bn.trn1.4D w4,  w12, w14
+    bn.trn2.4D w6,  w12, w14
+    bn.trn1.4D w5,  w13, w15
+    bn.trn2.4D w7,  w13, w15
+    bn.trn1.2Q w16, w0, w4
+    bn.trn2.2Q w20, w0, w4
+    bn.trn1.2Q w17, w1, w5
+    bn.trn2.2Q w21, w1, w5
+    bn.trn1.2Q w18, w2, w6
+    bn.trn2.2Q w22, w2, w6
+    bn.trn1.2Q w19, w3, w7
+    bn.trn2.2Q w23, w3, w7
+
+    li   t0, 16
+    loopi BITSLICE_B1_CNT, 3
+        bn.sid t0, 0(a0)
+        add    a0, a0, a2
+        addi   t0, t0, 1
+#endif
+
+#if BITSLICE_B2_CNT > 0
+    /* --- q=2 --- */
+    addi t3, a3, 64
+    li   t0, 0
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+
+    bn.trn1.8S w8,  w0, w1
+    bn.trn2.8S w9,  w0, w1
+    bn.trn1.8S w10, w2, w3
+    bn.trn2.8S w11, w2, w3
+    bn.trn1.8S w12, w4, w5
+    bn.trn2.8S w13, w4, w5
+    bn.trn1.8S w14, w6, w7
+    bn.trn2.8S w15, w6, w7
+    bn.trn1.4D w0,  w8,  w10
+    bn.trn2.4D w2,  w8,  w10
+    bn.trn1.4D w1,  w9,  w11
+    bn.trn2.4D w3,  w9,  w11
+    bn.trn1.4D w4,  w12, w14
+    bn.trn2.4D w6,  w12, w14
+    bn.trn1.4D w5,  w13, w15
+    bn.trn2.4D w7,  w13, w15
+    bn.trn1.2Q w16, w0, w4
+    bn.trn2.2Q w20, w0, w4
+    bn.trn1.2Q w17, w1, w5
+    bn.trn2.2Q w21, w1, w5
+    bn.trn1.2Q w18, w2, w6
+    bn.trn2.2Q w22, w2, w6
+    bn.trn1.2Q w19, w3, w7
+    bn.trn2.2Q w23, w3, w7
+
+    li   t0, 16
+    loopi BITSLICE_B2_CNT, 3
+        bn.sid t0, 0(a0)
+        add    a0, a0, a2
+        addi   t0, t0, 1
+#endif
+
+#if BITSLICE_B3_CNT > 0
+    /* --- q=3 --- */
+    addi t3, a3, 96
+    li   t0, 0
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.lid t0, 0(t3)
+
+    bn.trn1.8S w8,  w0, w1
+    bn.trn2.8S w9,  w0, w1
+    bn.trn1.8S w10, w2, w3
+    bn.trn2.8S w11, w2, w3
+    bn.trn1.8S w12, w4, w5
+    bn.trn2.8S w13, w4, w5
+    bn.trn1.8S w14, w6, w7
+    bn.trn2.8S w15, w6, w7
+    bn.trn1.4D w0,  w8,  w10
+    bn.trn2.4D w2,  w8,  w10
+    bn.trn1.4D w1,  w9,  w11
+    bn.trn2.4D w3,  w9,  w11
+    bn.trn1.4D w4,  w12, w14
+    bn.trn2.4D w6,  w12, w14
+    bn.trn1.4D w5,  w13, w15
+    bn.trn2.4D w7,  w13, w15
+    bn.trn1.2Q w16, w0, w4
+    bn.trn2.2Q w20, w0, w4
+    bn.trn1.2Q w17, w1, w5
+    bn.trn2.2Q w21, w1, w5
+    bn.trn1.2Q w18, w2, w6
+    bn.trn2.2Q w22, w2, w6
+    bn.trn1.2Q w19, w3, w7
+    bn.trn2.2Q w23, w3, w7
+
+    li   t0, 16
+    loopi BITSLICE_B3_CNT, 3
+        bn.sid t0, 0(a0)
+        add    a0, a0, a2
+        addi   t0, t0, 1
+#endif
+
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/masked_poly_uniform_eta.s
+++ b/sw/acc/crypto/mldsa/gadgets/masked_poly_uniform_eta.s
@@ -1,0 +1,585 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x0,  zero
+.equ x1,  ra
+.equ x2,  sp
+.equ x3,  fp
+.equ x5,  t0
+/* acc_as mangles identifiers ending in `t1` (kmac_digest1 -> kmac_digesx6)
+ * when t1 is set via `.equ`; use a token-based #define instead. */
+#define t1 x6
+.equ x7,  t2
+.equ x8,  s0
+.equ x9,  s1
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x15, a5
+.equ x16, a6
+.equ x17, a7
+.equ x18, s2
+.equ x19, s3
+.equ x20, s4
+.equ x21, s5
+.equ x22, s6
+.equ x23, s7
+.equ x24, s8
+.equ x25, s9
+.equ x26, s10
+.equ x27, s11
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+.equ w31, bn0
+
+#ifndef NSHARES
+  #define NSHARES 2
+#endif
+#if NSHARES != 2
+  #error "masked_poly_uniform_eta only supports NSHARES=2"
+#endif
+
+#ifndef ETA
+  #define ETA 2
+#endif
+
+#define CRHBYTES     64
+#define SHAKE256_CFG 0xA
+
+/* Scratch (a3, >= 3104 B).  Four live buffers; the gather stash (SQ*) and the
+ * mod-5 temps (Z,T,M1) reuse dead bytes since the phases run in sequence.  a3
+ * is also the b2a seca2b scratch.  Offsets > 2047 take an `li s11; add` pair. */
+#define OFF_G0     0      /* gathered nibbles, share 0 (canonical, 1024 B) */
+#define OFF_G1     1024   /* gathered nibbles, share 1 */
+#define OFF_BS     2048   /* bitslice output, reused per share (736 B) */
+#define OFF_N5     2784   /* n^{B,5}, share stride 160 (320 B) */
+#define OFF_SQ0    2048   /* squeeze stash, reuses BS (gather phase) */
+#define OFF_SQ1    2080
+#define OFF_REJ    2112
+#define OFF_Z      0      /* mod-5 temps, reuse G0 (after bitslice) */
+#define OFF_T      320
+#define OFF_M1     640
+
+#define STRIPE_K   5
+#define STRIDE5    160    /* STRIPE_K * 32 */
+
+/*
+ * Name: masked_poly_uniform_eta (PINI, d = 2), eta = 2 or 4
+ *
+ * Produces a 2-share arithmetic sharing (mod q) of one s1/s2 polynomial,
+ * ExpandS(rho', nonce): draw 4-bit nibbles from SHAKE-256(rho'||nonce) and
+ * map each accepted nibble n to eta - reduce(n) per FIPS 204 CoeffFromHalfByte:
+ *   eta=2: reject n == 15, coefficient = 2 - (n mod 5)
+ *   eta=4: reject n >= 9,  coefficient = 4 - n
+ *
+ *   1: start masked SHAKE-256 over the shared seed and nonce
+ *   2: draw nibbles; reveal the public reject bit and pack the accepted ones
+ *      (two shares each) into G0/G1 until 256 collected
+ *   3: bitslice G0 and G1
+ *   4: eta=2 only: m = n mod 5 = n - 5*(n>=5) - 5*(n>=10); eta=4 uses n as-is
+ *   5: B2A: reduce(n) -> arithmetic shares (mod q)
+ *   6: coefficient = eta - reduce(n)   (eta folded into one share)
+ *
+ * This is FIPS 204 CoeffFromHalfByte, NOT [ABCH+23] Alg. 6 SecSampleModp:
+ * Alg. 6 also samples [-eta, eta] but encodes the XOF differently (3-bit,
+ * accept 5/8 vs FIPS's 15/16), deriving a different key from the same seed;
+ * we must match the FIPS key bit-for-bit.
+ *
+ * Primitives: SecAnd / SecAdd / SecB2AModp [BC22]; (n>=5)/(n>=10) use the
+ * [ABCH+23] SecLeq carry bit.
+ *
+ * @param[out]  a0: dptr_out, 2 * 1024 B arithmetic shares (mod q); also holds
+ *                  bitsliced m transiently before the b2a consumes it.
+ * @param[in]   a1: dptr_seed, 2 * CRHBYTES masked rho' (share-major).
+ * @param[in]   a2: nonce (uint16_t).
+ * @param[in]   a3: dptr_scratch, >= 3104 B (also the b2a seca2b scratch).
+ * @param[in]   a4: dptr_b2a_buf, 1536 B (secb2amodq_eta Boolean buffer).
+ * @param[in]  w31: all-zero.
+ *
+ * clobbered registers: x2, x5 to x31, w0 to w27
+ * clobbered flag groups: FG0
+ */
+.globl masked_poly_uniform_eta
+masked_poly_uniform_eta:
+    addi sp, sp, -32
+    sw   a0, 0(sp)                 /* out ptr (also bitsliced m, then output) */
+    sw   a3, 4(sp)                 /* scratch base (= b2a seca2b scratch) */
+    sw   a4, 8(sp)                 /* b2a Boolean buffer */
+    sw   s0, 16(sp)                /* callee-save: caller parks pointers here */
+    sw   s1, 20(sp)
+    sw   s2, 24(sp)
+    sw   s11, 28(sp)
+
+    /* ---- Init masked SHAKE-256, absorb rho' shares + nonce. ---- */
+    addi  a4, x0, CRHBYTES
+    addi  a4, a4, 2
+    slli  t0, a4, 5
+    addi  t0, t0, SHAKE256_CFG
+    addi  a4, x0, 1
+    slli  a4, a4, 20              /* masking-enable bit */
+    add   t0, t0, a4
+    csrrw x0, kmac_cfg, t0
+
+    bn.lid  x0, 0(a1)             /* share0[0..32] */
+    bn.wsrw kmac_msg, w0
+    bn.xor  w0, w0, w0
+    bn.lid  x0, 64(a1)            /* share1[0..32] */
+    bn.wsrw kmac_msg1, w0
+    bn.lid  x0, 32(a1)            /* share0[32..64] */
+    bn.wsrw kmac_msg, w0
+    bn.xor  w0, w0, w0
+    bn.lid  x0, 96(a1)            /* share1[32..64] */
+    bn.wsrw kmac_msg1, w0
+
+    /* Nonce, using out[0..32] as scratch (overwritten later). */
+    bn.sid  x0, 0(a0)
+    sw      a2, 0(a0)
+    bn.lid  x0, 0(a0)
+    li      t0, 2
+    csrrw   x0, kmac_partial_write, t0
+    bn.wsrw kmac_msg, w0
+    bn.xor  w0, w0, w0
+    bn.wsrw kmac_msg1, w0
+
+    /* ---- Reject-and-gather 256 accepted nibbles into G0/G1. ---- */
+    /* wM = per-nibble bit-0 mask (bits 0,4,8,...,252).  Built from the byte
+     * pattern 0x11 (= bits 0,4) with byte-aligned shifts only, since the
+     * shifted-operand form encodes the shift as uimm5<<3 (multiples of 8). */
+    #define wM w30
+    bn.addi wM, bn0, 0x11
+    bn.or   wM, wM, wM << 8
+    bn.or   wM, wM, wM << 16
+    bn.or   wM, wM, wM << 32
+    bn.or   wM, wM, wM << 64
+    bn.or   wM, wM, wM << 128
+
+    lw   a3, 4(sp)
+    addi s0, a3, OFF_G0           /* G0 write cursor */
+    addi s1, a3, OFF_G1           /* G1 write cursor */
+    addi s2, a3, 1024             /* G0 end (256 nibbles done) */
+
+_mpue_squeeze:
+    /* s0_w/s1_w = next 64 masked nibbles (share 0 / share 1). */
+    bn.wsrr w0, kmac_digest
+    bn.wsrr w1, kmac_digest1
+
+#if ETA == 2
+    /* reject (n == 15) = AND of the nibble's 4 bits, at bit 4i. */
+    /* SecAnd: z = n & (n>>1) on the masked nibble n = (w0,w1). */
+    bn.rshi w2, w31, w0 >> 1
+    bn.rshi w3, w31, w1 >> 1
+    bn.wsrr w6, urnd
+    bn.and  w4, w0, w2
+    bn.xor  w4, w4, w6
+    bn.and  w7, w0, w3
+    bn.xor  w7, w7, w6
+    bn.and  w8, w1, w2
+    bn.xor  w7, w7, w8
+    bn.and  w5, w1, w3
+    bn.xor  w5, w5, w7           /* (w4,w5) = shares of z */
+
+    /* SecAnd: u = z & (z>>2)  -> bit 4i = AND of nibble's 4 bits. */
+    bn.rshi w2, w31, w4 >> 2
+    bn.rshi w3, w31, w5 >> 2
+    bn.wsrr w6, urnd
+    bn.and  w7, w4, w2
+    bn.xor  w7, w7, w6
+    bn.and  w8, w4, w3
+    bn.xor  w8, w8, w6
+    bn.and  w2, w5, w2
+    bn.xor  w8, w8, w2
+    bn.and  w3, w5, w3
+    bn.xor  w3, w3, w8           /* (w7,w3) = shares of u */
+#elif ETA == 4
+    /* reject (n >= 9) = b3 & (b0|b1|b2), at bit 4i.  Via De Morgan on m = ~n:
+     * three SecAnds give b3 & ~(~b0 & ~b1 & ~b2). */
+    /* SecAnd: za = m & (m>>1),  m = ~n = (~w0, w1). */
+    bn.not  w2, w0
+    bn.rshi w3, w31, w2 >> 1
+    bn.rshi w4, w31, w1 >> 1
+    bn.wsrr w6, urnd
+    bn.and  w7, w2, w3
+    bn.xor  w7, w7, w6
+    bn.and  w8, w2, w4
+    bn.xor  w8, w8, w6
+    bn.and  w9, w1, w3
+    bn.xor  w8, w8, w9
+    bn.and  w5, w1, w4
+    bn.xor  w5, w5, w8           /* za = (w7,w5) */
+
+    /* SecAnd: zb = za & (m>>2)  -> bit 4i = ~b0 & ~b1 & ~b2. */
+    bn.rshi w3, w31, w2 >> 2
+    bn.rshi w4, w31, w1 >> 2
+    bn.wsrr w6, urnd
+    bn.and  w8, w7, w3
+    bn.xor  w8, w8, w6
+    bn.and  w9, w7, w4
+    bn.xor  w9, w9, w6
+    bn.and  w10, w5, w3
+    bn.xor  w9, w9, w10
+    bn.and  w11, w5, w4
+    bn.xor  w11, w11, w9        /* zb = (w8,w11) */
+    bn.not  w8, w8             /* ~zb -> bit 4i = b0|b1|b2 */
+
+    /* SecAnd: reject = (n>>3) & ~zb  -> bit 4i = b3 & (b0|b1|b2). */
+    bn.rshi w3, w31, w0 >> 3
+    bn.rshi w4, w31, w1 >> 3
+    bn.wsrr w6, urnd
+    bn.and  w7, w3, w8
+    bn.xor  w7, w7, w6
+    bn.and  w9, w3, w11
+    bn.xor  w9, w9, w6
+    bn.and  w10, w4, w8
+    bn.xor  w9, w9, w10
+    bn.and  w3, w4, w11
+    bn.xor  w3, w3, w9          /* (w7,w3) = shares of reject */
+#endif
+
+    /* Reveal only the per-nibble reject bits (mask off the garbage). */
+    bn.and  w7, w7, wM
+    bn.and  w3, w3, wM
+    bn.xor  w7, w7, w3           /* public reject mask, bit 4i set => reject */
+
+    /* Stash share words + reject mask for the scalar gather. */
+    li   s11, OFF_SQ0
+    add  t2, a3, s11
+    bn.sid x0, 0(t2)             /* x0 indexes w0 */
+    li   s11, OFF_SQ1
+    add  t2, a3, s11
+    li   t3, 1
+    bn.sid t3, 0(t2)             /* w1 */
+    li   s11, OFF_REJ
+    add  t2, a3, s11
+    li   t3, 7
+    bn.sid t3, 0(t2)             /* w7 */
+
+    /* Gather: 8 words x 8 nibbles, compacting accepted nibbles. */
+    li   s11, OFF_SQ0
+    add  t0, a3, s11
+    li   s11, OFF_SQ1
+    add  t2, a3, s11
+    li   s11, OFF_REJ
+    add  t3, a3, s11
+    li   t4, 8                   /* word counter */
+_mpue_word:
+    lw   a4, 0(t0)               /* share0 word */
+    lw   a5, 0(t2)               /* share1 word */
+    lw   a6, 0(t3)               /* reject word */
+    addi t0, t0, 4
+    addi t2, t2, 4
+    addi t3, t3, 4
+    li   t5, 8                   /* nibble counter */
+_mpue_nib:
+    andi a7, a6, 1               /* reject bit */
+    andi t6, a4, 15              /* nibble share0 */
+    andi a1, a5, 15              /* nibble share1 */
+    srli a6, a6, 4
+    srli a4, a4, 4
+    srli a5, a5, 4
+    bne  a7, x0, _mpue_skip
+    sw   t6, 0(s0)
+    sw   a1, 0(s1)
+    addi s0, s0, 4
+    addi s1, s1, 4
+    beq  s0, s2, _mpue_gathered
+_mpue_skip:
+    addi t5, t5, -1
+    bne  t5, x0, _mpue_nib
+    addi t4, t4, -1
+    bne  t4, x0, _mpue_word
+    beq  x0, x0, _mpue_squeeze
+
+_mpue_gathered:
+#if ETA == 2
+    /* ---- mod-5 in the Boolean domain. ---- */
+    lw   a3, 4(sp)
+
+    /* Bitslice share 0 -> BS, copy low 5 stripes to N5 share 0; then reuse
+     * BS for share 1.  (Single bitslice buffer overlaid by lifetime.) */
+    li   s11, OFF_BS
+    add  a0, a3, s11
+    addi a1, a3, OFF_G0
+    li   a2, 32
+    jal  x1, bitslice
+
+    lw   a3, 4(sp)
+    li   s11, OFF_BS
+    add  t0, a3, s11
+    li   s11, OFF_N5
+    add  t1, a3, s11
+    li   t2, 0
+    loopi STRIPE_K, 2
+        bn.lid t2, 0(t0++)
+        bn.sid t2, 0(t1++)
+
+    /* Whitening */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    bn.xor w4, w4, w4
+    bn.xor w5, w5, w5
+    bn.xor w6, w6, w6
+    bn.xor w7, w7, w7
+    bn.xor w8, w8, w8
+    bn.xor w9, w9, w9
+    bn.xor w10, w10, w10
+    bn.xor w11, w11, w11
+    bn.xor w12, w12, w12
+    bn.xor w13, w13, w13
+    bn.xor w14, w14, w14
+    bn.xor w15, w15, w15
+    bn.xor w16, w16, w16
+    bn.xor w17, w17, w17
+    bn.xor w18, w18, w18
+    bn.xor w19, w19, w19
+    bn.xor w20, w20, w20
+    bn.xor w21, w21, w21
+    bn.xor w22, w22, w22
+    bn.xor w23, w23, w23
+    bn.xor w24, w24, w24
+    bn.xor w25, w25, w25
+    bn.xor w26, w26, w26
+    bn.xor w27, w27, w27
+    li   s11, OFF_BS
+    add  a0, a3, s11
+    addi a1, a3, OFF_G1
+    li   a2, 32
+    jal  x1, bitslice
+
+    lw   a3, 4(sp)
+    li   s11, OFF_BS
+    add  t0, a3, s11
+    li   s11, OFF_N5
+    add  t1, a3, s11
+    addi t1, t1, STRIDE5
+    loopi STRIPE_K, 2
+        bn.lid t2, 0(t0++)
+        bn.sid t2, 0(t1++)
+
+    /* c1 = [n>=5] = !SecLeq_4(n): SecAdd_5(n, 2^5-4-1=27), bit 4 = [n<=4]. */
+    li   s11, OFF_N5
+    add  a0, a3, s11
+    li   a2, STRIPE_K
+    li   a3, STRIDE5
+    li   a4, 2
+    lw   a5, 4(sp)
+    li   s11, OFF_Z
+    add  a5, a5, s11
+    bn.xor w17, w17, w17
+    bn.addi w17, w17, 27
+    jal  x1, secadd_bc22_immd_d2
+
+    /* Build T = c1 gated into the 27 bit-pattern {0,1,3,4}, c1 = !Z[4]. */
+    lw   a3, 4(sp)
+    jal  x1, _mpue_build_subtrahend
+
+    /* m1 = SecAdd_5(n, T) = n - 5*c1. */
+    lw   a3, 4(sp)
+    li   s11, OFF_N5
+    add  a0, a3, s11
+    li   s11, OFF_T
+    add  a1, a3, s11
+    li   a2, STRIPE_K
+    li   a3, STRIDE5
+    li   a4, 2
+    lw   a5, 4(sp)
+    li   s11, OFF_M1
+    add  a5, a5, s11
+    jal  x1, secadd_bc22
+
+    /* c2 = [n>=10] = !SecLeq_9(n): SecAdd_5(n, 2^5-9-1=22), bit 4 = [n<=9]. */
+    lw   a3, 4(sp)
+    li   s11, OFF_N5
+    add  a0, a3, s11
+    li   a2, STRIPE_K
+    li   a3, STRIDE5
+    li   a4, 2
+    lw   a5, 4(sp)
+    li   s11, OFF_Z
+    add  a5, a5, s11
+    bn.xor w17, w17, w17
+    bn.addi w17, w17, 22
+    jal  x1, secadd_bc22_immd_d2
+
+    lw   a3, 4(sp)
+    jal  x1, _mpue_build_subtrahend
+
+    /* m = SecAdd_5(m1, T) = n - 5*c1 - 5*c2 = n mod 5, written to the OUTPUT
+     * buffer (share0 at out+0, share1 at out+STRIDE5). */
+    lw   a3, 4(sp)
+    li   s11, OFF_M1
+    add  a0, a3, s11
+    li   s11, OFF_T
+    add  a1, a3, s11
+    li   a2, STRIPE_K
+    li   a3, STRIDE5
+    li   a4, 2
+    lw   a5, 0(sp)               /* out */
+    jal  x1, secadd_bc22
+
+    /* ---- B2A(m, k=3): out holds m; a3 (dead) is the seca2b scratch. ---- */
+    lw   a0, 0(sp)
+    addi a1, a0, 0               /* m share0 in out */
+    addi a2, a0, STRIDE5         /* m share1 in out */
+    li   a3, 3
+    lw   a4, 4(sp)               /* seca2b scratch (= a3) */
+    lw   a5, 8(sp)               /* Boolean buffer */
+    jal  x1, secb2amodq_eta
+#elif ETA == 4
+    /* ---- eta=4: no mod 5; coeff = 4 - n.  Bitslice n, B2A(k=4). ---- */
+    lw   a3, 4(sp)
+
+    /* Bitslice share 0 -> BS; copy low 4 stripes to out+0 (b2a share 0). */
+    li   s11, OFF_BS
+    add  a0, a3, s11
+    addi a1, a3, OFF_G0
+    li   a2, 32
+    jal  x1, bitslice
+
+    lw   a3, 4(sp)
+    li   s11, OFF_BS
+    add  t0, a3, s11
+    lw   t1, 0(sp)
+    li   t2, 0
+    loopi 4, 2
+        bn.lid t2, 0(t0++)
+        bn.sid t2, 0(t1++)
+
+    /* Whitening */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    bn.xor w4, w4, w4
+    bn.xor w5, w5, w5
+    bn.xor w6, w6, w6
+    bn.xor w7, w7, w7
+    bn.xor w8, w8, w8
+    bn.xor w9, w9, w9
+    bn.xor w10, w10, w10
+    bn.xor w11, w11, w11
+    bn.xor w12, w12, w12
+    bn.xor w13, w13, w13
+    bn.xor w14, w14, w14
+    bn.xor w15, w15, w15
+    bn.xor w16, w16, w16
+    bn.xor w17, w17, w17
+    bn.xor w18, w18, w18
+    bn.xor w19, w19, w19
+    bn.xor w20, w20, w20
+    bn.xor w21, w21, w21
+    bn.xor w22, w22, w22
+    bn.xor w23, w23, w23
+    bn.xor w24, w24, w24
+    bn.xor w25, w25, w25
+    bn.xor w26, w26, w26
+    bn.xor w27, w27, w27
+    /* Bitslice share 1 -> BS; copy low 4 stripes to out+128 (b2a share 1). */
+    li   s11, OFF_BS
+    add  a0, a3, s11
+    addi a1, a3, OFF_G1
+    li   a2, 32
+    jal  x1, bitslice
+
+    lw   a3, 4(sp)
+    li   s11, OFF_BS
+    add  t0, a3, s11
+    lw   t1, 0(sp)
+    addi t1, t1, 128
+    li   t2, 0
+    loopi 4, 2
+        bn.lid t2, 0(t0++)
+        bn.sid t2, 0(t1++)
+
+    /* B2A(n, k=4): out+0 / out+128 hold n; out receives arith shares. */
+    lw   a0, 0(sp)
+    addi a1, a0, 0
+    addi a2, a0, 128
+    li   a3, 4
+    lw   a4, 4(sp)               /* seca2b scratch */
+    lw   a5, 8(sp)               /* Boolean buffer */
+    jal  x1, secb2amodq_eta
+#endif
+
+    /* coeff = eta - reduce(n): share 0 = eta - m0, share 1 = -m1  (mod q). */
+    la     t0, eta
+    li     t1, 4
+    bn.lid t1, 0(t0)             /* w4 = eta in each lane */
+
+    lw   a0, 0(sp)
+    li   t0, 0
+    addi t1, a0, 0
+    loopi 32, 3
+        bn.lid t0, 0(t1)
+        bn.subvm.8s w0, w4, w0
+        bn.sid t0, 0(t1++)
+
+    /* Whitening */
+    bn.xor w0, w0, w0
+    lw   a0, 0(sp)
+    addi t1, a0, 1024
+    loopi 32, 3
+        bn.lid t0, 0(t1)
+        bn.subvm.8s w0, w31, w0
+        bn.sid t0, 0(t1++)
+
+    lw   s0, 16(sp)
+    lw   s1, 20(sp)
+    lw   s2, 24(sp)
+    lw   s11, 28(sp)
+    addi sp, sp, 32
+    ret
+
+#if ETA == 2
+/*
+ * Helper: build T (OFF_T) from the comparison bit at stripe 4 of OFF_Z.
+ * c = !Z[4] (flip share 0); gate c into the bit pattern of 27 (= -5 mod 2^5),
+ * i.e. stripes {0,1,3,4} = c, stripe 2 = 0.  a3 = scratch base.
+ */
+_mpue_build_subtrahend:
+    /* Load c shares: w0 = !Z[4]_s0, w1 = Z[4]_s1. */
+    li   s11, OFF_Z
+    add  t0, a3, s11
+    addi t0, t0, 128             /* stripe 4 (4 * 32), share 0 */
+    li   t2, 0
+    bn.lid t2, 0(t0)
+    bn.not w0, w0                /* c_s0 = NOT Z[4]_s0 */
+    li   s11, OFF_Z
+    add  t0, a3, s11
+    addi t0, t0, STRIDE5
+    addi t0, t0, 128             /* stripe 4, share 1 */
+    li   t2, 1
+    bn.lid t2, 0(t0)
+
+    /* Write share 0 stripes {0,1,3,4}=c, {2}=0. */
+    li   s11, OFF_T
+    add  t1, a3, s11
+    li   t2, 0
+    li   t3, 31                  /* w31 = 0 */
+    bn.sid t2, 0(t1)             /* stripe 0 = c */
+    bn.sid t2, 32(t1)            /* stripe 1 = c */
+    bn.sid t3, 64(t1)            /* stripe 2 = 0 */
+    bn.sid t2, 96(t1)            /* stripe 3 = c */
+    bn.sid t2, 128(t1)           /* stripe 4 = c */
+
+    /* Write share 1 stripes {0,1,3,4}=c, {2}=0. */
+    li   s11, OFF_T
+    add  t1, a3, s11
+    addi t1, t1, STRIDE5
+    li   t2, 1                   /* w1 = c_s1 */
+    bn.sid t2, 0(t1)
+    bn.sid t2, 32(t1)
+    bn.sid t3, 64(t1)
+    bn.sid t2, 96(t1)
+    bn.sid t2, 128(t1)
+    ret
+#endif

--- a/sw/acc/crypto/mldsa/gadgets/masked_poly_uniform_gamma1.s
+++ b/sw/acc/crypto/mldsa/gadgets/masked_poly_uniform_gamma1.s
@@ -1,0 +1,378 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x1,  ra
+.equ x2,  sp
+.equ x5,  t0
+#define t1 x6
+.equ x7,  t2
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+#ifndef NSHARES
+  #define NSHARES 2
+#endif
+
+#define KBITS    23
+#define CRHBYTES 64
+
+#ifndef DILITHIUM_MODE
+  #error "masked_poly_uniform_gamma_1 requires DILITHIUM_MODE"
+#endif
+
+#if DILITHIUM_MODE == 2
+  #define POLYZ_BITS    18
+  #define SQUEEZE_WORDS 18
+  #define RAW0_OFFSET   448    /* 1024 - 18*32 */
+  #define RAW1_OFFSET   1472   /* 2048 - 18*32 */
+#elif DILITHIUM_MODE == 3 || DILITHIUM_MODE == 5
+  #define POLYZ_BITS    20
+  #define SQUEEZE_WORDS 20
+  #define RAW0_OFFSET   384    /* 1024 - 20*32 */
+  #define RAW1_OFFSET   1408   /* 2048 - 20*32 */
+#else
+  #error "masked_poly_uniform_gamma_1: unsupported DILITHIUM_MODE"
+#endif
+
+#define SHAKE256_CFG 0xA
+
+#define SP_FRAME 32
+
+/*
+ * Name: masked_poly_uniform_gamma_1 (PINI, d=2)
+ *
+ * Masked version of poly_uniform_gamma_1: sample a 2-share arithmetic
+ * sharing of y mod q with y = gamma1 - u, u uniform in [0, 2^POLYZ_BITS).
+ * Differs from the unmasked version in that rho'|nonce go through the
+ * masked KMAC interface and the squeezed u stays masked through
+ * bitslice -> secb2amodq_bc22 -> unbitslice before the gamma1 - u step.
+ *
+ * @param[out]  a0: dptr_out, 2 * 1024 B output.
+ * @param[in]   a1: dptr_seed, 2 * CRHBYTES.
+ * @param[in]   a2: nonce (uint16_t).
+ * @param[in]   a3: dptr_scratch, 1536 B for internal seca2bmodq_bc22.
+ * @param[in]   a4: dptr_buf, 1536 B bitsliced-u staging buffer.
+ * @param[in]  w31: all-zero.
+ *
+ *
+ * clobbered registers: x2, x5 to x7, x10 to x17, x28 to x31, w0 to w27
+ * clobbered flag groups: FG0
+ */
+.globl masked_poly_uniform_gamma_1
+masked_poly_uniform_gamma_1:
+    addi sp, sp, -SP_FRAME
+    sw   a0, 0(sp)                 /* save out pointer */
+    sw   a3, 8(sp)                 /* save scratch_ptr for b2a */
+    sw   a4, 12(sp)                /* save bitslice buffer ptr */
+
+    bn.mov w28, w16
+    bn.mov w29, w22
+    bn.mov w30, w23
+
+    /* Init masked SHAKE256, send rho'. */
+    addi  a3, x0, CRHBYTES
+    addi  a3, a3, 2
+    slli  t0, a3, 5
+    addi  t0, t0, SHAKE256_CFG
+    addi  a3, x0, 1
+    slli  a3, a3, 20
+    add   t0, t0, a3
+    csrrw x0, kmac_cfg, t0
+
+    bn.lid  x0, 0(a1)
+    bn.wsrw kmac_msg, w0
+    bn.xor  w0, w0, w0
+    bn.lid  x0, 64(a1)
+    bn.wsrw kmac_msg1, w0
+    bn.lid  x0, 32(a1)
+    bn.wsrw kmac_msg, w0
+    bn.xor  w0, w0, w0
+    bn.lid  x0, 96(a1)
+    bn.wsrw kmac_msg1, w0
+
+    /* Send nonce (out[0..31] as scratch, overwritten later). */
+    bn.sid  x0, 0(a0)
+    sw      a2, 0(a0)
+    bn.lid  x0, 0(a0)
+    li      t0, 2
+    csrrw   x0, kmac_partial_write, t0
+    bn.wsrw kmac_msg, w0
+    bn.xor  w0, w0, w0
+    bn.wsrw kmac_msg1, w0
+
+    /* Squeeze raw into the tail of each share's output slot so the
+     * forward in-place unpack keeps writes below reads. */
+    addi t1, a0, RAW0_OFFSET
+    addi t2, a0, RAW1_OFFSET
+    li   t3, 0
+    li   t4, 1
+    loopi SQUEEZE_WORDS, 4
+        bn.wsrr w0, kmac_digest
+        bn.wsrr w1, kmac_digest1
+        bn.sid  t3, 0(t1++)
+        bn.sid  t4, 0(t2++)
+
+    /* Unpack each share in place (out[RAW..1023] -> out[0..1023]). */
+    li   t0, 5
+    la   t1, polyz_unpack_mask
+    bn.lid t0, 0(t1)
+
+    addi a1, a0, RAW0_OFFSET
+    /* Whitening */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    jal  ra, _unpack_share
+
+    lw   a0, 0(sp)
+    addi a1, a0, RAW1_OFFSET
+    addi a0, a0, 1024
+    /* Whitening */
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    bn.xor w6, w6, w6
+    jal  ra, _unpack_share
+
+    /* Bitslice each share to caller's buffer (top bit zeroed for k+1). */
+    lw   a1, 0(sp)
+    lw   a0, 12(sp)
+    li   a2, 32
+    jal  ra, bitslice
+    lw   t1, 12(sp)
+    addi t1, t1, 736
+    li   t0, 31
+    bn.sid t0, 0(t1)
+
+    lw   a1, 0(sp)
+    addi a1, a1, 1024
+    lw   a0, 12(sp)
+    addi a0, a0, 768
+    li   a2, 32
+    /* Whitening */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    bn.xor w4, w4, w4
+    bn.xor w5, w5, w5
+    bn.xor w6, w6, w6
+    bn.xor w7, w7, w7
+    bn.xor w8, w8, w8
+    bn.xor w9, w9, w9
+    bn.xor w10, w10, w10
+    bn.xor w11, w11, w11
+    bn.xor w12, w12, w12
+    bn.xor w13, w13, w13
+    bn.xor w14, w14, w14
+    bn.xor w15, w15, w15
+    bn.xor w16, w16, w16
+    bn.xor w17, w17, w17
+    bn.xor w18, w18, w18
+    bn.xor w19, w19, w19
+    bn.xor w20, w20, w20
+    bn.xor w21, w21, w21
+    bn.xor w22, w22, w22
+    bn.xor w23, w23, w23
+    bn.xor w24, w24, w24
+    bn.xor w25, w25, w25
+    bn.xor w26, w26, w26
+    bn.xor w27, w27, w27
+    jal  ra, bitslice
+    lw   t1, 12(sp)
+    addi t1, t1, 1504
+    li   t0, 31
+    bn.sid t0, 0(t1)
+
+    /* B2A: u^{B,k} (buffer) -> u^{A_p} at caller out. */
+    lw   a1, 12(sp)
+    lw   a0, 0(sp)
+    lw   a3, 8(sp)
+    jal  ra, secb2amodq_bc22
+
+    /* Unbitslice each share in place; share 1 first so its overlapping
+     * write [1024..1503] doesn't clobber share 0's source. */
+    lw   a0, 0(sp)
+    addi a1, a0, 768
+    addi a0, a0, 1024
+    jal  ra, unbitslice
+
+    lw   a0, 0(sp)
+    addi a1, a0, 0
+    /* Whitening */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    bn.xor w4, w4, w4
+    bn.xor w5, w5, w5
+    bn.xor w6, w6, w6
+    bn.xor w7, w7, w7
+    bn.xor w8, w8, w8
+    bn.xor w9, w9, w9
+    bn.xor w10, w10, w10
+    bn.xor w11, w11, w11
+    bn.xor w12, w12, w12
+    bn.xor w13, w13, w13
+    bn.xor w14, w14, w14
+    bn.xor w15, w15, w15
+    bn.xor w16, w16, w16
+    bn.xor w17, w17, w17
+    bn.xor w18, w18, w18
+    bn.xor w19, w19, w19
+    jal  ra, unbitslice
+
+    /* y = gamma1 - u on share 0, -u on share 1. */
+    li     t0, 4
+    la     t2, gamma1_vec_const
+    bn.lid t0, 0(t2)
+
+    lw   a0, 0(sp)
+    li   t0, 0
+    addi t1, a0, 0
+    loopi 32, 3
+        bn.lid t0, 0(t1)
+        bn.subvm.8s w0, w4, w0
+        bn.sid t0, 0(t1++)
+
+    /* Whitening */
+    bn.xor w0, w0, w0
+    lw   a0, 0(sp)
+    addi t1, a0, 1024
+    loopi 32, 3
+        bn.lid t0, 0(t1)
+        bn.subvm.8s w0, w31, w0
+        bn.sid t0, 0(t1++)
+
+    bn.mov w16, w28
+    bn.mov w22, w29
+    bn.mov w23, w30
+
+    addi sp, sp, SP_FRAME
+    ret
+
+
+/* Per-share unpack (caller pre-loads w5 = polyz_unpack_mask). */
+_unpack_share:
+    addi t1, a0, 0
+    addi t6, a1, 0
+    li   t2, 2
+    li   t0, 6
+    li   t3, 3
+
+#if POLYZ_BITS == 18
+    /* L2: 2 outer x 16 inner unpacks (144 raw bits each). */
+    loopi 2, 42
+        bn.lid  t0, 0(t6++)
+        bn.mov  w1, w6
+        jal     x1, _unpack_inner
+
+        bn.lid  t3, 0(t6++)
+        bn.rshi w1, w3, w6 >> 144
+        jal     x1, _unpack_inner
+
+        bn.rshi w1, w31, w3 >> 32
+        jal     x1, _unpack_inner
+
+        bn.lid  t0, 0(t6++)
+        bn.rshi w1, w6, w3 >> 176
+        jal     x1, _unpack_inner
+
+        bn.rshi w1, w31, w6 >> 64
+        jal     x1, _unpack_inner
+
+        bn.lid  t3, 0(t6++)
+        bn.rshi w1, w3, w6 >> 208
+        jal     x1, _unpack_inner
+
+        bn.rshi w1, w31, w3 >> 96
+        jal     x1, _unpack_inner
+
+        bn.lid  t0, 0(t6++)
+        bn.rshi w1, w6, w3 >> 240
+        jal     x1, _unpack_inner
+
+        bn.lid  t3, 0(t6++)
+        bn.rshi w1, w3, w6 >> 128
+        jal     x1, _unpack_inner
+
+        bn.rshi w1, w31, w3 >> 16
+        jal     x1, _unpack_inner
+
+        bn.lid  t0, 0(t6++)
+        bn.rshi w1, w6, w3 >> 160
+        jal     x1, _unpack_inner
+
+        bn.rshi w1, w31, w6 >> 48
+        jal     x1, _unpack_inner
+
+        bn.lid  t3, 0(t6++)
+        bn.rshi w1, w3, w6 >> 192
+        jal     x1, _unpack_inner
+
+        bn.rshi w1, w31, w3 >> 80
+        jal     x1, _unpack_inner
+
+        bn.lid  t0, 0(t6++)
+        bn.rshi w1, w6, w3 >> 224
+        jal     x1, _unpack_inner
+
+        bn.rshi w1, w31, w6 >> 112
+        jal     x1, _unpack_inner
+        nop
+
+    ret
+
+#elif POLYZ_BITS == 20
+    /* L3/L5: 4 outer x 8 inner unpacks (160 raw bits each). */
+    loopi 4, 22
+        bn.lid  t0, 0(t6++)
+        bn.mov  w1, w6
+        jal     x1, _unpack_inner
+
+        bn.lid  t3, 0(t6++)
+        bn.rshi w1, w3, w6 >> 160
+        jal     x1, _unpack_inner
+
+        bn.rshi w1, w31, w3 >> 64
+        jal     x1, _unpack_inner
+
+        bn.lid  t0, 0(t6++)
+        bn.rshi w1, w6, w3 >> 224
+        jal     x1, _unpack_inner
+
+        bn.lid  t3, 0(t6++)
+        bn.rshi w1, w3, w6 >> 128
+        jal     x1, _unpack_inner
+
+        bn.rshi w1, w31, w3 >> 32
+        jal     x1, _unpack_inner
+
+        bn.lid  t0, 0(t6++)
+        bn.rshi w1, w6, w3 >> 192
+        jal     x1, _unpack_inner
+
+        bn.rshi w1, w31, w6 >> 96
+        jal     x1, _unpack_inner
+        nop
+
+    ret
+#endif
+
+/* Inner: extract 8 coefs from w1, mask, store at t1++. */
+_unpack_inner:
+    loopi 8, 2
+        bn.rshi w2, w1, w2 >> 32
+        bn.rshi w1, w31, w1 >> POLYZ_BITS
+    bn.and w2, w2, w5
+    bn.sid t2, 0(t1++)
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/poly_rej_samp_bitsliced.s
+++ b/sw/acc/crypto/mldsa/gadgets/poly_rej_samp_bitsliced.s
@@ -1,0 +1,120 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x5,  t0
+.equ x6,  t1
+.equ x10, a0
+.equ x11, a1
+.equ x14, a4
+.equ x30, t5
+
+#ifndef TEST
+  #define TEST 0
+#endif
+
+#define MLDSA_KBITS 23
+
+/*
+ * Name: poly_rej_samp_bitsliced (ML-DSA)
+ *
+ * Sample 256 coefficients uniform in [0, q), q = 8380417, in bitsliced
+ * layout.
+ * Source: URND.  Re-draws until all 256 lanes < q check.
+ *
+ * Per-batch accept probability (Python):
+ *     p_batch = (8380417 / 2**23) ** 256  # ~ 0.77873, so ~ 1.28 draws expected
+ *
+ * @param[in]      a0: ptr_r, dmem output (k * 32 bytes).
+ * @param[in]      a1: (TEST=1 only) deterministic random stream pointer.
+ * @param[in]  w31: all-zero.
+ *
+ * clobbered registers: x5 to x6, x14, x30, w0 to w23
+ * clobbered flag groups: FG0
+ */
+.globl poly_rej_samp_bitsliced
+poly_rej_samp_bitsliced:
+_prs_bs_draw:
+#if TEST == 0
+    bn.wsrr w0,  URND
+    bn.wsrr w1,  URND
+    bn.wsrr w2,  URND
+    bn.wsrr w3,  URND
+    bn.wsrr w4,  URND
+    bn.wsrr w5,  URND
+    bn.wsrr w6,  URND
+    bn.wsrr w7,  URND
+    bn.wsrr w8,  URND
+    bn.wsrr w9,  URND
+    bn.wsrr w10, URND
+    bn.wsrr w11, URND
+    bn.wsrr w12, URND
+    bn.wsrr w13, URND
+    bn.wsrr w14, URND
+    bn.wsrr w15, URND
+    bn.wsrr w16, URND
+    bn.wsrr w17, URND
+    bn.wsrr w18, URND
+    bn.wsrr w19, URND
+    bn.wsrr w20, URND
+    bn.wsrr w21, URND
+    bn.wsrr w22, URND
+#else
+    /* TEST=1: read k WDRs from a1 in place of URND. */
+    li   t0, 0
+    li   t1, MLDSA_KBITS
+    loop t1, 2
+        bn.lid t0, 0(a1++)
+        addi   t0, t0, 1
+#endif
+
+    /* Per-lane v < q check: bit k of v + (2^k - q) is 0 iff v < q.
+     * With (2^k - q) = 0x1FFF (bits 0..12 = 1, bits 13..22 = 0), the
+     * carry chain collapses to:
+     *   bits 0..12  (const = 1):  c_{b+1} = v_b OR  c_b
+     *   bits 13..22 (const = 0):  c_{b+1} = v_b AND c_b
+     * Starting c_0 = 0, accept iff the folded c_23 (in w23) is all-zero.
+     *
+     * Probability that a random draw passes for all lanes is
+     *  (8380417 / 2**23) ** 256  = 0.77873, so ~ 1.28 draws expected
+     */
+    bn.or  w23, w0,  w1
+    bn.or  w23, w23, w2
+    bn.or  w23, w23, w3
+    bn.or  w23, w23, w4
+    bn.or  w23, w23, w5
+    bn.or  w23, w23, w6
+    bn.or  w23, w23, w7
+    bn.or  w23, w23, w8
+    bn.or  w23, w23, w9
+    bn.or  w23, w23, w10
+    bn.or  w23, w23, w11
+    bn.or  w23, w23, w12
+
+    bn.and w23, w23, w13
+    bn.and w23, w23, w14
+    bn.and w23, w23, w15
+    bn.and w23, w23, w16
+    bn.and w23, w23, w17
+    bn.and w23, w23, w18
+    bn.and w23, w23, w19
+    bn.and w23, w23, w20
+    bn.and w23, w23, w21
+    bn.and w23, w23, w22
+
+    /* Redraw if any lane >= q (w23 != 0). */
+    csrrs  a4, 0x7C0, x0
+    andi   a4, a4, 8
+    beq    a4, x0, _prs_bs_draw
+
+    /* Store w0..w22 to output. */
+    addi t5, a0, 0
+    li   t0, 0
+    li   t1, MLDSA_KBITS
+    loop t1, 2
+        bn.sid t0, 0(t5++)
+        addi   t0, t0, 1
+
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/scratch.s
+++ b/sw/acc/crypto/mldsa/gadgets/scratch.s
@@ -1,0 +1,11 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* 1 KiB scratch in the bus-inaccessible DMEM scratchpad, used by the masking
+ * gadgets. */
+.section .scratchpad, "aw"
+.balign 32
+.globl scratch
+scratch:
+    .zero 1024

--- a/sw/acc/crypto/mldsa/gadgets/seca2bmodq_bc22.s
+++ b/sw/acc/crypto/mldsa/gadgets/seca2bmodq_bc22.s
@@ -1,0 +1,107 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x1,  ra
+.equ x2,  sp
+.equ x5,  t0
+.equ x6,  t1
+.equ x7,  t2
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x15, a5
+.equ x16, a6
+.equ x17, a7
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+.equ w31, bn0
+
+#define MLDSA_KBITS         23
+#define MLDSA_KBITS_PLUS_1  24
+#define SHARE_STR_BYTES     768    /* (k+1) * 32 */
+
+/*
+ * Name: seca2bmodq_bc22 (PINI, d = 2)
+ *
+ * Convert a 2-share arithmetic sharing of x mod p (x^A_p) into a 2-share
+ * Boolean sharing z^{B,k}.  Implements [BC22] Alg.10 (SecA2BModp).
+ *
+ * Alg.10 (lines (n) are no-ops in the d = 2 path):
+ *  (1)  if d = 1 then
+ *  (2)    z^{B,k}   <- x^A_p
+ *   3:  else
+ *  (4)    y^{B,k}   <- SecA2BModp^1_k(x^A_p[0])             . d=1 recursion = identity
+ *  (5)    y'^{B,k}  <- SecA2BModp^1_k(x^A_p[1])             . d=1 recursion = identity
+ *   6:    p^{B,k+1} <- (2^{k+1} - p, 0)                     . immediate 0x801FFF
+ *   7:    s^{B,k+1} <- SecAdd^1_{k+1}(p^{B,k+1}, y^{B,k})
+ *   8:    s^{B,k+1} <- (y^{B,k+1}, 0)                       . expand to d shares
+ *   9:    s'^{B,k}  <- (0, y'^{B,k})                        . expand to d shares
+ *  10:    u^{B,k+1} <- SecAdd^d_{k+1}(s^{B,k+1}, s'^{B,k})
+ *  11:    b^{B,1}   <- u^{B,k+1}[k]
+ *  12:    a^{B,k}   <- BitCopyMask^d_k(b^{B,1}, p)
+ *  13:    z^{B,k}   <- SecAdd^d_k(a^{B,k}, u^{B,k+1})
+ *
+ * @param[in]   x10: dptr_z, output ((k+1) * 2 * 32 bytes, bit k = 0).
+ * @param[in]   x11: dptr_x, input  ((k+1) * 2 * 32 bytes, bit k = 0).
+ * @param[in]   x13: dptr_scratch, 1536 B caller-provided scratch (must not
+ *                   overlap z_in/z_out or any live caller buffer).
+ * @param[in]   w31: all-zero.
+ *
+ * clobbered registers: x2, x5 to x7, x10 to x17, x28 to x31, w0 to w23
+ * clobbered flag groups: FG0
+ */
+.globl seca2bmodq_bc22
+seca2bmodq_bc22:
+    addi sp, sp, -32
+    sw   a3, 0(sp)                 /* preserve scratch across secadd calls */
+    addi a7, a0, 0                 /* park z_out */
+
+    /* Step 9: s'^{B,k} <- (0, y'^{B,k}). */
+    addi t3, a1, SHARE_STR_BYTES
+    addi t1, a3, 0
+    li   t2, 31
+    loopi MLDSA_KBITS_PLUS_1, 1
+        bn.sid t2, 0(t1++)
+    bn.xor w0, w0, w0              /* whitening */
+    li   t2, 0
+    loopi MLDSA_KBITS_PLUS_1, 2
+        bn.lid t2, 0(t3++)
+        bn.sid t2, 0(t1++)
+    bn.xor w0, w0, w0              /* whitening */
+
+    /* Step 7: s^{B,k+1} <- SecAdd^1_{k+1}(p^{B,k+1}, y^{B,k}). */
+    addi a0, a1, 0
+    li   a2, MLDSA_KBITS
+    li   a3, MLDSA_KBITS_PLUS_1
+    addi a6, a7, 0
+    jal  x1, secadd_bc22_immd_d1
+
+    /* Step 8: s^{B,k+1} <- (y^{B,k+1}, 0). */
+    addi t1, a7, SHARE_STR_BYTES
+    li   t2, 31
+    loopi MLDSA_KBITS_PLUS_1, 1
+        bn.sid t2, 0(t1++)
+
+    /* Step 10: u^{B,k+1} <- SecAdd^d_{k+1}(s^{B,k+1}, s'^{B,k}). */
+    lw   a0, 0(sp)
+    addi a1, a7, 0
+    li   a2, MLDSA_KBITS_PLUS_1
+    li   a3, SHARE_STR_BYTES
+    li   a4, 2
+    addi a5, a7, 0
+    jal  x1, secadd_bc22
+
+    /* Steps 11-13 (fused): z^{B,k} <- u + BitCopyMask^d_k(u^{B,k+1}[k], p). */
+    addi a0, a7, 0
+    jal  x1, secadd_constant_bmsk_mldsa
+
+    addi sp, sp, 32
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/secadd_bc22.s
+++ b/sw/acc/crypto/mldsa/gadgets/secadd_bc22.s
@@ -1,0 +1,133 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+/* Register aliases */
+.equ x0, zero
+.equ x2, sp
+.equ x3, fp
+.equ x5, t0
+.equ x6, t1
+.equ x7, t2
+.equ x8, s0
+.equ x9, s1
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x15, a5
+.equ x16, a6
+.equ x17, a7
+.equ x18, s2
+.equ x19, s3
+.equ x20, s4
+.equ x21, s5
+.equ x22, s6
+.equ x23, s7
+.equ x24, s8
+.equ x25, s9
+.equ x26, s10
+.equ x27, s11
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+.equ w31, bn0
+
+/*
+ * Name: secadd_bc22 (PINI)
+ *
+ * Return Boolean shares of a value r = (x + y) mod 2^k, given Boolean shares of
+ * x and y mod 2^k.
+ * Bitsliced.
+ *
+ * Source: Alg.6 [BC22]
+ *         [BC22]: "Bitslicing Arithmetic/Boolean Masking Conversions for Fun and Profit: with Application to Lattice-Based KEMs"
+ *         Link: https://tches.iacr.org/index.php/TCHES/article/view/9831
+ *
+ * @param[in]  x10: dptr_x, dmem pointer to Boolean shares of x
+ * @param[in]  x11: dptr_y, dmem pointer to Boolean shares of y
+ * @param[in]  x12: k, bitsize of x and y.
+ * @param[in]  x13: share stride, distance between shares
+ * @param[in]  x14: nshares, the number of shares
+ * @param[out] x15: dptr_r, dmem pointer to the output Boolean shares of r
+ *
+ * clobbered registers: x2 to x13, x15 to x16, x18 to x22, x28 to x31, w0 to w10
+ * clobbered flag groups: FG0
+ */
+.globl secadd_bc22
+secadd_bc22:
+    /* Save fp to stack */
+    addi sp, sp, -32
+    sw   fp, 0(sp)
+    addi fp, sp, 0
+
+    /* Save registers. */
+    sw s0, 4(fp)
+
+    /* Adjust stack for temporary variable c. */
+    loop a4, 1
+        addi sp, sp, -32 /* ptr_c */
+
+    /* Initialize c = 0. */
+    bn.xor w0, w0, w0
+    addi   t0, sp, 0 /* ptr_c */
+    loop a4, 1
+        bn.sid x0, 0(t0++)
+
+    /* Ripple-carry adder. */
+    addi s0, a2, -1
+    /* Loop over i = 0, ..., k-2. */
+    loop s0, 4
+        /* a0 already points to x[i] */
+        /* a1 already points to y[i] */
+        addi a2, sp, 0 /* ptr_c */
+        /* a3 is already share stride. */
+        /* a4 is already nshares. */
+        /* a5 already points to r. */
+        addi a6, sp, 0 /* ptr_c */
+        jal  x1, secfulladder_bc22
+        /* After secfulladder_bc22:
+         *  - a0 and a1 points to x[i + 1] and y[i + 1].
+         *  - a3 is still share stride.
+         *  - a4 is still nshares.
+         *  - a5 points to r[i + 1].
+         *  - a6 points to c. */
+        nop
+
+    /* Handle top bit i = k-1. */
+    /* Compute r[k-1] = x[k-1] ^ y[k-1] ^ c. */
+    addi t0, sp, 0 /* ptr_c */
+    addi x4, x0, 1
+    addi t1, x0, 2
+    addi t2, x0, 3
+    loop a4, 13
+        /* Whitening. */
+        bn.xor w0, w0, w0
+        bn.xor w1, w1, w1
+        bn.xor w2, w2, w2
+        bn.xor w3, w3, w3
+        /* Computation. */
+        bn.lid x0, 0(a0)
+        bn.lid x4, 0(a1)
+        bn.lid t1, 0(t0++)
+        bn.xor w3, w0, w1
+        bn.xor w3, w3, w2
+        bn.sid t2, 0(a5)
+        /* Adjust addresses. */
+        add    a0, a0, a3
+        add    a1, a1, a3
+        add    a5, a5, a3
+
+    /* Restore registers. */
+    lw s0, 4(fp)
+
+    /* Restore sp and fp. */
+    addi sp, fp, 0
+    lw   fp, 0(sp)
+    addi sp, sp, 32
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/secadd_bc22_immd_d1.s
+++ b/sw/acc/crypto/mldsa/gadgets/secadd_bc22_immd_d1.s
@@ -1,0 +1,104 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x0, zero
+.equ x1, ra
+.equ x2, sp
+.equ x5, t0
+.equ x6, t1
+.equ x7, t2
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x16, a6
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+.equ w31, bn0
+
+/*
+ * Name: secadd_bc22_immd_d1
+ *
+ * Bitsliced SecAdd for d = 1 with y hard-coded to nq = 0x801FFF.  No
+ * DMEM scratch for y: nq is built into w7 lane 0 at function entry,
+ * then rotated 1 bit per iteration; per stripe the LSB of w7 is
+ * broadcast to 8 lanes via bn.cmp + bn.sel.
+ *
+ * @param[in]   x10: dptr_x, kbits * 32 B
+ * @param[in]   x12: kbits
+ * @param[in]   x13: kbits_out (kbits or kbits+1)
+ * @param[out]  x16: dptr_z, kbits_out * 32 B
+ * @param[in]   w31: all-zero
+ *
+ * clobbered registers: x5 to x7, x28 to x31, w0 to w8
+ * clobbered flag groups: FG0
+ */
+.globl secadd_bc22_immd_d1
+secadd_bc22_immd_d1:
+    li   t0, 0
+    li   t1, 1
+    li   t2, 2
+    li   t4, 4
+
+    bn.not w6, w31                /* w6 = all-ones */
+
+    /* Build nq = 0x801FFF in w7 lane 0 (= 2^23 + 2^13 - 1). */
+    bn.xor w7, w7, w7
+    bn.addi w7, w7, 1
+    bn.shv.8S w7, w7 << 23        /* lane 0 = 0x800000 */
+    bn.xor w8, w8, w8
+    bn.addi w8, w8, 1
+    bn.shv.8S w8, w8 << 13        /* w8 lane 0 = 0x2000 */
+    bn.subi w8, w8, 1             /* w8 lane 0 = 0x1FFF */
+    bn.add w7, w7, w8             /* w7 lane 0 = 0x801FFF */
+
+    bn.xor w8, w8, w8
+    bn.addi w8, w8, 1             /* w8 = 1 (lane 0 bit 0) */
+
+    /* Bit 0. */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    bn.lid t1, 0(a0++)
+    bn.and w3, w7, w8
+    bn.cmp w3, w31
+    bn.sel w2, w31, w6, FG0.Z
+    bn.rshi w7, w31, w7 >> 1
+    bn.xor w4, w1, w2
+    bn.sid t4, 0(a6++)
+    bn.and w0, w1, w2
+
+    /* Bits 1..kbits-1. */
+    addi t6, a2, -1
+    loop t6, 11
+        bn.lid t1, 0(a0++)
+        bn.and w3, w7, w8
+        bn.cmp w3, w31
+        bn.sel w2, w31, w6, FG0.Z
+        bn.rshi w7, w31, w7 >> 1
+        bn.xor w3, w1, w2
+        bn.xor w4, w3, w0
+        bn.sid t4, 0(a6++)
+        bn.and w5, w1, w2
+        bn.and w0, w0, w3
+        bn.xor w0, w0, w5
+
+    /* kbits_out == kbits: drop final carry. */
+    beq  a3, a2, _secadd_bc22_immd_d1_done
+
+    /* kbits_out == kbits + 1: z[kbits] = carry ^ y[kbits]. */
+    bn.and w3, w7, w8
+    bn.cmp w3, w31
+    bn.sel w2, w31, w6, FG0.Z
+    bn.xor w4, w0, w2
+    bn.sid t4, 0(a6)
+
+_secadd_bc22_immd_d1_done:
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/secadd_bc22_immd_d2.s
+++ b/sw/acc/crypto/mldsa/gadgets/secadd_bc22_immd_d2.s
@@ -1,0 +1,118 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x0, zero
+.equ x1, ra
+.equ x2, sp
+.equ x5, t0
+.equ x6, t1
+.equ x7, t2
+.equ x8, s0
+.equ x9, s1
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x15, a5
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+.equ w31, bn0
+
+/*
+ * Name: secadd_bc22_immd_d2 (PINI, d = 2)
+ *
+ * Inline d=2 SecAdd of x with a public k-bit constant in w17 lane 0.
+ *
+ * @param[in]  x10: dptr_x, k * 2 * 32 B
+ * @param[in]  x12: k, bitsize
+ * @param[in]  x13: share stride (= k * 32)
+ * @param[in]  x14: nshares (must be 2)
+ * @param[out] x15: dptr_z, k * 2 * 32 B
+ * @param[in]  w17: lane-0 holds the constant
+ * @param[in]  w31: all-zero
+ *
+ * clobbered registers: x5 to x7, x10 to x16, x28 to x31, w0 to w19
+ * clobbered flag groups: FG0
+ */
+.globl secadd_bc22_immd_d2
+secadd_bc22_immd_d2:
+    add  t4, a0, a3                /* t4 = x share 1 ptr */
+    add  t5, a5, a3                /* t5 = z share 1 ptr */
+
+    bn.not w19, w31                /* wONES */
+    bn.xor w18, w18, w18
+    bn.addi w18, w18, 1            /* wMASK = lane-0 bit 0 */
+
+    bn.xor w12, w12, w12           /* c_0 = 0 */
+    bn.xor w13, w13, w13           /* c_1 = 0 */
+
+    li   t0, 1                     /* x_0 -> w1 */
+    li   t1, 2                     /* x_1 -> w2 */
+    li   t2, 10                    /* r_0 idx (= w10) */
+    li   t3, 11                    /* r_1 idx (= w11) */
+
+    addi t6, a2, 0
+    loop t6, 39
+        /* Derive y_bit. */
+        bn.and w0, w17, w18
+        bn.cmp w0, w31
+        bn.sel w3, w31, w19, FG0.Z
+        bn.rshi w17, w31, w17 >> 1
+
+        /* Share 0: a_0 = x_0 ^ y_bit, t_0 = x_0 ^ c_0, r_0 = c_0 ^ a_0. */
+        bn.xor w1, w1, w1
+        bn.lid t0, 0(a0)
+        bn.xor w4, w1, w3
+        bn.xor w6, w1, w12
+        bn.xor w10, w12, w4
+        bn.sid t2, 0(a5)
+
+        /* Inter-share whitening. */
+        bn.xor w0, w0, w0
+
+        /* Share 1: a_1 = x_1, t_1 = x_1 ^ c_1, r_1 = c_1 ^ a_1. */
+        bn.xor w2, w2, w2
+        bn.lid t1, 0(t4)
+        bn.mov w5, w2
+        bn.xor w7, w2, w13
+        bn.xor w11, w13, w5
+        bn.sid t3, 0(t5)
+
+        /* SecAnd(a_0,a_1; t_0,t_1) -> (u_0, u_1). */
+        bn.wsrr w14, urnd
+        bn.xor w16, w7, w14
+        bn.and w16, w16, w4
+        bn.not w15, w4
+        bn.and w15, w15, w14
+        bn.xor w15, w15, w16
+        bn.and w8, w4, w6
+        bn.xor w8, w8, w15
+
+        bn.xor w0, w0, w0
+
+        bn.xor w16, w6, w14
+        bn.and w16, w16, w5
+        bn.not w15, w5
+        bn.and w15, w15, w14
+        bn.xor w15, w15, w16
+        bn.and w9, w5, w7
+        bn.xor w9, w9, w15
+
+        /* New carry: c = x ^ u. */
+        bn.xor w12, w1, w8
+        bn.xor w13, w2, w9
+
+        /* Advance pointers. */
+        addi a0, a0, 32
+        addi t4, t4, 32
+        addi a5, a5, 32
+        addi t5, t5, 32
+
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/secadd_constant_bmsk_mldsa.s
+++ b/sw/acc/crypto/mldsa/gadgets/secadd_constant_bmsk_mldsa.s
@@ -1,0 +1,125 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x1,  ra
+.equ x2,  sp
+.equ x5,  t0
+.equ x6,  t1
+.equ x7,  t2
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+.equ w31, bn0
+
+#define MLDSA_KBITS       23
+#define SHARE_STR_BYTES   768    /* (k+1) * 32 */
+
+/*
+ * Name: secadd_constant_bmsk_mldsa (PINI)
+ *
+ * Fused steps 5+6 of [BC22] Alg.7 specialised for ML-DSA q at d = 2:
+ *   z <- sp + BitCopyMask(sp[k], q)        (in-place over dptr_z)
+ *
+ * Per-bit unrolled per q = 0x7FE001 run structure (bit 0 + bits 1..12 +
+ * bits 13..22).  Bit k of z is zeroed.
+ *
+ * @param[in]   x10: dptr_z, in/out ((k+1) * 2 * 32 bytes, bit k = 0 on exit).
+ * @param[in]   w31: all-zero.
+ *
+ * clobbered registers: x5 to x7, x10 to x14, x28 to x31, w0 to w23
+ * clobbered flag groups: FG0
+ */
+
+/* WDR layout: w20/w21 = b[0]/b[1]; w22/w23 = carry[0]/[1]. */
+
+.macro BMSK_BIT_C0
+    bn.lid  t0, 0(a0)
+    bn.lid  t1, 0(a1)
+    bn.xor  w8, w22, w4            /* z = c ^ sp */
+    bn.xor  w9, w23, w5
+    bn.sid  t2, 0(a0++)
+    bn.sid  t3, 0(a1++)
+    /* c' = SecAnd(c, sp). */
+    bn.and  w12, w22, w4
+    bn.and  w13, w23, w5
+    bn.wsrr w14, urnd
+    bn.and  w15, w22, w5
+    bn.xor  w15, w15, w14
+    bn.and  w16, w23, w4
+    bn.xor  w16, w16, w14
+    bn.xor  w22, w12, w15
+    bn.xor  w23, w13, w16
+.endm
+
+.macro BMSK_BIT_C1
+    bn.lid  t0, 0(a0)
+    bn.lid  t1, 0(a1)
+    bn.xor  w6, w4, w20            /* xpy = sp ^ b */
+    bn.xor  w7, w5, w21
+    bn.xor  w8, w22, w6            /* z = c ^ xpy */
+    bn.xor  w9, w23, w7
+    bn.sid  t2, 0(a0++)
+    bn.sid  t3, 0(a1++)
+    bn.xor  w10, w4, w22           /* xpc = sp ^ c */
+    bn.xor  w11, w5, w23
+    /* c' = sp ^ SecAnd(xpy, xpc). */
+    bn.and  w12, w6, w10
+    bn.and  w13, w7, w11
+    bn.wsrr w14, urnd
+    bn.and  w15, w6, w11
+    bn.xor  w15, w15, w14
+    bn.and  w16, w7, w10
+    bn.xor  w16, w16, w14
+    bn.xor  w12, w12, w15
+    bn.xor  w13, w13, w16
+    bn.xor  w22, w4, w12
+    bn.xor  w23, w5, w13
+.endm
+
+.globl secadd_constant_bmsk_mldsa
+secadd_constant_bmsk_mldsa:
+    /* WDR id registers. */
+    li   t0, 4
+    li   t1, 5
+    li   t2, 8
+    li   t3, 9
+    li   t4, 20
+    li   t5, 21
+    li   t6, 31
+
+    addi a1, a0, SHARE_STR_BYTES
+
+    /* Load b = sp[k]; zero carry. */
+    li   a2, MLDSA_KBITS
+    slli a2, a2, 5
+    add  a3, a0, a2
+    add  a4, a1, a2
+    bn.lid t4, 0(a3)
+    bn.lid t5, 0(a4)
+    bn.xor w22, w22, w22
+    bn.xor w23, w23, w23
+
+    /* bit 0 (q=1) */
+    BMSK_BIT_C1
+    /* bits 1..12 (q=0) */
+    loopi 12, 15
+        BMSK_BIT_C0
+    /* bits 13..22 (q=1) */
+    loopi 10, 21
+        BMSK_BIT_C1
+
+    /* Zero z[k]. */
+    bn.sid t6, 0(a3)
+    bn.sid t6, 0(a4)
+
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/secaddmodq_bc22.s
+++ b/sw/acc/crypto/mldsa/gadgets/secaddmodq_bc22.s
@@ -1,0 +1,89 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x1,  ra
+.equ x2,  sp
+.equ x5,  t0
+.equ x6,  t1
+.equ x7,  t2
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x15, a5
+.equ x16, a6
+.equ x17, a7
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+.equ w31, bn0
+
+#define MLDSA_KBITS         23
+#define MLDSA_KBITS_PLUS_1  24
+#define SHARE_STR_BYTES     768    /* (k+1) * 32 */
+
+/*
+ * Name: secaddmodq_bc22 (PINI)
+ *
+ * Compute Boolean sharing z = (x + y) mod q from k-bit Boolean sharings of
+ * x, y with 0 <= x, y < q.  Implements [BC22] Alg.7 (SecAddModp):
+ *   1: nq^{B,k+1} <- (2^{k+1} - q, 0, ..., 0)   (immediate 0x801FFF)
+ *   2: s^{B,k+1}  <- SecAdd(x^{B,k}, y^{B,k})
+ *   3: sp^{B,k+1} <- SecAdd(s, nq)
+ *   4: b^{B,1}    <- sp[k]
+ *   5: a^{B,k}    <- BitCopyMask(b, q)
+ *   6: z^{B,k}    <- SecAdd(a, sp)
+ *
+ * Steps 4+5+6 are fused inside `secadd_constant_bmsk_mldsa`.
+ *
+ * Limitations: ML-DSA only (q = 0x7FE001 hardcoded; matches external nq).
+ *              d = 2 only (via `secadd_constant_bmsk_mldsa`).
+ *
+ * @param[in]   x10: dptr_z, output ((k+1) * nshares * 32 bytes, bit k = 0).
+ * @param[in]   x11: dptr_x, input  ((k+1) * nshares * 32 bytes, bit k = 0).
+ * @param[in]   x12: dptr_y, input  ((k+1) * nshares * 32 bytes, bit k = 0).
+ * @param[in]   x14: nshares.
+ * @param[in]   w31: all-zero.
+ *
+ * clobbered registers: x5 to x7, x10 to x17, x28 to x31, w0 to w23
+ * clobbered flag groups: FG0
+ */
+.globl secaddmodq_bc22
+secaddmodq_bc22:
+    addi a7, a0, 0                /* park z_out in a7 */
+
+    /* Step 2: s = SecAdd(x, y) -> z_out. */
+    addi a0, a1, 0
+    addi a1, a2, 0
+    li   a2, MLDSA_KBITS_PLUS_1
+    li   a3, SHARE_STR_BYTES
+    addi a5, a7, 0
+    jal  x1, secadd_bc22
+
+    /* Step 3: sp = SecAdd(s, nq) -> z_out, in place. */
+    bn.xor w17, w17, w17
+    bn.addi w17, w17, 1
+    bn.shv.8S w17, w17 << 23
+    bn.xor w18, w18, w18
+    bn.addi w18, w18, 1
+    bn.shv.8S w18, w18 << 13
+    bn.subi w18, w18, 1
+    bn.add w17, w17, w18           /* w17 lane 0 = nq = 0x801FFF */
+    addi a0, a7, 0
+    li   a2, MLDSA_KBITS_PLUS_1
+    li   a3, SHARE_STR_BYTES
+    li   a4, 2
+    addi a5, a7, 0
+    jal  x1, secadd_bc22_immd_d2
+
+    /* Step 4+5+6: z = sp + BitCopyMask(sp[k], q) -> z_out, in-place. */
+    addi a0, a7, 0
+    jal  x1, secadd_constant_bmsk_mldsa
+
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/secand_cs20.s
+++ b/sw/acc/crypto/mldsa/gadgets/secand_cs20.s
@@ -1,0 +1,195 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+/* Register aliases */
+.equ x0, zero
+.equ x2, sp
+.equ x3, fp
+.equ x5, t0
+.equ x6, t1
+.equ x7, t2
+.equ x8, s0
+.equ x9, s1
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x15, a5
+.equ x16, a6
+.equ x17, a7
+.equ x18, s2
+.equ x19, s3
+.equ x20, s4
+.equ x21, s5
+.equ x22, s6
+.equ x23, s7
+.equ x24, s8
+.equ x25, s9
+.equ x26, s10
+.equ x27, s11
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+.equ w31, bn0
+
+/*
+ * Name: secand_cs20 (PINI)
+ *
+ * Return new Boolean shares of a value r = x & y.
+ * Bitsliced.
+ *
+ * Source: Alg.2 in [CS20]
+ *         [CS20]: "Trivially and Efficiently Composing Masked Gadgets With Probe Isolating Non-Interference"
+ *         Link: https://ieeexplore.ieee.org/document/8979162/
+ *
+ * @param[in]  x10: dptr_xb, dmem pointer to the input Boolean shares of x
+ * @param[in]  x11: share stride, distance between shares of x
+ * @param[in]  x12: dptr_yb, dmem pointer to the input Boolean shares of y
+ * @param[in]  x13: share stride, distance between shares of y
+ * @param[in]  x14: nshares, the number of shares
+ * @param[in]  x15: output_share_str, distance between shares of the output
+ * @param[out] x16: dptr_rb, dmem pointer to the output Boolean shares of r
+ *
+ * clobbered registers: x2 to x10, x12, x16, x18 to x19, x28 to x31, w0 to w8
+ * clobbered flag groups: FG0
+ */
+.globl secand_cs20
+secand_cs20:
+    /* Save fp to stack */
+    addi sp, sp, -32
+    sw   fp, 0(sp)
+    addi fp, sp, 0
+
+    /* Save registers. */
+    sw  s0, 4(fp)
+    sw  s1, 8(fp)
+    sw  s2, 12(fp)
+    sw  s3, 16(fp)
+    addi s0, a0, 0
+    addi s1, a2, 0
+    addi s2, a6, 0
+
+    /* Adjust sp to accommodate temporary variable tb. */
+    loop a4, 1
+        add sp, sp, -32 /* ptr_tb */
+
+    /* Save input addresses. */
+    addi t0, sp, 0
+    addi x4, x0, 1
+    addi t1, x0, 2
+    /* Compute tb[i] = xb[i] & yb[i]. */
+    loop a4, 9
+        /* Whitening since we're accessing other shares in subsequent iterations. */
+        bn.xor w0, w0, w0
+        bn.xor w1, w1, w1
+        bn.xor w2, w2, w2
+        bn.lid x0, 0(a0)
+        bn.lid x4, 0(a2)
+        bn.and w2, w0, w1
+        bn.sid t1, 0(t0++)
+        add    a0, a0, a1
+        add    a2, a2, a3
+
+    #define wzij w0
+    #define wzji w5
+    #define wtmp0 w6
+    #define wtmp1 w7
+    #define wr w8
+    addi a0, s0, 0
+    addi a2, s1, 0
+    /* Compute the number of iterations of the outer loop: the last share is not counted. */
+    addi t0, a4, -1
+    /* Compute the number of iterations of the inner loop: the first share is not counted. */
+    addi t2, a4, -1
+    /* Compute address of tb. */
+    addi t4, sp, 0
+    /* Outer loop i = 1,...,nshares-1 */
+    loop t0, 41
+        /* Whitening since we're accessing other shares in subsequent iterations. */
+        bn.xor w0, w0, w0
+        bn.xor w1, w1, w1
+        bn.xor w2, w2, w2
+        /* Load data. */
+        bn.lid x0, 0(t4) /* w0 = tb[i] */
+        bn.lid x4, 0(a0) /* w1 = xb[i] */
+        bn.lid t1, 0(a2) /* w2 = yb[i] */
+        /* Point to next share. */
+        add a0, a0, a1
+        add a2, a2, a3
+        add t5, a0, 0
+        add t6, a2, 0
+        add s3, t4, 32
+        /* Inner loop j = i + 1,...,nshares. */
+        loop t2, 26
+            addi    t3, x0, 3
+            bn.wsrr wr, urnd
+            /* Whitening since we're accessing other shares in subsequent iterations. */
+            bn.xor  w3, w3, w3
+            bn.xor  w4, w4, w4
+            bn.xor  wzji, wzji, wzji
+            /* PINI */
+            bn.lid  t3++, 0(t5) /* w3 = xb[j] */
+            bn.lid  t3++, 0(t6) /* w4 = yb[j] */
+            /* Handle wzij. */
+            bn.xor  wtmp1, w4, wr /* wtmp1 = yb[j] ^ r */
+            bn.and  wtmp1, w1, wtmp1 /* wtmp1 &= xb[i] */
+            bn.not  wtmp0, w1 /* wtmp0 = xb[i] ^ 1 */
+            bn.and  wtmp0, wtmp0, wr /* wtmp0 &= r */
+            bn.xor  wtmp0, wtmp0, wtmp1 /* wtmp0 ^= wtmp1 */
+            bn.xor  wzij, wzij, wtmp0
+            /* Whitening. */
+            bn.xor  wtmp1, wtmp1, wtmp1
+            bn.xor  wtmp0, wtmp0, wtmp0
+            /* Handle wzji. */
+            bn.lid  t3, 0(s3) /* w5 = tb[j] */
+            bn.xor  wtmp1, w2, wr /* wtmp1 = yb[i] ^ r */
+            bn.and  wtmp1, w3, wtmp1 /* wtmp1 &= xb[j] */
+            bn.not  wtmp0, w3 /* wtmp0 = xb[j] ^ 1 */
+            bn.and  wtmp0, wtmp0, wr /* wtmp0 &= r */
+            bn.xor  wtmp0, wtmp0, wtmp1 /* wtmp0 ^= wtmp1 */
+            bn.xor  wzji, wzji, wtmp0
+            bn.sid  t3, 0(s3) /* Save tb[j]. */
+            /* Adjust addresses. */
+            add     t5, t5, a1
+            add     t6, t6, a3
+            add     s3, s3, 32
+        bn.sid x0, 0(t4) /* Save tb[i]. */
+        add    t4, t4, 32
+        /* Adjust inner loop according as outer loop moves on. We're safe here
+         * since j can never be 0: i will move (nshares - 2) steps forward,
+         * and j moves (nshares - 2) steps backward, meaning the minimum
+         * value of j is (nshares - 1) - (nshares - 2) = 1. */
+        addi t2, t2, -1
+
+    /* Copy tb to rb. */
+    addi t0, sp, 0
+    addi t1, s2, 0
+    loop a4, 5
+        /* Whitening since we're accessing other shares in subsequent iterations. */
+        bn.xor w0, w0, w0
+        bn.lid x0, 0(t0++)
+        bn.sid x0, 0(t1)
+        add    t1, t1, a5
+
+    /* We want a0, a2, a6 to point to next bit. */
+    addi a0, s0, 32
+    addi a2, s1, 32
+    addi a6, s2, 32
+
+    /* Restore registers. */
+    lw s0, 4(fp)
+    lw s1, 8(fp)
+    lw s2, 12(fp)
+    lw s3, 16(fp)
+
+    /* Restore sp and fp. */
+    addi sp, fp, 0
+    lw   fp, 0(sp)
+    addi sp, sp, 32
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/secand_cs20_d2.s
+++ b/sw/acc/crypto/mldsa/gadgets/secand_cs20_d2.s
@@ -1,0 +1,107 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+/* Register aliases */
+.equ x0, zero
+.equ x4, tp
+.equ x5, t0
+.equ x6, t1
+.equ x7, t2
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x15, a5
+.equ x16, a6
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+/*
+ * Name: secand_cs20 (PINI, d=2 only)
+ *
+ * Return new Boolean shares of a value r = x & y.
+ * Bitsliced.
+ *
+ * d=2 specialization of secand_cs20.s: hand-unrolled, no stack frame,
+ * tb[] kept in WDRs.  nshares (a4) is ignored.  Unlike the generic
+ * secand_cs20, a0/a2/a6 are not advanced on return.
+ *
+ * Source: Alg.2 in [CS20]
+ *         [CS20]: "Trivially and Efficiently Composing Masked Gadgets With Probe Isolating Non-Interference"
+ *         Link: https://ieeexplore.ieee.org/document/8979162/
+ *
+ * @param[in]  x10: dptr_xb, dmem pointer to the input Boolean shares of x
+ * @param[in]  x11: share stride, distance between shares of x
+ * @param[in]  x12: dptr_yb, dmem pointer to the input Boolean shares of y
+ * @param[in]  x13: share stride, distance between shares of y
+ * @param[in]  x14: nshares (ignored, fixed to 2)
+ * @param[in]  x15: output_share_str, distance between shares of the output
+ * @param[out] x16: dptr_rb, dmem pointer to the output Boolean shares of r
+ *
+ * clobbered registers: x4, x5, x6, x7, x28 to x30, w0 to w8
+ * clobbered flag groups: FG0
+ */
+.globl secand_cs20
+secand_cs20:
+    addi x4, x0, 1
+    addi t0, x0, 2
+    addi t1, x0, 3
+    addi t2, x0, 4
+    addi t3, x0, 5
+    addi t4, x0, 6
+
+    /* Compute tb[0] = xb[0] & yb[0]. */
+    /* Whitening since we're accessing other shares in subsequent steps. */
+    bn.xor w1, w1, w1
+    bn.xor w3, w3, w3
+    bn.xor w5, w5, w5
+    bn.lid x4, 0(a0)                /* w1 = xb[0] */
+    bn.lid t1, 0(a2)                /* w3 = yb[0] */
+    bn.and w5, w1, w3               /* w5 = tb[0] */
+
+    /* Compute tb[1] = xb[1] & yb[1]. */
+    /* Whitening since we're accessing other shares in subsequent steps. */
+    bn.xor w2, w2, w2
+    bn.xor w4, w4, w4
+    bn.xor w6, w6, w6
+    add    t5, a0, a1
+    bn.lid t0, 0(t5)                /* w2 = xb[1] */
+    add    t5, a2, a3
+    bn.lid t2, 0(t5)                /* w4 = yb[1] */
+    bn.and w6, w2, w4               /* w6 = tb[1] */
+
+    /* Single PINI pair (i, j) = (0, 1). */
+    bn.wsrr w0, urnd                /* w0 = r */
+
+    /* Handle wzij. */
+    bn.xor w7, w4, w0               /* wtmp1 = yb[j] ^ r */
+    bn.and w7, w7, w1               /* wtmp1 &= xb[i]    */
+    bn.not w8, w1                   /* wtmp0 = xb[i] ^ 1 */
+    bn.and w8, w8, w0               /* wtmp0 &= r        */
+    bn.xor w8, w8, w7               /* wtmp0 ^= wtmp1    */
+    bn.xor w5, w5, w8               /* tb[0] ^= wtmp0    */
+
+    /* Whitening. */
+    bn.xor w7, w7, w7
+    bn.xor w8, w8, w8
+
+    /* Handle wzji. */
+    bn.xor w7, w3, w0               /* wtmp1 = yb[i] ^ r */
+    bn.and w7, w7, w2               /* wtmp1 &= xb[j]    */
+    bn.not w8, w2                   /* wtmp0 = xb[j] ^ 1 */
+    bn.and w8, w8, w0               /* wtmp0 &= r        */
+    bn.xor w8, w8, w7               /* wtmp0 ^= wtmp1    */
+    bn.xor w6, w6, w8               /* tb[1] ^= wtmp0    */
+
+    /* Copy tb to rb. */
+    bn.sid t3, 0(a6)                /* rb[0] = tb[0] */
+    add    t5, a6, a5
+    bn.sid t4, 0(t5)                /* rb[1] = tb[1] */
+
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/secb2amodq_bc22.s
+++ b/sw/acc/crypto/mldsa/gadgets/secb2amodq_bc22.s
@@ -1,0 +1,145 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x1,  ra
+.equ x2,  sp
+.equ x5,  t0
+.equ x6,  t1
+.equ x7,  t2
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x15, a5
+.equ x16, a6
+.equ x17, a7
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+.equ w31, bn0
+
+#define MLDSA_KBITS         23
+#define MLDSA_KBITS_PLUS_1  24
+#define SHARE_STR_BYTES     768    /* (k+1) * 32 */
+
+/*
+ * Name: secb2amodq_bc22 (PINI, d = 2)
+ *
+ * Convert a 2-share Boolean sharing x^{B,k} of x in [0, q) into a 2-share
+ * arithmetic sharing z^{A_p} with z = x.  Implements [BC22] Alg.11
+ * (SecB2AModp).
+ *
+ * Alg.11 (d = 2; the line 1 loop runs once for i = 0):
+ *   1: for i = 0 to d - 2 do
+ *   2:    z_i^{A_p}     <- Z_p                                    . poly_rej_samp_bitsliced
+ *   3:    z'_i^{A_p}    <- p - z_i^{A_p}                          . bitsliced borrow chain
+ *   4: z'_{d-1}^{A_p}   <- 0
+ *   5: a^{B,k}          <- SecA2BModp^d_k(z'^{A_p})               . seca2bmodq_bc22
+ *   6: b^{B,k}          <- SecAddModp^d_k(a^{B,k}, x^{B,k})       . secaddmodq_bc22
+ *   7: c^{B,k}          <- RefreshIOS^d_k(b^{B,k})                . fused with step 8
+ *   8: z_{d-1}^{A_p}    <- UnMask^d_k(c^{B,k})                    . XOR-collapse
+ *
+ * @param[in]   x10: dptr_z, output ((k+1) * 2 * 32 bytes, bit k = 0).
+ * @param[in]   x11: dptr_x, input  ((k+1) * 2 * 32 bytes, bit k = 0).
+ * @param[in]   x13: dptr_scratch, 1536 B for seca2bmodq_bc22 (forwarded).
+ * @param[in]   w31: all-zero.
+ *
+ * clobbered registers: x2, x5 to x7, x10 to x17, x28 to x31, w0 to w23
+ * clobbered flag groups: FG0
+ */
+.globl secb2amodq_bc22
+secb2amodq_bc22:
+    /* z_0 staging in the shared scratchpad; standard 32 B prologue. */
+    la   a4, scratch
+    addi sp, sp, -32
+    sw   a0, 0(sp)                 /* save z_out */
+    sw   a1, 4(sp)                 /* save x_in */
+    sw   a3, 8(sp)                 /* save scratch_ptr for seca2b */
+    sw   a4, 12(sp)                /* save z_0 scratch ptr */
+
+    /* Step 2: z_0 staged in caller-provided a4. */
+    addi a0, a4, 0
+    jal  ra, poly_rej_samp_bitsliced
+
+    /* Step 3. */
+    lw   t6, 0(sp)
+    lw   t5, 12(sp)
+    li   t0, 0
+    li   t1, 1
+    li   t2, 2
+    li   t3, 31
+
+    bn.lid t0, 0(t5++)
+    bn.not w2, w0
+    bn.sid t2, 0(t6++)
+    bn.xor w1, w31, w31
+
+    loopi 12, 4
+        bn.lid t0, 0(t5++)
+        bn.xor w2, w0, w1
+        bn.sid t2, 0(t6++)
+        bn.or  w1, w0, w1
+
+    loopi 10, 5
+        bn.lid t0, 0(t5++)
+        bn.not w3, w0
+        bn.xor w2, w3, w1
+        bn.sid t2, 0(t6++)
+        bn.and w1, w0, w1
+
+    bn.sid t3, 0(t6++)
+
+    /* Step 4: z'_{d-1}^{A_p} <- 0. */
+    loopi MLDSA_KBITS_PLUS_1, 1
+        bn.sid t3, 0(t6++)
+
+    /* Step 5: a^{B,k} <- SecA2BModp^d_k(z'^{A_p}). */
+    lw   a0, 0(sp)
+    lw   a1, 0(sp)
+    lw   a3, 8(sp)
+    jal  ra, seca2bmodq_bc22
+
+    /* Step 6: b^{B,k} <- SecAddModp^d_k(a^{B,k}, x^{B,k}). */
+    lw   a0, 0(sp)
+    lw   a1, 4(sp)
+    lw   a2, 0(sp)
+    li   a4, 2
+    jal  ra, secaddmodq_bc22
+
+    /* Steps 7+8: z_{d-1}^{A_p} <- UnMask^d_k(RefreshIOS^d_k(b^{B,k})). */
+    lw   t6, 0(sp)
+    addi a3, t6, 0                 /* b[share 0] read */
+    addi a4, t6, SHARE_STR_BYTES   /* b[share 1] read */
+    li   t1, 1
+    li   t2, 2
+    addi t5, t6, SHARE_STR_BYTES   /* z[share 1] write */
+    li   t4, MLDSA_KBITS
+    loop t4, 7
+        bn.lid  t1, 0(a3++)
+        bn.lid  t2, 0(a4++)
+        bn.wsrr w3, URND
+        bn.xor  w1, w1, w3
+        bn.xor  w2, w2, w3
+        bn.xor  w1, w1, w2
+        bn.sid  t1, 0(t5++)
+    li   t3, 31
+    bn.sid t3, 0(t5)               /* z[share 1] bit k = 0 */
+
+    /* z[share 0] <- z_0. */
+    addi t5, t6, 0                 /* z[share 0] write */
+    lw   a1, 12(sp)                /* z_0 source */
+    li   t0, 0
+    li   t4, MLDSA_KBITS
+    loop t4, 2
+        bn.lid t0, 0(a1++)
+        bn.sid t0, 0(t5++)
+    bn.sid t3, 0(t5)               /* z[share 0] bit k = 0 */
+
+    addi sp, sp, 32
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/secb2amodq_eta.s
+++ b/sw/acc/crypto/mldsa/gadgets/secb2amodq_eta.s
@@ -1,0 +1,112 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x1,  ra
+.equ x2,  sp
+.equ x5,  t0
+.equ x6,  t1
+.equ x7,  t2
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+/*
+ * Name: secb2amodq_eta (PINI, d = 2)
+ *
+ * b2a for polyeta-shaped Boolean inputs (k = 3 for eta=2, k = 4 for eta=4):
+ * zero-pads the k-stripe shares to the full 24-stripe Z_q layout, runs
+ * secb2amodq_bc22, then unbitslices each output share to canonical 32-bit
+ * arithmetic at caller's a0.
+ *
+ * @param[in]   a0: dptr_out, 2 * 1024 B canonical arith shares (mod q).
+ * @param[in]   a1: dptr_x_share0, k * 32 B Boolean bitsliced.
+ * @param[in]   a2: dptr_x_share1, k * 32 B Boolean bitsliced.
+ * @param[in]   a3: bit-width k (3 or 4).
+ * @param[in]   a4: dptr_scratch, 1536 B for seca2bmodq_bc22 (forwarded).
+ * @param[in]   a5: dptr_buf, 1536 B share-major Boolean buffer
+ *                  (must not overlap dptr_scratch).
+ * @param[in]   w31: all-zero.
+ *
+ * clobbered registers: x2, x5 to x7, x10 to x17, x28 to x31, w0 to w27
+ * clobbered flag groups: FG0
+ */
+.globl secb2amodq_eta
+secb2amodq_eta:
+    addi sp, sp, -32
+    sw   ra,  0(sp)
+    sw   a0,  4(sp)
+    sw   a4,  8(sp)
+    sw   a5, 12(sp)
+
+    /* Zero the 48-WDR buffer at a5. */
+    li   t2, 31
+    addi t0, a5, 0
+    loopi 48, 1
+        bn.sid t2, 0(t0++)
+
+    /* share 0 low k stripes -> buffer + 0. */
+    li   t2, 0
+    addi t0, a5, 0
+    addi t4, a1, 0
+    loop a3, 2
+        bn.lid t2, 0(t4++)
+        bn.sid t2, 0(t0++)
+
+    /* Whitening */
+    bn.xor w0, w0, w0
+    /* share 1 low k stripes -> buffer + 768. */
+    addi t0, a5, 768
+    addi t4, a2, 0
+    loop a3, 2
+        bn.lid t2, 0(t4++)
+        bn.sid t2, 0(t0++)
+
+    /* b2a: caller's a0 receives bitsliced arith shares. */
+    lw   a0,  4(sp)
+    addi a1, a5, 0
+    lw   a3,  8(sp)
+    jal  x1, secb2amodq_bc22
+
+    /* Unbitslice each share to canonical 32-bit; share 1 first so its
+     * overlapping write [1024..1535] doesn't clobber share 0's source. */
+    lw   a0,  4(sp)
+    addi a1, a0, 768
+    addi a0, a0, 1024
+    jal  x1, unbitslice
+
+    /* Whitening */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    bn.xor w4, w4, w4
+    bn.xor w5, w5, w5
+    bn.xor w6, w6, w6
+    bn.xor w7, w7, w7
+    bn.xor w8, w8, w8
+    bn.xor w9, w9, w9
+    bn.xor w10, w10, w10
+    bn.xor w11, w11, w11
+    bn.xor w12, w12, w12
+    bn.xor w13, w13, w13
+    bn.xor w14, w14, w14
+    bn.xor w15, w15, w15
+    bn.xor w16, w16, w16
+    bn.xor w17, w17, w17
+    bn.xor w18, w18, w18
+    bn.xor w19, w19, w19
+    lw   a0,  4(sp)
+    addi a1, a0, 0
+    jal  x1, unbitslice
+
+    lw   ra,  0(sp)
+    addi sp, sp, 32
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/secboundcheck.s
+++ b/sw/acc/crypto/mldsa/gadgets/secboundcheck.s
@@ -1,0 +1,158 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x1,  ra
+.equ x2,  sp
+.equ x5,  t0
+.equ x6,  t1
+.equ x7,  t2
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x15, a5
+.equ x16, a6
+.equ x17, a7
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+/* Stack frame: SP_C (32 B WDR stash for secleq constant) + SP_SECA2B /
+ * SP_BUF (4 B word slots).  The bit-major share-inner buffer is now
+ * caller-provided in a4. */
+#define SP_SECA2B     0
+#define SP_BUF        4
+#define SP_C         32
+#define SP_FRAME     64
+
+/*
+ * Name: secboundcheck (PINI when output is public)
+ *
+ * Implements Alg.5 SecBoundCheck^d_{q,lambda_0,lambda_1}(x^{A_q}) of
+ * [ABCH+23].  Returns the per-lane "passed" mask b in w0 (b_i = 1 iff
+ * -lambda_0 <= x_i <= lambda_1 mod q).
+ *
+ *   1: x_0^{A_q}  <- x_0^{A_q} + lambda_0 mod q
+ *   2: x'^{B,k}   <- SecA2BModp^d_q(x^{A_q})                . seca2bmodq_bc22
+ *   3: b          <- SecLeq^d_{lambda_0+lambda_1}(x'^{B,k}) . secleq
+ *
+ * Source: Alg.5 of "Protecting Dilithium against Leakage --
+ *         Revisited Sensitivity Analysis and Improved Implementations",
+ *         https://eprint.iacr.org/2022/1406
+ *
+ * @param[in]      a0: dptr_x_arith, 2*1024 B arith shares (stride 1024).
+ * @param[in]      a2: dptr_lambda0_vec, 32 bytes broadcast of lambda_0.
+ * @param[in]      a3: dptr_scratch, 1536 B for seca2bmodq_bc22.
+ * @param[in]      a4: dptr_buf, 1536 B bit-major share-inner buffer
+ *                     (must not overlap dptr_scratch or dptr_x_arith).
+ * @param[in]     w17: lane-0 holds C = 2^{k+1} - (lambda_0+lambda_1) - 1.
+ * @param[in]     w31: all-zero.
+ * @param[out]     w0: per-lane b.
+ *
+ * w16/w22/w23 are stashed in w28/w29/w30 across the chain.
+ *
+ * clobbered registers: x2, x5 to x7, x10 to x17, x28 to x31, w0 to w27
+ * clobbered flag groups: FG0
+ */
+
+.globl secboundcheck
+secboundcheck:
+    bn.mov w28, w16
+    bn.mov w29, w22
+    bn.mov w30, w23
+
+    addi sp, sp, -SP_FRAME
+    sw   a3, SP_SECA2B(sp)
+    sw   a4, SP_BUF(sp)
+
+    /* Stash C across the seca2bmodq call. */
+    li   t0, 17
+    bn.sid t0, SP_C(sp)
+
+    /* Preserve arguments. */
+    addi a7, a0, 0
+
+    /* Step 1: x_0^{A_q} <- x_0^{A_q} + lambda_0 mod q.  Written to a4 so
+     * the caller's x stays intact. */
+    bn.lid x0, 0(a2)
+    addi t0, a7, 0
+    addi t1, a4, 0
+    li   t2, 1
+    loopi 32, 3
+        bn.lid      t2, 0(t0++)
+        bn.addvm.8S w1, w1, w0
+        bn.sid      t2, 0(t1++)
+
+    /* Bitslice each share into the share-major bit-inner buffer. */
+    addi a0, a4, 0
+    addi a1, a4, 0
+    li   a2, 32
+    jal  x1, bitslice
+
+    /* Whitening */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    bn.xor w4, w4, w4
+    bn.xor w5, w5, w5
+    bn.xor w6, w6, w6
+    bn.xor w7, w7, w7
+    bn.xor w8, w8, w8
+    bn.xor w9, w9, w9
+    bn.xor w10, w10, w10
+    bn.xor w11, w11, w11
+    bn.xor w12, w12, w12
+    bn.xor w13, w13, w13
+    bn.xor w14, w14, w14
+    bn.xor w15, w15, w15
+    bn.xor w16, w16, w16
+    bn.xor w17, w17, w17
+    bn.xor w18, w18, w18
+    bn.xor w19, w19, w19
+    bn.xor w20, w20, w20
+    bn.xor w21, w21, w21
+    bn.xor w22, w22, w22
+    bn.xor w23, w23, w23
+    bn.xor w24, w24, w24
+    bn.xor w25, w25, w25
+    bn.xor w26, w26, w26
+    bn.xor w27, w27, w27
+    lw   a4, SP_BUF(sp)
+    addi a0, a4, 768
+    addi a1, a7, 1024
+    li   a2, 32
+    jal  x1, bitslice
+
+    /* Zero bit-k pad of each share. */
+    lw   a4, SP_BUF(sp)
+    li   t0, 31
+    addi t1, a4, 736
+    bn.sid t0, 0(t1)
+    addi t1, a4, 1504
+    bn.sid t0, 0(t1)
+
+    /* Step 2: x'^{B,k} <- SecA2BModp^d_q(x^{A_q}). */
+    addi a0, a4, 0
+    addi a1, a4, 0
+    lw   a3, SP_SECA2B(sp)
+    jal  x1, seca2bmodq_bc22
+
+    /* Step 3: b <- SecLeq^d_{lambda_0+lambda_1}(x'^{B,k}). */
+    lw   a4, SP_BUF(sp)
+    li   t0, 17
+    bn.lid t0, SP_C(sp)
+    addi a1, a4, 0
+    jal  x1, secleq
+
+    addi sp, sp, SP_FRAME
+
+    bn.mov w16, w28
+    bn.mov w22, w29
+    bn.mov w23, w30
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/seccompress.s
+++ b/sw/acc/crypto/mldsa/gadgets/seccompress.s
@@ -1,0 +1,336 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x1,  ra
+.equ x2,  sp
+.equ x5,  t0
+.equ x6,  t1
+.equ x7,  t2
+.equ x8,  s0
+.equ x9,  s1
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x15, a5
+.equ x16, a6
+.equ x18, s2
+.equ x19, s3
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+#define KBITS            32
+#define POLY_BYTES     1024
+#define BSL_BYTES      1024            /* k * 32 per share */
+#define BOOL_BYTES     2048            /* d * k * 32 */
+#define SHARE_STR      1024            /* k * 32 */
+
+/* Stack layout */
+#define SP_OUT            4
+#define SP_X              8
+#define SP_S0            16
+#define SP_S1            20
+#define SP_S2            24
+#define SP_S3            28
+#define SP_SCRATCH       32            /* caller scratch base (a2) */
+#define SP_BPTR          36            /* caller B scratch (a3) */
+#define FRAME_SIZE       64
+
+#define T_DENSE_OFF       0
+#define T_BSL_OFF      2048
+
+
+/* CSUB constants */
+#define CSUB_VPTR          4
+#define CSUB_SCRATCH      16
+#define CSUB_FRAME        32
+#define CSUB_TMP_OFF      32
+#define CSUB_AND_OFF      96
+#define CSUB_DIFF_OFF    192
+
+/*
+ * Name: seccompress (PINI, d = 2)
+ *
+ * Masked SecCompress for the ML-DSA-44 SecDecompose: from 2 arithmetic shares
+ * of x mod q (q = 8380417) produce a Boolean sharing of
+ * w1 = round(x*delta/q) mod delta, delta = 44.  Hardcoded for d = 2 with
+ * ell = 24, c = 8, k = ell + c = 32.
+ *
+ * Source: [CGMZ23] Alg.2 (HOCompress).  Used for [ABCH+23] Alg.7 line 7 (the
+ * L2 SecDecompose branch).
+ *   [CGMZ23]: Coron, Gerard, Montoya, Zeitoun, "High-order Polynomial
+ *             Comparison and Masking Lattice-based Encryption", eprint 2021/1615.
+ *
+ * Paper Alg.2 verbatim (n shares, d output bits; Compress_{q,d}(x) = round(x*2^d/q) mod 2^d):
+ *   1: alpha <- ceil(log2(q*n))
+ *   2: z_1   <- floor((x_1*2^(d+alpha+1) + q)/(2q)) + 2^(alpha-1)  mod 2^(d+alpha)
+ *   3: for i = 2..n: z_i <- floor((x_i*2^(d+alpha+1) + q)/(2q))    mod 2^(d+alpha)
+ *   4: (c_1,..,c_n) <- A2B(d + alpha, (z_1,..,z_n))
+ *   5: for i = 1..n: y_i <- c_i >> alpha
+ *   6: return (y_1..y_n)
+ *
+ * What we compute (n = 2; compress modulus 2^d -> delta = 44, so alpha -> ell
+ * = 24 and d -> c = 8):
+ *   1: z_0 <- round(x_0*delta*2^ell / q) + 2^(ell-1)   mod 2^(ell+c)
+ *   2: z_1 <- round(x_1*delta*2^ell / q)               mod 2^(ell+c)
+ *   3: Z  <- A2B(ell + c, (z_0, z_1))
+ *   4: V' <- Z >> ell                                   (top c=8 stripes of Z)
+ *   5: for t = 1, 2:  V' <- (V' >= delta) ? V' - delta : V'
+ *
+ * After line 4, V' can be in [0,88] - hence, we need two conditional subtractions of 44.
+ *
+ * Rounded division by q (lines 1-2): ACC has no division, so we replace
+ * it by multiplication:
+ * round(x_i*delta*2^ell / q) is a truncating Barrett multiply
+ *   z_i = (x_i * K) >> 25,  K = round(delta*2^(ell+25) / q) = 0xB02C09A2.
+ *
+ *
+ * @param[out]    a0: dptr_z, 2048 B share-major a2b output (share_str=1024)
+ * @param[in]     a1: dptr_x, 2 * 1024 B arith shares mod q (contiguous)
+ * @param[in]     a2: dptr_scratch, 4096 B (T_DENSE + T_BSL), caller-provided
+ * @param[in]     a3: dptr_b, 2048 B scratch for the a2b's B, caller-provided
+ * @param[in]    w31: all-zero
+ *
+ * clobbered registers: x2, x5 to x7, x10 to x17, x28 to x31, w0 to w27
+ * clobbered flag groups: FG0
+ */
+.globl seccompress
+seccompress:
+    li   t0, FRAME_SIZE
+    sub  sp, sp, t0
+    sw   a0, SP_OUT(sp)
+    sw   a1, SP_X(sp)
+    sw   s0, SP_S0(sp)
+    sw   s1, SP_S1(sp)
+    sw   s2, SP_S2(sp)
+    sw   s3, SP_S3(sp)
+    sw   a2, SP_SCRATCH(sp)
+    sw   a3, SP_BPTR(sp)
+
+    /* K = 0xB02C09A2 -> w16 (broadcast to all 8 lanes). */
+    bn.addi  w16, w31, 0xB0
+    bn.rshi  w16, w16, w31 >> 248
+    bn.addi  w16, w16, 0x2C
+    bn.rshi  w16, w16, w31 >> 248
+    bn.addi  w16, w16, 0x09
+    bn.rshi  w16, w16, w31 >> 248
+    bn.addi  w16, w16, 0xA2
+    bn.rshi  w18, w16, w31 >> 224
+    bn.or    w16, w16, w18
+    bn.rshi  w18, w16, w31 >> 192
+    bn.or    w16, w16, w18
+    bn.rshi  w18, w16, w31 >> 128
+    bn.or    w16, w16, w18
+
+    /* BIAS = 2^23 -> w17 (broadcast to all 8 lanes). */
+    bn.addi   w17, w31, 1
+    bn.rshi   w18, w17, w31 >> 224
+    bn.or     w17, w17, w18
+    bn.rshi   w18, w17, w31 >> 192
+    bn.or     w17, w17, w18
+    bn.rshi   w18, w17, w31 >> 128
+    bn.or     w17, w17, w18
+    bn.shv.8S w17, w17 << 23
+
+    /* Steps 1-2: z_i = round(x_i*delta*2^ell / q) mod 2^(ell+c) for i in {0,1}. */
+    addi     s0, a1, 0
+    lw       s1, SP_SCRATCH(sp)
+    loopi    2, 10
+        li       t0, 0
+        li       t2, 3
+        loopi    32, 5
+            bn.lid               t0, 0(s0++)
+            bn.shv.8S            w0, w0 << 7
+            bn.mulv.8S.even.hi   w3, w0, w16
+            bn.mulv.8S.odd.hi    w3, w3, w16
+            bn.sid               t2, 0(s1++)
+        /* Whitening */
+        bn.xor w0, w0, w0
+        bn.xor w3, w3, w3
+
+    /* Add the rounding bias 2^(ell-1) = 2^23 to share 0. */
+    lw       s0, SP_SCRATCH(sp)
+    li       t0, 0
+    loopi    32, 3
+        bn.lid       t0, 0(s0)
+        bn.addv.8S   w0, w0, w17
+        bn.sid       t0, 0(s0++)
+
+    /* Step 3: Z = A2B(z_0, z_1) */
+
+    /* Bitslice each share */
+    lw       s0, SP_SCRATCH(sp)
+    lw       s1, SP_SCRATCH(sp)
+    li       t0, T_BSL_OFF
+    add      s1, s1, t0
+    loopi    2, 34
+        addi a0, s1, 0
+        addi a1, s0, 0
+        li   a2, 32
+        jal  x1, bitslice_k32
+        /* Whitening */
+        bn.xor w0, w0, w0
+        bn.xor w1, w1, w1
+        bn.xor w2, w2, w2
+        bn.xor w3, w3, w3
+        bn.xor w4, w4, w4
+        bn.xor w5, w5, w5
+        bn.xor w6, w6, w6
+        bn.xor w7, w7, w7
+        bn.xor w8, w8, w8
+        bn.xor w9, w9, w9
+        bn.xor w10, w10, w10
+        bn.xor w11, w11, w11
+        bn.xor w12, w12, w12
+        bn.xor w13, w13, w13
+        bn.xor w14, w14, w14
+        bn.xor w15, w15, w15
+        bn.xor w16, w16, w16
+        bn.xor w17, w17, w17
+        bn.xor w18, w18, w18
+        bn.xor w19, w19, w19
+        bn.xor w20, w20, w20
+        bn.xor w21, w21, w21
+        bn.xor w22, w22, w22
+        bn.xor w23, w23, w23
+        bn.xor w24, w24, w24
+        bn.xor w25, w25, w25
+        bn.xor w26, w26, w26
+        bn.xor w27, w27, w27
+        addi s0, s0, POLY_BYTES
+        addi s1, s1, BSL_BYTES
+
+
+    /* SecA2B (BCC22, Alg 8) */
+    /* A = (z_0, 0), B = (0, z_1). */
+    lw   a1, SP_SCRATCH(sp)
+    li   t0, T_BSL_OFF
+    add  a1, a1, t0                     /* z_0 bitsliced */
+    addi a2, a1, BSL_BYTES              /* z_1 bitsliced */
+    lw   a4, SP_SCRATCH(sp)
+    lw   a5, SP_BPTR(sp)
+    addi t3, a4, 0
+    addi t4, a5, 0
+    li   t0, 0
+    li   t1, 1
+    li   t2, 31
+    loopi 32, 6
+        bn.lid t0, 0(a1++)            /* z_0[i] */
+        bn.lid t1, 0(a2++)            /* z_1[i] */
+        bn.sid t0, 0(t3)              /* A.share0 = z_0[i] */
+        bn.sid t2, 1024(t3++)         /* A.share1 = 0 */
+        bn.sid t2, 0(t4)              /* B.share0 = 0 */
+        bn.sid t1, 1024(t4++)         /* B.share1 = z_1[i] */
+
+    /* Z = A + B mod 2^32 (secadd_bc22, k=32, share_str=1024, d=2). */
+    addi a0, a4, 0
+    addi a1, a5, 0
+    li   a2, 32
+    li   a3, 1024
+    li   a4, 2
+    lw   a5, SP_OUT(sp)
+    jal  x1, secadd_bc22
+
+    /* Step 4 implicit by using higher bits. */
+
+    /* Step 5: V' = V' mod delta, two passes of the conditional subtract-delta.
+     * V' from step 4 lies in [0, 2*delta] = [0, 88]:
+     *  pass 1 maps it to [0, 44],
+     *  pass 2 folds the residual 44 -> 0.*/
+    lw   a0, SP_OUT(sp)
+    addi a0, a0, 768                /* V' = top 8 stripes of Z (share 0) */
+    lw   a1, SP_SCRATCH(sp)
+    li   t0, CSUB_FRAME
+    sub  sp, sp, t0
+    sw   a0, CSUB_VPTR(sp)
+    sw   a1, CSUB_SCRATCH(sp)
+    jal  x1, _seccompress_csub
+    jal  x1, _seccompress_csub
+    li   t0, CSUB_FRAME
+    add  sp, sp, t0
+
+    lw   s0, SP_S0(sp)
+    lw   s1, SP_S1(sp)
+    lw   s2, SP_S2(sp)
+    lw   s3, SP_S3(sp)
+    li   t0, FRAME_SIZE
+    add  sp, sp, t0
+    ret
+
+
+/*
+ * _seccompress_csub (internal, d=2): one conditional subtract of delta=44,
+ * V' = (V' >= delta) ? V' - delta : V', as a masked select:
+ *   diff = V' + (256 - delta)             (secadd_bc22_immd_d2, 8 stripes)
+ *   mask = MSB(diff)                      (1 iff V' < delta)
+ *   tmp  = V' XOR diff                    (sharewise)
+ *   V'   = SecAnd(mask, tmp) XOR diff     (mask=1 keeps V', mask=0 takes diff)
+ */
+_seccompress_csub:
+    /* diff = V' + (256 - delta) mod 256 via inline-constant SecAdd. */
+    bn.addi w17, w31, 212
+    lw   a0, CSUB_VPTR(sp)
+    li   a2, 8
+    li   a3, 1024
+    li   a4, 2
+    lw   a5, CSUB_SCRATCH(sp)
+    addi a5, a5, CSUB_DIFF_OFF
+    jal  x1, secadd_bc22_immd_d2
+
+    /* Masked select over the 8 V'/diff stripes:
+     *   V'[i] = (mask & (V'[i] ^ diff[i])) ^ diff[i],  mask = MSB(diff).
+     */
+    lw   s0, CSUB_VPTR(sp)
+    lw   t6, CSUB_SCRATCH(sp)
+    addi s1, t6, CSUB_DIFF_OFF
+    loopi 8, 37
+        /* tmp = V'[i] ^ diff[i] sharewise */
+        li   t1, 0
+        li   t2, 1
+        bn.lid t1, 0(s0)
+        bn.lid t2, 0(s1)
+        bn.xor w0, w0, w1
+        addi t5, t6, CSUB_TMP_OFF
+        bn.sid t1, 0(t5)
+        /* Whitening */
+        bn.xor w0, w0, w0
+        bn.xor w1, w1, w1
+        bn.lid t1, 1024(s0)
+        bn.lid t2, 1024(s1)
+        bn.xor w0, w0, w1
+        bn.sid t1, 32(t5)
+        /* and = secand_cs20(mask = diff[bit 7], tmp) */
+        addi a0, t6, CSUB_DIFF_OFF
+        addi a0, a0, 224
+        li   a1, 1024
+        addi a2, t6, CSUB_TMP_OFF
+        li   a3, 32
+        li   a4, 2
+        li   a5, 32
+        addi a6, t6, CSUB_AND_OFF
+        jal  x1, secand_cs20
+        /* V'[i] = and ^ diff[i] sharewise */
+        li   t1, 0
+        li   t2, 1
+        addi t5, t6, CSUB_AND_OFF
+        bn.lid t1, 0(t5)
+        bn.lid t2, 0(s1)
+        bn.xor w0, w0, w1
+        bn.sid t1, 0(s0)
+        /* Whitening */
+        bn.xor w0, w0, w0
+        bn.xor w1, w1, w1
+        bn.lid t1, 32(t5)
+        bn.lid t2, 1024(s1)
+        bn.xor w0, w0, w1
+        bn.sid t1, 1024(s0)
+        addi s0, s0, 32
+        addi s1, s1, 32
+
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/secdecompose.s
+++ b/sw/acc/crypto/mldsa/gadgets/secdecompose.s
@@ -1,0 +1,328 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x1,  ra
+.equ x2,  sp
+.equ x5,  t0
+.equ x6,  t1
+.equ x7,  t2
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+#ifndef DILITHIUM_MODE
+  #error "secdecompose requires DILITHIUM_MODE"
+#endif
+
+#define KBITS 23
+
+#if DILITHIUM_MODE == 2
+  #define M_BITS          6
+  #define SHARE_STR    1024
+  #define ZERO_STRIPES   17   /* KBITS - M_BITS */
+#elif DILITHIUM_MODE == 3 || DILITHIUM_MODE == 5
+  #define M_BITS          4
+  #define SHARE_STR     768
+  #define ZERO_STRIPES   19   /* KBITS - M_BITS */
+#else
+  #error "secdecompose: unsupported DILITHIUM_MODE"
+#endif
+
+/* Stack layout. */
+#define SP_W1OUT     4
+#define SP_WIO       8
+#define SP_SCRATCH  12
+#define SP_S5       16
+#define SP_S6       20
+#define SP_S7       24
+#define SP_S8       28
+#define SP_S9       32
+#define SP_W0PACK0  36
+#define SP_W0PACK1  40
+#define SP_SECA2B   44
+
+#define FRAME_SIZE   64
+
+/*
+ * Name: secdecompose (PINI, d = 2)
+ *
+ * Masked SecDecompose for ML-DSA: from a 2-share arithmetic sharing of w mod q
+ * (q = 8380417) produce the unmasked w1 = HighBits(w, alpha) and a sharing of
+ * the low part w0, where w = alpha*w1 + w0 mod q and alpha = 2*gamma2.
+ *
+ * Source: [ABCH+23] Alg.7 (SecDecompose).
+ *   [ABCH+23]: Azouaoui et al., "Protecting Dilithium against Leakage",
+ *              TCHES 2023(4).
+ *
+ * [ABCH+23] Alg.7 (alpha = 2*gamma2; [[0,k'[[ = low k' bits):
+ *   1: if ML-DSA-65 or ML-DSA-87 then
+ *   2:     b  <- w + gamma2         mod q
+ *   3:     b' <- alpha^-1 * b - 1   mod q
+ *   4:     b' <- SecA2BModp(b')
+ *   5:     w1 <- b'[[0, k'[[
+ *   6: else                                          (ML-DSA-44)
+ *   7:     w1 <- SecCompress_{q,-alpha^-1}(w)
+ *   8: w1 <- SecUnMask(w1)
+ *   9: w0 <- w - alpha * w1        mod q
+ *
+ * What we compute (d = 2):
+ *   L2    (alpha = (q-1)/44, k' = 6): unmasked w1, and arithmetic shares of w0
+ *         reconstructed in place over the input shares.
+ *   L3/L5 (alpha = (q-1)/16, k' = 4): unmasked w1, and the Boolean bitsliced
+ *         shares of (gamma2 - w0) dumped per share to a5/a6.  w0 itself is not
+ *         reconstructed here; consumers recover it via b2a.
+ *
+ * @param[out]      a0: dptr_w1, 1024 B unmasked w1
+ * @param[in]       a1: dptr_w, base of arith shares (mod q) at stride a4
+ * @param[in]       a3: L3/L5: dptr_scratch, >=3296 B.
+ *                      L2: seccompress scratch, 4096 B.
+ * @param[in]       a4: stride between shares in bytes (>= 1024)
+ * @param[in]       a5: L3/L5: dptr_w0_packed_share0, 768 B.  L2: seccompress B
+ *                      scratch, 2048 B.
+ * @param[in]       a6: L3/L5: dptr_w0_packed_share1, 768 B.  L2: T_PACKED, 2048 B.
+ * @param[in]       a7: dptr_scratch, 1536 B for seca2bmodq_bc22 (L3/L5 only).
+ * @param[in]      w31: all-zero
+ *
+ * clobbered registers: x2, x5 to x7, x10 to x17, x28 to x31, w0 to w15, w17 to w21, w24 to w30
+ * clobbered flag groups: FG0
+ */
+.globl secdecompose
+secdecompose:
+    bn.mov w28, w16
+    bn.mov w29, w22
+    bn.mov w30, w23
+
+    li   t0, FRAME_SIZE
+    sub  sp, sp, t0
+
+    sw   a0,  SP_W1OUT(sp)
+    sw   a1,  SP_WIO(sp)
+#if DILITHIUM_MODE != 2
+    sw   a5,  SP_W0PACK0(sp)
+    sw   a6,  SP_W0PACK1(sp)
+    sw   a7,  SP_SECA2B(sp)
+#endif
+
+    sw   s5,  SP_S5(sp)
+    sw   s6,  SP_S6(sp)
+    sw   s7,  SP_S7(sp)
+    sw   s8,  SP_S8(sp)
+    sw   s9,  SP_S9(sp)
+
+#if DILITHIUM_MODE == 2
+    /* Line 7: w1 <- SecCompress_{q,delta}(w), delta = 44. */
+    sw   a6, SP_SCRATCH(sp)
+
+    /* Copy the 2 strided shares of w into contiguous T_PACKED (a6). */
+    addi t3, a1, 0
+    addi t4, a6, 0
+    li   t6, 0
+    loopi 2, 6
+        addi t1, t3, 0
+        loopi 32, 2
+            bn.lid t6, 0(t1++)
+            bn.sid t6, 0(t4++)
+        /* Whitening */
+        bn.xor w0, w0, w0
+        add  t3, t3, a4
+
+    /* seccompress in place. */
+    addi a0, a6, 0
+    addi a1, a6, 0
+    addi a2, a3, 0
+    addi a3, a5, 0
+    jal  x1, seccompress
+
+    lw   s9, SP_SCRATCH(sp)
+    addi s8, s9, 768
+
+#else
+    /* Lines 2-3 (L3/L5): Compute b'
+     *  2: b  <- w + gamma2         mod q
+     *  3: b' <- alpha^-1 * b - 1   mod q
+     *
+     * With alpha^-1 = -16 and gamma2 = (q-1)/32, line 3 specializes to
+     *   b' = alpha^-1*(w + gamma2) - 1
+     *      = -16*(w + gamma2) - 1
+     *      = -16*w + (q-1)/2 mod q.
+     */
+
+    addi s5, a3, 0
+    addi s8, s5, 1024
+
+    /* Share 0: -16*w_s0 + (q-1)/2. */
+    la   t0, qm1half_const
+    li   t1, 1
+    bn.lid t1, 0(t0)
+    lw   t3, SP_WIO(sp)
+    addi t4, s5, 0
+    li   t6, 0
+    loopi 32, 8
+        bn.lid      t6, 0(t3++)
+        bn.subvm.8S w0, w31, w0
+        bn.addvm.8S w0, w0, w0
+        bn.addvm.8S w0, w0, w0
+        bn.addvm.8S w0, w0, w0
+        bn.addvm.8S w0, w0, w0
+        bn.addvm.8S w0, w0, w1
+        bn.sid      t6, 0(t4++)
+
+    /* Bitslice share 0; zero bit k. */
+    addi a0, s8, 0
+    addi a1, s5, 0
+    li   a2, 32
+    jal  x1, bitslice
+    li   t0, 31
+    addi t1, s8, 736
+    bn.sid t0, 0(t1)
+
+    /* Whitening */
+    bn.xor w0, w0, w0
+    /* Share 1: -16*w_s1. */
+    lw   t3, SP_WIO(sp)
+    add  t3, t3, a4
+    addi t4, s5, 0
+    li   t6, 0
+    loopi 32, 7
+        bn.lid      t6, 0(t3++)
+        bn.subvm.8S w0, w31, w0
+        bn.addvm.8S w0, w0, w0
+        bn.addvm.8S w0, w0, w0
+        bn.addvm.8S w0, w0, w0
+        bn.addvm.8S w0, w0, w0
+        bn.sid      t6, 0(t4++)
+
+    /* Whitening */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    bn.xor w4, w4, w4
+    bn.xor w5, w5, w5
+    bn.xor w6, w6, w6
+    bn.xor w7, w7, w7
+    bn.xor w8, w8, w8
+    bn.xor w9, w9, w9
+    bn.xor w10, w10, w10
+    bn.xor w11, w11, w11
+    bn.xor w12, w12, w12
+    bn.xor w13, w13, w13
+    bn.xor w14, w14, w14
+    bn.xor w15, w15, w15
+    bn.xor w16, w16, w16
+    bn.xor w17, w17, w17
+    bn.xor w18, w18, w18
+    bn.xor w19, w19, w19
+    bn.xor w20, w20, w20
+    bn.xor w21, w21, w21
+    bn.xor w22, w22, w22
+    bn.xor w23, w23, w23
+    bn.xor w24, w24, w24
+    bn.xor w25, w25, w25
+    bn.xor w26, w26, w26
+    bn.xor w27, w27, w27
+    /* Bitslice share 1; zero bit k. */
+    addi a0, s8, 768
+    addi a1, s5, 0
+    li   a2, 32
+    jal  x1, bitslice
+    li   t0, 31
+    addi t1, s8, 1504             /* 768 + 736 */
+    bn.sid t0, 0(t1)
+
+    /* Line 4: b' <- SecA2BModp(b'). */
+    addi a0, s8, 0
+    addi a1, s8, 0
+    li   a2, 2
+    lw   a3, SP_SECA2B(sp)
+    jal  x1, seca2bmodq_bc22
+
+    /* Line 5: the low 4 stripes of b' are w1, left in place for the Line 8
+     * collapse.  Stripes 4..22 (19) hold the Boolean shares of (gamma2 - w0);
+     * dump per share to a5/a6 (608 B each). */
+    lw   t0, SP_W0PACK0(sp)
+    addi t3, s8, 128              /* share 0, stripe 4 */
+    li   t1, 0
+    loopi 19, 2
+        bn.lid t1, 0(t3++)
+        bn.sid t1, 0(t0++)
+    lw   t0, SP_W0PACK1(sp)
+    addi t3, s8, 896              /* share 1, stripe 4 (768 + 128) */
+    loopi 19, 2
+        bn.lid t1, 0(t3++)
+        bn.sid t1, 0(t0++)
+
+    /* W1_BSL base = T_BSL_BMSI + 768*d. */
+    addi s9, s8, 1536
+#endif
+
+    /* Line 8: w1 <- SecUnMask(w1) = refresh + XOR-collapse */
+    addi t3, s8, 0                /* share 0 stripe 0 */
+    addi t4, s8, SHARE_STR        /* share 1 stripe 0 */
+    addi t5, s9, 0
+    li   t0, 0
+    li   t1, 1
+    loopi M_BITS, 7
+        bn.lid  t0, 0(t3++)
+        bn.lid  t1, 0(t4++)
+        bn.wsrr w2, URND
+        bn.xor  w0, w0, w2
+        bn.xor  w1, w1, w2
+        bn.xor  w0, w0, w1
+        bn.sid  t0, 0(t5++)
+
+    /* Zero stripes M_BITS..KBITS-1. */
+    li   t0, ZERO_STRIPES
+    li   t1, 31
+    loop t0, 1
+        bn.sid t1, 0(t5++)
+
+    /* unbitslice w1. */
+    lw   a0, SP_W1OUT(sp)
+    addi a1, s9, 0
+    jal  x1, unbitslice
+
+#if DILITHIUM_MODE == 2
+    /* Line 9: w0 <- w - alpha*w1 mod q:
+     * share 0 := w_s0 - alpha*w1 (alpha = 2*gamma2)
+     * share 1 = w_s1.
+     */
+    bn.wsrw 0x0, w28 /* MOD = R|Q (stashed) for subvm */
+    la   t0, gamma2_vec_const
+    li   t1, 24
+    bn.lid t1, 0(t0)
+    lw   a0, SP_W1OUT(sp)
+    lw   a1, SP_WIO(sp)
+    li   t0, 0
+    li   t1, 1
+    loopi 32, 7
+        bn.lid t0, 0(a0++)
+        bn.mulv.8S.even.lo w0, w0, w24
+        bn.mulv.8S.odd.lo  w0, w0, w24
+        bn.addv.8S w0, w0, w0
+        bn.lid t1, 0(a1)
+        bn.subvm.8S w0, w1, w0
+        bn.sid t0, 0(a1++)
+#endif
+
+    lw   s5,  SP_S5(sp)
+    lw   s6,  SP_S6(sp)
+    lw   s7,  SP_S7(sp)
+    lw   s8,  SP_S8(sp)
+    lw   s9,  SP_S9(sp)
+    li   t0,  FRAME_SIZE
+    add  sp, sp, t0
+
+    bn.mov w16, w28
+    bn.mov w22, w29
+    bn.mov w23, w30
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/secfulladder_bc22.s
+++ b/sw/acc/crypto/mldsa/gadgets/secfulladder_bc22.s
@@ -1,0 +1,202 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+/* Register aliases */
+.equ x0, zero
+.equ x2, sp
+.equ x3, fp
+.equ x5, t0
+.equ x6, t1
+.equ x7, t2
+.equ x8, s0
+.equ x9, s1
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x15, a5
+.equ x16, a6
+.equ x17, a7
+.equ x18, s2
+.equ x19, s3
+.equ x20, s4
+.equ x21, s5
+.equ x22, s6
+.equ x23, s7
+.equ x24, s8
+.equ x25, s9
+.equ x26, s10
+.equ x27, s11
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+.equ w31, bn0
+
+/*
+ * Name: secfulladder_bc22 (PINI)
+ *
+ * Return Boolean shares of a value r = (x + y + c) mod 2^2, given Boolean
+ * shares of x and y mod 2.
+ * Bitsliced.
+ *
+ * Source: Alg.5 [BC22]
+ *         [BC22]: "Bitslicing Arithmetic/Boolean Masking Conversions for Fun and Profit: with Application to Lattice-Based KEMs"
+ *         Link: https://tches.iacr.org/index.php/TCHES/article/view/9831
+ *
+ * @param[in]  x10: dptr_x, dmem pointer to Boolean shares of x
+ * @param[in]  x11: dptr_y, dmem pointer to Boolean shares of y
+ * @param[in]  x12: dptr_c, dmem pointer to Boolean shares of the carry c
+ * @param[in]  x13: share stride, distance between shares
+ * @param[in]  x14: nshares, the number of shares
+ * @param[out] x15: dptr_r, dmem pointer to the output Boolean shares of r[0]
+ * @param[out] x16: dptr_r, dmem pointer to the output Boolean shares of r[1]
+ *
+ * clobbered registers: x2 to x13, x15 to x16, x18 to x22, x28 to x31, w0 to w8
+ * clobbered flag groups: FG0
+ */
+.globl secfulladder_bc22
+secfulladder_bc22:
+    /* Save fp to stack */
+    addi sp, sp, -32
+    sw   fp, 0(sp)
+    addi fp, sp, 0
+
+    /* Save input addresses. */
+    sw   s0, 4(fp)
+    sw   s1, 8(fp)
+    sw   s2, 12(fp)
+    sw   s3, 16(fp)
+    sw   s4, 20(fp)
+    sw   s5, 24(fp)
+    sw   s6, 28(fp)
+    addi s0, a0, 0
+    addi s1, a1, 0
+    addi s2, a2, 0
+    addi s3, a6, 0
+    addi s5, a5, 0
+    addi s6, a3, 0
+
+    /* Adjust stack for temporary variable a. */
+    loop a4, 1
+        addi sp, sp, -32
+    addi s4, sp, 0 /* ptr_a */
+    loop a4, 1
+        addi sp, sp, -32 /* ptr_t */
+
+    #define wx w0
+    #define wy w1
+    #define wc w1
+    #define wa w2
+    #define wt w2
+    #define wr w3
+    /* Compute a = x ^ y. */
+    addi x4, x0, 1
+    addi t0, x0, 2
+    addi t2, x0, 3
+    addi t1, s4, 0 /* ptr_a */
+    loop a4, 9
+        /* Whitening. */
+        bn.xor wx, wx, wx
+        bn.xor wy, wy, wy
+        bn.xor wa, wa, wa
+        /* Computation. */
+        bn.lid x0, 0(a0)
+        bn.lid x4, 0(a1)
+        bn.xor wa, wx, wy
+        bn.sid t0, 0(t1++)
+        /* Adjust addresses. */
+        add    a0, a0, a3
+        add    a1, a1, a3
+
+    /* Compute r[0] = c ^ a. */
+    addi t1, s4, 0 /* ptr_a */
+    loop a4, 8
+        /* Whitening. */
+        bn.xor wa, wa, wa
+        bn.xor wc, wc, wc
+        bn.xor wr, wr, wr
+        /* Computation. */
+        bn.lid t0, 0(t1++)
+        bn.lid x4, 0(a2++)
+        bn.xor wr, wa, wc
+        bn.sid t2, 0(a5)
+        /* Adjust addresses. */
+        add    a5, a5, a3
+
+    /* Compute r[1] = x ^ secand_cs20(a, x ^ c). */
+    /* Compute t = x ^ c. */
+    addi a0, s0, 0 /* ptr_x */
+    addi a2, s2, 0 /* ptr_c */
+    addi t1, sp, 0 /* ptr_t */
+    loop a4, 8
+        /* Whitening. */
+        bn.xor wx, wx, wx
+        bn.xor wc, wc, wc
+        bn.xor wt, wt, wt
+        /* Computation. */
+        bn.lid x0, 0(a0)
+        bn.lid x4, 0(a2++)
+        bn.xor wt, wx, wc
+        bn.sid t0, 0(t1++)
+        /* Adjust addresses. */
+        add    a0, a0, a3
+    /* Compute t = secand_cs20(a, t). */
+    addi a0, s4, 0 /* ptr_a */
+    addi a1, x0, 32
+    addi a2, sp, 0 /* ptr_t */
+    addi a3, x0, 32 /* share stride */
+    /* a4 is already nshares. */
+    addi a5, x0, 32 /* output share stride */
+    addi a6, a2, 0
+    jal  x1, secand_cs20
+    /* Compute r[1] = x ^ t. */
+    addi a0, s0, 0 /* ptr_x */
+    addi t1, sp, 0 /* ptr_t */
+    addi t0, x0, 2
+    addi t2, x0, 3
+    addi a6, s3, 0 /* ptr_r */
+    loop a4, 8 /* a4 is nshares. */
+        /* Whitening. */
+        bn.xor wx, wx, wx
+        bn.xor wt, wt, wt
+        bn.xor wr, wr, wr
+        /* Computation. */
+        bn.lid x0, 0(a0)
+        bn.lid t0, 0(t1++)
+        bn.xor wr, wx, wt
+        bn.sid t2, 0(a6++)
+        /* Adjust addresses. */
+        add    a0, a0, s6
+
+    /* Restore output pointer. */
+    /* Since this functio will be used in secadd_cs20, we need to reserve input
+     * to the carry a2, the number of shares a4 and output carry a6. We want a0
+     * and a1 to automatically points to next bit. */
+    addi a0, s0, 32
+    addi a1, s1, 32
+    addi a5, s5, 32
+    /* a4 is still nshares */
+    addi a3, s6, 0
+    addi a2, s2, 0
+    addi a6, s3, 0
+
+    /* Restore registers. */
+    lw s0, 4(fp)
+    lw s1, 8(fp)
+    lw s2, 12(fp)
+    lw s3, 16(fp)
+    lw s4, 20(fp)
+    lw s5, 24(fp)
+    lw s6, 28(fp)
+
+    /* Restore sp and fp. */
+    addi sp, fp, 0
+    lw   fp, 0(sp)
+    addi sp, sp, 32
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/secfulladder_bc22_d2.s
+++ b/sw/acc/crypto/mldsa/gadgets/secfulladder_bc22_d2.s
@@ -1,0 +1,139 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x0,  zero
+.equ x4,  tp
+.equ x5,  t0
+.equ x6,  t1
+.equ x7,  t2
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x15, a5
+.equ x16, a6
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+.equ w31, bn0
+
+/*
+ * Name: secfulladder_bc22 (PINI, d=2 only)
+ *
+ * Return Boolean shares of a value r = (x + y + c) mod 2^2, given Boolean
+ * shares of x, y, and the incoming carry c.  Bitsliced.
+ *
+ * d=2 specialization of secfulladder_bc22.s: hand-unrolled, no stack frame,
+ * intermediate `a` and `t` values kept in WDRs (no DMEM scratch).
+ * secand_cs20_d2 is inlined.  Same ABI as the generic; nshares (a4) ignored.
+ *
+ * Source: Alg.5 [BC22]
+ *
+ * @param[in]    x10/a0: dptr_x
+ * @param[in]    x11/a1: dptr_y
+ * @param[in]    x12/a2: dptr_c
+ * @param[in]    x13/a3: share stride
+ * @param[in]    x14/a4: nshares (ignored, fixed to 2)
+ * @param[inout] x15/a5: dptr_r0   (advanced by 32 on return)
+ * @param[inout] x16/a6: dptr_r1   (preserved; written in place)
+ *
+ * Post-call (for secadd_bc22's bit-loop):
+ *   a0 += 32, a1 += 32, a5 += 32 (advance to next bit slice).
+ *   a2, a3, a4, a6 unchanged.
+ *
+ * clobbered registers: x4 to x7, x28 to x31, w0 to w10
+ * clobbered flag groups: FG0
+ */
+.globl secfulladder_bc22
+secfulladder_bc22:
+    /* WDR index constants. */
+    addi x4, x0, 1                 /* w1 = x[0]                            */
+    addi t0, x0, 2                 /* w2 = x[1]                            */
+    addi t1, x0, 3                 /* w3 = a[0] (= x[0]^y[0])              */
+    addi t2, x0, 4                 /* w4 = a[1]                            */
+    addi t3, x0, 5                 /* w5 = c[0] then t[0]                  */
+    addi t4, x0, 6                 /* w6 = c[1] then t[1]                  */
+    addi t6, x0, 0                 /* w0 = scratch (rand + write temp)     */
+
+    /* --- Share 0: x[0] -> w1, a[0] -> w3, c[0] -> w5 ----------------- */
+    bn.xor w1, w1, w1
+    bn.xor w3, w3, w3
+    bn.xor w5, w5, w5
+    bn.lid x4, 0(a0)               /* w1 = x[0]                            */
+    bn.lid t1, 0(a1)               /* w3 = y[0]                            */
+    bn.xor w3, w1, w3              /* w3 = a[0] = x[0] ^ y[0]              */
+    bn.lid t3, 0(a2)               /* w5 = c[0]                            */
+
+    /* --- Share 1: x[1] -> w2, a[1] -> w4, c[1] -> w6 ----------------- */
+    bn.xor w2, w2, w2
+    bn.xor w4, w4, w4
+    bn.xor w6, w6, w6
+    add    t5, a0, a3
+    bn.lid t0, 0(t5)               /* w2 = x[1]                            */
+    add    t5, a1, a3
+    bn.lid t2, 0(t5)               /* w4 = y[1]                            */
+    bn.xor w4, w2, w4              /* w4 = a[1] = x[1] ^ y[1]              */
+    addi   t5, a2, 32              /* c shares are at stride 32 (caller's  */
+    bn.lid t4, 0(t5)               /* w6 = c[1]   stack-scratch layout)    */
+
+    /* --- r[0] = c ^ a -> dmem[a5..a5+a3] ------------------------------ */
+    bn.xor w0, w0, w0              /* whiten w0 (residual from caller)     */
+    bn.xor w0, w5, w3              /* w0 = r[0][0] = c[0] ^ a[0]           */
+    bn.sid t6, 0(a5)
+    bn.xor w0, w0, w0              /* whiten w0 between share writes       */
+    bn.xor w0, w6, w4              /* w0 = r[0][1]                         */
+    add    t5, a5, a3
+    bn.sid t6, 0(t5)
+
+    /* --- t = x ^ c (overwrites c slots w5, w6) ----------------------- */
+    bn.xor w5, w1, w5              /* w5 = t[0] = x[0] ^ c[0]              */
+    bn.xor w6, w2, w6              /* w6 = t[1] = x[1] ^ c[1]              */
+
+    /* --- Inlined secand_cs20_d2: tb = a & t (PINI, d=2) -------------- */
+    bn.xor w7, w7, w7
+    bn.and w7, w3, w5              /* tb[0] = a[0] & t[0]                  */
+    bn.xor w8, w8, w8
+    bn.and w8, w4, w6              /* tb[1] = a[1] & t[1]                  */
+
+    bn.wsrr w0, urnd               /* w0 = r (fresh randomness)            */
+
+    /* PINI pair (i, j) = (0, 1). */
+    bn.xor w9,  w6, w0             /* wtmp1 = t[1] ^ r                     */
+    bn.and w9,  w9, w3             /* wtmp1 &= a[0]                        */
+    bn.not w10, w3                 /* wtmp0 = ~a[0]                        */
+    bn.and w10, w10, w0            /* wtmp0 &= r                           */
+    bn.xor w10, w10, w9            /* wtmp0 ^= wtmp1                       */
+    bn.xor w7,  w7, w10            /* tb[0] ^= wtmp0                       */
+
+    /* PINI pair (i, j) = (1, 0). */
+    bn.xor w9,  w5, w0             /* wtmp1 = t[0] ^ r                     */
+    bn.and w9,  w9, w4             /* wtmp1 &= a[1]                        */
+    bn.not w10, w4                 /* wtmp0 = ~a[1]                        */
+    bn.and w10, w10, w0            /* wtmp0 &= r                           */
+    bn.xor w10, w10, w9            /* wtmp0 ^= wtmp1                       */
+    bn.xor w8,  w8, w10            /* tb[1] ^= wtmp0                       */
+
+    /* tb[0..1] now holds the secand output (= new t[0..1]).             */
+
+    /* --- r[1] = x ^ t -> dmem[a6..a6+a3] ------------------------------ */
+    bn.xor w0, w0, w0              /* whiten w0 (post-PINI residual)       */
+    bn.xor w0, w1, w7              /* w0 = r[1][0] = x[0] ^ t[0]           */
+    bn.sid t6, 0(a6)
+    bn.xor w0, w0, w0              /* whiten w0 between share writes       */
+    bn.xor w0, w2, w8              /* w0 = r[1][1]                         */
+    addi   t5, a6, 32              /* r[1] (= output carry) is at stride 32 */
+    bn.sid t6, 0(t5)
+
+    /* --- Advance per the secadd_bc22 bit loop's expectations --------- */
+    addi a0, a0, 32
+    addi a1, a1, 32
+    addi a5, a5, 32
+    /* a2, a3, a4, a6 preserved. */
+
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/secleq.s
+++ b/sw/acc/crypto/mldsa/gadgets/secleq.s
@@ -1,0 +1,74 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x1,  ra
+.equ x2,  sp
+.equ x5,  t0
+.equ x6,  t1
+.equ x7,  t2
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x15, a5
+.equ x16, a6
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+#define MLDSA_KBITS         23
+#define MLDSA_KBITS_PLUS_1  24
+#define SHARE_STR_BYTES     768
+
+/*
+ * Name: secleq^d_psi (PINI when output is public, d = 2)
+ *
+ * Implements Alg.4 SecLeq^d_psi(x^{B,k}) of [ABCH+23] for k = MLDSA_KBITS
+ * = 23.  Returns b = 1 iff x <= psi in w0, with 0 <= psi < 2^k - 1.
+ *
+ *   1: x'^{B,k+1}  <- SecAdd^d_{k+1}(x^{B,k}, 2^{k+1} - psi - 1)
+ *   2: b           <- SecUnMask^d_1(x'^{B,k+1}[k])
+ *
+ * Source: Alg.4 of "Protecting Dilithium against Leakage --
+ *         Revisited Sensitivity Analysis and Improved Implementations",
+ *         IACR TCHES 2023(4), pp. 58-79.
+ *         https://eprint.iacr.org/2022/1406
+ *
+ * @param[in]       a1: dptr_x, (k+1)*2*32 bytes (top WDR = 0; clobbered).
+ * @param[in]       w17: lane-0 holds C = 2^{k+1} - psi - 1.
+ * @param[in]  w31: all-zero.
+ * @param[out] w0: per-lane b (lane i = 1 iff x_i <= psi).
+ *
+ * clobbered registers: x5 to x7, x10 to x17, x28 to x31, w0 to w19
+ * clobbered flag groups: FG0
+ */
+.globl secleq
+secleq:
+    /* Stash x ptr in a7. */
+    addi a7, a1, 0
+
+    /* Step 1: x'^{B,k+1} <- SecAdd^d_{k+1}(C, x), in place. */
+    addi a0, a1, 0
+    addi a5, a1, 0
+    li   a2, MLDSA_KBITS_PLUS_1
+    li   a3, SHARE_STR_BYTES
+    li   a4, 2
+    jal  x1, secadd_bc22_immd_d2
+
+    /* Step 2: b <- SecUnMask^d_1(x'^{B,k+1}[k]). */
+    addi t1, a7, 736
+    addi t6, t1, SHARE_STR_BYTES
+    li   t3, 0
+    bn.lid t3, 0(t1)
+    li   t4, 1
+    bn.lid t4, 0(t6)
+    bn.wsrr w2, URND
+    bn.xor  w0, w0, w2
+    bn.xor  w1, w1, w2
+    bn.xor  w0, w0, w1
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/secunmask_modq.s
+++ b/sw/acc/crypto/mldsa/gadgets/secunmask_modq.s
@@ -1,0 +1,97 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x1,  ra
+.equ x5,  t0
+.equ x6,  t1
+.equ x7,  t2
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+#define POLY_BYTES 1024
+#define N_WDR      32     /* 256 / 8 */
+
+/*
+ * Name: secunmask_modq (PINI when output is public, d = 2)
+ *
+ * Refresh and unmask a 2-share arithmetic sharing of one polynomial mod q.
+ * Composes RefreshIOS^d_q ([BC22] Alg.18 in its linear-masking variant)
+ * with a sum-collapse.
+ *
+ *   1: x^{A_q}  <- RefreshIOS^d_q(x^{A_q})     . per-coef +/- with fresh r
+ *   2: out      <- x_0^{A_q} + x_1^{A_q} mod q . sum-collapse
+ *
+ * Runs per-WDR (8 coefs at a time).
+ * Caller must pre-load MOD with q in the lower half for .8s reductions.
+ *
+ * @param[out]      a0: dptr_out, 1024 B plaintext polynomial.
+ * @param[in,out]   a1: dptr_x, 2 * 1024 B input (stride 1024; refreshed in place).
+ * @param[in]  w31: all-zero.
+ *
+ * clobbered registers: x5 to x7, x28 to x31, w0 to w2, w11 to w15
+ * clobbered flag groups: FG0
+ */
+.globl secunmask_modq
+secunmask_modq:
+    /* w11 = 0x007FFFFF * 8 (23-bit per-lane mask). */
+    bn.not  w11, w31
+    bn.rshi w11, w31, w11 >> 233
+    bn.or   w11, w11, w11 << 32
+    bn.or   w11, w11, w11 << 64
+    bn.or   w11, w11, w11 << 128
+
+    /* w13 = 0xFF000000 * 8 (top byte of each lane). */
+    bn.shv.8s w13, w11 << 24
+
+    /* w12 = q packed 8 lanes. */
+    li     t0, 12
+    la     t1, modulus
+    bn.lid t0, 0(t1)
+
+    addi t3, a1, 0                /* share 0 cursor */
+    addi t4, a1, POLY_BYTES       /* share 1 cursor */
+    addi t5, a0, 0                /* output cursor */
+
+    li   t0, 0
+    li   t1, 1
+    li   t2, 2
+    loopi N_WDR, 9
+        jal         x1, _sample_rq
+        bn.lid      t0, 0(t3)
+        bn.addvm.8s w0, w0, w14        /* share 0 += r */
+        bn.sid      t0, 0(t3++)
+        bn.lid      t1, 0(t4)
+        bn.subvm.8s w1, w1, w14        /* share 1 -= r */
+        bn.sid      t1, 0(t4++)
+        bn.addvm.8s w2, w0, w1         /* out = share 0 + share 1 */
+        bn.sid      t2, 0(t5++)
+    ret
+
+/* Lane-parallel rejection sampler: returns w14 = 8 fresh uniform r in Z_q.
+ * Requires w11 = 23-bit mask, w12 = q vector, w13 = top-byte mask.
+ *   r  := URND & (2^23 - 1)                 (8 lanes of 23-bit uniform)
+ *   ok := (r - q signed) top byte == 0xFF   (per lane, encodes r < q)
+ *   retry while not all 8 lanes accept.
+ *
+ *   p_wdr = (8380417 / 2**23) ** 8  # ~0.9922
+ */
+_sample_rq:
+    bn.wsrr     w14, URND
+    bn.and      w14, w14, w11
+    bn.subv.8s  w15, w14, w12
+    bn.and      w15, w15, w13
+    bn.cmp      w15, w13
+    csrrs       t6, FG0, x0
+    andi        t6, t6, 8
+    beq         t6, x0, _sample_rq
+    ret

--- a/sw/acc/crypto/mldsa/gadgets/unbitslice.s
+++ b/sw/acc/crypto/mldsa/gadgets/unbitslice.s
@@ -1,0 +1,428 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+.equ x1,  ra
+.equ x2,  sp
+.equ x5,  t0
+.equ x6,  t1
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+
+#define KBITS 23
+
+/*
+ * Name: unbitslice (ML-DSA, KBITS = 23)
+ *
+ * Inverse of bitslice: take KBITS bitsliced WDRs (lane i of WDR j = bit
+ * j of coef i) and produce 32 canonical WDRs of 8 x 32-bit packed
+ * coefficients with the upper (32 - KBITS) bits zero.
+ *
+ * @param[in]       a0: ptr_out, dmem pointer to output (32 * 32 = 1024 B)
+ * @param[in]       a1: ptr_in,  dmem pointer to input  (KBITS * 32 bytes)
+ * @param[in]  w31: all-zero
+ *
+ * clobbered registers: x5, x10 to x12, x28, x30, w0 to w27
+ * clobbered flag groups: FG0
+ */
+.globl unbitslice
+unbitslice:
+    la   a2, scratch
+
+    /* === Phase 2: scatter 23 bitsliced inputs through three 8x8 lane
+     * transposes into 32 scratch WDRs.  q=3 (bits 23..31) is zero-filled. === */
+
+    /* --- q=0 --- */
+    li   t0, 0
+    loopi 8, 2
+        bn.lid t0, 0(a1++)
+        addi   t0, t0, 1
+
+    bn.trn1.8S w8,  w0, w1
+    bn.trn2.8S w9,  w0, w1
+    bn.trn1.8S w10, w2, w3
+    bn.trn2.8S w11, w2, w3
+    bn.trn1.8S w12, w4, w5
+    bn.trn2.8S w13, w4, w5
+    bn.trn1.8S w14, w6, w7
+    bn.trn2.8S w15, w6, w7
+    bn.trn1.4D w0,  w8,  w10
+    bn.trn2.4D w2,  w8,  w10
+    bn.trn1.4D w1,  w9,  w11
+    bn.trn2.4D w3,  w9,  w11
+    bn.trn1.4D w4,  w12, w14
+    bn.trn2.4D w6,  w12, w14
+    bn.trn1.4D w5,  w13, w15
+    bn.trn2.4D w7,  w13, w15
+    bn.trn1.2Q w16, w0, w4
+    bn.trn2.2Q w20, w0, w4
+    bn.trn1.2Q w17, w1, w5
+    bn.trn2.2Q w21, w1, w5
+    bn.trn1.2Q w18, w2, w6
+    bn.trn2.2Q w22, w2, w6
+    bn.trn1.2Q w19, w3, w7
+    bn.trn2.2Q w23, w3, w7
+
+    /* Store w16..w23 to scratch at stride 128. */
+    addi t3, a2, 0
+    li   t0, 16
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+
+    /* --- q=1 --- */
+    li   t0, 0
+    loopi 8, 2
+        bn.lid t0, 0(a1++)
+        addi   t0, t0, 1
+
+    bn.trn1.8S w8,  w0, w1
+    bn.trn2.8S w9,  w0, w1
+    bn.trn1.8S w10, w2, w3
+    bn.trn2.8S w11, w2, w3
+    bn.trn1.8S w12, w4, w5
+    bn.trn2.8S w13, w4, w5
+    bn.trn1.8S w14, w6, w7
+    bn.trn2.8S w15, w6, w7
+    bn.trn1.4D w0,  w8,  w10
+    bn.trn2.4D w2,  w8,  w10
+    bn.trn1.4D w1,  w9,  w11
+    bn.trn2.4D w3,  w9,  w11
+    bn.trn1.4D w4,  w12, w14
+    bn.trn2.4D w6,  w12, w14
+    bn.trn1.4D w5,  w13, w15
+    bn.trn2.4D w7,  w13, w15
+    bn.trn1.2Q w16, w0, w4
+    bn.trn2.2Q w20, w0, w4
+    bn.trn1.2Q w17, w1, w5
+    bn.trn2.2Q w21, w1, w5
+    bn.trn1.2Q w18, w2, w6
+    bn.trn2.2Q w22, w2, w6
+    bn.trn1.2Q w19, w3, w7
+    bn.trn2.2Q w23, w3, w7
+
+    addi t3, a2, 32
+    li   t0, 16
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+
+    /* --- q=2: 7 inputs + zero pad for missing bit 23. --- */
+    li   t0, 0
+    loopi 7, 2
+        bn.lid t0, 0(a1++)
+        addi   t0, t0, 1
+    bn.mov w7, w31
+
+    bn.trn1.8S w8,  w0, w1
+    bn.trn2.8S w9,  w0, w1
+    bn.trn1.8S w10, w2, w3
+    bn.trn2.8S w11, w2, w3
+    bn.trn1.8S w12, w4, w5
+    bn.trn2.8S w13, w4, w5
+    bn.trn1.8S w14, w6, w7
+    bn.trn2.8S w15, w6, w7
+    bn.trn1.4D w0,  w8,  w10
+    bn.trn2.4D w2,  w8,  w10
+    bn.trn1.4D w1,  w9,  w11
+    bn.trn2.4D w3,  w9,  w11
+    bn.trn1.4D w4,  w12, w14
+    bn.trn2.4D w6,  w12, w14
+    bn.trn1.4D w5,  w13, w15
+    bn.trn2.4D w7,  w13, w15
+    bn.trn1.2Q w16, w0, w4
+    bn.trn2.2Q w20, w0, w4
+    bn.trn1.2Q w17, w1, w5
+    bn.trn2.2Q w21, w1, w5
+    bn.trn1.2Q w18, w2, w6
+    bn.trn2.2Q w22, w2, w6
+    bn.trn1.2Q w19, w3, w7
+    bn.trn2.2Q w23, w3, w7
+
+    addi t3, a2, 64
+    li   t0, 16
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+    addi t3, t3, 128
+    addi t0, t0, 1
+    bn.sid t0, 0(t3)
+
+    /* --- q=3: zero-fill (no input bits). --- */
+    addi t3, a2, 96
+    li   t0, 31
+    loopi 8, 2
+        bn.sid t0, 0(t3)
+        addi   t3, t3, 128
+
+    /* === Rebuild masks w20..w27 (clobbered by Phase 2 transposes). === */
+    bn.not    w6,  w31
+    bn.shv.8S w20, w6  >> 16
+    bn.shv.8S w4,  w20 << 8
+    bn.xor    w21, w20, w4
+    bn.shv.8S w4,  w21 << 4
+    bn.xor    w22, w21, w4
+    bn.shv.8S w4,  w22 << 2
+    bn.xor    w23, w22, w4
+    bn.shv.8S w4,  w23 << 1
+    bn.xor    w24, w23, w4
+    bn.rshi   w25, w31, w6  >> 128
+    bn.rshi   w4,  w31, w6  >> 192
+    bn.rshi   w5,  w4,  w31 >> 128
+    bn.or     w26, w4,  w5
+    bn.rshi   w4,  w31, w6  >> 224
+    bn.rshi   w5,  w4,  w31 >> 192
+    bn.or     w4,  w4,  w5
+    bn.rshi   w5,  w4,  w31 >> 128
+    bn.or     w27, w4,  w5
+
+    /* === Phase 1: 8 groups of 32x32 bit transpose, scratch -> output. === */
+    addi t3, a2, 0
+    li   t5, 8
+
+    loop t5, 161
+        li   t0, 0
+        loopi 4, 2
+            bn.lid t0, 0(t3++)
+            addi   t0, t0, 1
+
+        /* Stage j=16 (cross-WDR). */
+        bn.shv.8S w4, w0 >> 16
+        bn.xor    w4, w2, w4
+        bn.and    w4, w4, w20
+        bn.xor    w2, w2, w4
+        bn.shv.8S w4, w4 << 16
+        bn.xor    w0, w0, w4
+
+        bn.shv.8S w4, w1 >> 16
+        bn.xor    w4, w3, w4
+        bn.and    w4, w4, w20
+        bn.xor    w3, w3, w4
+        bn.shv.8S w4, w4 << 16
+        bn.xor    w1, w1, w4
+
+        /* Stage j=8 (cross-WDR). */
+        bn.shv.8S w4, w0 >> 8
+        bn.xor    w4, w1, w4
+        bn.and    w4, w4, w21
+        bn.xor    w1, w1, w4
+        bn.shv.8S w4, w4 << 8
+        bn.xor    w0, w0, w4
+
+        bn.shv.8S w4, w2 >> 8
+        bn.xor    w4, w3, w4
+        bn.and    w4, w4, w21
+        bn.xor    w3, w3, w4
+        bn.shv.8S w4, w4 << 8
+        bn.xor    w2, w2, w4
+
+        /* Stage j=4 (intra-WDR). */
+        bn.rshi   w6, w31, w0 >> 128
+        bn.shv.8S w4, w0 >> 4
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w22
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 4
+        bn.xor    w0, w0, w4
+        bn.rshi   w6, w6, w31 >> 128
+        bn.and    w0, w0, w25
+        bn.or     w0, w0, w6
+
+        bn.rshi   w6, w31, w1 >> 128
+        bn.shv.8S w4, w1 >> 4
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w22
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 4
+        bn.xor    w1, w1, w4
+        bn.rshi   w6, w6, w31 >> 128
+        bn.and    w1, w1, w25
+        bn.or     w1, w1, w6
+
+        bn.rshi   w6, w31, w2 >> 128
+        bn.shv.8S w4, w2 >> 4
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w22
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 4
+        bn.xor    w2, w2, w4
+        bn.rshi   w6, w6, w31 >> 128
+        bn.and    w2, w2, w25
+        bn.or     w2, w2, w6
+
+        bn.rshi   w6, w31, w3 >> 128
+        bn.shv.8S w4, w3 >> 4
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w22
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 4
+        bn.xor    w3, w3, w4
+        bn.rshi   w6, w6, w31 >> 128
+        bn.and    w3, w3, w25
+        bn.or     w3, w3, w6
+
+        /* Stage j=2 (intra-WDR). */
+        bn.and    w5, w0, w26
+        bn.rshi   w6, w31, w0 >> 64
+        bn.and    w6, w6, w26
+        bn.shv.8S w4, w5 >> 2
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w23
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 2
+        bn.xor    w5, w5, w4
+        bn.rshi   w6, w6, w31 >> 192
+        bn.or     w0, w5, w6
+
+        bn.and    w5, w1, w26
+        bn.rshi   w6, w31, w1 >> 64
+        bn.and    w6, w6, w26
+        bn.shv.8S w4, w5 >> 2
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w23
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 2
+        bn.xor    w5, w5, w4
+        bn.rshi   w6, w6, w31 >> 192
+        bn.or     w1, w5, w6
+
+        bn.and    w5, w2, w26
+        bn.rshi   w6, w31, w2 >> 64
+        bn.and    w6, w6, w26
+        bn.shv.8S w4, w5 >> 2
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w23
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 2
+        bn.xor    w5, w5, w4
+        bn.rshi   w6, w6, w31 >> 192
+        bn.or     w2, w5, w6
+
+        bn.and    w5, w3, w26
+        bn.rshi   w6, w31, w3 >> 64
+        bn.and    w6, w6, w26
+        bn.shv.8S w4, w5 >> 2
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w23
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 2
+        bn.xor    w5, w5, w4
+        bn.rshi   w6, w6, w31 >> 192
+        bn.or     w3, w5, w6
+
+        /* Stage j=1 (intra-WDR). */
+        bn.and    w5, w0, w27
+        bn.rshi   w6, w31, w0 >> 32
+        bn.and    w6, w6, w27
+        bn.shv.8S w4, w5 >> 1
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w24
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 1
+        bn.xor    w5, w5, w4
+        bn.rshi   w6, w6, w31 >> 224
+        bn.or     w0, w5, w6
+
+        bn.and    w5, w1, w27
+        bn.rshi   w6, w31, w1 >> 32
+        bn.and    w6, w6, w27
+        bn.shv.8S w4, w5 >> 1
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w24
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 1
+        bn.xor    w5, w5, w4
+        bn.rshi   w6, w6, w31 >> 224
+        bn.or     w1, w5, w6
+
+        bn.and    w5, w2, w27
+        bn.rshi   w6, w31, w2 >> 32
+        bn.and    w6, w6, w27
+        bn.shv.8S w4, w5 >> 1
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w24
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 1
+        bn.xor    w5, w5, w4
+        bn.rshi   w6, w6, w31 >> 224
+        bn.or     w2, w5, w6
+
+        bn.and    w5, w3, w27
+        bn.rshi   w6, w31, w3 >> 32
+        bn.and    w6, w6, w27
+        bn.shv.8S w4, w5 >> 1
+        bn.xor    w4, w6, w4
+        bn.and    w4, w4, w24
+        bn.xor    w6, w6, w4
+        bn.shv.8S w4, w4 << 1
+        bn.xor    w5, w5, w4
+        bn.rshi   w6, w6, w31 >> 224
+        bn.or     w3, w5, w6
+
+        li   t0, 0
+        loopi 4, 2
+            bn.sid t0, 0(a0++)
+            addi   t0, t0, 1
+        nop
+
+    ret

--- a/sw/acc/crypto/mldsa/mldsa_consts.s
+++ b/sw/acc/crypto/mldsa/mldsa_consts.s
@@ -18,16 +18,19 @@
 #define ETA 2
 #define GAMMA1 131072
 #define GAMMA2 95232
+#define BETA 78
 
 #elif DILITHIUM_MODE == 3
 #define ETA 4
 #define GAMMA1 524288
 #define GAMMA2 261888
+#define BETA 196
 
 #elif DILITHIUM_MODE == 5
 #define ETA 2
 #define GAMMA1 524288
 #define GAMMA2 261888
+#define BETA 120
 
 #endif
 
@@ -327,6 +330,7 @@ twiddles_fwd:
   .word 0x006b16e0
   .word 0x001e29ce
 
+.balign 32
 .globl twiddles_inv
 twiddles_inv:
  /* Layer 8 - 1 */
@@ -609,18 +613,7 @@ reduce32_const:
     .word 0x1
     .word 0x1
 
-.balign 32
-.globl power2round_D
-power2round_D:
-    .word 0xd
-    .word 0xd
-    .word 0xd
-    .word 0xd
-    .word 0xd
-    .word 0xd
-    .word 0xd
-    .word 0xd
-
+#ifndef NSHARES
 .balign 32
 .globl power2round_D_preprocessed
 power2round_D_preprocessed:
@@ -632,6 +625,10 @@ power2round_D_preprocessed:
     .word 0xfff
     .word 0xfff
     .word 0xfff
+#else
+.globl power2round_D_preprocessed
+.set    power2round_D_preprocessed, 0
+#endif
 
 .balign 32
 .globl eta
@@ -657,6 +654,7 @@ polyt0_pack_const:
     .word 0x1000
     .word 0x1000
 
+#ifndef NSHARES
 .balign 32
 .globl decompose_const
 decompose_const:
@@ -678,6 +676,10 @@ decompose_const:
     .word 1025
     .word 1025
     .word 1025
+#endif
+#else
+.globl decompose_const
+.set    decompose_const, 0
 #endif
 
 .balign 32
@@ -716,6 +718,7 @@ qm1half_const:
     .word 0x003ff000
     .word 0x003ff000
 
+#ifndef NSHARES
 .balign 32
 .globl decompose_127_const
 decompose_127_const:
@@ -750,6 +753,12 @@ decompose_43_const:
     .word 0x000000f
     .word 0x000000f
 #endif
+#else
+.globl decompose_127_const
+.set    decompose_127_const, 0
+.globl decompose_43_const
+.set    decompose_43_const, 0
+#endif
 
 .balign 32
 .globl polyeta_unpack_mask
@@ -774,6 +783,7 @@ polyeta_unpack_mask:
     .word 0x0f
 #endif
 
+#ifndef NSHARES
 .balign 32
 .globl polyt1_unpack_mask
 polyt1_unpack_mask:
@@ -785,6 +795,10 @@ polyt1_unpack_mask:
     .word 0x3ff
     .word 0x3ff
     .word 0x3ff
+#else
+.globl polyt1_unpack_mask
+.set    polyt1_unpack_mask, 0
+#endif
 
 .balign 32
 .globl polyt0_unpack_mask
@@ -821,6 +835,7 @@ polyz_unpack_mask:
     .word 0xfffff
 #endif
 
+#ifndef NSHARES
 .balign 32
 .globl poly_uniform_eta_205
 poly_uniform_eta_205:
@@ -832,19 +847,12 @@ poly_uniform_eta_205:
     .word 205
     .word 205
     .word 205
+#else
+.globl poly_uniform_eta_205
+.set    poly_uniform_eta_205, 0
+#endif
 
-.balign 32
-.globl poly_uniform_eta_2
-poly_uniform_eta_2:
-    .word 2
-    .word 2
-    .word 2
-    .word 2
-    .word 2
-    .word 2
-    .word 2
-    .word 2
-
+#ifndef NSHARES
 .balign 32
 .globl poly_uniform_eta_5
 poly_uniform_eta_5:
@@ -856,7 +864,38 @@ poly_uniform_eta_5:
     .word 5
     .word 5
     .word 5
+#else
+.globl poly_uniform_eta_5
+.set    poly_uniform_eta_5, 0
+#endif
 
 .globl poly_wdr2gpr
 poly_wdr2gpr:
     .zero 32
+
+#ifdef NSHARES
+/* secboundcheck broadcast vectors (8 lanes of the lambda_0 bound). */
+.balign 32
+.globl lambda0_z_vec
+lambda0_z_vec:
+    .word (GAMMA1 - BETA - 1)
+    .word (GAMMA1 - BETA - 1)
+    .word (GAMMA1 - BETA - 1)
+    .word (GAMMA1 - BETA - 1)
+    .word (GAMMA1 - BETA - 1)
+    .word (GAMMA1 - BETA - 1)
+    .word (GAMMA1 - BETA - 1)
+    .word (GAMMA1 - BETA - 1)
+
+.balign 32
+.globl lambda0_r_vec
+lambda0_r_vec:
+    .word (GAMMA2 - BETA - 1)
+    .word (GAMMA2 - BETA - 1)
+    .word (GAMMA2 - BETA - 1)
+    .word (GAMMA2 - BETA - 1)
+    .word (GAMMA2 - BETA - 1)
+    .word (GAMMA2 - BETA - 1)
+    .word (GAMMA2 - BETA - 1)
+    .word (GAMMA2 - BETA - 1)
+#endif

--- a/sw/acc/crypto/mldsa/mldsa_keypair.s
+++ b/sw/acc/crypto/mldsa/mldsa_keypair.s
@@ -102,7 +102,7 @@
 .equ x3, fp
 
 .equ x5, t0
-.equ x6, t1
+#define t1 x6
 .equ x7, t2
 
 .equ x8, s0
@@ -154,10 +154,70 @@
  * @param[out] dmem[pk]: public key
  * @param[out] dmem[sk]: secret key
  *
- * clobbered registers: a0-a6, t0-t5, s1, w0-w30
+ * clobbered registers: a0-a7, t0-t6, s0-s11, w0-w30 (top-level entry,
+ * saves nothing and resets sp)
  */
 .globl crypto_sign_keypair
 crypto_sign_keypair:
+#ifdef NSHARES
+    /* Masked gadgets use sp for stack frames. */
+    la    sp, keygen_mask_stack_end
+    /* Masked seed expansion: absorb d=2 zeta shares into masked SHAKE-256. */
+    li    a1, SEEDBYTES
+    addi  a1, a1, 2 /* SEEDBYTES+2 */
+    slli  t0, a1, 5
+    addi  t0, t0, SHAKE256_CFG
+    li    a4, 1
+    slli  a4, a4, 20 /* masking-enable bit */
+    add   t0, t0, a4
+    csrrw x0, kmac_cfg, t0
+
+    la     t1, zeta_shares
+    bn.lid x0, 0(t1)
+    bn.wsrw kmac_msg, w0
+    bn.lid x0, 32(t1)
+    bn.wsrw kmac_msg1, w0
+
+    /* K, L are public: share 1 = 0. */
+    li      t0, 1
+    csrrw   x0, kmac_partial_write, t0
+    bn.addi w0, w31, K
+    bn.wsrw kmac_msg, w0
+    bn.xor  w0, w0, w0
+    bn.wsrw kmac_msg1, w0
+    csrrw   x0, kmac_partial_write, t0
+    bn.addi w0, w31, L
+    bn.wsrw kmac_msg, w0
+    bn.xor  w0, w0, w0
+    bn.wsrw kmac_msg1, w0
+
+    /* Sec-unmask of rho (public): refresh shares with URND, then XOR-collapse. */
+    la      t0, sk
+    bn.wsrr w0, kmac_digest
+    bn.wsrr w1, kmac_digest1
+    bn.wsrr w2, urnd
+    bn.xor  w0, w0, w2
+    bn.xor  w1, w1, w2
+    bn.xor  w0, w0, w1
+    bn.sid  x0, 0(t0)
+    /* rho': masked output to rho_prime_shares (share-major). */
+    la      t1, rho_prime_shares
+    li      t2, 1
+    bn.wsrr w0, kmac_digest
+    bn.wsrr w1, kmac_digest1
+    bn.sid  x0, 0(t1)
+    bn.sid  t2, 64(t1)
+    bn.wsrr w0, kmac_digest
+    bn.wsrr w1, kmac_digest1
+    bn.sid  x0, 32(t1)
+    bn.sid  t2, 96(t1)
+    /* K: masked output to K_shares (K is unused by keygen). */
+    la      t1, K_shares
+    bn.wsrr w0, kmac_digest
+    bn.wsrr w1, kmac_digest1
+    bn.sid  x0, 0(t1)
+    bn.sid  t2, 32(t1)
+#else
     /* Initialize a SHAKE256 operation. */
     li    a1, SEEDBYTES
     addi  a1, a1, 2 /* SEEDBYTES+2 */
@@ -190,19 +250,27 @@ crypto_sign_keypair:
     bn.sid  x0, 0(t1)
     bn.wsrr w0, kmac_digest
     bn.sid  x0, 0(t0)
+#endif
 
     /* Finish the SHAKE-256 operation. */
 
     bn.wsrr   w16, mod /* w16 = R | Q */
+
     bn.shv.8S w22, w16 << 1 /* w22 = 2*R | 2*Q */
     bn.wsrw   mod, w22 /* MOD = 2*R | 2*Q */
 
-    /* Load source pointers for matrix-vector multiplication. */
-    la  s0, s1_poly
-    la  s1, tmp_poly
-
     /* Load destination pointer for matrix-vector multiplication. */
     la  s2, t_polyvec
+
+    /* Load source pointers for matrix-vector multiplication. */
+#ifdef NSHARES
+    la   s5, eta_out
+    addi s10, s5, 1024
+    addi s0, s2, 1024
+#else
+    la  s0, s1_poly
+#endif
+    la  s1, tmp_poly
 
     /* Zero the destination buffer. */
     li t0, 31
@@ -211,23 +279,34 @@ crypto_sign_keypair:
         LOOPI 32, 1
           bn.sid t0, 0(t1++)
         nop
+#ifdef NSHARES
+    LOOPI K, 3
+        LOOPI 32, 1
+          bn.sid t0, 0(t1++)
+        nop
+#endif
 
     /* Load offset for resetting vector pointer. */
     li s3, POLYVECK_BYTES
+#ifdef NSHARES
+    slli s3, s3, 1
+#endif
 
     /* Initialize the nonce for matrix expansion. This value should be
          byte(i) || byte(j)
        for entry A[i][j]. */
     bn.xor w23, w23, w23
 
-    /* Load pointers to rho and rho'. */
+    /* Load pointer to rho. */
     la  s8, sk
+#ifndef NSHARES
     la  s5, rhoprime
+#endif
 
     /* Initialize the nonce for sampling s1. */
     li   s6, 0
 
-    /* Load the destination for packed s1 within the secret key. */
+    /* Secret-key write cursor (masked packs only t0, here at sk+128). */
     la   s7, sk
     addi s7, s7, 128
 
@@ -246,6 +325,121 @@ crypto_sign_keypair:
            for i in 0..k-1:
              t[i] += A[i][j] * s1j
     */
+#ifdef NSHARES
+    /* bne-based (not loopi) so masked_poly_uniform_eta's loop/secadd chain
+       gets the full hardware loop stack. */
+    li   s9, L
+matmul_col_loop:
+        bn.wsrw   mod, w16 /* MOD = R | Q for the gadget */
+        /* The gadget clobbers w0-w27; stash the matrix nonce. */
+        li     t0, 23
+        la     t1, matmul_nonce
+        bn.sid t0, 0(t1)
+        /* Masked ExpandS: s1[j] as arithmetic shares in eta_out. */
+        addi a0, s5, 0
+        la   a1, rho_prime_shares
+        addi a2, s6, 0
+#if DILITHIUM_MODE == 5
+        la   a3, sk
+        addi a3, a3, 128
+        la   a4, pk
+#else
+        la   a3, eta_scratch
+        la   a4, eta_b2a
+#endif
+        jal  x1, masked_poly_uniform_eta
+        addi s6, s6, 1
+        li     t0, 23
+        la     t1, matmul_nonce
+        bn.lid t0, 0(t1)
+        bn.wsrr w16, mod /* gadget left MOD = R | Q */
+        /* Start the SHAKE128 operation for poly_uniform for A[0][j]. */
+        csrrw x0, kmac_cfg, s4
+        addi  a0, s8, 0
+        bn.lid    x0, 0(a0)
+        bn.wsrw   kmac_msg, w0
+        addi      t0, x0, 2
+        csrrw     x0, kmac_partial_write, t0
+        bn.wsrw   kmac_msg, w23
+        bn.shv.8S w22, w16 << 1 /* w22 = 2*R | 2*Q */
+        bn.wsrw   mod, w22 /* MOD = 2*R | 2*Q */
+        /* ntt both shares of s1[j] in place. */
+        addi a0, s5, 0
+        addi a2, s5, 0
+        jal  x1, ntt
+        /* Whitening */
+        bn.xor w0, w0, w0
+        bn.xor w1, w1, w1
+        bn.xor w2, w2, w2
+        bn.xor w3, w3, w3
+        bn.xor w4, w4, w4
+        bn.xor w5, w5, w5
+        bn.xor w6, w6, w6
+        bn.xor w7, w7, w7
+        bn.xor w8, w8, w8
+        bn.xor w9, w9, w9
+        bn.xor w10, w10, w10
+        bn.xor w11, w11, w11
+        bn.xor w12, w12, w12
+        bn.xor w13, w13, w13
+        bn.xor w14, w14, w14
+        bn.xor w15, w15, w15
+        bn.xor w17, w17, w17
+        bn.xor w18, w18, w18
+        bn.xor w19, w19, w19
+        bn.xor w20, w20, w20
+        bn.xor w21, w21, w21
+        bn.xor w24, w24, w24
+        bn.xor w25, w25, w25
+        bn.xor w26, w26, w26
+        bn.xor w27, w27, w27
+        bn.xor w28, w28, w28
+        bn.xor w29, w29, w29
+        bn.xor w30, w30, w30
+        addi a0, s10, 0
+        addi a2, s10, 0
+        jal  x1, ntt
+        loopi K, 24
+            /* Compute A[i][j]. */
+            addi a1, s1, 0
+            jal  x1, poly_uniform
+            /* Increment the row in the matrix nonce (upper byte). */
+            bn.addi w23, w23, 256
+            /* Start the SHAKE128 operation for poly_uniform for A[i+1][j]. */
+            csrrw x0, kmac_cfg, s4
+            addi  a0, s8, 0
+            bn.lid    x0, 0(a0)
+            bn.wsrw   kmac_msg, w0
+            addi      t0, x0, 2
+            csrrw     x0, kmac_partial_write, t0
+            bn.wsrw   kmac_msg, w23
+            /* t share 0 += A[i][j] * ntt(s1[j])_share0. */
+            addi a0, s5, 0
+            addi a1, s1, 0
+            addi a2, s2, 0
+            jal  x1, poly_pointwise_acc
+            /* Whitening */
+            bn.xor w0, w0, w0
+            bn.xor w1, w1, w1
+            /* t share 1 += A[i][j] * ntt(s1[j])_share1. */
+            addi a0, s10, 0
+            addi a1, s1, 0
+            addi a2, s0, 0
+            jal  x1, poly_pointwise_acc
+            addi s2, s2, 1024
+            addi s2, s2, 1024
+            addi s0, s0, 1024
+            addi s0, s0, 1024
+        /* Reset output vector pointers. */
+        sub  s2, s2, s3
+        sub  s0, s0, s3
+        /* Increment the column index in the nonce by one. */
+        bn.addi w23, w23, 1
+        /* Reset the row index in the nonce to zero. */
+        bn.rshi w23, w23, bn0 >> 8
+        bn.rshi w23, bn0, w23 >> 248
+        bne s6, s9, matmul_col_loop
+#else
     loopi L, 41
         bn.wsrw   mod, w16 /* MOD = R | Q */
         /* Sample the next polynomial from s1. */
@@ -300,25 +494,139 @@ crypto_sign_keypair:
         /* Reset the row index in the nonce to zero. */
         bn.rshi w23, w23, bn0 >> 8
         bn.rshi w23, bn0, w23 >> 248
+#endif
 
     /* After poly_pointwise, w16 is still R | Q and MOD is still 2*R | 2*Q */
     /* Inverse NTT on t=A*s1 */
     la  a0, t_polyvec
 
+#ifdef NSHARES
+    LOOPI K, 30
+        /* Whitening */
+        bn.xor w0, w0, w0
+        bn.xor w1, w1, w1
+        bn.xor w2, w2, w2
+        bn.xor w3, w3, w3
+        bn.xor w4, w4, w4
+        bn.xor w5, w5, w5
+        bn.xor w6, w6, w6
+        bn.xor w7, w7, w7
+        bn.xor w8, w8, w8
+        bn.xor w9, w9, w9
+        bn.xor w10, w10, w10
+        bn.xor w11, w11, w11
+        bn.xor w12, w12, w12
+        bn.xor w13, w13, w13
+        bn.xor w14, w14, w14
+        bn.xor w15, w15, w15
+        bn.xor w17, w17, w17
+        bn.xor w18, w18, w18
+        bn.xor w19, w19, w19
+        bn.xor w20, w20, w20
+        bn.xor w21, w21, w21
+        bn.xor w24, w24, w24
+        bn.xor w25, w25, w25
+        bn.xor w26, w26, w26
+        bn.xor w27, w27, w27
+        bn.xor w28, w28, w28
+        bn.xor w29, w29, w29
+        bn.xor w30, w30, w30
+        jal  x1, intt
+        addi a0, a0, 1024
+    LOOPI K, 30
+        /* Whitening */
+        bn.xor w0, w0, w0
+        bn.xor w1, w1, w1
+        bn.xor w2, w2, w2
+        bn.xor w3, w3, w3
+        bn.xor w4, w4, w4
+        bn.xor w5, w5, w5
+        bn.xor w6, w6, w6
+        bn.xor w7, w7, w7
+        bn.xor w8, w8, w8
+        bn.xor w9, w9, w9
+        bn.xor w10, w10, w10
+        bn.xor w11, w11, w11
+        bn.xor w12, w12, w12
+        bn.xor w13, w13, w13
+        bn.xor w14, w14, w14
+        bn.xor w15, w15, w15
+        bn.xor w17, w17, w17
+        bn.xor w18, w18, w18
+        bn.xor w19, w19, w19
+        bn.xor w20, w20, w20
+        bn.xor w21, w21, w21
+        bn.xor w24, w24, w24
+        bn.xor w25, w25, w25
+        bn.xor w26, w26, w26
+        bn.xor w27, w27, w27
+        bn.xor w28, w28, w28
+        bn.xor w29, w29, w29
+        bn.xor w30, w30, w30
+        jal  x1, intt
+        addi a0, a0, 1024
+#else
     LOOPI K, 2
         jal  x1, intt
         addi a0, a0, 1024 /* Go to next input polynomial */
+#endif
     bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
 
     /* Load pointers for loop. */
+#ifdef NSHARES
+    la   s2, t_polyvec
+    addi s0, s2, 1024
+    la   s1, tmp_poly
+#else
     la  s0, tmp_poly
     la  s1, t_polyvec
     la  s3, rhoprime
+#endif
 
     /* Initialize the nonce for sampling s2. */
     li s6, L
 
     /* This loop samples s2 and adds it to A*s1 (currently in the t buffer). */
+#ifdef NSHARES
+    li   s9, L
+    addi s9, s9, K
+s2_sample_loop:
+        /* Masked ExpandS: s2[i] as arithmetic shares in eta_out. */
+        addi a0, s5, 0
+        la   a1, rho_prime_shares
+        addi a2, s6, 0
+#if DILITHIUM_MODE == 5
+        la   a3, sk
+        addi a3, a3, 128
+        la   a4, pk
+#else
+        la   a3, eta_scratch
+        la   a4, eta_b2a
+#endif
+        jal  x1, masked_poly_uniform_eta
+        addi s6, s6, 1
+        /* t share 0 += s2[i]_share0. */
+        addi a0, s5, 0
+        addi a1, s2, 0
+        addi a2, s2, 0
+        jal  x1, poly_add
+        /* Whitening */
+        bn.xor w0, w0, w0
+        bn.xor w1, w1, w1
+        /* t share 1 += s2[i]_share1. */
+        addi a0, s10, 0
+        addi a1, s0, 0
+        addi a2, s0, 0
+        jal  x1, poly_add
+        /* Whitening */
+        bn.xor w0, w0, w0
+        bn.xor w1, w1, w1
+        addi s2, s2, 1024
+        addi s2, s2, 1024
+        addi s0, s0, 1024
+        addi s0, s0, 1024
+        bne s6, s9, s2_sample_loop
+#else
     LOOPI K, 14
         /* Sample the next polynomial from s2 and store in temp buffer. */
         addi a0, s3, 0
@@ -338,6 +646,24 @@ crypto_sign_keypair:
         jal  x1, poly_add
         /* Increment polyvec pointer *t. */
         addi s1, s1, 1024
+#endif
+
+#ifdef NSHARES
+    /* Unmask t into t_polyvec[0:K*1024]. */
+    la   s0, t_polyvec
+    addi s1, s0, 0
+    li   s9, K
+t_unmask_loop:
+        addi a0, s1, 0
+        addi a1, s0, 0
+        jal  x1, secunmask_modq
+        addi s0, s0, 1024
+        addi s0, s0, 1024
+        addi s1, s1, 1024
+        addi s9, s9, -1
+        bne  s9, x0, t_unmask_loop
+    la  s0, tmp_poly
+#endif
 
     /* Reset t pointer for power2round loop. */
     la  s1, t_polyvec
@@ -400,22 +726,62 @@ crypto_sign_keypair:
 
 .bss
 
+#ifdef NSHARES
+.balign 32
+.globl rho_prime_shares
+rho_prime_shares:
+.zero 128
+.balign 32
+.globl K_shares
+K_shares:
+.zero 64
+
+/* masked_poly_uniform_eta scratch; the bitslice scratch reuses tmp_poly.
+   L5 reuses the dead sk t0-region (a3) and pk (a4) to fit DMEM. */
+.balign 32
+eta_out:
+.zero 2048
+#if DILITHIUM_MODE != 5
+.balign 32
+eta_scratch:
+.zero 3104
+.balign 32
+eta_b2a:
+.zero 1536
+#endif
+/* Matrix nonce saved across the gadget call. */
+.balign 32
+matmul_nonce:
+.zero 32
+/* Stack for the masked gadget frames. */
+.balign 32
+keygen_mask_stack:
+.zero 224
+keygen_mask_stack_end:
+#else
 /* rho' intermediate value (64B). */
 .balign 32
 rhoprime:
 .zero 64
+#endif
 
 /* Temporary polynomial buffer (1024B). */
 .balign 32
 tmp_poly:
 .zero 1024
 
+#ifndef NSHARES
 /* s1 intermediate polynomial buffer (1024B). */
 .balign 32
 s1_poly:
 .zero 1024
+#endif
 
-/* t polynomial vector (K*1024B). */
+/* t polyvec; masked holds 2*K*1024 interleaved share pairs. */
 .balign 32
 t_polyvec:
+#ifdef NSHARES
+.zero 2 * POLYVECK_BYTES
+#else
 .zero POLYVECK_BYTES
+#endif

--- a/sw/acc/crypto/mldsa/mldsa_sign.s
+++ b/sw/acc/crypto/mldsa/mldsa_sign.s
@@ -91,17 +91,49 @@
 #define POLYW1_PACKEDBYTES  128
 #endif
 
+/* secboundcheck bounds C_Z = (1 << 24) - 2*(GAMMA1-BETA-1) - 1 and
+ * C_R = (1 << 24) - 2*(GAMMA2-BETA-1) - 1, split into 8-bit slices for
+ * the per-call bn.addi/bn.shv.8S build of w17 (acc_as does not evaluate
+ * arithmetic in bn.addi immediates). */
+#if DILITHIUM_MODE == 2
+#define C_Z_HI  0xFC
+#define C_Z_MID 0x00
+#define C_Z_LO  0x9D
+#define C_R_HI  0xFD
+#define C_R_MID 0x18
+#define C_R_LO  0x9D
+#elif DILITHIUM_MODE == 3
+#define C_Z_HI  0xF0
+#define C_Z_MID 0x01
+#define C_Z_LO  0x89
+#define C_R_HI  0xF8
+#define C_R_MID 0x03
+#define C_R_LO  0x89
+#elif DILITHIUM_MODE == 5
+#define C_Z_HI  0xF0
+#define C_Z_MID 0x00
+#define C_Z_LO  0xF1
+#define C_R_HI  0xF8
+#define C_R_MID 0x02
+#define C_R_LO  0xF1
+#endif
+
 #if ETA == 2
 #define POLYETA_PACKEDBYTES  96
+#define ETA_KBITS              3
 #elif ETA == 4
 #define POLYETA_PACKEDBYTES 128
+#define ETA_KBITS              4
 #endif
 /* Register aliases */
 .equ x2, sp
 .equ x3, fp
 
 .equ x5, t0
-.equ x6, t1
+/* TODO(acc_as): switch back to `.equ x6, t1` once the assembler's
+ * naive textual substitution stops mangling identifiers that end in
+ * `t1` (e.g., `kmac_digest1` -> `kmac_digesx6`). */
+#define t1 x6
 .equ x7, t2
 
 .equ x8, s0
@@ -146,20 +178,23 @@
 /* Config to start a SHA3_512 operation. */
 #define SHA3_512_CFG 0x10
 
+#define W0_POLYVEC w0_polyvec
+
 
 /**
- * Dilithium Sign
+ * Dilithium Sign_internal (external-mu mode; FIPS 204 Algorithm 7).
  *
  * Returns: 0 on success
+ *
+ * The caller pre-hashes the message+context to mu and places it in
+ * dmem[mu].  ML-DSA-spec mu = SHAKE256(tr || 0x00 || byte(ctxlen) ||
+ * ctx || msg, 64).
  *
  * All input DMEM buffers must be 32-byte aligned and initialized up to the
  * next 32B boundary so wide-reads succeed.
  *
  * @param[in]  x10: *sig (destination pointer)
- * @param[in]  dmem[msg]: message
- * @param[in]  x11: message length in bytes
- * @param[in]  dmem[ctx]: context value (0-256B)
- * @param[in]  x12: context length in bytes
+ * @param[in]  dmem[mu]: pre-hashed message (64B)
  * @param[in]  dmem[sk]: secret key, 32B aligned
  * @param[in]  dmem[rnd]: signature randomization value (32B)
  * @param[out] x10: 0 (success)
@@ -169,65 +204,10 @@
  */
 .global crypto_sign_signature_internal
 crypto_sign_signature_internal:
-    /* Store pointer parameters. */
-    la  t0, dptr_sig
-    sw  a0, 0(t0)
-
-    /* Save length parameters to registers. */
-    addi s0, a1, 0
-    addi s1, a2, 0
-
-    /* CRH(tr, msg) */
-
-    /* Compute the total length of tr + [0,ctxlen] + ctx + msg. */
-    li   t1, TRBYTES
-    addi t1, t1, 2
-    add  t1, t1, s1 /* Add len(ctx) */
-    add  t1, t1, s0 /* Add msglen */
-
-    /* Initialize a SHAKE256 operation. */
-    slli  t0, t1, 5
-    addi  t0, t0, SHAKE256_CFG
-    csrrw x0, KECCAK_CFG_REG, t0
-
-    /* Send tr component of secret key (sk[64:128]) to the Keccak core. */
-    li   a1, TRBYTES
-    la   a0, sk
-    addi a0, a0, 64
-    jal  x1, keccak_send_message
-
-    /* Write zeroes to the tmp buffer (necessary so reads don't fail after a
-       partial write). */
-    la      a0, tmp_poly
-    li      t1, 31
-    bn.sid  t1, 0(a0)
-
-    /* Copy 0 || ctxlen to a 32B-aligned buffer temporarily. */
-    slli t1, s1, 8
-    sw   t1, 0(a0)
-
-    /* Send 0 || ctxlen to the Keccak core (2B). */
-    li  a1, 2
-    jal x1, keccak_send_message
-
-    /* Send ctx to the Keccak core. */
-    addi a1, s1, 0 /* a1 <= ctxlen */
-    la   a0, ctx /* a0 <= *ctx */
-    jal  x1, keccak_send_message
-
-    /* Send message to the Keccak core. */
-    addi a1, s0, 0 /* a1 <= msglen */
-    la   a0, msg /* a0 <= *msg */
-    jal  x1, keccak_send_message
-
-    /* Write 64B of SHAKE output to dmem[mu]. */
-    la  a0, mu
-    bn.wsrr w0, kmac_digest
-    bn.sid  x0, 0(a0++)
-    bn.wsrr w0, kmac_digest
-    bn.sid  x0, 0(a0)
-
-    /* Finish the SHAKE-256 operation. */
+    /* External-mu mode (FIPS 204 Algorithm 7, ML-DSA.Sign_internal):
+     * caller pre-hashes the message and provides mu in dmem[mu].  The
+     * msg/ctx buffers and the initial SHAKE-256 over tr||ctxlen||ctx||msg
+     * are gone -- saves ~2.4 KiB DMEM and one Keccak invocation. */
 
     /* Initialize a SHAKE256 operation. */
     addi  a1, x0, SEEDBYTES
@@ -267,17 +247,26 @@ crypto_sign_signature_internal:
     /* Prepare modulus */
     #define mod_x2 w22
     bn.wsrr   w16, 0x0 /* w16 = MOD = R | Q */
+
     bn.shv.8S mod_x2, w16 << 1 /* mod_x2 = 2*R | 2*Q */
 
     li s11, 0 /* nonce */
 
-_rej_crypto_sign_signature_internal:
+    jal  x1, sign_attempt
+    ret
+
+/* sign_attempt: rejection-retry body.  Computes w, w0/w1 + c~, c,
+ * z (z-loop), h (hint loop); restarts in place on rejection.  Inputs
+ * are taken from caller-set state (masked_gamma1_buf, sk, etc.); on
+ * success returns a0 = 0, a1 = CRYPTO_BYTES. */
+.global sign_attempt
+sign_attempt:
     /* Matrix-vector multiplication */
 
     /* Get destination pointer. */
-    la s1, w0_polyvec
+    la s1, W0_POLYVEC
 
-    /* Initialize destination to 0. */
+    /* Zero each share's polyvec; t1 walks the contiguous buffer. */
     li t0, 31
     addi t1, s1, 0
     LOOPI K, 3
@@ -376,15 +365,14 @@ _rej_crypto_sign_signature_internal:
         bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
 
     bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
-    /* Inverse NTT on w */
-    la  a0, w0_polyvec
-
+    /* Inverse NTT on w. */
+    la  a0, W0_POLYVEC
     LOOPI K, 2
         jal x1, intt
-        /* Go to next input polynomial */
         addi a0, a0, 1024
 
     bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
+
 
     /* Random oracle */
     /* Initialize a SHAKE256 operation. */
@@ -401,13 +389,12 @@ _rej_crypto_sign_signature_internal:
     jal x1, keccak_send_message
 
     /* Save some pointers for loop. */
-    la  s0, w0_polyvec
+    la  s0, W0_POLYVEC
     la  s1, w1_repvec
     la  s4, tmp_poly
 
     /* Get the pointer to the signature (used as tmp buffer for packed w1). */
-    la  s2, dptr_sig
-    lw  s2, 0(s2) /* Get *sig */
+    la  s2, sig
     addi s3, s2, 0 /* Save *sig. */
 #if CTILDEBYTES == 48
     /* Use an offset of 16 to get an aligned buffer (alignment hack for CTILDE). */
@@ -510,8 +497,7 @@ _rej_crypto_sign_signature_internal:
     la   s2, tmp_poly
     la   s3, rhoprime
     la   s7, c_poly
-    la   s9, dptr_sig
-    lw   s9, 0(s9)
+    la   s9, sig
     addi s9, s9, CTILDEBYTES /* c is already packed */
     la   s10, gamma1_vec_const
 
@@ -566,7 +552,7 @@ _rej_crypto_sign_signature_internal:
         sub  a1, t0, t1
         jal x1, poly_chknorm
 
-        bne a2, x0, _rej_crypto_sign_signature_internal
+        bne a2, x0, sign_attempt
 
         /* Speculatively pack z[i] into the signature. */
         addi a0, s9, 0
@@ -610,8 +596,10 @@ _rej_crypto_sign_signature_internal:
     addi s0, s0, 1568
 #endif
 
-    /* Initialize some pointers for the loop. */
-    la  s3, w0_polyvec
+    /* s3 walks packed share 0 (608 B/poly), share 1 at s3 +
+     * POLYVECK_BYTES.  hint_b2a_scratch re-`la`'d per use to keep s11
+     * free for the y-sampling nonce on rejection. */
+    la  s3, W0_POLYVEC
     la  s5, w1_repvec
     la  s7, c_poly
     la  s10, tmp_poly
@@ -622,8 +610,8 @@ _rej_crypto_sign_signature_internal:
     /* Initialize the counter for the index in the hint vector. */
     li  s6, 0
 
-    /* Initialize the register that says whether the checks failed. */
-    li  s8, 0
+    /* Hint loop counter. */
+    li  s8, K
 
     /* Normalize w0 to the [0, q) range (in-place). */
     addi   a0, s3, 0
@@ -655,11 +643,7 @@ _rej_crypto_sign_signature_internal:
            reject
          make_hint(h, w0[i], w1[i]) # gets written directly into signature
      */
-    loopi K, 73
-        /* If there was a failure, skip to the end of the
-           loop body (because of architectural loop rules, we have to complete
-           all iterations). */
-        bne  s8, x0, _mldsa_sign_hint_loop_end
+_mldsa_sign_hint_loop:
 
         /* Unpack the next polynomial from s2. */
         addi a0, s10, 0
@@ -706,8 +690,8 @@ _rej_crypto_sign_signature_internal:
         sub  a1, t0, t1
         jal  x1, poly_chknorm
 
-        /* Update the continuation register. */
-        or  s8, s8, a2
+        /* Reject if ||rtilde|| >= gamma2 - beta on any lane. */
+        bne a2, x0, sign_attempt
 
         /* Unpack the next polynomial from t0. */
         addi a0, s10, 0
@@ -752,8 +736,8 @@ _rej_crypto_sign_signature_internal:
         addi a0, s10, 0
         jal  x1, poly_chknorm
 
-        /* Update the continuation register. */
-        or  s8, s8, a2
+        /* Reject if ||c*t0|| >= gamma2 on any lane. */
+        bne a2, x0, sign_attempt
 
         /* h[i] = make_hint(w0[i], w1[i]) */
         addi   a0, s10, 0
@@ -770,8 +754,8 @@ _rej_crypto_sign_signature_internal:
         sub  t0, t0, s4
         srli t0, t0, 31
 
-        /* Update the continuation register. */
-        or  s8, s8, t0
+        /* Reject if hint weight > omega. */
+        bne t0, x0, sign_attempt
 
         /* Encode h[i] into the signature. */
         addi a0, s9, 0
@@ -781,12 +765,11 @@ _rej_crypto_sign_signature_internal:
 
         /* Increment i. */
         addi s6, s6, 1
-        _mldsa_sign_hint_loop_end:
-        /* Update pointer into w0. */
+        /* Advance to next poly. */
         addi s3, s3, 1024
-
-    /* Reject the signature if any conditions failed in the hint loop. */
-    bne  s8, x0, _rej_crypto_sign_signature_internal
+        /* Decrement remaining-iter count and loop while > 0. */
+        addi s8, s8, -1
+        bne  s8, x0, _mldsa_sign_hint_loop
 
     /* Return success and signature length */
     li a0, 0
@@ -795,31 +778,20 @@ _rej_crypto_sign_signature_internal:
 
 .bss
 
-/* Pointer to the signature. */
-.balign 4
-dptr_sig:
-.zero 4
-
-/* mu intermediate value (64B). */
-.balign 32
-mu:
-.zero 64
+/* mu (64B) is supplied by the caller's data section in external-mu mode. */
 
 /* rho' intermediate value (64B). */
 .balign 32
 rhoprime:
 .zero 64
 
-/* Challenge polynomial (1024B). */
-.balign 32
-c_poly:
-/* y[i] intermediate value (1024B, shares a slot with c_poly). */
-y_poly:
-.zero 1024
-
-/* Temporary polynomial buffer (1024B). */
 .balign 32
 tmp_poly:
+.zero 1024
+.balign 32
+.globl c_poly
+c_poly:
+y_poly:
 .zero 1024
 
 /* w1 representative vector (K*32B). */
@@ -833,7 +805,6 @@ w1_repvec:
 .zero 256
 #endif
 
-/* w0 polynomial vector (K*1024B). */
 .balign 32
 w0_polyvec:
 .zero POLYVECK_BYTES

--- a/sw/acc/crypto/mldsa/mldsa_sign_masked.s
+++ b/sw/acc/crypto/mldsa/mldsa_sign_masked.s
@@ -1,0 +1,1302 @@
+/* Copyright zeroRISC Inc. */
+/* Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192). */
+/* Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors. */
+/* Modified by Ruben Niederhagen and Hoang Nguyen Hien Pham - authors of */
+/* "Improving ML-KEM & ML-DSA on OpenTitan - Efficient Multiplication Vector Instructions for OTBN" */
+/* (https://eprint.iacr.org/2025/2028). */
+/* Copyright Ruben Niederhagen and Hoang Nguyen Hien Pham. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.text
+
+#define SEEDBYTES 32
+#define CRHBYTES 64
+#define TRBYTES 64
+#define RNDBYTES 32
+#define N 256
+#define Q 8380417
+#define D 13
+#define ROOT_OF_UNITY 1753
+
+#if DILITHIUM_MODE == 2
+#define K 4
+#define L 4
+#define ETA 2
+#define TAU 39
+#define BETA 78
+#define GAMMA1 131072
+#define GAMMA2 95232
+#define OMEGA 80
+#define CTILDEBYTES 32
+
+#define POLYVECK_BYTES 4096
+#define POLYVECL_BYTES 4096
+
+#define CRYPTO_PUBLICKEYBYTES 1312
+#define CRYPTO_SECRETKEYBYTES 2560
+#define CRYPTO_BYTES 2420
+
+#elif DILITHIUM_MODE == 3
+#define K 6
+#define L 5
+#define ETA 4
+#define TAU 49
+#define BETA 196
+#define GAMMA1 524288
+#define GAMMA2 261888
+#define OMEGA 55
+#define CTILDEBYTES 48
+
+#define POLYVECK_BYTES 6144
+#define POLYVECL_BYTES 5120
+
+#define CRYPTO_PUBLICKEYBYTES 1952
+#define CRYPTO_SECRETKEYBYTES 4032
+#define CRYPTO_BYTES 3309
+
+#elif DILITHIUM_MODE == 5
+#define K 8
+#define L 7
+#define ETA 2
+#define TAU 60
+#define BETA 120
+#define GAMMA1 524288
+#define GAMMA2 261888
+#define OMEGA 75
+#define CTILDEBYTES 64
+
+#define POLYVECK_BYTES 8192
+#define POLYVECL_BYTES 7168
+
+#define CRYPTO_PUBLICKEYBYTES 2592
+#define CRYPTO_SECRETKEYBYTES 4896
+#define CRYPTO_BYTES 4627
+
+#endif
+
+#define POLYT1_PACKEDBYTES  320
+#define POLYT0_PACKEDBYTES  416
+#define POLYVECH_PACKEDBYTES (OMEGA + K)
+
+/* w0_polyvec_shares is sized at the L5 width (8 polys/share) for every param set,
+ * so the scratch layout is K-independent. */
+#define W0_POLYS        8
+#define W0_SHARE_STRIDE 8192
+
+#if GAMMA1 == (1 << 17)
+#define POLYZ_PACKEDBYTES   576
+#elif GAMMA1 == (1 << 19)
+#define POLYZ_PACKEDBYTES   640
+#endif
+
+#if GAMMA2 == (Q-1)/88
+#define POLYW1_PACKEDBYTES  192
+#elif GAMMA2 == (Q-1)/32
+#define POLYW1_PACKEDBYTES  128
+#endif
+
+/* secboundcheck bounds C_Z = (1 << 24) - 2*(GAMMA1-BETA-1) - 1 and
+ * C_R = (1 << 24) - 2*(GAMMA2-BETA-1) - 1, split into 8-bit slices for
+ * the per-call bn.addi/bn.shv.8S build of w17 (acc_as does not evaluate
+ * arithmetic in bn.addi immediates). */
+#if DILITHIUM_MODE == 2
+#define C_Z_HI  0xFC
+#define C_Z_MID 0x00
+#define C_Z_LO  0x9D
+#define C_R_HI  0xFD
+#define C_R_MID 0x18
+#define C_R_LO  0x9D
+#elif DILITHIUM_MODE == 3
+#define C_Z_HI  0xF0
+#define C_Z_MID 0x01
+#define C_Z_LO  0x89
+#define C_R_HI  0xF8
+#define C_R_MID 0x03
+#define C_R_LO  0x89
+#elif DILITHIUM_MODE == 5
+#define C_Z_HI  0xF0
+#define C_Z_MID 0x00
+#define C_Z_LO  0xF1
+#define C_R_HI  0xF8
+#define C_R_MID 0x02
+#define C_R_LO  0xF1
+#endif
+
+#if ETA == 2
+#define POLYETA_PACKEDBYTES  96
+#define ETA_KBITS              3
+#elif ETA == 4
+#define POLYETA_PACKEDBYTES 128
+#define ETA_KBITS              4
+#endif
+
+/* Register aliases */
+.equ x2, sp
+.equ x3, fp
+
+.equ x5, t0
+/* TODO(acc_as): switch back to `.equ x6, t1` once the assembler's
+ * naive textual substitution stops mangling identifiers that end in
+ * `t1` (e.g., `kmac_digest1` -> `kmac_digesx6`). */
+#define t1 x6
+.equ x7, t2
+
+.equ x8, s0
+.equ x9, s1
+
+.equ x10, a0
+.equ x11, a1
+
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x15, a5
+.equ x16, a6
+.equ x17, a7
+
+.equ x18, s2
+.equ x19, s3
+.equ x20, s4
+.equ x21, s5
+.equ x22, s6
+.equ x23, s7
+.equ x24, s8
+.equ x25, s9
+.equ x26, s10
+.equ x27, s11
+
+.equ x28, t3
+.equ x29, t4
+.equ x30, t5
+.equ x31, t6
+
+.equ w31, bn0
+
+/* Index of the Keccak command special register. */
+#define KECCAK_CFG_REG 0x7d9
+/* Config to start a SHAKE-128 operation. */
+#define SHAKE128_CFG 0x2
+/* Config to start a SHAKE-256 operation. */
+#define SHAKE256_CFG 0xA
+/* Config to start a SHA3_256 operation. */
+#define SHA3_256_CFG 0x8
+/* Config to start a SHA3_512 operation. */
+#define SHA3_512_CFG 0x10
+
+/* Matrix-mult accumulator. In the masked build it holds NSHARES contiguous
+ * polyvecs (share-major); after the unmask boundary, share 0's slot holds
+ * the plaintext result and the rest of the pipeline reads it as before. */
+#define W0_POLYVEC w0_polyvec_shares
+
+
+/**
+ * Dilithium Sign_internal (external-mu mode; FIPS 204 Algorithm 7).
+ *
+ * Returns: 0 on success
+ *
+ * The caller pre-hashes the message+context to mu and places it in
+ * dmem[mu].  ML-DSA-spec mu = SHAKE256(tr || 0x00 || byte(ctxlen) ||
+ * ctx || msg, 64).
+ *
+ * All input DMEM buffers must be 32-byte aligned and initialized up to the
+ * next 32B boundary so wide-reads succeed.
+ *
+ * @param[in]  x10: *sig (destination pointer)
+ * @param[in]  dmem[mu]: pre-hashed message (64B)
+ * @param[in]  dmem[sk]: secret key, 32B aligned
+ * @param[in]  dmem[rnd]: signature randomization value (32B)
+ * @param[out] x10: 0 (success)
+ * @param[out] x11: siglen
+ * @param[out] dmem[*sig]: signature
+ *
+ */
+.global crypto_sign_signature_internal
+crypto_sign_signature_internal:
+    /* Masked gadgets use sp for stack frames; init it once on entry. */
+    la sp, mask_stack_end
+    /* External-mu mode (FIPS 204 Algorithm 7, ML-DSA.Sign_internal):
+     * caller pre-hashes the message and provides mu in dmem[mu].  The
+     * msg/ctx buffers and the initial SHAKE-256 over tr||ctxlen||ctx||msg
+     * are gone -- saves ~2.4 KiB DMEM and one Keccak invocation. */
+
+    /* Initialize a SHAKE256 operation. */
+    addi  a1, x0, SEEDBYTES
+    addi  a1, a1, RNDBYTES
+    addi  a1, a1, CRHBYTES
+    slli  t0, a1, 5
+    addi  t0, t0, SHAKE256_CFG
+    /* Set masked-digest bit (bit 20) of kmac_cfg so K stays shared
+     * across the SHAKE256 and rho' is produced as 2 shares. */
+    addi  t1, x0, 1
+    slli  t1, t1, 20
+    add   t0, t0, t1
+    csrrw x0, KECCAK_CFG_REG, t0
+
+    /* Send K shares: K_shares[0..31] -> share 0, K_shares[32..63] -> share 1. */
+    la     t0, K_shares
+    bn.lid x0, 0(t0)
+    bn.wsrw kmac_msg, w0
+    bn.xor w0, w0, w0              /* Whitening */
+    bn.lid x0, 32(t0)
+    bn.wsrw kmac_msg1, w0
+
+    /* Send rnd as (rnd, 0): public input trivially shared on share 0. */
+    la     t0, rnd
+    bn.lid x0, 0(t0)
+    bn.wsrw kmac_msg, w0
+    bn.xor w0, w0, w0
+    bn.wsrw kmac_msg1, w0
+
+    /* Send mu (64B = 2 chunks) as (mu, 0). */
+    la     t0, mu
+    bn.lid x0, 0(t0)
+    bn.wsrw kmac_msg, w0
+    bn.xor w0, w0, w0
+    bn.wsrw kmac_msg1, w0
+    la     t0, mu
+    bn.lid x0, 32(t0)
+    bn.wsrw kmac_msg, w0
+    bn.xor w0, w0, w0
+    bn.wsrw kmac_msg1, w0
+
+    /* Read 64B masked digest into sign_gamma1_buf[0..127] in the
+     * share-major chunked layout that masked_poly_uniform_gamma_1
+     * expects: share 0 chunks at [0,32], share 1 chunks at [64,96]. */
+    la      a0, sign_gamma1_buf
+    bn.wsrr w0, kmac_digest
+    bn.sid  x0, 0(a0)
+    bn.xor  w0, w0, w0             /* Whitening */
+    bn.wsrr w0, kmac_digest1
+    bn.sid  x0, 64(a0)
+    bn.xor  w0, w0, w0             /* Whitening */
+    bn.wsrr w0, kmac_digest
+    bn.sid  x0, 32(a0)
+    bn.xor  w0, w0, w0             /* Whitening */
+    bn.wsrr w0, kmac_digest1
+    bn.sid  x0, 96(a0)
+
+    /* Finish the SHAKE-256 operation. */
+
+    /* Prepare modulus */
+    #define mod_x2 w22
+    bn.wsrr   w16, 0x0 /* w16 = MOD = R | Q */
+    bn.shv.8S mod_x2, w16 << 1 /* mod_x2 = 2*R | 2*Q */
+
+    li s11, 0 /* nonce */
+
+    jal  x1, sign_attempt
+    ret
+
+/* sign_attempt: rejection-retry body.  Computes w, w0/w1 + c~, c,
+ * z (z-loop), h (hint loop); restarts in place on rejection.  Inputs
+ * are taken from caller-set state (sign_gamma1_buf, sk, etc.); on
+ * success returns a0 = 0, a1 = CRYPTO_BYTES. */
+.global sign_attempt
+sign_attempt:
+    /* sign_w params: w_out, rho, rho_prime, y_staging, A_staging,
+     * seca2b_scratch, gamma1_buf.  A_staging + gamma1_buf live in
+     * dead sig during P1; c_poly (= NTT(c) post-P1) is now in overlay slack. */
+    la   a0, W0_POLYVEC
+    la   a1, sk                        /* rho is sk[0..32) */
+    la   a2, sign_gamma1_buf
+    la   a3, sign_y
+    la   a4, sig                       /* A_staging at sig+1536 (after gamma1 buf) */
+    addi a4, a4, 1536
+#if CTILDEBYTES == 48
+    addi a4, a4, 16                    /* L3 sig is 16 B off 32-align */
+#endif
+    la   a5, sig                       /* seca2b scratch at sig+2560 */
+    addi a5, a5, 1024
+    addi a5, a5, 1536
+#if CTILDEBYTES == 48
+    addi a5, a5, 16
+#endif
+    la   a6, sig                       /* gamma1 bitslice buf at sig+0 */
+#if CTILDEBYTES == 48
+    addi a6, a6, 16                    /* L3 sig is 16 B off 32-align */
+#endif
+    jal  x1, sign_w
+
+    /* sign_w0_w1_ctilde params: w_polyvec, mu, w1_repvec, sig,
+     * w1_tmp_scratch, seca2b_scratch (sig+2560, same as in sign_w). */
+    la   a0, W0_POLYVEC
+    la   a1, mu
+    la   a2, sign_w1_repvec
+    la   a3, sig
+    la   a4, sign_tmp
+    la   a5, sig
+    addi a5, a5, 1024
+    addi a5, a5, 1536
+#if CTILDEBYTES == 48
+    addi a5, a5, 16
+#endif
+    jal  x1, sign_w0_w1_ctilde
+
+    la   a0, c_poly                    /* ntt_c output */
+    la   a1, sign_tmp                /* aligned c~ stash */
+    jal  x1, sign_c
+
+    /* sign_z params: ntt_c, rho_prime(gamma1), sig_z_start,
+     * z_staging, tmp_poly, cs1_share1, seca2b_scratch.  s1 is now derived
+     * from rho_prime_shares in-loop, so a0 (was s1_packed) is unused. */
+    la   a1, c_poly
+    la   a2, sign_gamma1_buf
+    la   a3, sig
+    addi a3, a3, CTILDEBYTES
+    la   a4, sign_c_poly_shares
+    la   a5, sign_tmp
+    la   a6, sign_y
+    la   a7, sign_hint_b2a
+    jal  x1, sign_z
+    bne  a0, x0, sign_attempt
+
+    /* sign_h params: sk_t0, ntt_c, packed_b, w1_repvec, sig_h.  s2 is now
+     * derived from rho_prime_shares in-loop, so a1 (was s2_packed) is unused. */
+    la   a0, sk
+    addi a0, a0, 128
+    la   a2, c_poly
+    la   a3, W0_POLYVEC
+    la   a4, sign_w1_repvec
+    la   a5, sig
+    addi a5, a5, CTILDEBYTES
+    .rept L
+        addi a5, a5, POLYZ_PACKEDBYTES
+    .endr
+    jal  x1, sign_h
+    bne  a0, x0, sign_attempt
+    li   a0, 0
+    li   a1, CRYPTO_BYTES
+    ret
+
+/* sign_w: matrix-vector multiplication w = A * y.  Column-wise loop over
+ * j in [0, L): sample y[j] both shares via gamma1, NTT each share in place,
+ * then for each i in [0, K): generate A[i][j] from rho and accumulate
+ * A[i][j] * NTT(y[j])[d] into w[i][d].  Inverse-NTT w at the end.
+ *
+ * @param[out] a0: dptr_w, NSHARES * K * 1024 B accumulator (W0_POLYVEC).
+ * @param[in]  a1: dptr_rho, 32 B (sk[0..32)).
+ * @param[in]  a2: dptr_rho_prime, 128 B rho' seed (sign_gamma1_buf).
+ * @param[in]  a3: dptr_y_staging, 2 KiB (y[j] both shares).
+ * @param[in]  a4: dptr_A_staging, 1 KiB.
+ * @param[in]  a5: dptr_seca2b_scratch, 1.5 KiB (forwarded to gamma1's b2a).
+ * @param[in]  a6: dptr_gamma1_buf, 1.5 KiB bitslice-u staging.
+ *
+ * In/out: advances nonce counter in s11 by L (each gamma1 call uses it).
+ * Clobbers a/t regs, s0-s10, w16/w22/w23.  Restores MOD = R|Q.
+ */
+.global sign_w
+sign_w:
+    /* Park pointer args in s-regs so internal jals can clobber a-regs. */
+    addi s1, a0, 0           /* w_out */
+    addi s0, a1, 0           /* rho */
+    addi s9, a2, 0           /* rho_prime */
+    addi s3, a3, 0           /* y_staging */
+    addi s10, a4, 0          /* A_staging */
+    addi s2, a5, 0           /* seca2b_scratch (was: rhoprime slot) */
+    addi s7, a6, 0           /* gamma1_buf (was: gamma1_vec_const slot) */
+
+    /* Zero each share's polyvec; t1 walks the contiguous buffer. */
+    li t0, 31
+    addi t1, s1, 0
+    .rept NSHARES
+    LOOPI W0_POLYS, 3
+        LOOPI 32, 1
+          bn.sid t0, 0(t1++)
+        nop
+    .endr
+
+    /* Per-column constants. */
+    li s6, W0_SHARE_STRIDE           /* stride between w shares */
+    bn.xor w23, w23, w23             /* matrix nonce = byte(i) || byte(j) */
+    li s5, 31                        /* w31 ref (unused but historical) */
+
+    /* SHAKE128 cfg for poly_uniform (rho||i||j). */
+    addi s4, x0, 34
+    slli s4, s4, 5
+    addi s4, s4, SHAKE128_CFG
+
+    loopi L, 81
+        addi a0, s3, 0
+        addi a1, s9, 0
+        addi a2, s11, 0
+        addi a3, s2, 0
+        addi a4, s7, 0
+        jal  x1, masked_poly_uniform_gamma_1
+        addi s11, s11, 1
+
+        /* Start the SHAKE128 operation for poly_uniform for A[0][j]. */
+        csrrw x0, kmac_cfg, s4
+        addi  a0, s0, 0
+        bn.lid    x0, 0(a0)
+        bn.wsrw   kmac_msg, w0
+        addi      t0, x0, 2
+        csrrw     x0, kmac_partial_write, t0
+        bn.wsrw   kmac_msg, w23
+        bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
+        /* NTT each share of y[j] in place. */
+        addi s8, s3, 0
+        li   t5, NSHARES
+        loop t5, 32
+            addi a0, s8, 0
+            addi a2, s8, 0
+            jal  x1, ntt
+            addi s8, s8, 1024
+            /* Whitening */
+            bn.xor w0, w0, w0
+            bn.xor w1, w1, w1
+            bn.xor w2, w2, w2
+            bn.xor w3, w3, w3
+            bn.xor w4, w4, w4
+            bn.xor w5, w5, w5
+            bn.xor w6, w6, w6
+            bn.xor w7, w7, w7
+            bn.xor w8, w8, w8
+            bn.xor w9, w9, w9
+            bn.xor w10, w10, w10
+            bn.xor w11, w11, w11
+            bn.xor w12, w12, w12
+            bn.xor w13, w13, w13
+            bn.xor w14, w14, w14
+            bn.xor w15, w15, w15
+            bn.xor w17, w17, w17
+            bn.xor w18, w18, w18
+            bn.xor w19, w19, w19
+            bn.xor w20, w20, w20
+            bn.xor w21, w21, w21
+            bn.xor w24, w24, w24
+            bn.xor w25, w25, w25
+            bn.xor w26, w26, w26
+            bn.xor w27, w27, w27
+            bn.xor w28, w28, w28
+            bn.xor w29, w29, w29
+            bn.xor w30, w30, w30
+        loopi K, 23
+            /* Compute A[i][j]. */
+            addi a1, s10, 0
+            jal  x1, poly_uniform
+            /* Increment the row index by 1. */
+            bn.addi w23, w23, 256
+            /* Start the SHAKE128 operation for poly_uniform for A[i+1][j]. */
+            csrrw x0, kmac_cfg, s4
+            addi  a0, s0, 0
+            bn.lid    x0, 0(a0)
+            bn.wsrw   kmac_msg, w0
+            addi      t0, x0, 2
+            csrrw     x0, kmac_partial_write, t0
+            bn.wsrw   kmac_msg, w23
+            /* For each share d:  w_d[i] += A[i][j] * y_d[j]. */
+            addi s8, s3, 0
+            addi s5, s1, 0
+            li   t5, NSHARES
+            loop t5, 8
+                addi a0, s8, 0
+                addi a1, s10, 0
+                addi a2, s5, 0
+                jal  x1, poly_pointwise_acc
+                addi s8, s8, 1024
+                add  s5, s5, s6
+                /* Whitening */
+                bn.xor w0, w0, w0
+                bn.xor w1, w1, w1
+            addi s1, s1, 1024
+        /* Reset w pointer for next column. */
+        la   s1, W0_POLYVEC
+        /* Increment the column index in the nonce by one. */
+        bn.addi w23, w23, 1
+        /* Reset the row index in the nonce to zero. */
+        bn.rshi w23, w23, bn0 >> 8
+        bn.rshi w23, bn0, w23 >> 248
+        bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
+
+    bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
+    /* Inverse NTT each share's K polys; shares are W0_SHARE_STRIDE apart. */
+    la  s1, W0_POLYVEC
+    .rept NSHARES
+    addi a0, s1, 0
+    LOOPI K, 2
+        jal x1, intt
+        addi a0, a0, 1024
+    li  t0, W0_SHARE_STRIDE
+    add s1, s1, t0
+    /* Whitening */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    bn.xor w4, w4, w4
+    bn.xor w5, w5, w5
+    bn.xor w6, w6, w6
+    bn.xor w7, w7, w7
+    bn.xor w8, w8, w8
+    bn.xor w9, w9, w9
+    bn.xor w10, w10, w10
+    bn.xor w11, w11, w11
+    bn.xor w12, w12, w12
+    bn.xor w13, w13, w13
+    bn.xor w14, w14, w14
+    bn.xor w15, w15, w15
+    bn.xor w17, w17, w17
+    bn.xor w18, w18, w18
+    bn.xor w19, w19, w19
+    bn.xor w20, w20, w20
+    bn.xor w21, w21, w21
+    bn.xor w24, w24, w24
+    bn.xor w25, w25, w25
+    bn.xor w26, w26, w26
+    bn.xor w27, w27, w27
+    bn.xor w28, w28, w28
+    bn.xor w29, w29, w29
+    bn.xor w30, w30, w30
+    .endr
+
+    bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
+    ret
+
+/* sign_w0_w1_ctilde: per-poly decompose w[i] -> (w1[i], packed b'[i]);
+ * polyw1_pack(w1[i]); SHAKE absorb; record w1 nonzero positions.
+ * Finalize SHAKE -> c~ at sig[0..CTILDEBYTES).
+ *
+ * @param[inout] a0: dptr_w_polyvec.  Read as w (NSHARES*K*1024 B); the
+ *                   K decompose iters overlay it in place with packed b'
+ *                   (K*608 B per share at stride W0_SHARE_STRIDE).
+ * @param[in]    a1: dptr_mu, 64 B (caller's mu).
+ * @param[out]   a2: dptr_w1_repvec, K*32 B nonzero-summary of each w1[i].
+ * @param[out]   a3: dptr_sig_ctilde, CTILDEBYTES at sig[0..).  Also
+ *                   serves as decompose's scratch base (+16 for L3
+ *                   alignment).
+ * @param[scratch] a4: dptr_w1_tmp, 1 KiB temporary for decompose's w1
+ *                   output and Keccak interim.
+ * @param[scratch] a5: dptr_seca2b_scratch, 1.5 KiB (decompose internal).
+ *
+ * Clobbers: a/t regs, s0-s9.
+ */
+.global sign_w0_w1_ctilde
+sign_w0_w1_ctilde:
+    /* Park pointer args.  s7 holds mu just long enough for the
+     * keccak_send_message; the K-loop later overwrites it with NSHARES. */
+    addi s0, a0, 0            /* w polyvec walker */
+    addi s7, a1, 0            /* mu (consumed below) */
+    addi s1, a2, 0            /* sign_w1_repvec walker */
+    addi s3, a3, 0            /* sig (for c~ writes) */
+    addi s2, a3, 0            /* decompose scratch base (aligned below) */
+#if CTILDEBYTES == 48
+    addi s2, s2, 16           /* L3 sig is 16 B off 32-align */
+#endif
+    addi s4, a4, 0            /* w1 tmp scratch */
+    addi s5, a5, 0            /* seca2b scratch */
+
+    /* Initialize a SHAKE256 operation. */
+    addi  a1, x0, CRHBYTES
+    LOOPI K, 1
+        addi a1, a1, POLYW1_PACKEDBYTES
+    slli  t0, a1, 5
+    addi  t0, t0, SHAKE256_CFG
+    csrrw x0, KECCAK_CFG_REG, t0
+
+    /* Send mu (parked in s7). */
+    li   a1, CRHBYTES
+    addi a0, s7, 0
+    jal  x1, keccak_send_message
+    li   s6, W0_SHARE_STRIDE  /* stride between w_in / packed b' shares */
+
+    /* Masked path: per poly, secdecompose produces an unmasked w1 (in
+     * sign_tmp) and updates share 0 of w0 in place.  The K outer loop is
+     * bne-based (not loopi) so it does not consume an ACC hardware loop-
+     * stack slot -- secdecompose's call chain already uses every available
+     * level. */
+    li   s7, NSHARES
+    li   s8, K
+    /* Packed b' poly i: share 0 at i*608, share 1 at W0_SHARE_STRIDE +
+     * i*608.  Per-poly stride 608 < input stride 1024, so dumps stay
+     * in the consumed slot of their own share. */
+    addi s9, s0, 0
+_decompose_loop:
+    addi   a0, s4, 0
+    addi   a1, s0, 0
+    addi   a4, s6, 0
+#if DILITHIUM_MODE == 2
+    /* L2: secdecompose scratch in w0_polyvec slots dead during decompose. */
+    la     a3, sign_w0_l2_seccompress_scratch
+    la     a5, sign_w0_l2_b
+    la     a6, sign_w0_l2_t_packed
+#else
+    /* scratch_base = aligned sig (= s2); sig is empty during matrix-mult +
+     * decompose (c~ writes happen after this K-loop's Keccak finalize).
+     * a5/a6 = packed b' shares; a7 = seca2b scratch. */
+    addi   a3, s2, 0
+    addi   a5, s9, 0
+    add    a6, s9, s6
+    addi   a7, s5, 0
+#endif
+    jal    x1, secdecompose
+    /* Pack w1, send to Keccak, record nonzero bits. */
+    addi   a0, s2, 0
+    addi   a1, s4, 0
+    jal    x1, polyw1_pack
+    addi   a0, s2, 0
+    addi   a1, x0, POLYW1_PACKEDBYTES
+    jal    x1, keccak_send_message
+    addi   a0, s4, 0
+    jal    x1, poly_nonzero_encode
+    bn.sid x0, 0(s1++)
+    addi   s0, s0, 1024
+    addi   s9, s9, 608
+    addi   s8, s8, -1
+    bne    s8, x0, _decompose_loop
+
+    /* Setup WDR */
+    li t1, 8
+
+    /* Read first 32 bytes of digest. */
+    bn.wsrr w8, 0xA
+
+    /* Get always-aligned temporary buffer. */
+    la   t0, sign_tmp
+#if CTILDEBYTES == 32
+    /* Store first 32 bytes into temp buffer and signature. */
+    bn.sid  t1, 0(t0)
+    bn.sid  t1, 0(s3)
+#elif CTILDEBYTES == 48
+    /* Store first 32 bytes into temp buffer and (unaligned) signature. */
+    bn.sid  t1, 0(t0)
+    LOOPI 8, 4
+        lw t2, 0(t0)
+        sw t2, 0(s3)
+        addi t0, t0, 4
+        addi s3, s3, 4
+
+    /* Read 32 more bytes and store 16 of them. */
+    bn.wsrr w8, 0xA
+    bn.sid  t1, 0(t0)
+    LOOPI 4, 4
+        lw t2, 0(t0)
+        sw t2, 0(s3)
+        addi t0, t0, 4
+        addi s3, s3, 4
+#elif CTILDEBYTES == 64
+    /* Store first 32 bytes into temp buffer and signature. */
+    bn.sid  t1, 0(t0)
+    bn.sid  t1, 0(s3)
+    /* Store 32 more bytes (both places). */
+    bn.wsrr w8, 0xA
+    bn.sid  t1, 32(t0)
+    bn.sid  t1, 32(s3)
+#endif
+
+    /* Finish the SHAKE-256 operation. */
+    ret
+
+/* sign_c: sample challenge c from c~ (poly_challenge); NTT(c) in place.
+ *
+ * @param[out] a0: dptr_ntt_c, 1024 B buffer for NTT(c).
+ * @param[in]  a1: dptr_ctilde, 32-byte aligned source of c~.
+ *
+ * Clobbers: t-regs, a-regs, s0.  Restores MOD = R|Q.
+ */
+.global sign_c
+sign_c:
+    addi s0, a0, 0            /* park ntt_c_out across poly_challenge */
+    jal  x1, poly_challenge
+
+    bn.wsrw 0x0, mod_x2
+    addi a0, s0, 0
+    addi a2, a0, 0
+    jal  x1, ntt
+    bn.wsrw 0x0, w16
+    ret
+
+/* sign_z: z = y + c * s1.  Loops over L polys: unpack/b2a s1, NTT chain
+ * c*s1, sample y (gamma1), z = y + c*s1, bound-check; on success, pack
+ * z to sig[CTILDE..CTILDE+L*POLYZ_PACKEDBYTES) and zero the hint tail.
+ *
+ * @param[in]   a1: dptr_ntt_c, 1 KiB.
+ * @param[in]   a2: dptr_rho_prime, 128 B.
+ * @param[in]   a3: dptr_sig_z_start (sig + CTILDEBYTES).
+ * @param[scratch] a4: dptr_z_staging, 3.3 KiB (sign_c_poly_shares-sized).
+ * @param[scratch] a5: dptr_tmp_poly, 1 KiB (polyeta_unpack tgt + collapsed z).
+ * @param[scratch] a6: dptr_cs1_share1, 1 KiB (also secb2amodq_eta/secboundcheck
+ *                    bitslice buf).
+ * @param[scratch] a7: dptr_seca2b_scratch, 3.3 KiB (forwarded to inner gadgets;
+ *                    L5 also takes its +1536 as gamma1 staging).
+ *
+ * In/out: reads s11 (= nonce counter advanced by sign_w); uses
+ * s11 - L as the per-iter gamma1 nonce base.
+ * Returns a0 = 0 on success, a0 = 1 on rejection.
+ */
+.global sign_z
+sign_z:
+    /* Park pointer args. */
+    li   s0, 0               /* ExpandS nonce: s1[j] uses nonce j */
+    addi s7, a1, 0            /* NTT(c) */
+    addi s4, a2, 0            /* rho_prime (gamma1 seed) */
+    addi s9, a3, 0            /* sig_z write ptr (advances per polyz_pack) */
+    addi s6, a4, 0            /* z staging */
+    addi s2, a5, 0            /* sign_tmp */
+    addi s3, a6, 0            /* c*s1 share 1 + bitslice buf */
+    addi s10, a7, 0           /* seca2b scratch (eta/gamma1/boundcheck) */
+
+    li   s5, NSHARES
+    /* Per-iter gamma1 nonce starts at s11 - L (sign_w advanced s11 by L). */
+    addi s8, s11, -L
+
+    /* This loop computes z = (cp * s1) = y one element at a time, and does
+       rejection sampling on each element before packing it into the signature. */
+    .rept L
+        /* Derive s1[j] = ExpandS(rho', nonce=j) to canonical arith shares.
+         * seca2b scratch = hint_b2a, b2a buf = sign_y; m rides in the
+         * output until the gadget's b2a consumes it. */
+        addi a0, s6, 0
+        la   a1, rho_prime_shares
+        addi a2, s0, 0
+        la   a3, sign_hint_b2a
+        la   a4, sign_y
+        jal  x1, masked_poly_uniform_eta
+        addi s0, s0, 1
+
+        /* gadget's b2a clobbered w16/w22; rebuild from MOD (still R|Q). */
+        bn.wsrr   w16, 0x0
+
+        bn.shv.8S mod_x2, w16 << 1
+
+        /* c*s1 share 0 at s2 (sign_tmp), share 1 at s3; delta in t3
+         * (survives ntt/intt/poly_pointwise; t0-t2 don't). */
+        bn.wsrw 0x0, mod_x2
+        addi s1, s6, 0
+        addi t6, s2, 0
+        sub  t3, s3, s2
+        loop s5, 39
+            addi x10, s1, 0
+            addi x12, t6, 0
+            jal  x1, ntt
+            addi x10, t6, 0
+            addi x11, s7, 0
+            addi x12, t6, 0
+            jal  x1, poly_pointwise
+            addi x10, t6, 0
+            jal  x1, intt
+            addi s1, s1, 1024
+            add  t6, t6, t3
+            /* Whitening */
+            bn.xor w0, w0, w0
+            bn.xor w1, w1, w1
+            bn.xor w2, w2, w2
+            bn.xor w3, w3, w3
+            bn.xor w4, w4, w4
+            bn.xor w5, w5, w5
+            bn.xor w6, w6, w6
+            bn.xor w7, w7, w7
+            bn.xor w8, w8, w8
+            bn.xor w9, w9, w9
+            bn.xor w10, w10, w10
+            bn.xor w11, w11, w11
+            bn.xor w12, w12, w12
+            bn.xor w13, w13, w13
+            bn.xor w14, w14, w14
+            bn.xor w15, w15, w15
+            bn.xor w17, w17, w17
+            bn.xor w18, w18, w18
+            bn.xor w19, w19, w19
+            bn.xor w20, w20, w20
+            bn.xor w21, w21, w21
+            bn.xor w24, w24, w24
+            bn.xor w25, w25, w25
+            bn.xor w26, w26, w26
+            bn.xor w27, w27, w27
+            bn.xor w28, w28, w28
+            bn.xor w29, w29, w29
+            bn.xor w30, w30, w30
+        bn.wsrw 0x0, w16
+
+        /* Sample y -> z_staging (overwrites bitsliced s1, now consumed). */
+        addi a0, s6, 0
+        addi a1, s4, 0
+        addi a2, s8, 0
+        addi a3, s10, 0           /* seca2b scratch */
+        /* hint_b2a region is L5-sized (8192 B) for both params; gamma1
+         * staging fits at scratch+1536. */
+        addi a4, s10, 1536
+        jal  x1, masked_poly_uniform_gamma_1
+        addi s8, s8, 1
+
+        /* z = y + c*s1 per share; same s2 / s3 split as NTT. */
+        addi s1, s6, 0
+        addi t6, s2, 0
+        sub  t3, s3, s2
+        loop s5, 8
+            addi a0, s1, 0
+            addi a1, t6, 0
+            addi a2, s1, 0
+            jal  x1, poly_add
+            addi s1, s1, 1024
+            add  t6, t6, t3
+            /* Whitening */
+            bn.xor w0, w0, w0
+            bn.xor w1, w1, w1
+
+        /* Reduce z to unsigned canonical [0, q). */
+        addi t0, s6, 0
+        li   t1, 0
+        loop s5, 5
+            loopi 32, 3
+                bn.lid t1, 0(t0)
+                bn.addvm.8S w0, w0, w31
+                bn.sid t1, 0(t0++)
+            bn.xor w0, w0, w0          /* Whitening */
+
+
+        /* secboundcheck on shared z, then AND-reduce the per-lane mask
+         * to a 1-bit verdict; retry on fail.  Collapse z to sign_tmp
+         * only after the bound check passes. */
+        /* Build C_Z in w17 lane 0. */
+        bn.xor    w17, w17, w17
+        bn.addi   w17, w17, C_Z_HI
+        bn.shv.8S w17, w17 << 8
+        bn.addi   w17, w17, C_Z_MID
+        bn.shv.8S w17, w17 << 8
+        bn.addi   w17, w17, C_Z_LO
+        addi a0, s6, 0
+        la   a2, lambda0_z_vec
+        addi a3, s10, 0           /* seca2b scratch */
+        addi a4, s3, 0            /* boundcheck bitslice buf */
+        jal  x1, secboundcheck
+
+        bn.not w0, w0
+        bn.cmp w0, w31
+        csrrs a2, FG0, x0
+        andi a2, a2, 8
+        xori a2, a2, 8
+        /* Reject if ||z|| >= gamma1 - beta on any lane. */
+        bne  a2, x0, _sign_z_reject
+
+        addi a0, s2, 0
+        addi a1, s6, 0
+        jal  x1, secunmask_modq
+
+        /* TODO(masking,perf): polyz_pack expects mod^{+-} z, so we send
+         * collapsed z through poly_reduce32 here.  Investigate whether
+         * the share-wise reduce-to-canonical above can be reshaped so
+         * the collapsed result is already mod^{+-}, dropping this call. */
+        addi a0, s2, 0
+        addi a1, s2, 0
+        jal  x1, poly_reduce32
+
+        /* Speculatively pack z[i] into the signature. */
+        addi a0, s9, 0
+        addi a1, s2, 0
+        jal x1, polyz_pack
+        /* Update the pointer to the end of the packed part. */
+        addi s9, a0, 0
+    .endr
+
+    /* get *sig + CTILDEBYTES + L*POLYZ_PACKEDBYTES */
+    addi a0, s9, 0
+
+    /* Set hint bytes at end of signature (length omega + k) to 0. Round to
+       next word boundary. */
+    li    t1, OMEGA
+    addi  t1, t1, K
+    addi  t1, t1, 3
+    srli  t1, t1, 2
+    LOOP  t1, 2
+      sw   x0, 0(a0)
+      addi a0, a0, 4
+
+    li   a0, 0
+    ret
+_sign_z_reject:
+    li   a0, 1
+    ret
+
+/* sign_h: per-poly hint computation.  Loops over K polys: unpack/b2a s2,
+ * c*s2, build r-tilde from packed_b'[i], subtract c*s2, bound-check,
+ * compute c*t0, combine, poly_make_hint, encode_h to sig tail.
+ *
+ * @param[in]  a0: dptr_sk_t0, K * POLYT0_PACKEDBYTES (packed t0).
+ * @param[in]  a2: dptr_ntt_c, 1 KiB.
+ * @param[in]  a3: dptr_packed_b (post-decompose b' share 0 base; share 1 at +W0_SHARE_STRIDE).
+ * @param[in]  a4: dptr_w1_repvec, K * 32 B (nonzero summary written by sign_w0_w1_ctilde).
+ * @param[out] a5: dptr_sig_h_start, write target for hint bytes (sig + CTILDE + L*POLYZ_PACKEDBYTES).
+ *
+ * Scratch (currently hardcoded via la): sign_c_poly_shares, sign_hint_b2a,
+ * sign_y, sign_tmp.
+ *
+ * Returns a0 = 0 on success, a0 = 1 on rejection.
+ */
+.global sign_h
+sign_h:
+    /* Park pointer args; preserve s11 (nonce counter) for sign_z's retry. */
+    addi s0, a0, 0            /* sk t0 walker */
+    li   s2, L               /* ExpandS nonce: s2[i] uses nonce L+i */
+    addi s7, a2, 0            /* NTT(c) */
+    addi s3, a3, 0            /* packed b' walker */
+    addi s5, a4, 0            /* sign_w1_repvec walker */
+    addi s9, a5, 0            /* sig hint write ptr */
+
+    la   s10, sign_tmp
+
+    /* Initialize the coefficient sum for the hint for post-check. */
+    li  s4, 0
+
+    /* Initialize the counter for the index in the hint vector. */
+    li  s6, 0
+
+    /* Hint loop counter. */
+    li  s8, K
+
+    /* Normalize w0 to the [0, q) range (in-place).  The masked path
+     * doesn't carry arithmetic w0; its r-tilde computation produces
+     * canonical [0, q) directly via bn.subvm.8S. */
+
+_mldsa_sign_hint_loop:
+
+        /* Derive s2[i] = ExpandS(rho', nonce=L+i) to canonical arith shares.
+         * seca2b scratch = hint_b2a, b2a buf = hint_b2a+1536; m rides in the
+         * output until the gadget's b2a consumes it. */
+        la   a0, sign_c_poly_shares
+        la   a1, rho_prime_shares
+        addi a2, s2, 0
+        la   a3, sign_hint_b2a
+        la   a4, sign_hint_b2a
+        addi a4, a4, 1536
+        jal  x1, masked_poly_uniform_eta
+        addi s2, s2, 1
+
+        /* b2a chain clobbered w16/w22; rebuild from MOD (still R|Q). */
+        bn.wsrr   w16, 0x0
+
+        bn.shv.8S mod_x2, w16 << 1
+
+        /* Per-share NTT chain in place on sign_c_poly_shares -> c*s2. */
+        la   s1, sign_c_poly_shares
+        li   t0, NSHARES
+        bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
+        loop t0, 39
+            addi x10, s1, 0
+            addi x12, s1, 0
+            jal  x1, ntt
+            addi x10, s1, 0
+            addi x11, s7, 0
+            addi x12, s1, 0
+            jal  x1, poly_pointwise
+            addi x10, s1, 0
+            jal  x1, intt
+            addi s1, s1, 1024
+            nop
+            /* Whitening */
+            bn.xor w0, w0, w0
+            bn.xor w1, w1, w1
+            bn.xor w2, w2, w2
+            bn.xor w3, w3, w3
+            bn.xor w4, w4, w4
+            bn.xor w5, w5, w5
+            bn.xor w6, w6, w6
+            bn.xor w7, w7, w7
+            bn.xor w8, w8, w8
+            bn.xor w9, w9, w9
+            bn.xor w10, w10, w10
+            bn.xor w11, w11, w11
+            bn.xor w12, w12, w12
+            bn.xor w13, w13, w13
+            bn.xor w14, w14, w14
+            bn.xor w15, w15, w15
+            bn.xor w17, w17, w17
+            bn.xor w18, w18, w18
+            bn.xor w19, w19, w19
+            bn.xor w20, w20, w20
+            bn.xor w21, w21, w21
+            bn.xor w24, w24, w24
+            bn.xor w25, w25, w25
+            bn.xor w26, w26, w26
+            bn.xor w27, w27, w27
+            bn.xor w28, w28, w28
+            bn.xor w29, w29, w29
+            bn.xor w30, w30, w30
+        bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
+
+        /* Reduce c*s2 shares to unsigned canonical [0, q). */
+        la   t0, sign_c_poly_shares
+        li   t1, 0
+        li   t2, NSHARES
+        loop t2, 5
+            loopi 32, 3
+                bn.lid t1, 0(t0)
+                bn.addvm.8S w0, w0, w31
+                bn.sid t1, 0(t0++)
+            bn.xor w0, w0, w0          /* Whitening */
+
+#if DILITHIUM_MODE == 2
+        /* L2: r-tilde_s = w0_s - c*s2_s (mod q) sharewise.  Arithmetic w0[i]
+         * lives in W0_POLYVEC (s3, shares W0_SHARE_STRIDE apart); c*s2 and the
+         * r-tilde dst are in sign_c_poly_shares (shares 1024 apart). */
+        la   t4, sign_c_poly_shares
+        addi t5, s3, 0
+        li   t2, 0
+        li   t3, 2
+        loopi 32, 4
+            bn.lid t2, 0(t5++)
+            bn.lid t3, 0(t4)
+            bn.subvm.8S w0, w0, w2
+            bn.sid t2, 0(t4++)
+        /* Whitening */
+        bn.xor w0, w0, w0
+        bn.xor w2, w2, w2
+        li   t6, W0_SHARE_STRIDE
+        add  t5, s3, t6
+        loopi 32, 4
+            bn.lid t2, 0(t5++)
+            bn.lid t3, 0(t4)
+            bn.subvm.8S w0, w0, w2
+            bn.sid t2, 0(t4++)
+#else
+        /* r-tilde = (gamma2 - U) - c*s2; b2a in/out at sign_hint_b2a. */
+        li   t2, 0
+        li   t3, 31
+        la   t0, sign_hint_b2a
+        addi t1, s3, 0
+        loopi 19, 2
+            bn.lid t2, 0(t1++)
+            bn.sid t2, 0(t0++)
+        loopi 5, 1
+            bn.sid t3, 0(t0++)
+        bn.xor w0, w0, w0              /* Whitening */
+        li   t1, W0_SHARE_STRIDE
+        add  t1, s3, t1
+        loopi 19, 2
+            bn.lid t2, 0(t1++)
+            bn.sid t2, 0(t0++)
+        loopi 5, 1
+            bn.sid t3, 0(t0++)
+
+        /* gamma2-U b2a: scratch at sign_y (dead). */
+        la   a1, sign_hint_b2a
+        addi a0, a1, 1536
+        la   a3, sign_y
+        jal  x1, secb2amodq_bc22
+
+        la   a0, sign_tmp
+        la   a1, sign_hint_b2a
+        addi a1, a1, 1536
+        jal  x1, unbitslice
+
+        la     t0, gamma2_vec_const
+        li     t1, 1
+        bn.lid t1, 0(t0)
+        la     t4, sign_c_poly_shares
+        la     t5, sign_tmp
+        li     t2, 0
+        li     t3, 2
+        loopi 32, 5
+            bn.lid t2, 0(t4)
+            bn.lid t3, 0(t5++)
+            bn.addvm.8S w0, w0, w2
+            bn.subvm.8S w0, w1, w0
+            bn.sid t2, 0(t4++)
+
+        /* Whitening */
+        bn.xor w0, w0, w0
+        bn.xor w1, w1, w1
+        bn.xor w2, w2, w2
+        bn.xor w3, w3, w3
+        bn.xor w4, w4, w4
+        bn.xor w5, w5, w5
+        bn.xor w6, w6, w6
+        bn.xor w7, w7, w7
+        bn.xor w8, w8, w8
+        bn.xor w9, w9, w9
+        bn.xor w10, w10, w10
+        bn.xor w11, w11, w11
+        bn.xor w12, w12, w12
+        bn.xor w13, w13, w13
+        bn.xor w14, w14, w14
+        bn.xor w15, w15, w15
+        bn.xor w16, w16, w16
+        bn.xor w17, w17, w17
+        bn.xor w18, w18, w18
+        bn.xor w19, w19, w19
+        la   a0, sign_tmp
+        la   a1, sign_hint_b2a
+        addi a1, a1, 1536
+        addi a1, a1, 768
+        jal  x1, unbitslice
+
+        la     t4, sign_c_poly_shares
+        addi   t4, t4, 1024
+        la     t5, sign_tmp
+        li     t2, 0
+        li     t3, 2
+        loopi 32, 5
+            bn.lid t2, 0(t4)
+            bn.lid t3, 0(t5++)
+            bn.addvm.8S w0, w0, w2
+            bn.subvm.8S w0, w31, w0
+            bn.sid t2, 0(t4++)
+#endif
+
+        /* b2a chain clobbered w16/w22; rebuild from MOD (still R|Q). */
+        bn.wsrr   w16, 0x0
+        bn.shv.8S mod_x2, w16 << 1
+
+        /* secboundcheck on shared r-tilde, AND-reduce verdict into s8. */
+        /* Build C_R in w17 lane 0. */
+        bn.xor    w17, w17, w17
+        bn.addi   w17, w17, C_R_HI
+        bn.shv.8S w17, w17 << 8
+        bn.addi   w17, w17, C_R_MID
+        bn.shv.8S w17, w17 << 8
+        bn.addi   w17, w17, C_R_LO
+        la   a0, sign_c_poly_shares
+        la   a2, lambda0_r_vec
+        la   a3, sign_hint_b2a
+        la   a4, sign_y
+        jal  x1, secboundcheck
+
+        bn.not w0, w0
+        bn.cmp w0, w31
+        csrrs a2, FG0, x0
+        andi a2, a2, 8
+        xori a2, a2, 8
+        /* Reject if ||rtilde|| >= gamma2 - beta on any lane. */
+        bne  a2, x0, _sign_h_reject
+
+        la   a0, sign_hint_b2a
+        la   a1, sign_c_poly_shares
+        jal  x1, secunmask_modq
+
+        /* Restore w16 = MOD (secunmask_modq's contract leaves low32 = q). */
+        bn.wsrr w16, 0x0
+
+        /* Unpack the next polynomial from t0. */
+        addi a0, s10, 0
+        addi a1, s0, 0
+        jal  x1, polyt0_unpack
+
+        /* Update the packed t0 pointer. */
+        addi s0, a1, 0
+
+        bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
+
+        /* Compute ntt(t0[i]) in-place. */
+        addi a0, s10, 0
+        addi a2, a0, 0
+        jal x1, ntt
+
+        /* tmp = cp * t0 */
+        addi a0, s10, 0
+        addi a1, s7, 0
+        addi a2, s10, 0
+        jal  x1, poly_pointwise
+
+        /* Inverse NTT on tmp */
+        addi a0, s10, 0
+        jal x1, intt
+
+        bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
+
+        /* w0[i] += tmp */
+        la   a0, sign_hint_b2a
+        addi a1, s10, 0
+        addi a2, a0, 0
+        jal  x1, poly_add
+
+        /* h = reduce32(tmp) to move to mod^{+-} for bound check */
+        addi a0, s10, 0
+        addi a1, s10, 0
+        jal  x1, poly_reduce32
+
+        /* chknorm(h, gamma2) */
+        li   a1, GAMMA2 /* This li expands to 2 instructions */
+        addi a0, s10, 0
+        jal  x1, poly_chknorm
+
+        /* Reject if ||c*t0|| >= gamma2 on any lane. */
+        bne a2, x0, _sign_h_reject
+
+        /* h[i] = make_hint(w0[i], w1[i]) */
+        addi   a0, s10, 0
+        la     a1, sign_hint_b2a
+        bn.lid x0, 0(s5++)
+        jal    x1, poly_make_hint
+
+        /* Update the coefficient sum accumulator (saving previous value). */
+        add  a2, s4, 0
+        add  s4, s4, a0
+
+        /* If the accumulator (# nonzero coeffs in h) is > omega, reject. */
+        addi t0, x0, OMEGA
+        sub  t0, t0, s4
+        srli t0, t0, 31
+
+        /* Reject if hint weight > omega. */
+        bne t0, x0, _sign_h_reject
+
+        /* Encode h[i] into the signature. */
+        addi a0, s9, 0
+        addi a1, s10, 0
+        addi a3, s6, 0
+        jal  x1, poly_encode_h
+
+        /* Increment i. */
+        addi s6, s6, 1
+        /* Advance to next poly. */
+#if DILITHIUM_MODE == 2
+        addi s3, s3, 1024              /* W0_POLYVEC stride (arithmetic w0) */
+#else
+        addi s3, s3, 608               /* packed-b' stride */
+#endif
+        /* Decrement remaining-iter count and loop while > 0. */
+        addi s8, s8, -1
+        bne  s8, x0, _mldsa_sign_hint_loop
+
+    li   a0, 0
+    ret
+_sign_h_reject:
+    li   a0, 1
+    ret
+
+.bss
+
+/* mu (64B) is supplied by the caller's data section in external-mu mode. */
+
+/* Sign working buffers, laid out back to back in .bss.  sign_y and sign_tmp are
+ * independent 1 KiB scratch polys, except in sign_w where together they form a
+ * 2 KiB y_staging (y[j] both shares).  w0_polyvec_shares is the matrix-mult
+ * accumulator; once sign_w0 consumes it, packed_b' overwrites it in place and the
+ * hint_b2a/c_poly_shares/c_poly scratch reuses its remaining bytes.  Per-phase
+ * role (W write, R read, . idle):
+ *
+ *   region             off,size     w      w0       c     z        h
+ *   sign_y             0,   1024     y[0]   .        .     cs1_1    bitsl+twid
+ *   sign_tmp           1024,1024     y[1]   w1tmp/c~ c~ R  cs1_0/z  c*t0,h
+ *   sign_w1_repvec     2048, 256     .      W        .     .        R
+ *   w0_polyvec_shares  2304,16384    accW   packd-b' .     scratch  packd-b' R
+ *   sign_gamma1_buf    18688,128     rho'R  .        .     rho'R    . */
+.balign 32
+sign_y:
+    .zero 1024
+sign_tmp:
+    .zero 1024
+sign_w1_repvec:
+    .zero 256
+w0_polyvec_shares:
+    .zero 16384
+sign_gamma1_buf:
+    .zero 128
+
+.balign 32
+mask_stack:
+    .zero 256
+mask_stack_end:
+
+/* Scratch overlaying w0_polyvec_shares once its rows are consumed: hint_b2a
+ * past packed_b' share 0 (W0_POLYS*608 B), then c_poly_shares and c_poly past
+ * share 1. */
+.set sign_hint_b2a,      w0_polyvec_shares + W0_POLYS * 608
+.set sign_c_poly_shares, w0_polyvec_shares + W0_SHARE_STRIDE + W0_POLYS * 608
+.set c_poly,             w0_polyvec_shares + W0_SHARE_STRIDE + W0_POLYS * 608 + NSHARES * 1024
+
+/* L2 only: secdecompose scratch overlaying w0_polyvec's dead rows (only K of
+ * each share's 8 rows are live during decompose). */
+.set sign_w0_l2_seccompress_scratch, w0_polyvec_shares + K*1024
+.set sign_w0_l2_b,                   w0_polyvec_shares + W0_SHARE_STRIDE + K*1024
+.set sign_w0_l2_t_packed,            sign_w0_l2_b + 2048

--- a/sw/acc/crypto/mldsa/mldsa_verify.s
+++ b/sw/acc/crypto/mldsa/mldsa_verify.s
@@ -303,6 +303,7 @@ crypto_sign_verify_internal:
     /* Prepare modulus */
     #define mod_x2 w22
     bn.wsrr   w16, 0x0 /* w16 = R | Q */
+
     bn.shv.8S mod_x2, w16 << 1 /* mod_x2 = 2*R | 2*Q */
 
     bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */

--- a/sw/acc/crypto/mldsa/poly.s
+++ b/sw/acc/crypto/mldsa/poly.s
@@ -2013,6 +2013,7 @@ _inner_polyw1_pack:
         nop
     ret
 #endif
+
 /**
  * polyeta_unpack
  *

--- a/sw/acc/crypto/mldsa/rounding.s
+++ b/sw/acc/crypto/mldsa/rounding.s
@@ -135,13 +135,13 @@
 
 /* Macros */
 .macro push reg
-    addi sp, sp, -4      /* Decrement stack pointer by 4 bytes */
-    sw \reg, 0(sp)      /* Store register value at the top of the stack */
+    addi sp, sp, -4
+    sw \reg, 0(sp)
 .endm
 
 .macro pop reg
-    lw \reg, 0(sp)      /* Load value from the top of the stack into register */
-    addi sp, sp, 4     /* Increment stack pointer by 4 bytes */
+    lw \reg, 0(sp)
+    addi sp, sp, 4
 .endm
 
 /**

--- a/sw/acc/crypto/tests/mldsa/BUILD
+++ b/sw/acc/crypto/tests/mldsa/BUILD
@@ -72,6 +72,63 @@ py_binary(
     for params in MLDSA_PARAMS
 ]
 
+py_binary(
+    name = "mldsa_masked_keypair_testgen",
+    srcs = ["mldsa_masked_keypair_testgen.py"],
+    imports = [
+        "../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+        requirement("dilithium-py"),
+    ],
+)
+
+[
+    acc_autogen_sim_test(
+        name = params + "_keypair_masked_test" + str(i) + "_2shares",
+        srcs = ["mldsa_keypair_test.s"],
+        copts = [
+            "-DDILITHIUM_MODE=" + str(MODE_FOR_PARAMS[params]),
+            "-DNSHARES=2",
+        ],
+        pqc = True,
+        seed = i,
+        stats = STATS,
+        testgen = ":mldsa_masked_keypair_testgen",
+        testgen_args = [params],
+        deps = [
+            "//sw/acc/crypto/mldsa/gadgets:bitslice_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:masked_poly_uniform_eta_" + params,
+            "//sw/acc/crypto/mldsa:intt",
+            "//sw/acc/crypto/mldsa:kmac_send_msg",
+            "//sw/acc/crypto/mldsa/gadgets:poly_rej_samp_bitsliced_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:scratch",
+            "//sw/acc/crypto/mldsa/gadgets:seca2bmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d1",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_constant_bmsk_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secaddmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secand_cs20_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secb2amodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secb2amodq_eta",
+            "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secunmask_modq",
+            "//sw/acc/crypto/mldsa/gadgets:unbitslice_mldsa",
+            "//sw/acc/crypto/mldsa:" + params + "_consts",
+            "//sw/acc/crypto/mldsa:" + params + "_keypair_masked_2shares",
+            "//sw/acc/crypto/mldsa:" + params + "_poly",
+            "//sw/acc/crypto/mldsa:" + params + "_rounding",
+            "//sw/acc/crypto/mldsa:ntt",
+            "//sw/acc/crypto/mldsa:poly_add",
+            "//sw/acc/crypto/mldsa:poly_pointwise",
+        ],
+    )
+    for i in range(NTESTS)
+    for params in MLDSA_PARAMS
+]
+
 # Signature generation tests
 py_binary(
     name = "mldsa_sign_testgen",
@@ -84,6 +141,22 @@ py_binary(
         requirement("dilithium-py"),
     ],
 )
+
+_SIGN_DEPS = {
+    params: [
+        "//sw/acc/crypto/mldsa:intt",
+        "//sw/acc/crypto/mldsa:kmac_send_msg",
+        "//sw/acc/crypto/mldsa:" + params + "_consts",
+        "//sw/acc/crypto/mldsa:" + params + "_poly",
+        "//sw/acc/crypto/mldsa:" + params + "_rounding",
+        "//sw/acc/crypto/mldsa:" + params + "_sign",
+        "//sw/acc/crypto/mldsa:ntt",
+        "//sw/acc/crypto/mldsa:poly_add",
+        "//sw/acc/crypto/mldsa:poly_pointwise",
+        "//sw/acc/crypto/mldsa:poly_sub",
+    ]
+    for params in MLDSA_PARAMS
+}
 
 [
     acc_autogen_sim_test(
@@ -98,21 +171,167 @@ py_binary(
         stats = STATS,
         testgen = ":mldsa_sign_testgen",
         testgen_args = [params],
-        deps = [
-            "//sw/acc/crypto/mldsa:intt",
-            "//sw/acc/crypto/mldsa:kmac_send_msg",
-            "//sw/acc/crypto/mldsa:" + params + "_consts",
-            "//sw/acc/crypto/mldsa:" + params + "_poly",
-            "//sw/acc/crypto/mldsa:" + params + "_rounding",
-            "//sw/acc/crypto/mldsa:" + params + "_sign",
-            "//sw/acc/crypto/mldsa:ntt",
-            "//sw/acc/crypto/mldsa:poly_add",
-            "//sw/acc/crypto/mldsa:poly_pointwise",
-            "//sw/acc/crypto/mldsa:poly_sub",
-        ],
+        deps = _SIGN_DEPS[params],
     )
     for i in range(NTESTS)
     for params in MLDSA_PARAMS
+]
+
+# 10-vector mean set from https://github.com/zerorisc/mldsa-sign-bench.
+[
+    acc_autogen_sim_test(
+        name = params + "_sign_bench_mean_" + str(idx),
+        timeout = "long",
+        srcs = ["mldsa_sign_test.s"],
+        copts = [
+            "-DDILITHIUM_MODE=" + str(MODE_FOR_PARAMS[params]),
+        ],
+        pqc = True,
+        seed = 0,
+        stats = STATS,
+        tags = ["manual"],
+        testgen = ":mldsa_sign_testgen",
+        testgen_args = [params],
+        vector_index = idx,
+        vectors = "@mldsa_sign_bench//:testsets/mean/" + params + "_10.json",
+        deps = _SIGN_DEPS[params],
+    )
+    for idx in range(10)
+    for params in MLDSA_PARAMS
+]
+
+[
+    test_suite(
+        name = params + "_sign_bench_mean",
+        tags = ["manual"],
+        tests = [params + "_sign_bench_mean_" + str(idx) for idx in range(10)],
+    )
+    for params in MLDSA_PARAMS
+]
+
+# Masked signature generation tests
+NSHARES = [2]
+
+MLDSA_MASKED_PARAMS = [
+    "mldsa44",
+    "mldsa65",
+    "mldsa87",
+]
+
+py_binary(
+    name = "mldsa_masked_sign_testgen",
+    srcs = ["mldsa_masked_sign_testgen.py"],
+    imports = [
+        "../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+        requirement("dilithium-py"),
+    ],
+)
+
+_MASKED_SIGN_DEPS = {
+    params: [
+        "//sw/acc/crypto/mldsa/gadgets:bitslice_mldsa",
+        "//sw/acc/crypto/mldsa/gadgets:bitslice_mldsa_k32",
+        "//sw/acc/crypto/mldsa/gadgets:masked_poly_uniform_eta_" + params,
+        "//sw/acc/crypto/mldsa/gadgets:masked_poly_uniform_gamma1_" + params,
+        "//sw/acc/crypto/mldsa/gadgets:poly_rej_samp_bitsliced_mldsa",
+        "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d1",
+        "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d2",
+        "//sw/acc/crypto/mldsa/gadgets:seca2bmodq_bc22_mldsa",
+        "//sw/acc/crypto/mldsa/gadgets:secadd_bc22",
+        "//sw/acc/crypto/mldsa/gadgets:secaddmodq_bc22_mldsa",
+        "//sw/acc/crypto/mldsa/gadgets:secadd_constant_bmsk_mldsa",
+        "//sw/acc/crypto/mldsa/gadgets:secand_cs20_d2",
+        "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22_d2",
+        "//sw/acc/crypto/mldsa/gadgets:secb2amodq_bc22_mldsa",
+        "//sw/acc/crypto/mldsa/gadgets:secb2amodq_eta",
+        "//sw/acc/crypto/mldsa/gadgets:secboundcheck_mldsa",
+        "//sw/acc/crypto/mldsa/gadgets:secdecompose_" + params,
+        "//sw/acc/crypto/mldsa/gadgets:secleq",
+        "//sw/acc/crypto/mldsa/gadgets:secunmask_modq",
+        "//sw/acc/crypto/mldsa/gadgets:scratch",
+        "//sw/acc/crypto/mldsa/gadgets:unbitslice_mldsa",
+        "//sw/acc/crypto/mldsa:intt",
+        "//sw/acc/crypto/mldsa:kmac_send_msg",
+        "//sw/acc/crypto/mldsa:" + params + "_consts_masked",
+        "//sw/acc/crypto/mldsa:" + params + "_poly",
+        "//sw/acc/crypto/mldsa:" + params + "_rounding",
+        "//sw/acc/crypto/mldsa:ntt",
+        "//sw/acc/crypto/mldsa:poly_add",
+        "//sw/acc/crypto/mldsa:poly_pointwise",
+        "//sw/acc/crypto/mldsa:poly_sub",
+    ] + (
+        # seccompress is only used by mldsa44 SecDecompose.
+        ["//sw/acc/crypto/mldsa/gadgets:seccompress"] if params == "mldsa44" else []
+    )
+    for params in MLDSA_MASKED_PARAMS
+}
+
+[
+    acc_autogen_sim_test(
+        name = params + "_masked_sign_test" + str(i) + "_" + str(nshares) + "shares",
+        timeout = "long",
+        srcs = ["mldsa_masked_sign_test.s"],
+        copts = [
+            "-DDILITHIUM_MODE=" + str(MODE_FOR_PARAMS[params]),
+            "-DNSHARES=" + str(nshares),
+        ],
+        nshares = nshares,
+        pqc = True,
+        seed = i,
+        stats = STATS,
+        testgen = ":mldsa_masked_sign_testgen",
+        testgen_args = [params],
+        deps = _MASKED_SIGN_DEPS[params] + [
+            "//sw/acc/crypto/mldsa:" + params + "_sign_masked_" + str(nshares) + "shares",
+        ],
+    )
+    for i in range(NTESTS)
+    for nshares in NSHARES
+    for params in MLDSA_MASKED_PARAMS
+]
+
+# 10-vector mean set from https://github.com/zerorisc/mldsa-sign-bench.
+[
+    acc_autogen_sim_test(
+        name = params + "_masked_sign_bench_mean_" + str(idx) + "_" + str(nshares) + "shares",
+        timeout = "long",
+        srcs = ["mldsa_masked_sign_test.s"],
+        copts = [
+            "-DDILITHIUM_MODE=" + str(MODE_FOR_PARAMS[params]),
+            "-DNSHARES=" + str(nshares),
+        ],
+        nshares = nshares,
+        pqc = True,
+        seed = 0,
+        stats = STATS,
+        tags = ["manual"],
+        testgen = ":mldsa_masked_sign_testgen",
+        testgen_args = [params],
+        vector_index = idx,
+        vectors = "@mldsa_sign_bench//:testsets/mean/" + params + "_10.json",
+        deps = _MASKED_SIGN_DEPS[params] + [
+            "//sw/acc/crypto/mldsa:" + params + "_sign_masked_" + str(nshares) + "shares",
+        ],
+    )
+    for idx in range(10)
+    for nshares in NSHARES
+    for params in MLDSA_MASKED_PARAMS
+]
+
+[
+    test_suite(
+        name = params + "_masked_sign_bench_mean_" + str(nshares) + "shares",
+        tags = ["manual"],
+        tests = [
+            params + "_masked_sign_bench_mean_" + str(idx) + "_" + str(nshares) + "shares"
+            for idx in range(10)
+        ],
+    )
+    for nshares in NSHARES
+    for params in MLDSA_MASKED_PARAMS
 ]
 
 # Signature verification tests

--- a/sw/acc/crypto/tests/mldsa/gadgets/BUILD
+++ b/sw/acc/crypto/tests/mldsa/gadgets/BUILD
@@ -1,0 +1,820 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@ot_python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary")
+load("//rules:acc.bzl", "acc_autogen_sim_test")
+
+package(default_visibility = ["//visibility:public"])
+
+NSHARES = [
+    2,
+    3,
+    4,
+]
+
+SCHEME = {
+    0: "mlkem",
+    1: "mldsa",
+}
+
+py_binary(
+    name = "secunmask_modq_testgen",
+    srcs = ["secunmask_modq_testgen.py"],
+    imports = [
+        "../../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+    ],
+)
+
+[
+    acc_autogen_sim_test(
+        name = "secunmask_modq_test{}_{}shares".format(
+            str(i),
+            str(nshares),
+        ),
+        srcs = ["secunmask_modq_test.s"],
+        copts = [
+            "-DNSHARES=" + str(nshares),
+        ],
+        nshares = nshares,
+        pqc = True,
+        seed = i,
+        testgen = ":secunmask_modq_testgen",
+        deps = [
+            "//sw/acc/crypto/mldsa:mldsa65_consts",
+            "//sw/acc/crypto/mldsa/gadgets:secunmask_modq",
+        ],
+    )
+    for i in range(3)
+    for nshares in [2]
+]
+
+py_binary(
+    name = "secleq_testgen",
+    srcs = ["secleq_testgen.py"],
+    imports = [
+        "../../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+    ],
+)
+
+SECLEQ_CASES = [
+    (23, 1048182),
+    (23, 523382),
+]
+
+[
+    acc_autogen_sim_test(
+        name = "secleq_test{}_{}shares_k{}_p{}".format(
+            str(i),
+            str(nshares),
+            str(kbits),
+            str(psi),
+        ),
+        srcs = ["secleq_test.s"],
+        copts = [
+            "-DNSHARES=" + str(nshares),
+            "-DKBITS=" + str(kbits),
+        ],
+        nshares = nshares,
+        pqc = True,
+        seed = i,
+        testgen = ":secleq_testgen",
+        testgen_args = [
+            "-k",
+            str(kbits),
+            "-p",
+            str(psi),
+        ],
+        deps = [
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secleq",
+        ],
+    )
+    for i in range(3)
+    for nshares in [2]
+    for (kbits, psi) in SECLEQ_CASES
+]
+
+py_binary(
+    name = "secboundcheck_testgen",
+    srcs = ["secboundcheck_testgen.py"],
+    imports = [
+        "../../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+    ],
+)
+
+SECBOUNDCHECK_CASES = [
+    (524091, 524091),
+    (261691, 261691),
+]
+
+[
+    acc_autogen_sim_test(
+        name = "secboundcheck_test{}_{}shares_l0_{}_l1_{}".format(
+            str(i),
+            str(nshares),
+            str(l0),
+            str(l1),
+        ),
+        srcs = ["secboundcheck_test.s"],
+        copts = [
+            "-DNSHARES=" + str(nshares),
+        ],
+        nshares = nshares,
+        pqc = True,
+        seed = i,
+        testgen = ":secboundcheck_testgen",
+        testgen_args = [
+            "--lambda0",
+            str(l0),
+            "--lambda1",
+            str(l1),
+        ],
+        deps = [
+            "//sw/acc/crypto/mldsa:mldsa65_consts",
+            "//sw/acc/crypto/mldsa/gadgets:bitslice_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:scratch",
+            "//sw/acc/crypto/mldsa/gadgets:seca2bmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d1",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_constant_bmsk_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secaddmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secand_cs20_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secboundcheck_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:secleq",
+        ],
+    )
+    for i in range(3)
+    for nshares in [2]
+    for (l0, l1) in SECBOUNDCHECK_CASES
+]
+
+py_binary(
+    name = "secand_cs20_testgen",
+    srcs = ["secand_cs20_testgen.py"],
+    imports = [
+        "../../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+    ],
+)
+
+[
+    acc_autogen_sim_test(
+        name = "secand_cs20_test{}_{}shares".format(
+            str(i),
+            str(nshares),
+        ),
+        srcs = ["secand_cs20_test.s"],
+        copts = [
+            "-DNSHARES=" + str(nshares),
+        ],
+        nshares = nshares,
+        pqc = True,
+        seed = i,
+        testgen = ":secand_cs20_testgen",
+        deps = [
+            "//sw/acc/crypto/mldsa/gadgets:secand_cs20",
+            "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22",
+        ],
+    )
+    for i in range(10)
+    for nshares in NSHARES
+]
+
+py_binary(
+    name = "secfulladder_bc22_testgen",
+    srcs = ["secfulladder_bc22_testgen.py"],
+    imports = [
+        "../../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+    ],
+)
+
+[
+    acc_autogen_sim_test(
+        name = "secfulladder_bc22_test{}_{}shares".format(
+            str(i),
+            str(nshares),
+        ),
+        srcs = ["secfulladder_bc22_test.s"],
+        copts = [
+            "-DNSHARES=" + str(nshares),
+        ],
+        nshares = nshares,
+        pqc = True,
+        seed = i,
+        testgen = ":secfulladder_bc22_testgen",
+        deps = [
+            "//sw/acc/crypto/mldsa/gadgets:secand_cs20",
+            "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22",
+        ],
+    )
+    for i in range(10)
+    for nshares in NSHARES
+]
+
+[
+    acc_autogen_sim_test(
+        name = "secfulladder_bc22_d2_test{}".format(str(i)),
+        srcs = ["secfulladder_bc22_test.s"],
+        copts = [
+            "-DNSHARES=2",
+        ],
+        nshares = 2,
+        pqc = True,
+        seed = i,
+        testgen = ":secfulladder_bc22_testgen",
+        deps = [
+            "//sw/acc/crypto/mldsa/gadgets:secand_cs20_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22_d2",
+        ],
+    )
+    for i in range(5)
+]
+
+py_binary(
+    name = "secadd_bc22_testgen",
+    srcs = ["secadd_bc22_testgen.py"],
+    imports = [
+        "../../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+    ],
+)
+
+[
+    acc_autogen_sim_test(
+        name = "secadd_bc22_test{}_{}shares_{}".format(
+            str(i),
+            str(nshares),
+            name,
+        ),
+        srcs = ["secadd_bc22_test.s"],
+        copts = [
+            "-DNSHARES=" + str(nshares),
+            "-DSCHEME=" + str(scheme),
+        ],
+        nshares = nshares,
+        pqc = True,
+        scheme = scheme,
+        seed = i,
+        testgen = ":secadd_bc22_testgen",
+        deps = [
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:secand_cs20",
+            "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22",
+        ],
+    )
+    for i in range(10)
+    for scheme, name in SCHEME.items()
+    for nshares in NSHARES
+]
+
+[
+    acc_autogen_sim_test(
+        name = "secadd_bc22_d2_test{}_{}".format(
+            str(i),
+            name,
+        ),
+        srcs = ["secadd_bc22_test.s"],
+        copts = [
+            "-DNSHARES=2",
+            "-DSCHEME=" + str(scheme),
+        ],
+        nshares = 2,
+        pqc = True,
+        scheme = scheme,
+        seed = i,
+        testgen = ":secadd_bc22_testgen",
+        deps = [
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:secand_cs20_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22_d2",
+        ],
+    )
+    for i in range(3)
+    for scheme, name in SCHEME.items()
+]
+
+py_binary(
+    name = "secaddmodq_bc22_testgen",
+    srcs = ["secaddmodq_bc22_testgen.py"],
+    imports = [
+        "../../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+    ],
+)
+
+[
+    acc_autogen_sim_test(
+        name = "secaddmodq_bc22_mldsa_test{}_{}shares".format(
+            str(i),
+            str(nshares),
+        ),
+        srcs = ["secaddmodq_bc22_test.s"],
+        copts = [
+            "-DNSHARES=" + str(nshares),
+        ],
+        nshares = nshares,
+        pqc = True,
+        seed = i,
+        testgen = ":secaddmodq_bc22_testgen",
+        deps = [
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_constant_bmsk_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secaddmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secand_cs20_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22",
+        ],
+    )
+    for i in range(5)
+    for nshares in [2]
+]
+
+py_binary(
+    name = "seca2bmodq_bc22_testgen",
+    srcs = ["seca2bmodq_bc22_testgen.py"],
+    imports = [
+        "../../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+    ],
+)
+
+[
+    acc_autogen_sim_test(
+        name = "seca2bmodq_bc22_mldsa_test{}_{}shares".format(
+            str(i),
+            str(nshares),
+        ),
+        srcs = ["seca2bmodq_bc22_test.s"],
+        copts = [
+            "-DNSHARES=" + str(nshares),
+        ],
+        nshares = nshares,
+        pqc = True,
+        seed = i,
+        stats = True,
+        testgen = ":seca2bmodq_bc22_testgen",
+        deps = [
+            "//sw/acc/crypto/mldsa/gadgets:seca2bmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d1",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_constant_bmsk_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secaddmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secand_cs20_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22",
+        ],
+    )
+    for i in range(5)
+    for nshares in [2]
+]
+
+py_binary(
+    name = "seccompress_testgen",
+    srcs = ["seccompress_testgen.py"],
+    imports = [
+        "../../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+        requirement("dilithium-py"),
+    ],
+)
+
+[
+    acc_autogen_sim_test(
+        name = "seccompress_test{}_{}shares".format(
+            str(i),
+            str(nshares),
+        ),
+        srcs = ["seccompress_test.s"],
+        copts = [
+            "-DNSHARES=" + str(nshares),
+        ],
+        nshares = nshares,
+        pqc = True,
+        seed = i,
+        stats = True,
+        testgen = ":seccompress_testgen",
+        deps = [
+            "//sw/acc/crypto/mldsa/gadgets:bitslice_mldsa_k32",
+            "//sw/acc/crypto/mldsa/gadgets:scratch",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secand_cs20_d2",
+            "//sw/acc/crypto/mldsa/gadgets:seccompress",
+            "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22",
+        ],
+    )
+    for i in range(5)
+    for nshares in [2]
+]
+
+py_binary(
+    name = "bitslice_testgen",
+    srcs = ["bitslice_testgen.py"],
+    imports = [
+        "../../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+    ],
+)
+
+[
+    acc_autogen_sim_test(
+        name = "bitslice_mldsa_test" + str(i),
+        srcs = ["bitslice_test.s"],
+        pqc = True,
+        seed = i,
+        stats = True,
+        testgen = ":bitslice_testgen",
+        deps = [
+            "//sw/acc/crypto/mldsa/gadgets:bitslice_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:scratch",
+        ],
+    )
+    for i in range(3)
+]
+
+py_binary(
+    name = "unbitslice_testgen",
+    srcs = ["unbitslice_testgen.py"],
+    imports = [
+        "../../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+    ],
+)
+
+[
+    acc_autogen_sim_test(
+        name = "unbitslice_mldsa_test" + str(i),
+        srcs = ["unbitslice_test.s"],
+        pqc = True,
+        seed = i,
+        stats = True,
+        testgen = ":unbitslice_testgen",
+        deps = [
+            "//sw/acc/crypto/mldsa/gadgets:scratch",
+            "//sw/acc/crypto/mldsa/gadgets:unbitslice_mldsa",
+        ],
+    )
+    for i in range(3)
+]
+
+py_binary(
+    name = "masked_poly_uniform_gamma1_testgen",
+    srcs = ["masked_poly_uniform_gamma1_testgen.py"],
+    imports = [
+        "../../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+    ],
+)
+
+[
+    acc_autogen_sim_test(
+        name = "masked_poly_uniform_gamma1_mldsa65_test" + str(i),
+        srcs = ["masked_poly_uniform_gamma1_test.s"],
+        pqc = True,
+        seed = i,
+        stats = True,
+        testgen = ":masked_poly_uniform_gamma1_testgen",
+        deps = [
+            "//sw/acc/crypto/mldsa:kmac_send_msg",
+            "//sw/acc/crypto/mldsa:mldsa65_consts",
+            "//sw/acc/crypto/mldsa:mldsa65_poly",
+            "//sw/acc/crypto/mldsa:mldsa65_rounding",
+            "//sw/acc/crypto/mldsa/gadgets:bitslice_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:masked_poly_uniform_gamma1_mldsa65",
+            "//sw/acc/crypto/mldsa/gadgets:poly_rej_samp_bitsliced_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:scratch",
+            "//sw/acc/crypto/mldsa/gadgets:seca2bmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d1",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_constant_bmsk_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secaddmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secand_cs20_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secb2amodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:unbitslice_mldsa",
+        ],
+    )
+    for i in range(3)
+]
+
+py_binary(
+    name = "masked_poly_uniform_eta_testgen",
+    srcs = ["masked_poly_uniform_eta_testgen.py"],
+    imports = [
+        "../../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+    ],
+)
+
+[
+    acc_autogen_sim_test(
+        name = "masked_poly_uniform_eta_mldsa87_test" + str(i),
+        srcs = ["masked_poly_uniform_eta_test.s"],
+        pqc = True,
+        seed = i,
+        stats = True,
+        testgen = ":masked_poly_uniform_eta_testgen",
+        deps = [
+            "//sw/acc/crypto/mldsa:mldsa87_consts",
+            "//sw/acc/crypto/mldsa/gadgets:bitslice_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:masked_poly_uniform_eta_mldsa87",
+            "//sw/acc/crypto/mldsa/gadgets:poly_rej_samp_bitsliced_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:scratch",
+            "//sw/acc/crypto/mldsa/gadgets:seca2bmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d1",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_constant_bmsk_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secaddmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secand_cs20_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secb2amodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secb2amodq_eta",
+            "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:unbitslice_mldsa",
+        ],
+    )
+    for i in range(3)
+]
+
+[
+    acc_autogen_sim_test(
+        name = "masked_poly_uniform_eta_mldsa65_test" + str(i),
+        srcs = ["masked_poly_uniform_eta_test.s"],
+        pqc = True,
+        seed = i,
+        stats = True,
+        testgen = ":masked_poly_uniform_eta_testgen",
+        testgen_args = [
+            "--eta",
+            "4",
+        ],
+        deps = [
+            "//sw/acc/crypto/mldsa:mldsa65_consts",
+            "//sw/acc/crypto/mldsa/gadgets:bitslice_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:masked_poly_uniform_eta_mldsa65",
+            "//sw/acc/crypto/mldsa/gadgets:poly_rej_samp_bitsliced_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:scratch",
+            "//sw/acc/crypto/mldsa/gadgets:seca2bmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d1",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_constant_bmsk_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secaddmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secand_cs20_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secb2amodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secb2amodq_eta",
+            "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:unbitslice_mldsa",
+        ],
+    )
+    for i in range(3)
+]
+
+py_binary(
+    name = "secdecompose_testgen",
+    srcs = ["secdecompose_testgen.py"],
+    imports = [
+        "../../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+        requirement("dilithium-py"),
+    ],
+)
+
+[
+    acc_autogen_sim_test(
+        name = "secdecompose_mldsa65_test{}_{}shares".format(
+            str(i),
+            str(nshares),
+        ),
+        srcs = ["secdecompose_test.s"],
+        copts = [
+            "-DNSHARES=" + str(nshares),
+            "-DDILITHIUM_MODE=3",
+        ],
+        nshares = nshares,
+        pqc = True,
+        scheme = 3,
+        seed = i,
+        stats = True,
+        testgen = ":secdecompose_testgen",
+        deps = [
+            "//sw/acc/crypto/mldsa:mldsa65_consts",
+            "//sw/acc/crypto/mldsa/gadgets:bitslice_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:poly_rej_samp_bitsliced_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:scratch",
+            "//sw/acc/crypto/mldsa/gadgets:seca2bmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d1",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_constant_bmsk_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secaddmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secand_cs20_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secb2amodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secdecompose_mldsa65",
+            "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:unbitslice_mldsa",
+        ],
+    )
+    for i in range(3)
+    for nshares in [2]
+]
+
+[
+    acc_autogen_sim_test(
+        name = "secdecompose_mldsa44_test{}_{}shares".format(
+            str(i),
+            str(nshares),
+        ),
+        srcs = ["secdecompose_test.s"],
+        copts = [
+            "-DNSHARES=" + str(nshares),
+            "-DDILITHIUM_MODE=2",
+        ],
+        nshares = nshares,
+        pqc = True,
+        scheme = 2,
+        seed = i,
+        stats = True,
+        testgen = ":secdecompose_testgen",
+        deps = [
+            "//sw/acc/crypto/mldsa:kmac_send_msg",
+            "//sw/acc/crypto/mldsa:mldsa44_consts",
+            "//sw/acc/crypto/mldsa:mldsa44_poly",
+            "//sw/acc/crypto/mldsa:mldsa44_rounding",
+            "//sw/acc/crypto/mldsa/gadgets:bitslice_mldsa_k32",
+            "//sw/acc/crypto/mldsa/gadgets:scratch",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secand_cs20_d2",
+            "//sw/acc/crypto/mldsa/gadgets:seccompress",
+            "//sw/acc/crypto/mldsa/gadgets:secdecompose_mldsa44",
+            "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:unbitslice_mldsa",
+        ],
+    )
+    for i in range(20)
+    for nshares in [2]
+]
+
+py_binary(
+    name = "poly_rej_samp_bitsliced_testgen",
+    srcs = ["poly_rej_samp_bitsliced_testgen.py"],
+    imports = [
+        "../../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+    ],
+)
+
+[
+    acc_autogen_sim_test(
+        name = "poly_rej_samp_bitsliced_mldsa_test" + str(i),
+        srcs = ["poly_rej_samp_bitsliced_test.s"],
+        pqc = True,
+        seed = i,
+        stats = True,
+        testgen = ":poly_rej_samp_bitsliced_testgen",
+        deps = [
+            "//sw/acc/crypto/mldsa/gadgets:poly_rej_samp_bitsliced_mldsa_test",
+        ],
+    )
+    for i in range(5)
+]
+
+py_binary(
+    name = "secb2amodq_bc22_testgen",
+    srcs = ["secb2amodq_bc22_testgen.py"],
+    imports = [
+        "../../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+    ],
+)
+
+[
+    acc_autogen_sim_test(
+        name = "secb2amodq_bc22_mldsa_test{}_{}shares".format(
+            str(i),
+            str(nshares),
+        ),
+        srcs = ["secb2amodq_bc22_test.s"],
+        copts = [
+            "-DNSHARES=" + str(nshares),
+        ],
+        nshares = nshares,
+        pqc = True,
+        seed = i,
+        stats = True,
+        testgen = ":secb2amodq_bc22_testgen",
+        deps = [
+            "//sw/acc/crypto/mldsa/gadgets:poly_rej_samp_bitsliced_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:scratch",
+            "//sw/acc/crypto/mldsa/gadgets:seca2bmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d1",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_constant_bmsk_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secaddmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secand_cs20_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secb2amodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22",
+        ],
+    )
+    for i in range(5)
+    for nshares in [2]
+]
+
+py_binary(
+    name = "secb2amodq_eta_testgen",
+    srcs = ["secb2amodq_eta_testgen.py"],
+    imports = [
+        "../../../../../../hw/ip/acc/util",
+    ],
+    deps = [
+        "//hw/ip/acc/util/shared:testgen",
+    ],
+)
+
+[
+    acc_autogen_sim_test(
+        name = "secb2amodq_eta_test{}_k{}".format(
+            str(i),
+            str(kbits),
+        ),
+        srcs = ["secb2amodq_eta_test.s"],
+        copts = [
+            "-DNSHARES=2",
+            "-DKBITS=" + str(kbits),
+        ],
+        nshares = 2,
+        pqc = True,
+        seed = i,
+        stats = True,
+        testgen = ":secb2amodq_eta_testgen",
+        testgen_args = [
+            "-k",
+            str(kbits),
+        ],
+        deps = [
+            "//sw/acc/crypto/mldsa:mldsa44_consts",
+            "//sw/acc/crypto/mldsa/gadgets:bitslice_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:poly_rej_samp_bitsliced_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:scratch",
+            "//sw/acc/crypto/mldsa/gadgets:seca2bmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d1",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_bc22_immd_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secadd_constant_bmsk_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secaddmodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secand_cs20_d2",
+            "//sw/acc/crypto/mldsa/gadgets:secb2amodq_bc22_mldsa",
+            "//sw/acc/crypto/mldsa/gadgets:secb2amodq_eta",
+            "//sw/acc/crypto/mldsa/gadgets:secfulladder_bc22",
+            "//sw/acc/crypto/mldsa/gadgets:unbitslice_mldsa",
+        ],
+    )
+    for i in range(3)
+    for kbits in [
+        3,
+        4,
+    ]
+]

--- a/sw/acc/crypto/tests/mldsa/gadgets/bitslice_test.s
+++ b/sw/acc/crypto/tests/mldsa/gadgets/bitslice_test.s
@@ -1,0 +1,23 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.section .text.start
+
+main:
+    la  x2, stack_end
+    bn.xor w31, w31, w31
+
+    la  x10, r
+    la  x11, in
+    li  x12, 32
+    jal x1, bitslice
+
+    ecall
+
+.data
+.balign 32
+stack:
+    .zero 2048
+stack_end:
+    .byte 0

--- a/sw/acc/crypto/tests/mldsa/gadgets/bitslice_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/bitslice_testgen.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import random
+from typing import TextIO, Optional
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+N_COEFS = 256
+KBITS = 23
+
+
+def pack_canonical(vals):
+    """256 x 32-bit coefs -> 32 WDRs (1024 bytes)."""
+    buf = bytearray()
+    for v in vals:
+        buf += v.to_bytes(4, 'little')
+    return bytes(buf)
+
+
+def pack_bitsliced(vals):
+    """256 coefs -> KBITS WDRs bitsliced (lane i of WDR j = bit j of coef i)."""
+    out = bytearray()
+    for b in range(KBITS):
+        w = sum(((v >> b) & 1) << i for i, v in enumerate(vals))
+        out += w.to_bytes(32, 'little')
+    return bytes(out)
+
+
+def gen(seed: Optional[int],
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+    if seed is not None:
+        random.seed(seed)
+    vals = [random.randrange(1 << KBITS) for _ in range(N_COEFS)]
+    write_test_data({'in': pack_canonical(vals),
+                     'r': b'\x00' * (KBITS * 32)}, data_file)
+    write_test_exp({}, exp_file)
+    write_test_dexp({'r': pack_bitsliced(vals)}, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed', type=int, required=False)
+    parser.add_argument('--scheme', type=int, required=False, default=1)
+    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'))
+    args = parser.parse_args()
+    gen(args.seed, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/gadgets/masked_poly_uniform_eta_test.s
+++ b/sw/acc/crypto/tests/mldsa/gadgets/masked_poly_uniform_eta_test.s
@@ -1,0 +1,54 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.section .text.start
+
+main:
+    la  x2, stack_end
+    bn.xor w31, w31, w31
+
+    /* MOD <= R | Q for bn.subvm.8s unmasking. */
+    li      x5, 2
+    la      x6, modulus
+    bn.lid  x5, 0(x6)
+    li      x5, 3
+    la      x6, montg_R
+    bn.lid  x5, 0(x6)
+    bn.rshi w2, w3, w2 >> 224
+    bn.wsrw 0x0, w2
+
+    la   x6, nonce
+    lw   x12, 0(x6)
+    la   x10, s_shares
+    la   x11, rho_shares
+    la   x13, mpue_arena
+    la   x14, mpue_b2a_buf
+    jal  x1, masked_poly_uniform_eta
+
+    /* r = s_shares[0] + s_shares[1] mod q (lane-wise). */
+    la   x10, s_shares
+    addi x11, x10, 1024
+    la   x12, r
+    li   x4, 1
+    li   x5, 2
+    LOOPI 32, 4
+        bn.lid x4, 0(x10++)
+        bn.lid x5, 0(x11++)
+        bn.addvm.8S w1, w1, w2
+        bn.sid x4, 0(x12++)
+
+    ecall
+
+.data
+.balign 32
+stack:
+    .zero 4096
+stack_end:
+
+.balign 32
+mpue_arena:
+    .zero 3104
+.balign 32
+mpue_b2a_buf:
+    .zero 1536

--- a/sw/acc/crypto/tests/mldsa/gadgets/masked_poly_uniform_eta_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/masked_poly_uniform_eta_testgen.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import hashlib
+import random
+from typing import TextIO, Optional
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+N_COEFS = 256
+Q = 8380417
+CRHBYTES = 64
+
+
+def expand_s_poly(seed: bytes, nonce: int, eta: int):
+    """Reference poly_uniform_eta (ML-DSA, FIPS 204 CoeffFromHalfByte):
+    4-bit nibble; eta=2 rejects 15, coeff = 2 - (n mod 5); eta=4 rejects
+    n >= 9, coeff = 4 - n.  Mirrors sw/acc/crypto/mldsa/poly.s."""
+    shake = hashlib.shake_256()
+    shake.update(seed)
+    shake.update(nonce.to_bytes(2, 'little'))
+    buf = shake.digest(1024)
+    out = []
+    pos = 0
+    while len(out) < N_COEFS:
+        b = buf[pos]
+        pos += 1
+        for t in (b & 0xF, b >> 4):
+            if len(out) >= N_COEFS:
+                break
+            if eta == 2 and t < 15:
+                t = t - (205 * t >> 10) * 5
+                out.append((eta - t) % Q)
+            elif eta == 4 and t < 9:
+                out.append((eta - t) % Q)
+    return out
+
+
+def pack_canonical(vals):
+    buf = bytearray()
+    for v in vals:
+        buf += v.to_bytes(4, 'little')
+    return bytes(buf)
+
+
+def pack_share_major(seed_shares):
+    buf = bytearray()
+    for s in seed_shares:
+        buf += s
+    return bytes(buf)
+
+
+def gen(seed: Optional[int], eta: int,
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+    if seed is not None:
+        random.seed(seed)
+    nonce = random.randrange(1 << 16)
+    rho = random.randbytes(CRHBYTES)
+    mask = random.randbytes(CRHBYTES)
+    rho_share0 = bytes(a ^ b for a, b in zip(rho, mask))
+    rho_share1 = mask
+
+    s = expand_s_poly(rho, nonce, eta)
+
+    write_test_data({
+        'rho_shares': pack_share_major([rho_share0, rho_share1]),
+        'nonce': nonce.to_bytes(4, 'little'),
+        's_shares': b'\x00' * (2 * N_COEFS * 4),
+        'r': b'\x00' * (N_COEFS * 4),
+    }, data_file)
+    write_test_exp({}, exp_file)
+    write_test_dexp({'r': pack_canonical(s)}, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed', type=int, required=False)
+    parser.add_argument('--scheme', type=int, required=False, default=1)
+    parser.add_argument('--eta', type=int, required=False, default=2)
+    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'))
+    args = parser.parse_args()
+    gen(args.seed, args.eta, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/gadgets/masked_poly_uniform_gamma1_test.s
+++ b/sw/acc/crypto/tests/mldsa/gadgets/masked_poly_uniform_gamma1_test.s
@@ -1,0 +1,55 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.section .text.start
+
+main:
+    la  x2, stack_end
+    bn.xor w31, w31, w31
+
+    /* MOD <= R | Q for bn.addvm.8S unmasking. */
+    li      x5, 2
+    la      x6, modulus
+    bn.lid  x5, 0(x6)
+    li      x5, 3
+    la      x6, montg_R
+    bn.lid  x5, 0(x6)
+    bn.rshi w2, w3, w2 >> 224
+    bn.wsrw 0x0, w2
+
+    la   x6, nonce
+    lw   x12, 0(x6)
+    la   x10, y_shares
+    la   x11, rho_shares
+    la   x13, seca2b_scratch
+    la   x14, gamma1_buf
+    jal  x1, masked_poly_uniform_gamma_1
+
+    /* r = y_shares[0] + y_shares[1] mod q (lane-wise). */
+    la   x10, y_shares
+    addi x11, x10, 1024
+    la   x12, r
+    li   x4, 1
+    li   x5, 2
+    LOOPI 32, 4
+        bn.lid x4, 0(x10++)
+        bn.lid x5, 0(x11++)
+        bn.addvm.8S w1, w1, w2
+        bn.sid x4, 0(x12++)
+
+    ecall
+
+.data
+.balign 32
+stack:
+    .zero 8192
+stack_end:
+
+.balign 32
+seca2b_scratch:
+    .zero 1536
+
+.balign 32
+gamma1_buf:
+    .zero 1536

--- a/sw/acc/crypto/tests/mldsa/gadgets/masked_poly_uniform_gamma1_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/masked_poly_uniform_gamma1_testgen.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import hashlib
+import random
+from typing import TextIO, Optional
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+N_COEFS = 256
+Q = 8380417
+KBITS = 23
+GAMMA1 = 1 << 19
+CRHBYTES = 64
+
+
+def expand_mask(seed: bytes, nonce: int):
+    """Reference implementation of poly_uniform_gamma_1 (ML-DSA-65/87)."""
+    n_bytes = N_COEFS * 20 // 8
+    shake = hashlib.shake_256()
+    shake.update(seed)
+    shake.update(nonce.to_bytes(2, 'little'))
+    buf = shake.digest(n_bytes)
+    out = []
+    for i in range(N_COEFS):
+        bit = i * 20
+        b = buf[bit // 8:bit // 8 + 3]
+        v = int.from_bytes(b, 'little')
+        v = (v >> (bit % 8)) & ((1 << 20) - 1)
+        out.append((GAMMA1 - v) % Q)
+    return out
+
+
+def pack_canonical(vals):
+    buf = bytearray()
+    for v in vals:
+        buf += v.to_bytes(4, 'little')
+    return bytes(buf)
+
+
+def pack_share_major(seed_shares):
+    """Concatenate NSHARES x CRHBYTES seed shares share-major."""
+    buf = bytearray()
+    for s in seed_shares:
+        buf += s
+    return bytes(buf)
+
+
+def gen(seed: Optional[int],
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+    if seed is not None:
+        random.seed(seed)
+    nonce = random.randrange(1 << 16)
+    rho = random.randbytes(CRHBYTES)
+    mask = random.randbytes(CRHBYTES)
+    rho_share0 = bytes(a ^ b for a, b in zip(rho, mask))
+    rho_share1 = mask
+
+    y = expand_mask(rho, nonce)
+
+    write_test_data({
+        'rho_shares': pack_share_major([rho_share0, rho_share1]),
+        'nonce': nonce.to_bytes(4, 'little'),
+        'y_shares': b'\x00' * (2 * N_COEFS * 4),
+        'r': b'\x00' * (N_COEFS * 4),
+    }, data_file)
+    write_test_exp({}, exp_file)
+    write_test_dexp({'r': pack_canonical(y)}, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed', type=int, required=False)
+    parser.add_argument('--scheme', type=int, required=False, default=1)
+    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'))
+    args = parser.parse_args()
+    gen(args.seed, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/gadgets/poly_rej_samp_bitsliced_test.s
+++ b/sw/acc/crypto/tests/mldsa/gadgets/poly_rej_samp_bitsliced_test.s
@@ -1,0 +1,22 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.section .text.start
+
+main:
+    la  x2, stack_end
+    bn.xor w31, w31, w31
+
+    la  x10, r
+    la  x11, rand
+    jal x1, poly_rej_samp_bitsliced
+
+    ecall
+
+.data
+.balign 32
+stack:
+    .zero 1024
+stack_end:
+    .byte 0

--- a/sw/acc/crypto/tests/mldsa/gadgets/poly_rej_samp_bitsliced_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/poly_rej_samp_bitsliced_testgen.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import random
+from typing import TextIO, Optional
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+N_LANES = 256
+Q = 8380417
+KBITS = 23
+WDR_BYTES = 32
+BLOCK_BYTES = KBITS * WDR_BYTES
+
+
+def bitslice(vals):
+    out = bytearray()
+    for b in range(KBITS):
+        w = sum(((v >> b) & 1) << lane for lane, v in enumerate(vals))
+        out += w.to_bytes(WDR_BYTES, 'little')
+    return bytes(out)
+
+
+def rejecting_block(rng):
+    vals = [rng.randrange(1 << KBITS) for _ in range(N_LANES)]
+    bad_lane = rng.randrange(N_LANES)
+    vals[bad_lane] = Q + rng.randrange((1 << KBITS) - Q)
+    return bitslice(vals)
+
+
+def accepting_block(rng):
+    vals = [rng.randrange(Q) for _ in range(N_LANES)]
+    return bitslice(vals)
+
+
+def gen(seed: Optional[int],
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+    # seed is 0,1,2,3,4 -- use that as the number of rejecting blocks
+    n_rejects = seed if seed is not None else 0
+    rng = random.Random(seed)
+
+    rand_bytes = b''.join(rejecting_block(rng) for _ in range(n_rejects))
+    expected = accepting_block(rng)
+    rand_bytes += expected
+
+    write_test_data({'rand': rand_bytes, 'r': b'\x00' * BLOCK_BYTES},
+                    data_file)
+    write_test_exp({}, exp_file)
+    write_test_dexp({'r': expected}, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed', type=int, required=False)
+    parser.add_argument('--scheme', type=int, required=False, default=1)
+    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'))
+    args = parser.parse_args()
+    gen(args.seed, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/gadgets/seca2bmodq_bc22_test.s
+++ b/sw/acc/crypto/tests/mldsa/gadgets/seca2bmodq_bc22_test.s
@@ -1,0 +1,63 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef NSHARES
+    #define NSHARES 2
+#endif
+#define Q_KBITS 23
+#define SHARE_STR 768
+
+.equ x5, t0
+.equ x6, t1
+.equ x7, t2
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x28, t3
+.equ x29, t4
+
+.section .text.start
+
+main:
+    la  x2, stack_end
+    bn.xor w31, w31, w31
+    la  x10, zb
+    la  x11, xa
+    la  x13, seca2b_scratch
+    jal x1, seca2bmodq_bc22
+
+    /* Reconstruct r per bit-plane.  zb[share s][bit b] @ s*SHARE_STR + b*32. */
+    la   x10, zb
+    la   x11, r
+    li   x12, SHARE_STR
+    li   x13, Q_KBITS
+    li   x29, NSHARES
+    addi x29, x29, -1
+    li   x4, 1
+    li   x5, 0
+    loop x13, 9
+        addi x28, x10, 0
+        bn.lid x5, 0(x28)
+        loop x29, 3
+            add    x28, x28, x12
+            bn.lid x4, 0(x28)
+            bn.xor w0, w0, w1
+        bn.sid x5, 0(x11)
+        addi x10, x10, 32
+        addi x11, x11, 32
+
+    ecall
+
+.data
+.balign 32
+stack:
+    .zero 8192
+stack_end:
+r:
+    .zero Q_KBITS * 32
+
+.balign 32
+seca2b_scratch:
+    .zero 1536

--- a/sw/acc/crypto/tests/mldsa/gadgets/seca2bmodq_bc22_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/seca2bmodq_bc22_testgen.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import random
+from typing import TextIO, Optional
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+N_LANES = 256
+Q = 8380417
+KBITS = 23
+
+
+def bitslice(vals, bit):
+    word = 0
+    for i, v in enumerate(vals):
+        word |= ((v >> bit) & 1) << i
+    return word
+
+
+def arith_share(vals, nshares):
+    """Arithmetic-share mod Q across nshares shares, per lane."""
+    shares = [[0] * N_LANES for _ in range(nshares)]
+    for lane in range(N_LANES):
+        acc = vals[lane]
+        for s in range(nshares - 1):
+            r = random.randrange(Q)
+            shares[s][lane] = r
+            acc = (acc - r) % Q
+        shares[nshares - 1][lane] = acc % Q
+    return shares
+
+
+def pack_arith_shares(share_vals, kbits, nshares):
+    """Produce (kbits+1) * nshares * 32 bytes, share-major bit-inner.
+    Top bit (kbits) is zero per share."""
+    buf = bytearray()
+    for s in range(nshares):
+        for bit in range(kbits):
+            w = bitslice(share_vals[s], bit)
+            buf += w.to_bytes(32, 'little')
+        buf += b'\x00' * 32
+    return bytes(buf)
+
+
+def gen(seed: Optional[int], nshares: int,
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+    if seed is not None:
+        random.seed(seed)
+
+    x_vals = [random.randrange(Q) for _ in range(N_LANES)]
+    share_vals = arith_share(x_vals, nshares)
+
+    xa = pack_arith_shares(share_vals, KBITS, nshares)
+    zb_init = b'\x00' * ((KBITS + 1) * nshares * 32)
+
+    r_bytes = bytearray()
+    for bit in range(KBITS):
+        r_bytes += bitslice(x_vals, bit).to_bytes(32, 'little')
+
+    write_test_data({'xa': xa, 'zb': zb_init}, data_file)
+    write_test_exp({}, exp_file)
+    write_test_dexp({'r': bytes(r_bytes)}, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed', type=int, required=False)
+    parser.add_argument('-n', '--nshares', type=int, required=False, default=2)
+    parser.add_argument('--scheme', type=int, required=False, default=1)
+    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'))
+    args = parser.parse_args()
+    gen(args.seed, args.nshares, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/gadgets/secadd_bc22_test.s
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secadd_bc22_test.s
@@ -1,0 +1,61 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef NSHARES
+    #define NSHARES 2
+#endif
+#ifndef SCHEME
+    #define SCHEME 0
+#endif
+
+#if SCHEME == 0
+    #define BITSIZE 16
+    #define SHARE_STR 512
+#else
+    #define BITSIZE 32
+    #define SHARE_STR 1024
+#endif
+
+#define STACK_SIZE 1024
+
+.section .text.start
+
+main:
+    /* Load stack pointer. */
+    la  x2, stack_end
+
+    /* dmem[rb] <= secadd_bc22(dmem[xb], dmem[yb], nshares) */
+    la  x10, xb
+    la  x11, yb
+    li  x12, BITSIZE
+    li  x13, SHARE_STR
+    li  x14, NSHARES
+    la  x15, rb
+    jal x1, secadd_bc22
+
+    /* Compute r */
+    la     x2, rb
+    la     x3, r
+    li     x4, 1
+    li     x5, NSHARES
+    addi   x5, x5, -1
+    li     x6, BITSIZE
+    loop x6, 7
+        addi   x7, x2, SHARE_STR
+        bn.lid x0, 0(x2++)
+        loop x5, 3
+            bn.lid x4, 0(x7)
+            bn.xor w0, w0, w1
+            addi   x7, x7, SHARE_STR
+        bn.sid x0, 0(x3++)
+
+    ecall
+
+.data
+.balign 32
+stack:
+    .zero STACK_SIZE
+stack_end:
+r:
+    .zero 32 * BITSIZE

--- a/sw/acc/crypto/tests/mldsa/gadgets/secadd_bc22_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secadd_bc22_testgen.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import random
+from typing import TextIO, Optional
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+N = 256
+NSHARES = 2
+
+
+def gen_secadd_bc22_test(
+        seed: Optional[int], scheme: Optional[int], nshares: Optional[int],
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+    # Generate random operands.
+    if seed is not None:
+        random.seed(seed)
+
+    if scheme:
+        k = 32
+    else:
+        k = 16
+
+    if nshares is None:
+        nshares = NSHARES
+
+    operand_nbytes = 32 * nshares * k
+
+    x = [0] * k
+    y = [0] * k
+    xb = bytes()
+    yb = bytes()
+    for _ in range(nshares):
+        for i in range(k):
+            tx = random.getrandbits(N)
+            ty = random.getrandbits(N)
+            x[i] ^= tx
+            y[i] ^= ty
+            tx = int.to_bytes(tx, byteorder="little", length=32)
+            ty = int.to_bytes(ty, byteorder="little", length=32)
+            xb += tx
+            yb += ty
+
+    r = [0] * k
+    for i in range(N):
+        xi = 0
+        yi = 0
+        for j in range(k):
+            xi |= (((x[j] >> i) & 1) << j)
+            yi |= (((y[j] >> i) & 1) << j)
+        ri = (xi + yi) & ((1 << k) - 1)
+        for j in range(k):
+            r[j] |= (((ri >> j) & 1) << i)
+
+    r_bytes = bytes()
+    for i in range(k):
+        t = int.to_bytes(r[i], byteorder="little", length=32)
+        r_bytes += t
+
+    rb_bytes = int.to_bytes(0, byteorder='little', length=operand_nbytes)
+
+    # Write input values.
+    inputs = {'xb': xb, 'yb': yb, 'rb': rb_bytes}
+    write_test_data(inputs, data_file)
+
+    # Write expected register values (none).
+    write_test_exp({}, exp_file)
+
+    # Write expected dmem values.
+    write_test_dexp({'r': r_bytes}, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed',
+                        type=int,
+                        required=False,
+                        help=('Seed value for pseudorandomness.'))
+    parser.add_argument('-n', '--nshares',
+                        type=int,
+                        required=False,
+                        help=('Number of shares.'))
+    parser.add_argument('--scheme',
+                        type=int,
+                        required=False,
+                        default=0,
+                        help=('False: ML-KEM. True: ML-DSA.'))
+    parser.add_argument('data',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for input DMEM values.'))
+    parser.add_argument('exp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected register values.'))
+    parser.add_argument('dexp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected DMEM values.'))
+    args = parser.parse_args()
+
+    gen_secadd_bc22_test(args.seed, args.scheme, args.nshares, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/gadgets/secaddmodq_bc22_test.s
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secaddmodq_bc22_test.s
@@ -1,0 +1,61 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef NSHARES
+    #define NSHARES 2
+#endif
+#define Q_KBITS 23
+#define SHARE_STR 768
+
+.equ x5, t0
+.equ x6, t1
+.equ x7, t2
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x14, a4
+.equ x28, t3
+.equ x29, t4
+
+.section .text.start
+
+main:
+    la  x2, stack_end
+    bn.xor w31, w31, w31
+    la  x10, zb
+    la  x11, xb
+    la  x12, yb
+    li  x14, NSHARES
+    jal x1, secaddmodq_bc22
+
+    /* Reconstruct r per bit-plane.  zb[share s][bit b] @ s*SHARE_STR + b*32. */
+    la   x10, zb              /* per-bit-0 base */
+    la   x11, r               /* r write ptr */
+    li   x12, SHARE_STR       /* share stride */
+    li   x13, Q_KBITS         /* bit count */
+    li   x14, NSHARES
+    addi x14, x14, -1         /* d - 1 inner iters */
+    li   x4, 1
+    li   x5, 0
+    loop x13, 9
+        addi x28, x10, 0
+        bn.lid x5, 0(x28)
+        loop x14, 3
+            add    x28, x28, x12
+            bn.lid x4, 0(x28)
+            bn.xor w0, w0, w1
+        bn.sid x5, 0(x11)
+        addi x10, x10, 32
+        addi x11, x11, 32
+
+    ecall
+
+.data
+.balign 32
+stack:
+    .zero 16384
+stack_end:
+r:
+    .zero Q_KBITS * 32

--- a/sw/acc/crypto/tests/mldsa/gadgets/secaddmodq_bc22_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secaddmodq_bc22_testgen.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import random
+from typing import TextIO, Optional
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+N_LANES = 256  # bitslice width = one ACC WDR
+Q = 8380417
+KBITS = 23
+
+
+def bitslice(vals, bit):
+    """Pack bit `bit` of each of 256 values into one 256-bit word."""
+    word = 0
+    for i, v in enumerate(vals):
+        word |= ((v >> bit) & 1) << i
+    return word
+
+
+def share(word, nshares):
+    """Boolean-share a 256-bit word into nshares 256-bit shares."""
+    shares = []
+    acc = word
+    for _ in range(nshares - 1):
+        s = random.getrandbits(N_LANES)
+        shares.append(s)
+        acc ^= s
+    shares.append(acc)
+    return shares
+
+
+def pack_shared_bits(vals, kbits, nshares):
+    """Produce (kbits+1) * nshares * 32 bytes, share-major bit-inner.
+    Top bit (kbits) is zero per share."""
+    shares_bits = [[0] * kbits for _ in range(nshares)]
+    for bit in range(kbits):
+        w = bitslice(vals, bit)
+        ss = share(w, nshares)
+        for s in range(nshares):
+            shares_bits[s][bit] = ss[s]
+    buf = bytearray()
+    for s in range(nshares):
+        for bit in range(kbits):
+            buf += shares_bits[s][bit].to_bytes(32, 'little')
+        # bit kbits = 0
+        buf += b'\x00' * 32
+    return bytes(buf)
+
+
+def gen(seed: Optional[int], nshares: int,
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+    if seed is not None:
+        random.seed(seed)
+
+    x_vals = [random.randrange(Q) for _ in range(N_LANES)]
+    y_vals = [random.randrange(Q) for _ in range(N_LANES)]
+    z_vals = [(x + y) % Q for x, y in zip(x_vals, y_vals)]
+
+    xb = pack_shared_bits(x_vals, KBITS, nshares)
+    yb = pack_shared_bits(y_vals, KBITS, nshares)
+    zb_init = b'\x00' * ((KBITS + 1) * nshares * 32)
+
+    r_bytes = bytearray()
+    for bit in range(KBITS):
+        r_bytes += bitslice(z_vals, bit).to_bytes(32, 'little')
+
+    write_test_data({'xb': xb, 'yb': yb, 'zb': zb_init}, data_file)
+    write_test_exp({}, exp_file)
+    write_test_dexp({'r': bytes(r_bytes)}, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed', type=int, required=False)
+    parser.add_argument('-n', '--nshares', type=int, required=False, default=2)
+    parser.add_argument('--scheme', type=int, required=False, default=1)
+    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'))
+    args = parser.parse_args()
+    gen(args.seed, args.nshares, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/gadgets/secand_cs20_test.s
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secand_cs20_test.s
@@ -1,0 +1,46 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef NSHARES
+    #define NSHARES 2
+#endif
+#define STACK_SIZE 1024
+
+.section .text.start
+
+main:
+    /* Load stack pointer. */
+    la  x2, stack_end
+
+    /* dmem[rb] <= secand_cs20(dmem[xb], dmem[yb], nshares) */
+    la  x10, xb
+    li  x11, 32
+    la  x12, yb
+    li  x13, 32
+    li  x14, NSHARES
+    li  x15, 32
+    la  x16, rb
+    jal x1, secand_cs20
+
+    /* Compute r */
+    la     x2, rb
+    la     x3, r
+    li     x4, 1
+    li     x5, NSHARES
+    addi   x5, x5, -1
+    bn.lid x0, 0(x2++)
+    loop x5, 2
+        bn.lid x4, 0(x2++)
+        bn.xor w0, w0, w1
+    bn.sid x0, 0(x3)
+
+    ecall
+
+.data
+.balign 32
+stack:
+    .zero STACK_SIZE
+stack_end:
+r:
+    .zero 32

--- a/sw/acc/crypto/tests/mldsa/gadgets/secand_cs20_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secand_cs20_testgen.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import random
+from typing import TextIO, Optional
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+N = 256
+NSHARES = 2
+
+
+def gen_secand_cs20_test(
+        seed: Optional[int], scheme: Optional[int], nshares: Optional[int],
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+    # Generate random operands.
+    if seed is not None:
+        random.seed(seed)
+
+    if nshares is None:
+        nshares = NSHARES
+
+    operand_nbytes = 32 * nshares
+
+    x = 0
+    y = 0
+    xb = 0
+    yb = 0
+    for i in range(nshares):
+        tx = random.getrandbits(N)
+        ty = random.getrandbits(N)
+        x ^= tx
+        y ^= ty
+        xb |= (tx << (i * N))
+        yb |= (ty << (i * N))
+
+    r = x & y
+
+    xb_bytes = int.to_bytes(xb, byteorder='little', length=operand_nbytes)
+    yb_bytes = int.to_bytes(yb, byteorder='little', length=operand_nbytes)
+    r_bytes = int.to_bytes(r, byteorder='little', length=32)
+    rb_bytes = int.to_bytes(0, byteorder='little', length=operand_nbytes)
+
+    # Write input values.
+    inputs = {'xb': xb_bytes, 'yb': yb_bytes, 'rb': rb_bytes}
+    write_test_data(inputs, data_file)
+
+    # Write expected register values (none).
+    write_test_exp({}, exp_file)
+
+    # Write expected dmem values.
+    write_test_dexp({'r': r_bytes}, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed',
+                        type=int,
+                        required=False,
+                        help=('Seed value for pseudorandomness.'))
+    parser.add_argument('-n', '--nshares',
+                        type=int,
+                        required=False,
+                        help=('Number of shares.'))
+    parser.add_argument('--scheme',
+                        type=int,
+                        required=False,
+                        default=0,
+                        help=('False: ML-KEM. True: ML-DSA.'))
+    parser.add_argument('data',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for input DMEM values.'))
+    parser.add_argument('exp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected register values.'))
+    parser.add_argument('dexp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected DMEM values.'))
+    args = parser.parse_args()
+
+    gen_secand_cs20_test(args.seed, args.scheme, args.nshares, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/gadgets/secb2amodq_bc22_test.s
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secb2amodq_bc22_test.s
@@ -1,0 +1,71 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef NSHARES
+    #define NSHARES 2
+#endif
+#define Q_KBITS 23
+#define SHARE_STR 768
+
+.equ x5, t0
+.equ x6, t1
+.equ x7, t2
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x28, t3
+.equ x29, t4
+
+.section .text.start
+
+/* Round-trip: za = secb2amodq_bc22(xb); zb2 = seca2bmodq_bc22(za); reconstruct.
+ * Layouts: share-major bit-inner, share_str = (k+1)*32 = 768. */
+main:
+    la  x2, stack_end
+    bn.xor w31, w31, w31
+
+    la  x10, za
+    la  x11, xb
+    la  x13, seca2b_scratch
+    jal x1, secb2amodq_bc22
+
+    la  x10, zb2
+    la  x11, za
+    la  x13, seca2b_scratch
+    jal x1, seca2bmodq_bc22
+
+    /* XOR-unmask zb2 into r. */
+    la   x10, zb2
+    la   x11, r
+    li   x12, SHARE_STR
+    li   x13, Q_KBITS
+    li   x29, NSHARES
+    addi x29, x29, -1
+    li   x4, 1
+    li   x5, 0
+    loop x13, 9
+        addi x28, x10, 0
+        bn.lid x5, 0(x28)
+        loop x29, 3
+            add    x28, x28, x12
+            bn.lid x4, 0(x28)
+            bn.xor w0, w0, w1
+        bn.sid x5, 0(x11)
+        addi x10, x10, 32
+        addi x11, x11, 32
+
+    ecall
+
+.data
+.balign 32
+stack:
+    .zero 8192
+stack_end:
+r:
+    .zero Q_KBITS * 32
+
+.balign 32
+seca2b_scratch:
+    .zero 1536

--- a/sw/acc/crypto/tests/mldsa/gadgets/secb2amodq_bc22_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secb2amodq_bc22_testgen.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import random
+from typing import TextIO, Optional
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+N_LANES = 256
+Q = 8380417
+KBITS = 23
+
+
+def bitslice(vals, bit):
+    word = 0
+    for i, v in enumerate(vals):
+        word |= ((v >> bit) & 1) << i
+    return word
+
+
+def pack_bool_shares(shares, kbits):
+    """Share-major bit-inner: (kbits+1) * nshares * 32 bytes, top bit zero."""
+    nshares = len(shares)
+    buf = bytearray()
+    for s in range(nshares):
+        for bit in range(kbits):
+            buf += bitslice(shares[s], bit).to_bytes(32, 'little')
+        buf += b'\x00' * 32
+    return bytes(buf)
+
+
+def gen(seed: Optional[int], nshares: int,
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+    if seed is not None:
+        random.seed(seed)
+
+    if nshares != 2:
+        raise ValueError('secb2amodq_bc22 currently only supports nshares=2')
+
+    x_vals = [random.randrange(Q) for _ in range(N_LANES)]
+    x_share0 = [random.randrange(1 << KBITS) for _ in range(N_LANES)]
+    x_share1 = [x_vals[i] ^ x_share0[i] for i in range(N_LANES)]
+
+    xb = pack_bool_shares([x_share0, x_share1], KBITS)
+    za_init = b'\x00' * ((KBITS + 1) * nshares * 32)
+    zb2_init = b'\x00' * ((KBITS + 1) * nshares * 32)
+
+    r_bytes = bytearray()
+    for bit in range(KBITS):
+        r_bytes += bitslice(x_vals, bit).to_bytes(32, 'little')
+
+    write_test_data({'xb': xb, 'za': za_init, 'zb2': zb2_init}, data_file)
+    write_test_exp({}, exp_file)
+    write_test_dexp({'r': bytes(r_bytes)}, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed', type=int, required=False)
+    parser.add_argument('-n', '--nshares', type=int, required=False, default=2)
+    parser.add_argument('--scheme', type=int, required=False, default=1)
+    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'))
+    args = parser.parse_args()
+    gen(args.seed, args.nshares, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/gadgets/secb2amodq_eta_test.s
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secb2amodq_eta_test.s
@@ -1,0 +1,77 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef NSHARES
+    #define NSHARES 2
+#endif
+#ifndef KBITS
+    #define KBITS 3
+#endif
+
+.equ x5, t0
+.equ x6, t1
+.equ x7, t2
+.equ x10, a0
+.equ x11, a1
+.equ x12, a2
+.equ x13, a3
+.equ x28, t3
+.equ x29, t4
+
+.section .text.start
+
+main:
+    la  x2, stack_end
+    bn.xor w31, w31, w31
+
+    /* MOD = R | Q (low half = q) for bn.addvm/subvm. */
+    li      x5, 2
+    la      x6, modulus
+    bn.lid  x5, 0(x6)
+    li      x5, 3
+    la      x6, montg_R
+    bn.lid  x5, 0(x6)
+    bn.rshi w2, w3, w2 >> 224
+    bn.wsrw 0x0, w2
+
+    la  x10, out
+    la  x11, xb_share0
+    la  x12, xb_share1
+    li  x13, KBITS
+    la  x14, seca2b_scratch
+    la  x15, eta_buf
+    jal x1, secb2amodq_eta
+
+    /* Sum arith shares: r[i] = (out[0..1023][i] + out[1024..2047][i]) mod q. */
+    la  x10, out
+    la  x11, r
+    li  x5, 0
+    li  x6, 1
+    loopi 32, 6
+        bn.lid x5, 0(x10)
+        addi   x4, x10, 1024
+        bn.lid x6, 0(x4)
+        bn.addvm.8S w0, w0, w1
+        bn.sid x5, 0(x11++)
+        addi x10, x10, 32
+
+    ecall
+
+.data
+.balign 32
+stack:
+    .zero 8192
+stack_end:
+
+.balign 32
+r:
+    .zero 1024
+
+.balign 32
+seca2b_scratch:
+    .zero 1536
+
+.balign 32
+eta_buf:
+    .zero 1536

--- a/sw/acc/crypto/tests/mldsa/gadgets/secb2amodq_eta_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secb2amodq_eta_testgen.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import random
+from typing import TextIO, Optional
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+N_LANES = 256
+Q = 8380417
+
+
+def bitslice(vals, bit):
+    word = 0
+    for i, v in enumerate(vals):
+        word |= ((v >> bit) & 1) << i
+    return word
+
+
+def pack_bitsliced(vals, kbits):
+    """k stripes * 32 B, contiguous."""
+    buf = bytearray()
+    for bit in range(kbits):
+        buf += bitslice(vals, bit).to_bytes(32, 'little')
+    return bytes(buf)
+
+
+def gen(seed: Optional[int], nshares: int, kbits: int,
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+    if seed is not None:
+        random.seed(seed)
+
+    if nshares != 2:
+        raise ValueError('secb2amodq_eta currently only supports nshares=2')
+
+    x_vals = [random.randrange(1 << kbits) for _ in range(N_LANES)]
+    x_share0 = [random.randrange(1 << kbits) for _ in range(N_LANES)]
+    x_share1 = [x_vals[i] ^ x_share0[i] for i in range(N_LANES)]
+
+    xb_share0 = pack_bitsliced(x_share0, kbits)
+    xb_share1 = pack_bitsliced(x_share1, kbits)
+    out_init = b'\x00' * (nshares * 1024)
+
+    # Expected: per-coef sum of the two arith shares == x_vals mod q.
+    # The test fixture sums the shares and writes the result to `r`.
+    r_bytes = bytearray()
+    for v in x_vals:
+        r_bytes += v.to_bytes(4, 'little')
+
+    write_test_data(
+        {'xb_share0': xb_share0, 'xb_share1': xb_share1, 'out': out_init},
+        data_file)
+    write_test_exp({}, exp_file)
+    write_test_dexp({'r': bytes(r_bytes)}, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed', type=int, required=False)
+    parser.add_argument('-n', '--nshares', type=int, required=False, default=2)
+    parser.add_argument('-k', '--kbits', type=int, required=False, default=3)
+    parser.add_argument('--scheme', type=int, required=False, default=1)
+    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'))
+    args = parser.parse_args()
+    gen(args.seed, args.nshares, args.kbits, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/gadgets/secboundcheck_test.s
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secboundcheck_test.s
@@ -1,0 +1,60 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef NSHARES
+    #define NSHARES 2
+#endif
+
+.section .text.start
+
+main:
+    la  x2, stack_end
+    bn.xor w31, w31, w31
+
+    /* MOD <= R | Q for bn.subvm.8S / bn.addvm.8S inside the gadget. */
+    li      x5, 2
+    la      x6, modulus
+    bn.lid  x5, 0(x6)
+    li      x5, 3
+    la      x6, montg_R
+    bn.lid  x5, 0(x6)
+    bn.rshi w2, w3, w2 >> 224
+    bn.wsrw 0x0, w2
+
+    /* Load C into w17 lane 0. */
+    li  x5, 17
+    la  x6, c_wdr
+    bn.lid x5, 0(x6)
+
+    la  x10, x_arith
+    la  x12, lambda0_vec
+    la  x13, seca2b_scratch
+    la  x14, secboundcheck_buf
+    jal x1, secboundcheck
+
+    /* Write w0 (per-lane b) to y_out for dexp check. */
+    la  x10, y_out
+    li  x11, 0
+    bn.sid x11, 0(x10)
+
+    ecall
+
+.data
+.balign 32
+stack:
+    .zero 8192
+stack_end:
+
+.balign 32
+.globl y_out
+y_out:
+    .zero 32
+
+.balign 32
+seca2b_scratch:
+    .zero 1536
+
+.balign 32
+secboundcheck_buf:
+    .zero 1536

--- a/sw/acc/crypto/tests/mldsa/gadgets/secboundcheck_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secboundcheck_testgen.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import random
+from typing import TextIO, Optional
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+N_LANES = 256
+SHARE_BYTES = 32
+KBITS = 23
+Q = 8380417
+
+
+def arith_share(vals, nshares):
+    """nshares dense polys of 256 int32 lane values, XOR-summing... no,
+    arithmetic-summing mod Q to vals."""
+    shares = [[0] * N_LANES for _ in range(nshares)]
+    for lane in range(N_LANES):
+        acc = vals[lane] % Q
+        for s in range(nshares - 1):
+            r = random.randrange(Q)
+            shares[s][lane] = r
+            acc = (acc - r) % Q
+        shares[nshares - 1][lane] = acc
+    return shares
+
+
+def pack_arith_shares(share_vals, nshares):
+    """nshares * 1024 B, share-major (each share is a 256-coef poly)."""
+    buf = bytearray()
+    for s in range(nshares):
+        for v in share_vals[s]:
+            buf += int(v).to_bytes(4, 'little')
+    return bytes(buf)
+
+
+def pack_c_wdr(C):
+    """32-byte WDR-image with C in lane 0 (low 4 bytes); other lanes = 0."""
+    return C.to_bytes(4, 'little') + b'\x00' * 28
+
+
+def gen(seed: Optional[int], nshares: int, lambda0: int, lambda1: int,
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+    if seed is not None:
+        random.seed(seed)
+
+    psi = lambda0 + lambda1
+    assert psi < (1 << KBITS) - 1, "psi too large; SecLeq trivially true"
+    assert lambda0 + lambda1 < Q, "lambda_0 + lambda_1 must be < q"
+
+    # Mix lanes that pass and lanes that fail.
+    x_vals = []
+    for _ in range(N_LANES):
+        if random.random() < 0.5:
+            v = random.randint(-lambda0, lambda1)
+        else:
+            r = random.randint(lambda1 + 1, Q - lambda0 - 1)
+            v = r - lambda0
+            v = v % Q
+        x_vals.append(v % Q)
+
+    share_vals = arith_share(x_vals, nshares)
+    xb = pack_arith_shares(share_vals, nshares)
+
+    C = (1 << (KBITS + 1)) - psi - 1
+    cb = pack_c_wdr(C)
+
+    # lambda_0 broadcast vector: 8 lanes (8 int32) packed into one 32-byte WDR.
+    lam_bytes = (lambda0 % Q).to_bytes(4, 'little') * 8
+    assert len(lam_bytes) == SHARE_BYTES
+
+    # Expected per-lane mask: bit set iff -lambda_0 <= x <= lambda_1 mod q.
+    out_word = 0
+    for lane, v in enumerate(x_vals):
+        # v in [0, Q).  Centered: c = v if v <= Q/2 else v - Q.
+        c = v if v <= (Q - 1) // 2 else v - Q
+        if -lambda0 <= c <= lambda1:
+            out_word |= 1 << lane
+    out_bytes = out_word.to_bytes(SHARE_BYTES, 'little')
+
+    write_test_data({
+        'x_arith': xb,
+        'c_wdr': cb,
+        'lambda0_vec': lam_bytes,
+    }, data_file)
+    write_test_exp({}, exp_file)
+    write_test_dexp({'y_out': out_bytes}, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed', type=int, required=False)
+    parser.add_argument('-n', '--nshares', type=int, required=False, default=2)
+    parser.add_argument('--lambda0', type=int, required=True)
+    parser.add_argument('--lambda1', type=int, required=True)
+    parser.add_argument('--scheme', type=int, required=False, default=1)
+    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'))
+    args = parser.parse_args()
+    gen(args.seed, args.nshares, args.lambda0, args.lambda1,
+        args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/gadgets/seccompress_test.s
+++ b/sw/acc/crypto/tests/mldsa/gadgets/seccompress_test.s
@@ -1,0 +1,59 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef NSHARES
+    #define NSHARES 2
+#endif
+
+/* ML-DSA-44 SecCompress + cap output: w1 in ceil(log2(44)) = 6 bit-stripes. */
+#define C_BITS 6
+
+.section .text.start
+
+/* Compute  zb = seccompress(xa, NSHARES); then XOR-collapse the d
+ * Boolean shares per stripe into a single 256-bit word per stripe:
+ *   r[b] = XOR over s in [0, NSHARES) of zb[b][s].
+ * Expected: r[b] = bit-b of V' = (round(x*44/q) + j*44) mod 2^c across
+ *           all 256 lanes, where j is the per-lane wrap count produced
+ *           by the testgen's share split. */
+main:
+    la  x2, stack_end
+    bn.xor w31, w31, w31
+    la  x10, zb
+    la  x11, xa
+    la  x12, seccompress_scratch
+    la  x13, seccompress_b
+    jal x1, seccompress
+
+    /* XOR-collapse share-major layout: V' = bottom 6 stripes of seccompress
+     * output Z's top-8 region.  V' share 0 at zb + 768; share 1 at zb + 1792. */
+    la   x2, zb
+    addi x2, x2, 768
+    la   x3, r
+    li   x4, 1
+    li   x5, 0
+    loopi C_BITS, 5
+        bn.lid x5, 0(x2)
+        bn.lid x4, 1024(x2)
+        bn.xor w0, w0, w1
+        bn.sid x5, 0(x3++)
+        addi   x2, x2, 32
+
+    ecall
+
+.data
+.balign 32
+stack:
+    .zero 2048
+stack_end:
+r:
+    .zero C_BITS * 32
+
+.balign 32
+seccompress_scratch:
+    .zero 4096
+
+.balign 32
+seccompress_b:
+    .zero 2048

--- a/sw/acc/crypto/tests/mldsa/gadgets/seccompress_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/seccompress_testgen.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Test vectors for seccompress (ML-DSA-44 L2 SecCompress, d = 2): from a 2-share
+# arithmetic sharing of x mod q, the expected output is w1 = HighBits(x), packed
+# as ceil(log2(delta)) = 6 bit-stripes.  The harness XOR-collapses the gadget's
+# Boolean output and compares stripe-by-stripe.
+
+import argparse
+import random
+from typing import TextIO, Optional
+
+from dilithium_py.ml_dsa import ML_DSA_44
+from dilithium_py.utilities.utils import high_bits
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+N_LANES = 256
+Q = 8380417
+
+
+def arith_share_modq(vals, nshares):
+    shares = [[0] * N_LANES for _ in range(nshares)]
+    for lane in range(N_LANES):
+        acc = vals[lane]
+        for s in range(nshares - 1):
+            r = random.randrange(Q)
+            shares[s][lane] = r
+            acc = (acc - r) % Q
+        shares[nshares - 1][lane] = acc % Q
+    return shares
+
+
+def pack_dense_shares(share_vals, nshares):
+    """nshares * 1024 B, share-major (each share is a 256-coef poly)."""
+    buf = bytearray()
+    for s in range(nshares):
+        for v in share_vals[s]:
+            buf += int(v).to_bytes(4, 'little')
+    return bytes(buf)
+
+
+def pack_stripes(vals, nbits):
+    """Bit b of each lane packed into a 256-bit word, for b in [0, nbits)."""
+    buf = bytearray()
+    for bit in range(nbits):
+        word = 0
+        for i, v in enumerate(vals):
+            word |= ((v >> bit) & 1) << i
+        buf += word.to_bytes(32, 'little')
+    return bytes(buf)
+
+
+def gen(seed: Optional[int], nshares: int, delta: int,
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+    if seed is not None:
+        random.seed(seed)
+    assert nshares == 2, "this testgen only emits d=2"
+
+    x_vals = [random.randrange(Q) for _ in range(N_LANES)]
+    x_vals[:4] = [Q - 1, Q - 2, 0, 1]            # pin corner cases
+    share_vals = arith_share_modq(x_vals, nshares)
+
+    alpha = 2 * ML_DSA_44.gamma_2
+    w1 = [high_bits(x, alpha, Q) for x in x_vals]
+    c_out = (delta - 1).bit_length()             # ceil(log2(delta)) = 6
+
+    write_test_data({
+        'xa': pack_dense_shares(share_vals, nshares),
+        'zb': b'\x00' * (32 * nshares * 32),
+    }, data_file)
+    write_test_exp({}, exp_file)
+    write_test_dexp({'r': pack_stripes(w1, c_out)}, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed', type=int, required=False)
+    parser.add_argument('-n', '--nshares', type=int, required=False, default=2)
+    parser.add_argument('-d', '--delta', type=int, required=False, default=44)
+    parser.add_argument('--scheme', type=int, required=False, default=1)
+    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'))
+    args = parser.parse_args()
+    gen(args.seed, args.nshares, args.delta, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/gadgets/secdecompose_test.s
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secdecompose_test.s
@@ -1,0 +1,181 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+
+#ifndef NSHARES
+    #define NSHARES 2
+#endif
+
+.section .text.start
+
+main:
+    la  x2, stack_end
+    bn.xor w31, w31, w31
+
+    /* MOD <= R | Q for bn.subvm.8S / bn.addvm.8S inside the gadget. */
+    li      x5, 2
+    la      x6, modulus
+    bn.lid  x5, 0(x6)
+    li      x5, 3
+    la      x6, montg_R
+    bn.lid  x5, 0(x6)
+    bn.rshi w2, w3, w2 >> 224
+    bn.wsrw 0x0, w2
+    bn.wsrr w16, 0x0
+
+#if DILITHIUM_MODE == 2
+
+    la  x10, w1_out
+    la  x11, w_in
+    li  x12, NSHARES
+    la  x13, seccompress_scratch
+    li  x14, 1024
+    la  x15, seccompress_b
+    la  x16, t_packed
+    jal x1, secdecompose
+
+    /* w0_unmasked[i] = w_in_s0[i] + w_in_s1[i] mod q.  secdecompose left
+     * arithmetic w0 in place: share 0 = w_s0 - alpha*w1, share 1 = w_s1. */
+    la   x10, w_in
+    addi x11, x10, 1024
+    la   x12, w0_unmasked
+    li   x4, 1
+    li   x5, 2
+    LOOPI 32, 4
+        bn.lid x4, 0(x10++)
+        bn.lid x5, 0(x11++)
+        bn.addvm.8S w1, w1, w2
+        bn.sid x4, 0(x12++)
+
+    ecall
+
+#else
+
+    la  x10, w1_out
+    la  x11, w_in
+    la  x13, secdecompose_scratch
+    li  x14, 1024
+    la  x15, w0_packed_share0
+    la  x16, w0_packed_share1
+    la  x17, seca2b_scratch
+    jal x1, secdecompose
+
+    /* Zero-pad 19-stripe packed shares to 24-stripe Boolean for b2a. */
+    li   x7, 0
+    li   x28, 31
+    la   x5, b2a_in
+    la   x6, w0_packed_share0
+    loopi 19, 2
+        bn.lid x7, 0(x6++)
+        bn.sid x7, 0(x5++)
+    loopi 5, 1
+        bn.sid x28, 0(x5++)
+    bn.xor w0, w0, w0
+    la   x6, w0_packed_share1
+    loopi 19, 2
+        bn.lid x7, 0(x6++)
+        bn.sid x7, 0(x5++)
+    loopi 5, 1
+        bn.sid x28, 0(x5++)
+
+    /* b2a -> bitsliced arithmetic shares of U; unbitslice each share. */
+    la  x10, b2a_out
+    la  x11, b2a_in
+    la  x13, seca2b_scratch
+    jal x1, secb2amodq_bc22
+
+    la   x10, u_share0
+    la   x11, b2a_out
+    jal  x1, unbitslice
+
+    la   x10, u_share1
+    la   x11, b2a_out
+    addi x11, x11, 768
+    jal  x1, unbitslice
+
+    /* u_unmasked[i] = u_share0[i] + u_share1[i] mod q. */
+    la   x10, u_share0
+    la   x11, u_share1
+    la   x12, u_unmasked
+    li   x4, 1
+    li   x5, 2
+    LOOPI 32, 4
+        bn.lid x4, 0(x10++)
+        bn.lid x5, 0(x11++)
+        bn.addvm.8S w1, w1, w2
+        bn.sid x4, 0(x12++)
+
+    ecall
+
+#endif
+
+.data
+.balign 32
+stack:
+
+#if DILITHIUM_MODE == 2
+
+    .zero 2048
+stack_end:
+    .byte 0
+
+.balign 32
+t_packed:
+    .zero 2048
+
+.balign 32
+seccompress_scratch:
+    .zero 4096
+
+.balign 32
+seccompress_b:
+    .zero 2048
+
+.balign 32
+.globl w0_unmasked
+w0_unmasked:
+    .zero 1024
+
+#else
+
+    .zero 8192
+stack_end:
+
+.balign 32
+secdecompose_scratch:
+    .zero 3296
+
+.balign 32
+w0_packed_share0:
+    .zero 608
+.balign 32
+w0_packed_share1:
+    .zero 608
+
+.balign 32
+b2a_in:
+    .zero NSHARES * 768
+
+.balign 32
+b2a_out:
+    .zero NSHARES * 768
+
+.balign 32
+u_share0:
+    .zero 1024
+
+.balign 32
+u_share1:
+    .zero 1024
+
+.balign 32
+.globl u_unmasked
+u_unmasked:
+    .zero 1024
+
+.balign 32
+seca2b_scratch:
+    .zero 1536
+
+#endif

--- a/sw/acc/crypto/tests/mldsa/gadgets/secdecompose_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secdecompose_testgen.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import random
+from typing import TextIO, Optional
+
+from dilithium_py.ml_dsa import ML_DSA_44, ML_DSA_65, ML_DSA_87
+from dilithium_py.utilities.utils import decompose
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+N_COEFS = 256
+Q = 8380417
+
+# Per scheme: parameter set, whether to check U = gamma2 - w0 (L3/L5) vs w0 (L2),
+# and Alg.36 special-case coeffs to pin (folded bucket + adjacent unfolded one).
+SCHEMES = {
+    2: {'mldsa': ML_DSA_44, 'emit_u': False,
+        'special': [Q - 1, Q - 2, 8285185, 8285184, 8330000]},
+    3: {'mldsa': ML_DSA_65, 'emit_u': True,
+        'special': [Q - 1, Q - 2, 8118529, 8118528, 8249473]},
+    5: {'mldsa': ML_DSA_87, 'emit_u': True,
+        'special': [Q - 1, Q - 2, 8118529, 8118528, 8249473]},
+}
+
+
+def arith_share(vals, nshares):
+    shares = [[0] * N_COEFS for _ in range(nshares)]
+    for lane in range(N_COEFS):
+        acc = vals[lane]
+        for s in range(nshares - 1):
+            r = random.randrange(Q)
+            shares[s][lane] = r
+            acc = (acc - r) % Q
+        shares[nshares - 1][lane] = acc % Q
+    return shares
+
+
+def pack_arith_shares(share_vals, nshares):
+    """NSHARES * 1024 B, share-major (each share is a 256-coef poly)."""
+    buf = bytearray()
+    for s in range(nshares):
+        for v in share_vals[s]:
+            buf += int(v).to_bytes(4, 'little')
+    return bytes(buf)
+
+
+def pack_canonical(vals):
+    buf = bytearray()
+    for v in vals:
+        buf += (int(v) % Q).to_bytes(4, 'little')
+    return bytes(buf)
+
+
+def gen(seed: Optional[int], nshares: int, scheme: int,
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+    if seed is not None:
+        random.seed(seed)
+    cfg = SCHEMES[scheme]
+    gamma2 = cfg['mldsa'].gamma_2
+    alpha = 2 * gamma2
+
+    w_vals = [random.randrange(Q) for _ in range(N_COEFS)]
+    # Pin some special cases
+    w_vals[:len(cfg['special'])] = cfg['special']
+    share_vals = arith_share(w_vals, nshares)
+
+    w1_ref, w0_ref = [], []
+    for v in w_vals:
+        r1, r0 = decompose(v, alpha, Q)
+        w1_ref.append(r1)
+        w0_ref.append(r0)
+
+    write_test_data({
+        'w_in': pack_arith_shares(share_vals, nshares),
+        'w1_out': b'\x00' * (N_COEFS * 4),
+    }, data_file)
+    write_test_exp({}, exp_file)
+    dexp = {'w1_out': pack_canonical(w1_ref)}
+    if cfg['emit_u']:
+        # L3/L5 expose U = gamma2 - w0; L2 exposes arithmetic w0 directly.
+        dexp['u_unmasked'] = pack_canonical([gamma2 - a0 for a0 in w0_ref])
+    else:
+        dexp['w0_unmasked'] = pack_canonical(w0_ref)
+    write_test_dexp(dexp, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed', type=int, required=False)
+    parser.add_argument('-n', '--nshares', type=int, required=False, default=2)
+    parser.add_argument('--scheme', type=int, required=False, default=2)
+    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'))
+    args = parser.parse_args()
+    gen(args.seed, args.nshares, args.scheme, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/gadgets/secfulladder_bc22_test.s
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secfulladder_bc22_test.s
@@ -1,0 +1,54 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef NSHARES
+    #define NSHARES 2
+#endif
+#define STACK_SIZE 1024
+
+.section .text.start
+
+main:
+    /* Load stack pointer */
+    la x2, stack_end
+
+    /* dmem[rb] <= secfulladder_bc22(dmem[xb], dmem[yb], nshares) */
+    la  x10, xb
+    la  x11, yb
+    la  x12, cb
+    la  x13, 32
+    li  x14, NSHARES
+    la  x15, rb
+    la  x16, coutb
+    jal x1, secfulladder_bc22
+
+    /* Compute r */
+    la     x3, r
+    li     x4, 1
+    addi   x5, x0, NSHARES
+    addi   x5, x5, -1
+    /* Compute r[0]. */
+    la     x2, rb
+    bn.lid x0, 0(x2++)
+    loop x5, 2
+        bn.lid x4, 0(x2++)
+        bn.xor w0, w0, w1
+    bn.sid x0, 0(x3++)
+    /* Compute r[1]. */
+    la     x2, coutb
+    bn.lid x0, 0(x2++)
+    loop x5, 2
+        bn.lid x4, 0(x2++)
+        bn.xor w0, w0, w1
+    bn.sid x0, 0(x3++)
+
+    ecall
+
+.data
+.balign 32
+stack:
+    .zero STACK_SIZE
+stack_end:
+r:
+    .zero 64

--- a/sw/acc/crypto/tests/mldsa/gadgets/secfulladder_bc22_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secfulladder_bc22_testgen.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import random
+from typing import TextIO, Optional
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+N = 256
+NSHARES = 2
+
+
+def gen_secfulladder_bc22_test(
+        seed: Optional[int], scheme: Optional[int], nshares: Optional[int],
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+    # Generate random operands.
+    if seed is not None:
+        random.seed(seed)
+
+    if nshares is None:
+        nshares = NSHARES
+
+    operand_nbytes = 32 * nshares
+
+    x = 0
+    y = 0
+    c = 0
+    xb = 0
+    yb = 0
+    cb = 0
+    for i in range(nshares):
+        tx = random.getrandbits(N)
+        ty = random.getrandbits(N)
+        tc = random.getrandbits(N)
+        x ^= tx
+        y ^= ty
+        c ^= tc
+        xb |= (tx << (i * N))
+        yb |= (ty << (i * N))
+        cb |= (tc << (i * N))
+
+    # Compute expected result x + y + c.
+    w0 = 0
+    w1 = 0
+    for i in range(N):
+        xi = (x >> i) & 1
+        yi = (y >> i) & 1
+        ci = (c >> i) & 1
+        t = xi + yi + ci
+        w0 |= ((t & 1) << i)
+        w1 |= (((t >> 1) & 1) << i)
+    w = w0 | (w1 << N)
+
+    xb_bytes = int.to_bytes(xb, byteorder='little', length=operand_nbytes)
+    yb_bytes = int.to_bytes(yb, byteorder='little', length=operand_nbytes)
+    cb_bytes = int.to_bytes(cb, byteorder='little', length=operand_nbytes)
+    r_bytes = int.to_bytes(w, byteorder='little', length=64)
+    rb_bytes = int.to_bytes(0, byteorder='little', length=operand_nbytes)
+    coutb_bytes = int.to_bytes(0, byteorder='little', length=operand_nbytes)
+
+    # Write input values.
+    inputs = {
+        'xb': xb_bytes, 'yb': yb_bytes, 'cb': cb_bytes,
+        'rb': rb_bytes, 'coutb': coutb_bytes
+    }
+    write_test_data(inputs, data_file)
+
+    # Write expected register values (none).
+    write_test_exp({}, exp_file)
+
+    # Write expected dmem values.
+    write_test_dexp({'r': r_bytes}, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed',
+                        type=int,
+                        required=False,
+                        help=('Seed value for pseudorandomness.'))
+    parser.add_argument('-n', '--nshares',
+                        type=int,
+                        required=False,
+                        help=('Number of shares.'))
+    parser.add_argument('--scheme',
+                        type=int,
+                        required=False,
+                        default=0,
+                        help=('False: ML-KEM. True: ML-DSA.'))
+    parser.add_argument('data',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for input DMEM values.'))
+    parser.add_argument('exp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected register values.'))
+    parser.add_argument('dexp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected DMEM values.'))
+    args = parser.parse_args()
+
+    gen_secfulladder_bc22_test(args.seed, args.scheme, args.nshares, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/gadgets/secleq_test.s
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secleq_test.s
@@ -1,0 +1,39 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef NSHARES
+    #define NSHARES 2
+#endif
+
+.section .text.start
+
+main:
+    la  x2, stack_end
+    bn.xor w31, w31, w31
+
+    /* Load C into w17 lane 0. */
+    li  x5, 17
+    la  x6, c_wdr
+    bn.lid x5, 0(x6)
+
+    la  x11, x_in
+    jal x1, secleq
+
+    /* Write w0 (per-lane b) to y_out for dexp check. */
+    la  x10, y_out
+    li  x11, 0
+    bn.sid x11, 0(x10)
+
+    ecall
+
+.data
+.balign 32
+stack:
+    .zero 4096
+stack_end:
+
+.balign 32
+.globl y_out
+y_out:
+    .zero 32

--- a/sw/acc/crypto/tests/mldsa/gadgets/secleq_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secleq_testgen.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import random
+from typing import TextIO, Optional
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+SHARE_BYTES = 32  # 256 bitsliced lanes per WDR
+N_LANES = 256
+
+
+def bitslice(vals, bit):
+    word = 0
+    for i, v in enumerate(vals):
+        word |= ((v >> bit) & 1) << i
+    return word
+
+
+def bool_share(word, nshares):
+    shares = []
+    acc = word
+    for _ in range(nshares - 1):
+        s = random.getrandbits(N_LANES)
+        shares.append(s)
+        acc ^= s
+    shares.append(acc)
+    return shares
+
+
+def pack_shares_sharemajor(vals, kbits, nshares):
+    """(kbits+1) * nshares * 32 bytes, share-major bit-inner with bit k = 0."""
+    bit_shares = [bool_share(bitslice(vals, bit), nshares) for bit in range(kbits)]
+    buf = bytearray()
+    for s in range(nshares):
+        for bit in range(kbits):
+            buf += bit_shares[bit][s].to_bytes(SHARE_BYTES, 'little')
+        buf += b'\x00' * SHARE_BYTES  # bit k pad
+    return bytes(buf)
+
+
+def pack_c_wdr(C):
+    """32-byte WDR-image with C in lane 0 (low 4 bytes); other lanes = 0."""
+    return C.to_bytes(4, 'little') + b'\x00' * 28
+
+
+def gen(seed: Optional[int], nshares: int, kbits: int, psi: int,
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+    if seed is not None:
+        random.seed(seed)
+
+    # Random kbits-wide values per lane.
+    x_vals = [random.randrange(0, 1 << kbits) for _ in range(N_LANES)]
+
+    # Boolean share x.
+    xb = pack_shares_sharemajor(x_vals, kbits, nshares)
+
+    C = (1 << (kbits + 1)) - psi - 1
+    cb = pack_c_wdr(C)
+
+    # Expected per-lane bit: 1 iff x[lane] <= psi.
+    out_word = 0
+    for lane, v in enumerate(x_vals):
+        if v <= psi:
+            out_word |= 1 << lane
+    out_bytes = out_word.to_bytes(SHARE_BYTES, 'little')
+
+    write_test_data({
+        'x_in': xb,
+        'c_wdr': cb,
+    }, data_file)
+    write_test_exp({}, exp_file)
+    write_test_dexp({'y_out': out_bytes}, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed', type=int, required=False)
+    parser.add_argument('-n', '--nshares', type=int, required=False, default=2)
+    parser.add_argument('-k', '--kbits', type=int, required=False, default=23)
+    parser.add_argument('-p', '--psi', type=int, required=True)
+    parser.add_argument('--scheme', type=int, required=False, default=0)
+    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'))
+    args = parser.parse_args()
+    gen(args.seed, args.nshares, args.kbits, args.psi,
+        args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/gadgets/secunmask_modq_test.s
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secunmask_modq_test.s
@@ -1,0 +1,43 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef NSHARES
+    #define NSHARES 2
+#endif
+
+#define NB_POLY 1024
+#define STACK_SIZE 4096
+
+.section .text.start
+
+main:
+    la  x2, stack_end
+    bn.xor w31, w31, w31
+
+    /* MOD <= R | Q for bn.addvm.8s / bn.subvm.8s inside the gadget. */
+    li      x5, 2
+    la      x6, modulus
+    bn.lid  x5, 0(x6)
+    li      x5, 3
+    la      x6, montg_R
+    bn.lid  x5, 0(x6)
+    bn.rshi w2, w3, w2 >> 224
+    bn.wsrw 0x0, w2
+
+    la  x10, y_out
+    la  x11, x_in
+    jal x1, secunmask_modq
+
+    ecall
+
+.data
+.balign 32
+stack:
+    .zero STACK_SIZE
+stack_end:
+
+.balign 32
+.globl y_out
+y_out:
+    .zero NB_POLY

--- a/sw/acc/crypto/tests/mldsa/gadgets/secunmask_modq_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secunmask_modq_testgen.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import random
+from typing import TextIO, Optional
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+N_LANES = 256
+Q = 8380417
+
+
+def arith_share(vals, nshares):
+    """Split each lane into nshares additive shares mod Q."""
+    shares = [[0] * N_LANES for _ in range(nshares)]
+    for lane in range(N_LANES):
+        acc = vals[lane] % Q
+        for s in range(nshares - 1):
+            r = random.randrange(Q)
+            shares[s][lane] = r
+            acc = (acc - r) % Q
+        shares[nshares - 1][lane] = acc
+    return shares
+
+
+def pack_arith_shares(share_vals, nshares):
+    """nshares * 1024 B, share-major (each share is a 256-coef poly)."""
+    buf = bytearray()
+    for s in range(nshares):
+        for v in share_vals[s]:
+            buf += int(v).to_bytes(4, 'little')
+    return bytes(buf)
+
+
+def pack_poly(vals):
+    buf = bytearray()
+    for v in vals:
+        buf += int(v).to_bytes(4, 'little')
+    return bytes(buf)
+
+
+def gen(seed: Optional[int], nshares: int,
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+    if seed is not None:
+        random.seed(seed)
+
+    x_vals = [random.randrange(Q) for _ in range(N_LANES)]
+    share_vals = arith_share(x_vals, nshares)
+    xb = pack_arith_shares(share_vals, nshares)
+    yb = pack_poly(x_vals)
+
+    write_test_data({'x_in': xb}, data_file)
+    write_test_exp({}, exp_file)
+    write_test_dexp({'y_out': yb}, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed', type=int, required=False)
+    parser.add_argument('-n', '--nshares', type=int, required=False, default=2)
+    parser.add_argument('--scheme', type=int, required=False, default=1)
+    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'))
+    args = parser.parse_args()
+    gen(args.seed, args.nshares, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/gadgets/unbitslice_test.s
+++ b/sw/acc/crypto/tests/mldsa/gadgets/unbitslice_test.s
@@ -1,0 +1,22 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.section .text.start
+
+main:
+    la  x2, stack_end
+    bn.xor w31, w31, w31
+
+    la  x10, r
+    la  x11, in
+    jal x1, unbitslice
+
+    ecall
+
+.data
+.balign 32
+stack:
+    .zero 2048
+stack_end:
+    .byte 0

--- a/sw/acc/crypto/tests/mldsa/gadgets/unbitslice_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/unbitslice_testgen.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import random
+from typing import TextIO, Optional
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+N_COEFS = 256
+KBITS = 23
+
+
+def pack_canonical(vals):
+    """256 x 32-bit coefs -> 32 WDRs (1024 bytes)."""
+    buf = bytearray()
+    for v in vals:
+        buf += v.to_bytes(4, 'little')
+    return bytes(buf)
+
+
+def pack_bitsliced(vals):
+    """256 coefs -> KBITS WDRs bitsliced (lane i of WDR j = bit j of coef i)."""
+    out = bytearray()
+    for b in range(KBITS):
+        w = sum(((v >> b) & 1) << i for i, v in enumerate(vals))
+        out += w.to_bytes(32, 'little')
+    return bytes(out)
+
+
+def gen(seed: Optional[int],
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+    if seed is not None:
+        random.seed(seed)
+    vals = [random.randrange(1 << KBITS) for _ in range(N_COEFS)]
+    write_test_data({'in': pack_bitsliced(vals),
+                     'r': b'\x00' * (N_COEFS * 4)}, data_file)
+    write_test_exp({}, exp_file)
+    write_test_dexp({'r': pack_canonical(vals)}, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed', type=int, required=False)
+    parser.add_argument('--scheme', type=int, required=False, default=1)
+    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'))
+    args = parser.parse_args()
+    gen(args.seed, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/mldsa_keypair_test.s
+++ b/sw/acc/crypto/tests/mldsa/mldsa_keypair_test.s
@@ -110,6 +110,27 @@ main:
 
   jal x1, crypto_sign_keypair
 
+#ifdef NSHARES
+  /* Unmask the keygen's d=2 share outputs for the dexp check. */
+  li     x4, 1
+  la     x5, rho_prime_shares
+  la     x6, rho_prime_unmasked
+  bn.lid x0, 0(x5)
+  bn.lid x4, 64(x5)
+  bn.xor w0, w0, w1
+  bn.sid x0, 0(x6)
+  bn.lid x0, 32(x5)
+  bn.lid x4, 96(x5)
+  bn.xor w0, w0, w1
+  bn.sid x0, 32(x6)
+  la     x5, K_shares
+  la     x6, K_unmasked
+  bn.lid x0, 0(x5)
+  bn.lid x4, 32(x5)
+  bn.xor w0, w0, w1
+  bn.sid x0, 0(x6)
+#endif
+
   ecall
 
 .bss
@@ -122,3 +143,14 @@ pk:
 .globl sk
 sk:
   .zero CRYPTO_SECRETKEYBYTES
+
+#ifdef NSHARES
+.balign 32
+.globl rho_prime_unmasked
+rho_prime_unmasked:
+  .zero 64
+.balign 32
+.globl K_unmasked
+K_unmasked:
+  .zero 32
+#endif

--- a/sw/acc/crypto/tests/mldsa/mldsa_keypair_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/mldsa_keypair_testgen.py
@@ -55,6 +55,10 @@ if __name__ == '__main__':
                         metavar='FILE',
                         type=argparse.FileType('w'),
                         help=('Output file for expected DMEM values.'))
+    parser.add_argument('--scheme',
+                        metavar='SCHEME',
+                        type=int,
+                        help=('This is not used in this test.'))
     args = parser.parse_args()
 
     if args.seed is not None:

--- a/sw/acc/crypto/tests/mldsa/mldsa_masked_keypair_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/mldsa_masked_keypair_testgen.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import random
+from typing import TextIO
+from dilithium_py.ml_dsa import ML_DSA_44, ML_DSA_65, ML_DSA_87
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+INSTANCE_FOR_PARAMS = {
+    'mldsa44': ML_DSA_44,
+    'mldsa65': ML_DSA_65,
+    'mldsa87': ML_DSA_87,
+}
+
+# (k, l, eta) per parameter set.
+KLE_FOR_PARAMS = {
+    'mldsa44': (4, 4, 2),
+    'mldsa65': (6, 5, 4),
+    'mldsa87': (8, 7, 2),
+}
+
+
+def boolean_shares(secret: bytes, nshares: int) -> bytes:
+    shares = []
+    acc = secret
+    for _ in range(nshares - 1):
+        s = random.randbytes(len(secret))
+        acc = bytes(a ^ b for a, b in zip(acc, s))
+        shares.append(s)
+    shares.append(acc)
+    return b''.join(shares)
+
+
+def gen_masked_keypair_test(mldsa, k, ell, eta, nshares, data_file: TextIO,
+                            exp_file: TextIO, dexp_file: TextIO):
+    zeta = random.randbytes(32)
+    pk, sk = mldsa._keygen_internal(zeta)
+    seed_bytes = mldsa._h(zeta + bytes([k]) + bytes([ell]), 128)
+    rho_prime = seed_bytes[32:96]
+    K = sk[32:64]
+    tr = sk[64:128]
+
+    polyeta_packed_bytes = 96 if eta == 2 else 128
+    t0_start = 128 + (ell + k) * polyeta_packed_bytes
+    t0_bytes = k * 416
+
+    sk_blob = bytearray(128 + t0_bytes)
+    sk_blob[0:32] = sk[0:32]
+    sk_blob[64:128] = tr
+    sk_blob[128:128 + t0_bytes] = sk[t0_start:t0_start + t0_bytes]
+
+    # keygen writes rho'/K as random boolean shares (split unknown here); the
+    # test harness XORs them back into rho_prime_unmasked/K_unmasked, which the
+    # dexp checks against this plaintext.
+    write_test_data({'zeta_shares': boolean_shares(zeta, nshares)}, data_file)
+    write_test_exp({}, exp_file)
+    write_test_dexp({
+        'pk': pk,
+        'sk': bytes(sk_blob),
+        'rho_prime_unmasked': rho_prime,
+        'K_unmasked': K,
+    }, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed', type=int, required=False,
+                        help='Seed value for pseudorandomness.')
+    parser.add_argument('-n', '--nshares', type=int, default=2,
+                        help='Number of shares.')
+    parser.add_argument('params', type=str,
+                        help='Parameters: ' + ', '.join(INSTANCE_FOR_PARAMS))
+    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'))
+    parser.add_argument('--scheme', metavar='SCHEME', type=int,
+                        help='Not used in this test.')
+    args = parser.parse_args()
+
+    if args.seed is not None:
+        random.seed(args.seed)
+    if args.params not in INSTANCE_FOR_PARAMS:
+        raise ValueError(f'Invalid parameters: {args.params}')
+    mldsa = INSTANCE_FOR_PARAMS[args.params]
+    k, ell, eta = KLE_FOR_PARAMS[args.params]
+    gen_masked_keypair_test(mldsa, k, ell, eta, args.nshares,
+                            args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mldsa/mldsa_masked_sign_test.s
+++ b/sw/acc/crypto/tests/mldsa/mldsa_masked_sign_test.s
@@ -1,0 +1,122 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.section .text.start
+
+#if DILITHIUM_MODE == 2
+#define CRYPTO_BYTES 2420
+#elif DILITHIUM_MODE == 3
+#define CRYPTO_BYTES 3309
+#elif DILITHIUM_MODE == 5
+#define CRYPTO_BYTES 4627
+#endif
+
+.globl main
+main:
+#ifdef RTL_ISS_TEST
+  xor  x2, x2, x2
+  xor  x3, x3, x3
+  xor  x4, x4, x4
+  xor  x5, x5, x5
+  xor  x6, x6, x6
+  xor  x7, x7, x7
+  xor  x8, x8, x8
+  xor  x9, x9, x9
+  xor  x10, x10, x10
+  xor  x11, x11, x11
+  xor  x12, x12, x12
+  xor  x13, x13, x13
+  xor  x14, x14, x14
+  xor  x15, x15, x15
+  xor  x16, x16, x16
+  xor  x17, x17, x17
+  xor  x18, x18, x18
+  xor  x19, x19, x19
+  xor  x20, x20, x20
+  xor  x21, x21, x21
+  xor  x22, x22, x22
+  xor  x23, x23, x23
+  xor  x24, x24, x24
+  xor  x25, x25, x25
+  xor  x26, x26, x26
+  xor  x27, x27, x27
+  xor  x28, x28, x28
+  xor  x29, x29, x29
+  xor  x30, x30, x30
+  xor  x31, x31, x31
+
+  bn.xor  w0, w0, w0
+  bn.xor  w1, w1, w1
+  bn.xor  w2, w2, w2
+  bn.xor  w3, w3, w3
+  bn.xor  w4, w4, w4
+  bn.xor  w5, w5, w5
+  bn.xor  w6, w6, w6
+  bn.xor  w7, w7, w7
+  bn.xor  w8, w8, w8
+  bn.xor  w9, w9, w9
+  bn.xor  w10, w10, w10
+  bn.xor  w11, w11, w11
+  bn.xor  w12, w12, w12
+  bn.xor  w13, w13, w13
+  bn.xor  w14, w14, w14
+  bn.xor  w15, w15, w15
+  bn.xor  w16, w16, w16
+  bn.xor  w17, w17, w17
+  bn.xor  w18, w18, w18
+  bn.xor  w19, w19, w19
+  bn.xor  w20, w20, w20
+  bn.xor  w21, w21, w21
+  bn.xor  w22, w22, w22
+  bn.xor  w23, w23, w23
+  bn.xor  w24, w24, w24
+  bn.xor  w25, w25, w25
+  bn.xor  w26, w26, w26
+  bn.xor  w27, w27, w27
+  bn.xor  w28, w28, w28
+  bn.xor  w29, w29, w29
+  bn.xor  w30, w30, w30
+#endif
+  bn.xor  w31, w31, w31
+
+  li      x5, 2
+  la      x6, modulus
+  bn.lid  x5, 0(x6)
+
+  li      x5, 3
+  la      x6, montg_R
+  bn.lid  x5, 0(x6)
+  bn.rshi w2, w3, w2 >> 224
+  bn.wsrw 0x0, w2
+
+  /* External-mu mode: testgen supplies dmem[mu]; signer skips the
+   * initial SHAKE over tr||ctxlen||ctx||msg. */
+  la x10, sig
+  li x13, NSHARES
+
+  jal x1, crypto_sign_signature_internal
+
+#if DILITHIUM_MODE == 3
+  li   x10, CRYPTO_BYTES
+  addi x10, x10, -1
+  la   x11, sig
+  add  x11, x11, x10
+  lw   x10, 0(x11)
+  slli x10, x10, 24
+  srli x10, x10, 24
+  sw   x10, 0(x11)
+#endif
+
+  ecall
+
+.data
+
+.balign 32
+.globl sig
+/* sig doubles as P1 scratch past CRYPTO_BYTES; size for the worst case. */
+#if DILITHIUM_MODE == 3
+  .zero 16                /* sig at 16 mod 32 so z (sig+48) is 32-aligned */
+#endif
+sig:
+  .zero 4640

--- a/sw/acc/crypto/tests/mldsa/mldsa_masked_sign_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/mldsa_masked_sign_testgen.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import hashlib
+import json
+import random
+from typing import TextIO
+from dilithium_py.ml_dsa import ML_DSA_44, ML_DSA_65, ML_DSA_87
+
+from shared.testgen import write_test_data, write_test_exp, write_test_dexp
+
+INSTANCE_FOR_PARAMS = {
+    'mldsa44': ML_DSA_44,
+    'mldsa65': ML_DSA_65,
+    'mldsa87': ML_DSA_87,
+}
+
+L_K_ETA = {
+    'mldsa44': (4, 4, 2),
+    'mldsa65': (5, 6, 4),
+    'mldsa87': (7, 8, 2),
+}
+
+MIN_MSG_LEN = 0
+MAX_MSG_LEN = 3072
+
+MIN_CTX_LEN = 0
+MAX_CTX_LEN = 255
+
+
+def boolean_shares(secret: bytes, nshares: int) -> bytes:
+    shares = []
+    acc = secret
+    for _ in range(nshares - 1):
+        s = random.randbytes(len(secret))
+        acc = bytes(a ^ b for a, b in zip(acc, s))
+        shares.append(s)
+    shares.append(acc)
+    return b''.join(shares)
+
+
+def boolean_shares_polyeta_packed(packed_polys: bytes, polyeta_bytes: int, nshares: int) -> bytes:
+    '''Boolean shares of polyeta-packed bytes, poly-major / share-inner.'''
+    out = bytearray()
+    for poly_i in range(len(packed_polys) // polyeta_bytes):
+        poly = packed_polys[poly_i * polyeta_bytes:(poly_i + 1) * polyeta_bytes]
+        out += boolean_shares(poly, nshares)
+    return bytes(out)
+
+
+def gen_sign_test(
+        mldsa, ell, k, eta, nshares: int, data_file: TextIO,
+        exp_file: TextIO, dexp_file: TextIO, vector=None):
+    if vector is not None:
+        # Curated bench vector (empty context, as produced by mldsa-sign-bench).
+        sk = bytes.fromhex(vector['sk'])
+        rnd = bytes.fromhex(vector['rnd'])
+        msg = bytes.fromhex(vector['msg'])
+        ctx = b''
+        ctxlen = 0
+        sig = bytes.fromhex(vector['sig'])
+        rho_prime = mldsa._h(
+            bytes.fromhex(vector['keygen_seed']) + bytes([k]) + bytes([ell]),
+            128)[32:96]
+    else:
+        seed = random.randbytes(32)
+        pk, sk = mldsa._keygen_internal(seed)
+        rho_prime = mldsa._h(seed + bytes([k]) + bytes([ell]), 128)[32:96]
+
+        msglen = random.randrange(MIN_MSG_LEN, MAX_MSG_LEN + 1)
+        ctxlen = random.randrange(MIN_CTX_LEN, MAX_CTX_LEN + 1)
+        msg = random.randbytes(msglen)
+        ctx = random.randbytes(ctxlen)
+
+        rnd = bytes([0] * 32)
+        sig = mldsa.sign(sk, msg, ctx=ctx, deterministic=True)
+
+    K = sk[32:64]
+    tr = sk[64:128]
+
+    # External-mu mode: caller pre-hashes message+context.  mu = SHAKE256
+    # (tr || 0x00 || byte(ctxlen) || ctx || msg, 64).  Matches FIPS 204
+    # Algorithm 7 (ML-DSA.Sign_internal) and the M* construction in Sign.
+    shake = hashlib.shake_256()
+    shake.update(tr)
+    shake.update(bytes([0x00, ctxlen]))
+    shake.update(ctx)
+    shake.update(msg)
+    mu = shake.digest(64)
+
+    polyeta_packed_bytes = 96 if eta == 2 else 128
+    s1_start = 128
+    s2_start = s1_start + ell * polyeta_packed_bytes
+    t0_start = s2_start + k * polyeta_packed_bytes
+
+    # sk for masked-sign build: rho@0, tr@64, t0@128.  K slot zeroed to keep tr at 64.
+    t0_bytes = k * 416
+    sk_blob = bytearray(128 + t0_bytes)
+    sk_blob[0:32] = sk[0:32]
+    sk_blob[64:128] = sk[64:128]
+    sk_blob[128:128 + t0_bytes] = sk[t0_start:t0_start + t0_bytes]
+
+    data = {
+        'mu': mu,
+        'sk': bytes(sk_blob),
+        'K_shares': boolean_shares(K, nshares),
+        'rho_prime_shares': boolean_shares(rho_prime, nshares),
+        'rnd': rnd,
+    }
+    write_test_data(data, data_file)
+
+    write_test_exp({}, exp_file)
+
+    write_test_dexp({'sig': sig}, dexp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed',
+                        type=int,
+                        required=False,
+                        help=('Seed value for pseudorandomness.'))
+    parser.add_argument('-n', '--nshares',
+                        type=int,
+                        required=False,
+                        default=2,
+                        help=('Number of shares.'))
+    parser.add_argument('params',
+                        type=str,
+                        help=('Parameters to use. Options: '
+                              f'{", ".join(INSTANCE_FOR_PARAMS.keys())}'))
+    parser.add_argument('data',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for input DMEM values.'))
+    parser.add_argument('exp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected register values.'))
+    parser.add_argument('dexp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected DMEM values.'))
+    parser.add_argument('--scheme',
+                        metavar='SCHEME',
+                        type=int,
+                        help=('This is not used in this test.'))
+    parser.add_argument('--from-vector',
+                        dest='from_vector',
+                        type=str,
+                        required=False,
+                        help=('Load inputs from a mldsa-sign-bench JSON testset '
+                              'instead of generating them randomly.'))
+    parser.add_argument('--index',
+                        type=int,
+                        default=0,
+                        help=('Index of the vector within the testset.'))
+    args = parser.parse_args()
+
+    if args.seed is not None:
+        random.seed(args.seed)
+    if args.params not in INSTANCE_FOR_PARAMS:
+        raise ValueError(f'Invalid parameters: {args.params}. Expected one of '
+                         f'{", ".join(INSTANCE_FOR_PARAMS.keys())}')
+    mldsa = INSTANCE_FOR_PARAMS[args.params]
+    # dilithium_py binds random_bytes to os.urandom at instance creation;
+    # redirect to seeded random so sk is reproducible across testgen runs.
+    if args.seed is not None:
+        mldsa.random_bytes = lambda n: random.randbytes(n)
+    ell, k, eta = L_K_ETA[args.params]
+    vector = None
+    if args.from_vector is not None:
+        vector = json.load(open(args.from_vector))[args.index]
+    gen_sign_test(mldsa, ell, k, eta, args.nshares, args.data, args.exp, args.dexp, vector=vector)

--- a/sw/acc/crypto/tests/mldsa/mldsa_sign_test.s
+++ b/sw/acc/crypto/tests/mldsa/mldsa_sign_test.s
@@ -106,12 +106,8 @@ main:
   /* Write back MOD */
   bn.wsrw 0x0, w2
 
-  /* Load parameters */
+  /* External-mu mode: testgen supplies dmem[mu]. */
   la x10, sig
-  la x11, msglen
-  lw x11, 0(x11)
-  la x12, ctxlen
-  lw x12, 0(x12)
 
   jal x1, crypto_sign_signature_internal
 

--- a/sw/acc/crypto/tests/mldsa/mldsa_sign_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/mldsa_sign_testgen.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import hashlib
+import json
 import random
 from typing import TextIO
 from dilithium_py.ml_dsa import ML_DSA_44, ML_DSA_65, ML_DSA_87
@@ -24,32 +26,42 @@ MIN_CTX_LEN = 0
 MAX_CTX_LEN = 255
 
 
-def gen_sign_test(mldsa, data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
-    # Generate a random key pair.
-    pk, sk = mldsa.keygen()
+def gen_sign_test(mldsa, data_file: TextIO, exp_file: TextIO, dexp_file: TextIO, vector=None):
+    if vector is not None:
+        # Curated bench vector (empty context, as produced by mldsa-sign-bench).
+        sk = bytes.fromhex(vector['sk'])
+        rnd = bytes.fromhex(vector['rnd'])
+        msg = bytes.fromhex(vector['msg'])
+        ctx = b''
+        ctxlen = 0
+        sig = bytes.fromhex(vector['sig'])
+    else:
+        # Generate a random key pair.
+        pk, sk = mldsa.keygen()
 
-    # Generate a random message and context.
-    msglen = random.randrange(MIN_MSG_LEN, MAX_MSG_LEN + 1)
-    ctxlen = random.randrange(MIN_CTX_LEN, MAX_CTX_LEN + 1)
-    msg = random.randbytes(msglen)
-    ctx = random.randbytes(ctxlen)
+        # Generate a random message and context.
+        msglen = random.randrange(MIN_MSG_LEN, MAX_MSG_LEN + 1)
+        ctxlen = random.randrange(MIN_CTX_LEN, MAX_CTX_LEN + 1)
+        msg = random.randbytes(msglen)
+        ctx = random.randbytes(ctxlen)
 
-    # Sign the message using deterministic signing.
-    rnd = bytes([0] * 32)
-    sig = mldsa.sign(sk, msg, ctx=ctx, deterministic=True)
+        # Sign the message using deterministic signing.
+        rnd = bytes([0] * 32)
+        sig = mldsa.sign(sk, msg, ctx=ctx, deterministic=True)
 
-    # Ensure ctx and message end up 32-byte aligned
-    if ctxlen <= 4:
-        ctx += bytes([0] * (5 - ctxlen))
-    if msglen <= 4:
-        msg += bytes([0] * (5 - msglen))
+    # External-mu mode: caller pre-hashes message+context.  mu = SHAKE256
+    # (tr || 0x00 || byte(ctxlen) || ctx || msg, 64).
+    tr = sk[64:128]
+    shake = hashlib.shake_256()
+    shake.update(tr)
+    shake.update(bytes([0x00, ctxlen]))
+    shake.update(ctx)
+    shake.update(msg)
+    mu = shake.digest(64)
 
     # Write input values.
     data = {
-        'ctxlen': int.to_bytes(ctxlen, length=4, byteorder='little'),
-        'msglen': int.to_bytes(msglen, length=4, byteorder='little'),
-        'ctx': ctx,
-        'msg': msg,
+        'mu': mu,
         'sk': sk,
         'rnd': rnd,
     }
@@ -84,6 +96,20 @@ if __name__ == '__main__':
                         metavar='FILE',
                         type=argparse.FileType('w'),
                         help=('Output file for expected DMEM values.'))
+    parser.add_argument('--scheme',
+                        metavar='SCHEME',
+                        type=int,
+                        help=('This is not used in this test.'))
+    parser.add_argument('--from-vector',
+                        dest='from_vector',
+                        type=str,
+                        required=False,
+                        help=('Load inputs from a mldsa-sign-bench JSON testset '
+                              'instead of generating them randomly.'))
+    parser.add_argument('--index',
+                        type=int,
+                        default=0,
+                        help=('Index of the vector within the testset.'))
     args = parser.parse_args()
 
     if args.seed is not None:
@@ -92,4 +118,11 @@ if __name__ == '__main__':
         raise ValueError(f'Invalid parameters: {args.params}. Expected one of '
                          f'{", ".join(INSTANCE_FOR_PARAMS.keys())}')
     mldsa = INSTANCE_FOR_PARAMS[args.params]
-    gen_sign_test(mldsa, args.data, args.exp, args.dexp)
+    # dilithium_py binds random_bytes to os.urandom at instance creation;
+    # redirect to seeded random so sk is reproducible across testgen runs.
+    if args.seed is not None:
+        mldsa.random_bytes = lambda n: random.randbytes(n)
+    vector = None
+    if args.from_vector is not None:
+        vector = json.load(open(args.from_vector))[args.index]
+    gen_sign_test(mldsa, args.data, args.exp, args.dexp, vector=vector)

--- a/sw/acc/crypto/tests/mldsa/mldsa_verify_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/mldsa_verify_testgen.py
@@ -87,6 +87,10 @@ if __name__ == '__main__':
                         metavar='FILE',
                         type=argparse.FileType('w'),
                         help=('Output file for expected DMEM values.'))
+    parser.add_argument('--scheme',
+                        metavar='SCHEME',
+                        type=int,
+                        help=('This is not used in this test.'))
     args = parser.parse_args()
 
     if args.seed is not None:

--- a/third_party/mldsa_sign_bench/BUILD
+++ b/third_party/mldsa_sign_bench/BUILD
@@ -1,0 +1,7 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This file marks the directory as a Bazel package.
+
+package(default_visibility = ["//visibility:public"])

--- a/third_party/mldsa_sign_bench/BUILD.mldsa_sign_bench.bazel
+++ b/third_party/mldsa_sign_bench/BUILD.mldsa_sign_bench.bazel
@@ -1,0 +1,7 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["testsets/**/*.json"]))

--- a/third_party/mldsa_sign_bench/extensions.bzl
+++ b/third_party/mldsa_sign_bench/extensions.bzl
@@ -1,0 +1,20 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+mldsa_sign_bench = module_extension(
+    implementation = lambda _: _mldsa_sign_bench_repos(),
+)
+
+def _mldsa_sign_bench_repos():
+    http_archive(
+        name = "mldsa_sign_bench",
+        build_file = Label("//third_party/mldsa_sign_bench:BUILD.mldsa_sign_bench.bazel"),
+        sha256 = "adfc61b35a64df8d43c67ac6c2b190a6344115f9f12ff357af56f1d57b08ff8b",
+        strip_prefix = "mldsa-sign-bench-66da53064d4323c024fcd15e423c2afc28b2ecf4",
+        urls = [
+            "https://github.com/zerorisc/mldsa-sign-bench/archive/66da53064d4323c024fcd15e423c2afc28b2ecf4.tar.gz",
+        ],
+    )


### PR DESCRIPTION
This PR adds a masked ML-DSA implementation for Pavona's ACC.

It adds first-order-DPA protection to ML-DSA-44, -65, and -87 signing and key generation. Developed in parallel with last week's masked ML-KEM work, it follows the same design: it uses the first-order masked KMAC hardware already present in the ACC, with everything else in software to set a first baseline to build on. It fits within the 32 KB of DMEM and IMEM in the default ACC post-quantum configuration. Overhead versus the unprotected implementation is 2.4–2.8× for key generation and 3.6–4.1× for signing. This implementation is currently undergoing SCA evaluation.

I have also written a [blog post](https://www.zerorisc.com/blog/hardened-pqc-on-pavona-part-ii-masking-ml-dsa) about this implementation.

This draft PR is ready for evaluation, but there's still work we'd like to do:

 - Restructuring the implementation to align with the other ACC code 
 - Consolidating the documentation with the ML-KEM implementation
 - Extend the testing

We'd welcome community feedback while we incorporate these changes.