### PR TITLE
[ci] Update Github action versions

### DIFF
--- a/.github/actions/download-partial-build-bin/action.yml
+++ b/.github/actions/download-partial-build-bin/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Download partial build bins
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: partial-build-bin-${{ inputs.job-patterns }}
         path: downloads

--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -81,7 +81,7 @@ runs:
         fi
       shell: bash
 
-    - uses: astral-sh/setup-uv@v6
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         version: '0.7.14'
         enable-cache: true

--- a/.github/actions/publish-bazel-test-results/action.yml
+++ b/.github/actions/publish-bazel-test-results/action.yml
@@ -45,7 +45,7 @@ runs:
 
     - name: Upload report as artifact
       if: inputs.artifact-name != ''
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.merged-results }}
@@ -59,7 +59,7 @@ runs:
         gcloud storage cp "${{ inputs.merged-results }}" "gs://${{ inputs.bucket-destination }}"
 
     - name: Publish job summary
-      uses: mikepenz/action-junit-report@ec3a351c13e080dc4fa94c49ab7ad5bf778a9668 # v5
+      uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6.4.2
       with:
         report_paths: ${{ inputs.merged-results }}
         annotate_only: true

--- a/.github/actions/third_party/verible/action.yml
+++ b/.github/actions/third_party/verible/action.yml
@@ -38,7 +38,7 @@ runs:
           cd reviewdog
           git checkout df70ed74df59de7ebfd9276afabd62ea2de4d7dd # v0.21.0
     - name: Install go (for reviewdog)
-      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      uses: actions/setup-go@v6
       with:
         go-version-file: ./reviewdog/go.mod
     - name: Build reviewdog

--- a/.github/workflows/bitstream.yml
+++ b/.github/workflows/bitstream.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       bitstreamStrategy: ${{ steps.strategy.outputs.bitstreamStrategy }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Required by get-bitstream-strategy.sh
       - name: Prepare environment
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload step outputs
         if: steps.strategy.outputs.bitstreamStrategy == 'cached'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: partial-build-bin-chip_${{ inputs.top_name }}_${{ inputs.design_suffix }}
           path: build-bin.tar
@@ -72,7 +72,7 @@ jobs:
     if: needs.check-cache.outputs.bitstreamStrategy != 'cached'
     timeout-minutes: 240
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
         with:
@@ -118,14 +118,14 @@ jobs:
           cat $OBJ_DIR/hw/top_${{ inputs.top_name }}/${design_name}/${vlnv_path}.runs/impl_1/${design_name}_timing_summary_routed.rpt || true
 
       - name: Upload step outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: partial-build-bin-chip_${{ inputs.top_name }}_${{ inputs.design_suffix }}
           path: build-bin.tar
 
       - name: Upload artifacts if build failed
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chip_${{ inputs.top_name }}_${{ inputs.design_suffix }}-build-out
           path: build-out

--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -31,7 +31,7 @@ jobs:
     if: github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('CherryPick:', github.event.label.name))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on:
       group: pavona-basic
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Required so we can lint commit messages.
       - name: Prepare environment
@@ -81,7 +81,7 @@ jobs:
       group: pavona-basic
     needs: quick_lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Bitstream cache requires all commits.
       - name: Prepare environment
@@ -141,7 +141,7 @@ jobs:
       group: pavona-basic
     needs: quick_lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
       - name: Check Python licenses
@@ -194,7 +194,7 @@ jobs:
       verible_config: hw/lint/tools/veriblelint/lowrisc-styleguide.rules.verible_lint
       verible_version: v0.0-3430-g060bde0f
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Prepare Verible config
         run: |
           echo "Concatenating Verible waivers"
@@ -225,7 +225,7 @@ jobs:
           INPUT_SUGGEST_FIXES: 'false'
         run: ./.github/actions/third_party/verible/entrypoint.sh
       - name: Upload Verible linter log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: verible-linter
           path: 'verible-verilog-lint.log'
@@ -237,7 +237,7 @@ jobs:
       group: pavona-basic
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Bitstream cache requires all commits.
       - name: Prepare environment
@@ -262,7 +262,7 @@ jobs:
       group: pavona-basic
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Bitstream cache requires all commits.
       - name: Prepare environment
@@ -281,7 +281,7 @@ jobs:
     needs: quick_lint
     timeout-minutes: 240
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
       - name: Run fast Verilator tests
@@ -335,7 +335,7 @@ jobs:
     timeout-minutes: 120
     needs: quick_lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Required for bitstream cache to work.
       - name: Prepare environment
@@ -363,7 +363,7 @@ jobs:
     timeout-minutes: 120
     needs: quick_lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Required for bitstream cache to work.
       - name: Prepare environment
@@ -390,7 +390,7 @@ jobs:
       group: pavona-basic
     needs: quick_lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Prepare environment

--- a/.github/workflows/cryptotest.yml
+++ b/.github/workflows/cryptotest.yml
@@ -52,7 +52,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Prepare environment

--- a/.github/workflows/dv-all.yml
+++ b/.github/workflows/dv-all.yml
@@ -46,7 +46,7 @@ jobs:
       group: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
     # TODO: Filter DV jobs based on changed paths (`if-changed`).

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -61,7 +61,7 @@ jobs:
       group: pavona-${{ inputs.board }}
     timeout-minutes: ${{ inputs.timeout }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Prepare environment
@@ -116,7 +116,7 @@ jobs:
 
       - name: Upload target pattern file
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.job_name }}-targets
           path: target_pattern_file.txt

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on:
       group: pavona-basic
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
@@ -70,7 +70,7 @@ jobs:
       - chip_egret_cw310
       - chip_egret_cw340
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
       - name: Download partial build-bin

--- a/.github/workflows/pr_change_check.yml
+++ b/.github/workflows/pr_change_check.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout the default branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Checkout the target branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           path: "target-branch"

--- a/.github/workflows/verify-fpga.yml
+++ b/.github/workflows/verify-fpga.yml
@@ -29,9 +29,9 @@ jobs:
     runs-on:
       group: pavona-basic
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Download target pattern files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: execute_*-targets
           path: verify_fpga_jobs
@@ -71,7 +71,7 @@ jobs:
             false
           fi
       - name: Upload complete target list
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.test_group }}-fpga_targets
           path: all_fpga.txt

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on:
       group: pavona-large
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Prepare environment


### PR DESCRIPTION
This resolves a number of warnings that appear in the Github Actions about deprecated actions that depend on Node.js 20. For example:
```
Lint (quick)
Node.js 20 is deprecated. The following actions target Node.js 20 but
are being forced to run on Node.js 24: actions/checkout@v4,
astral-sh/setup-uv@v6. For more information see:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```
These are the actions that are updated by this change:
* actions/checkout: v4 -> v7
* actions/download-artifact: v4 -> v8
* actions/setup-go: v5.5.0 -> v6
* actions/upload-artifact: v4 -> v7
* astral-sh/setup-uv: v6 -> v8.1.0
* mikepenz/action-junit-report: v5 -> v6.4.2