### PR TITLE
[ci] Update versions for post-merge actions

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -139,7 +139,7 @@ runs:
       name: Authenticate to Google Cloud
       # This uses secrets, so it does not work on pull requests from forks.
       if: github.event_name != 'pull_request'
-      uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         workload_identity_provider: projects/877782468570/locations/global/workloadIdentityPools/github-actions-pool/providers/${{ github.event.repository.name }}
         service_account: ${{ github.event.repository.name }}-gh-actions-sa@pavona-caches-430f6d3b.iam.gserviceaccount.com
@@ -159,7 +159,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
-    - uses: google-github-actions/setup-gcloud@v2
+    - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       if: github.event_name != 'pull_request'
 
     - name: Configure ~/.bazelrc

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -21,7 +21,7 @@ jobs:
       group: pavona-basic
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
+      - uses: actions/configure-pages@v6
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
       - name: Build documentation


### PR DESCRIPTION
My previous commit foobar updated Github Action versions for actions that run before merge, but there are several more that run post-merge that I missed:

* actions/configure-pages: v5 -> v6
* google-github-actions/auth: v2.1.3 -> v3
* google-github-actions/setup-gcloud: v2 -> v3.0.1

This resolves errors that looked like:
```
Node.js 20 is deprecated. The following actions target Node.js 20 but
are being forced to run on Node.js 24:
actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b.
```
As with the previous commit, I've followed the pattern of referencing actions by label for official Github actions, and by hash for third party ones.