### PR TITLE
[yum] Fix yum-requirements for AlmaLinux 10

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -62,6 +62,8 @@ runs:
           wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
           sudo apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb
         else
+          # Install Extra Packages for Enterprise Linux first
+          sudo yum install -y epel-release
           # Install groupinstall groups
           grep '^["]' yum-requirements.txt | xargs sudo yum groupinstall -y
           # Install individual packages

--- a/yum-requirements.txt
+++ b/yum-requirements.txt
@@ -2,10 +2,11 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# List of packages installed with yum on RHEL/CentOS 7 platforms.
+# List of packages installed with yum on AlmaLinux 10 platforms.
 #
 # Keep it sorted.
 "Development Tools"
+bc
 brotli
 cmake
 curl
@@ -31,6 +32,7 @@ python3
 python3-pip
 python3-setuptools
 python3-wheel
+time
 tree
 libxslt
 zlib-devel


### PR DESCRIPTION
Install epel-release first (in prepare-env) to make libftdi and libftdi-devel available to install in the "Install individual packages" step. Then, additionally install `bc` and `time`, which are used by VCS in the dvsim regressions.