### PR TITLE
[top_dragonfly,rom1] Add second_rom arg for dragonfly BUILD

### DIFF
--- a/hw/top_dragonfly/BUILD
+++ b/hw/top_dragonfly/BUILD
@@ -118,4 +118,5 @@ sim_dv(
     base = ":sim_dv_base",
     exec_env = "sim_dv",
     rom = "//sw/device/lib/testing/test_rom:test_rom",
+    second_rom = "//sw/device/lib/testing/test_second_rom:test_second_rom",
 )

--- a/hw/top_dragonfly/data/chip_testplan.hjson
+++ b/hw/top_dragonfly/data/chip_testplan.hjson
@@ -1032,6 +1032,8 @@
       stage: V2
       tests: ["chip_sw_pwrmgr_random_sleep_all_reset_reqs"]
     }
+    // This test is not suitable for dragonfly because it uses sysrst_ctrl
+    // and dragonfly doesn't instantiate it.
     // {
     //   name: chip_sw_pwrmgr_b2b_sleep_reset_req
     //   desc: '''Verify that the pwrmgr sequences sleep_req and reset req coming in almost at the same

--- a/hw/top_dragonfly/dv/chip_dragonfly_sim_cfg.hjson
+++ b/hw/top_dragonfly/dv/chip_dragonfly_sim_cfg.hjson
@@ -340,7 +340,10 @@
     }
     {
       name: sw_test_mode_test_rom
-      sw_images: ["//sw/device/lib/testing/test_rom:test_rom:0"]
+      sw_images: [
+          "//sw/device/lib/testing/test_rom:test_rom:0",
+          "//sw/device/lib/testing/test_second_rom:test_second_rom:7",
+      ]
       en_run_modes: ["sw_test_mode_common"]
     }
     {
@@ -614,8 +617,8 @@
     //   uvm_test_seq: chip_sw_base_vseq
     //   sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_lc_signals_test:6:new_rules"]
     //   en_run_modes: ["sw_test_mode_test_rom"],
-      // Use the image as basis, but clear provisioning state of the SECRET2 and SECRET3
-      // partitions so that the test can make front-door accesses to those partitions.
+    //   // Use the image as basis, but clear provisioning state of the SECRET2 and SECRET3
+    //   // partitions so that the test can make front-door accesses to those partitions.
     //   run_opts: ["+use_otp_image=OtpTypeLcStTestUnlocked0", "+otp_clear_secret2=1",
     //              "+otp_clear_secret3=1"]
     // }
@@ -1324,6 +1327,7 @@
     //   run_timeout_mins: 180
     // }
     // End of TODO(Pavona #44)
+    // This test relies on sysrst_ctrl, which is not instantiated in dragonfly.
     // {
     //   name: chip_sw_pwrmgr_b2b_sleep_reset_req
     //   uvm_test_seq: chip_sw_repeat_reset_wkup_vseq

--- a/rules/pavona/exec_env.bzl
+++ b/rules/pavona/exec_env.bzl
@@ -151,6 +151,11 @@ def exec_env_common_attrs(**kwargs):
             allow_files = True,
             doc = "ROM_EXT image to use in this environment",
         ),
+        "second_rom": attr.label(
+            default = kwargs.get("second_rom"),
+            allow_files = True,
+            doc = "ROM1 image to use in this environment",
+        ),
         "slot_spec": attr.string_dict(
             default = kwargs.get("slot_spec", {}),
             doc = "Firmware slot addresses to use in this environment",


### PR DESCRIPTION
- Add "second_rom" attribute in exec_env_common_attrs in exec_env.bzl.
- Add test_second_rom image at slot 7 in the `sw_test_mode_test_rom` mode, so any dragonfly sim_dv test that uses that mode will also use test_second_rom.
- Changed some comments in chip_dragonfly_sim_cfg.hjson.