### PR TITLE
[acc,mlkem] Test ACC ML-KEM on a PQCEn=1 CW340 bitstream in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,15 @@ jobs:
       top_name: egret
       design_suffix: cw340
 
+  chip_egret_cw340_pqc:
+    name: Egret for CW340 (PQC)
+    needs: quick_lint
+    uses: ./.github/workflows/bitstream.yml
+    secrets: inherit
+    with:
+      top_name: egret
+      design_suffix: cw340_pqc
+
   # CW310 FPGA jobs
   execute_tests_cw310:
     name: Egret CW310 Tests
@@ -322,7 +331,9 @@ jobs:
   # CW340 FPGA jobs
   execute_tests_cw340:
     name: Egret CW340 Tests
-    needs: chip_egret_cw340
+    needs:
+      - chip_egret_cw340
+      - chip_egret_cw340_pqc
     uses: ./.github/workflows/egret-cw340-pr.yml
     secrets: inherit
     with:

--- a/.github/workflows/egret-cw340-nightly.yml
+++ b/.github/workflows/egret-cw340-nightly.yml
@@ -96,6 +96,21 @@ jobs:
       timeout_filters: 'long,eternal'
       timeout: 300
 
+  execute_long_pqc_fpga_tests_cw340:
+    name: CW340 PQCEn=1 Long Tests
+    uses: ./.github/workflows/fpga.yml
+    secrets: inherit
+    with:
+      name: CW340 PQCEn=1 Long Tests
+      job_name: execute_long_pqc_fpga_tests_cw340
+      bitstream: chip_egret_cw340_pqc
+      board: cw340
+      interface: cw340
+      tag_filters: cw340_pqc_test_rom
+      timeout_filters: 'long,eternal'
+      timeout: 300
+      extra_bazel_flags: --define=acc_has_pqc=true
+
   verify_fpga_jobs:
     name: Verify FPGA jobs
     uses: ./.github/workflows/verify-fpga.yml
@@ -110,4 +125,5 @@ jobs:
       - execute_long_sival_fpga_tests_cw340
       - execute_long_sival_rom_ext_fpga_tests_cw340
       - execute_long_manuf_fpga_tests_cw340
+      - execute_long_pqc_fpga_tests_cw340
     if: success() || failure()

--- a/.github/workflows/egret-cw340-pr.yml
+++ b/.github/workflows/egret-cw340-pr.yml
@@ -91,6 +91,22 @@ jobs:
       interface: cw340
       tag_filters: "manuf,-cw310"
 
+  execute_pqc_fpga_tests_cw340:
+    name: CW340 PQCEn=1 Tests
+    uses: ./.github/workflows/fpga.yml
+    if: ${{ github.event_name != 'merge_group' }}
+    secrets: inherit
+    with:
+      name: CW340 PQCEn=1 Tests
+      job_name: execute_pqc_fpga_tests_cw340
+      bitstream: chip_egret_cw340_pqc
+      board: cw340
+      interface: cw340
+      tag_filters: cw340_pqc_test_rom
+      timeout_filters: 'short,moderate,long,eternal'
+      timeout: 120
+      extra_bazel_flags: --define=acc_has_pqc=true
+
   verify_fpga_jobs:
     name: Verify FPGA jobs
     uses: ./.github/workflows/verify-fpga.yml
@@ -104,4 +120,5 @@ jobs:
       - execute_sival_fpga_tests_cw340
       - execute_sival_rom_ext_fpga_tests_cw340
       - execute_manuf_fpga_tests_cw340
+      - execute_pqc_fpga_tests_cw340
     if: success() || failure()

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -53,6 +53,10 @@ on:
         default: true
         type: boolean
         description: Skip tests that previously passed and were cached by Bazel
+      extra_bazel_flags:
+        default: ""
+        type: string
+        description: Additional flags to pass to the Bazel test invocation.
 
 jobs:
   fpga:
@@ -101,7 +105,7 @@ jobs:
 
           # Run FPGA tests
           if [[ -s target_pattern_file.txt ]]; then
-            ci/scripts/run-fpga-tests.sh "${{ inputs.interface }}" target_pattern_file.txt "$cache_test_results" || {
+            ci/scripts/run-fpga-tests.sh "${{ inputs.interface }}" target_pattern_file.txt "$cache_test_results" ${{ inputs.extra_bazel_flags }} || {
               res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}";
             }
           else

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -62,6 +62,14 @@ jobs:
       top_name: egret
       design_suffix: cw340
 
+  chip_egret_cw340_pqc:
+    name: Egret for CW340 (PQC)
+    uses: ./.github/workflows/bitstream.yml
+    secrets: inherit
+    with:
+      top_name: egret
+      design_suffix: cw340_pqc
+
   cache_bitstreams:
     name: Cache bitstreams to GCP
     runs-on:
@@ -69,6 +77,7 @@ jobs:
     needs:
       - chip_egret_cw310
       - chip_egret_cw340
+      - chip_egret_cw340_pqc
     steps:
       - uses: actions/checkout@v7
       - name: Prepare environment
@@ -76,7 +85,7 @@ jobs:
       - name: Download partial build-bin
         uses: ./.github/actions/download-partial-build-bin
         with:
-          job-patterns: chip_egret_{cw310_hyperdebug,cw340}
+          job-patterns: chip_egret_{cw310_hyperdebug,cw340,cw340_pqc}
       - name: Create bitstream cache archive
         run: |
           shopt -s globstar # Allow use of **

--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -1,4 +1,5 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -149,5 +150,27 @@ pkg_tar(
     mode = "0444",
     package_dir = "build-bin/hw/top_egret/chip_egret_cw340",
     strip_prefix = "/hw/bitstream/chip_egret_cw340_cached_fragment",
+    tags = ["manual"],
+)
+
+bitstream_fragment_from_manifest(
+    name = "chip_egret_cw340_pqc_cached_fragment",
+    testonly = True,
+    srcs = [
+        "@bitstreams//:chip_egret_cw340_pqc_bitstream",
+        "@bitstreams//:chip_egret_cw340_pqc_mmi",
+    ],
+    design = "chip_egret_cw340_pqc",
+    manifest = "@bitstreams//:manifest",
+    tags = ["manual"],
+)
+
+pkg_tar(
+    name = "chip_egret_cw340_pqc_cached_archive",
+    testonly = True,
+    srcs = [":chip_egret_cw340_pqc_cached_fragment"],
+    mode = "0444",
+    package_dir = "build-bin/hw/top_egret/chip_egret_cw340_pqc",
+    strip_prefix = "/hw/bitstream/chip_egret_cw340_pqc_cached_fragment",
     tags = ["manual"],
 )

--- a/hw/bitstream/cw340_pqc/BUILD
+++ b/hw/bitstream/cw340_pqc/BUILD
@@ -1,0 +1,30 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "bitstream",
+    testonly = True,
+    srcs = select({
+        "//hw/bitstream:bitstream_skip": ["//hw/bitstream/universal:none"],
+        "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw340_pqc_test_rom"],
+        "//hw/bitstream:bitstream_gcp_splice": ["@bitstreams//:chip_egret_cw340_pqc_bitstream"],
+        "//conditions:default": ["@bitstreams//:chip_egret_cw340_pqc_bitstream"],
+    }),
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "mmi",
+    testonly = True,
+    srcs = select({
+        "//hw/bitstream:bitstream_skip": ["//hw/bitstream/universal:none"],
+        "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:cw340_pqc_mmi"],
+        "//hw/bitstream:bitstream_gcp_splice": ["@bitstreams//:chip_egret_cw340_pqc_mmi"],
+        "//conditions:default": ["@bitstreams//:chip_egret_cw340_pqc_mmi"],
+    }),
+    tags = ["manual"],
+)

--- a/hw/bitstream/vivado/BUILD
+++ b/hw/bitstream/vivado/BUILD
@@ -1,4 +1,5 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -159,6 +160,48 @@ filegroup(
     tags = ["manual"],
 )
 
+# CW340 bitstream with the ACC PQC vector ISA extension enabled
+fusesoc_build(
+    name = "fpga_cw340_pqc",
+    testonly = True,
+    srcs = [
+        "//hw:rtl_files",
+        _CW340_TESTROM,
+        _OTP_RMA,
+    ],
+    cores = ["//hw:cores"],
+    data = ["//hw/ip/acc:rtl_files"],
+    flags = [
+        "--BootRomInitFile=" + _CW340_TESTROM_PATH,
+        "--OtpMacroMemInitFile=" + _OTP_RMA_PATH,
+        "--AccPQCEn=1",
+    ],
+    output_groups = {
+        "bitstream": [_FPGA_PATH_TMPL.format("chip_egret_cw340", "lowrisc_systems_chip_egret_cw340_0.1.bit")],
+        "mmi": [_FPGA_PATH_TMPL.format("chip_egret_cw340", "memories.mmi")],
+        "logs": [_FPGA_PATH_TMPL.format("chip_egret_cw340", "lowrisc_systems_chip_egret_cw340_0.1.runs/")],
+    },
+    systems = ["lowrisc:systems:chip_egret_cw340"],
+    tags = ["manual"],
+    target = "synth",
+)
+
+filegroup(
+    name = "fpga_cw340_pqc_test_rom",
+    testonly = True,
+    srcs = [":fpga_cw340_pqc"],
+    output_group = "bitstream",
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "cw340_pqc_mmi",
+    testonly = True,
+    srcs = [":fpga_cw340_pqc"],
+    output_group = "mmi",
+    tags = ["manual"],
+)
+
 # Bitstream cache manifest fragment targets
 bitstream_manifest_fragment(
     name = "egret_cw310_manifest",
@@ -247,6 +290,36 @@ pkg_tar(
     mode = "0444",
     package_dir = "build-bin/hw/top_egret/chip_egret_cw340",
     strip_prefix = "/hw/bitstream/vivado/egret_cw340_manifest",
+    tags = ["manual"],
+)
+
+bitstream_manifest_fragment(
+    name = "egret_cw340_pqc_manifest",
+    testonly = True,
+    srcs = [":fpga_cw340_pqc"],
+    bitstream = "bitstream",
+    design = "chip_egret_cw340_pqc",
+    memories = [
+        "rom",
+        "otp",
+        "flash0_info0",
+        "flash0_info1",
+        "flash0_info2",
+        "flash1_info0",
+        "flash1_info1",
+        "flash1_info2",
+    ],
+    memory_map_file = ":cw340_pqc_mmi",
+    tags = ["manual"],
+)
+
+pkg_tar(
+    name = "egret_cw340_pqc_archive",
+    testonly = True,
+    srcs = [":egret_cw340_pqc_manifest"],
+    mode = "0444",
+    package_dir = "build-bin/hw/top_egret/chip_egret_cw340_pqc",
+    strip_prefix = "/hw/bitstream/vivado/egret_cw340_pqc_manifest",
     tags = ["manual"],
 )
 

--- a/hw/top_egret/BUILD
+++ b/hw/top_egret/BUILD
@@ -1,4 +1,5 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -269,6 +270,24 @@ fpga_cw340(
     base_bitstream = "//hw/bitstream/cw340:bitstream",
     exec_env = "fpga_cw340_test_rom",
     mmi = "//hw/bitstream/cw340:mmi",
+    otp = "//hw/top_egret/data/otp:img_rma",
+    rom = "//sw/device/lib/testing/test_rom:test_rom",
+    test_cmd = """
+        --exec="transport init"
+        --exec="fpga load-bitstream {bitstream}"
+        --exec="bootstrap --clear-uart=true {firmware}"
+        --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+        no-op
+    """,
+)
+
+fpga_cw340(
+    name = "fpga_cw340_pqc_test_rom",
+    testonly = True,
+    base = ":fpga_cw340",
+    base_bitstream = "//hw/bitstream/cw340_pqc:bitstream",
+    exec_env = "fpga_cw340_pqc_test_rom",
+    mmi = "//hw/bitstream/cw340_pqc:mmi",
     otp = "//hw/top_egret/data/otp:img_rma",
     rom = "//sw/device/lib/testing/test_rom:test_rom",
     test_cmd = """

--- a/hw/top_egret/chip_egret_cw340.core
+++ b/hw/top_egret/chip_egret_cw340.core
@@ -62,6 +62,11 @@ parameters:
     description: OTP initialization file in vmem hex format
     default: ""
     paramtype: vlogparam
+  AccPQCEn:
+    datatype: int
+    description: Enable the PQC vector ISA extension in the ACC
+    default: 0
+    paramtype: vlogparam
   AST_BYPASS_CLK:
     datatype: bool
     paramtype: vlogdefine
@@ -85,6 +90,7 @@ targets:
     parameters:
       - BootRomInitFile
       - OtpMacroMemInitFile
+      - AccPQCEn
       - AST_BYPASS_CLK=true
     tools:
       vivado:

--- a/hw/top_egret/rtl/autogen/chip_egret_cw310.sv
+++ b/hw/top_egret/rtl/autogen/chip_egret_cw310.sv
@@ -15,7 +15,8 @@ module chip_egret_cw310 #(
   parameter BootRomInitFile = "test_rom_fpga_cw310.32.vmem",
   // Path to a VMEM file containing the contents of the emulated OTP, which will be
   // baked into the FPGA bitstream.
-  parameter OtpMacroMemInitFile = "otp_img_fpga_cw310.vmem"
+  parameter OtpMacroMemInitFile = "otp_img_fpga_cw310.vmem",
+  parameter bit AccPQCEn = 0
 ) (
   // Dedicated Pads
   inout POR_N, // Manual Pad
@@ -1067,6 +1068,7 @@ module chip_egret_cw310 #(
     .AccRegFile(acc_pkg::RegFileFPGA),
     .SecAccMuteUrnd(1'b0),
     .SecAccSkipUrndReseedAtStart(1'b0),
+    .AccAccPQCEn(AccPQCEn),
     .OtpMacroMemInitFile(OtpMacroMemInitFile),
     .RvCoreIbexPipeLine(1),
     .SramCtrlRetAonInstrExec(0),

--- a/hw/top_egret/rtl/autogen/chip_egret_cw340.sv
+++ b/hw/top_egret/rtl/autogen/chip_egret_cw340.sv
@@ -15,7 +15,8 @@ module chip_egret_cw340 #(
   parameter BootRomInitFile = "test_rom_fpga_cw340.32.vmem",
   // Path to a VMEM file containing the contents of the emulated OTP, which will be
   // baked into the FPGA bitstream.
-  parameter OtpMacroMemInitFile = "otp_img_fpga_cw340.vmem"
+  parameter OtpMacroMemInitFile = "otp_img_fpga_cw340.vmem",
+  parameter bit AccPQCEn = 0
 ) (
   // Dedicated Pads
   inout POR_N, // Manual Pad
@@ -1053,6 +1054,7 @@ module chip_egret_cw340 #(
     .AccRegFile(acc_pkg::RegFileFPGA),
     .SecAccMuteUrnd(1'b0),
     .SecAccSkipUrndReseedAtStart(1'b0),
+    .AccAccPQCEn(AccPQCEn),
     .OtpMacroMemInitFile(OtpMacroMemInitFile),
     .RvCoreIbexPipeLine(1),
     .SramCtrlRetAonInstrExec(0),

--- a/hw/top_egret/templates/chiplevel.sv.tpl
+++ b/hw/top_egret/templates/chiplevel.sv.tpl
@@ -70,7 +70,8 @@ module chip_${top["name"]}_${target["name"]} #(
   parameter BootRomInitFile = "test_rom_fpga_${target["name"]}.32.vmem",
   // Path to a VMEM file containing the contents of the emulated OTP, which will be
   // baked into the FPGA bitstream.
-  parameter OtpMacroMemInitFile = "otp_img_fpga_${target["name"]}.vmem"
+  parameter OtpMacroMemInitFile = "otp_img_fpga_${target["name"]}.vmem",
+  parameter bit AccPQCEn = 0
 %   endif
 ) (
 % else:
@@ -1149,6 +1150,7 @@ module chip_${top["name"]}_${target["name"]} #(
     .AccRegFile(acc_pkg::RegFileFPGA),
     .SecAccMuteUrnd(1'b0),
     .SecAccSkipUrndReseedAtStart(1'b0),
+    .AccAccPQCEn(AccPQCEn),
     .OtpMacroMemInitFile(OtpMacroMemInitFile),
     .RvCoreIbexPipeLine(1),
     .SramCtrlRetAonInstrExec(0),

--- a/rules/scripts/bitstreams_workspace.py
+++ b/rules/scripts/bitstreams_workspace.py
@@ -48,6 +48,10 @@ KNOWN_DESIGNS = {
         "bitstream": "@//hw/bitstream/vivado:fpga_cw340_test_rom",
         "mmi": "@//hw/bitstream/vivado:cw340_mmi",
     },
+    "chip_egret_cw340_pqc": {
+        "bitstream": "@//hw/bitstream/vivado:fpga_cw340_pqc_test_rom",
+        "mmi": "@//hw/bitstream/vivado:cw340_pqc_mmi",
+    },
 }
 
 parser = argparse.ArgumentParser(

--- a/rules/scripts/bitstreams_workspace_test.py
+++ b/rules/scripts/bitstreams_workspace_test.py
@@ -165,6 +165,16 @@ alias(
     name = "chip_egret_cw340_mmi",
     actual = "@//hw/bitstream/vivado:cw340_mmi",
 )
+
+alias(
+    name = "chip_egret_cw340_pqc_bitstream",
+    actual = "@//hw/bitstream/vivado:fpga_cw340_pqc_test_rom",
+)
+
+alias(
+    name = "chip_egret_cw340_pqc_mmi",
+    actual = "@//hw/bitstream/vivado:cw340_pqc_mmi",
+)
 ''')
 
 

--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -90,6 +90,9 @@ MLKEM_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "mlkem_kat",
+    extra_exec_envs = {
+        "//hw/top_egret:fpga_cw340_pqc_test_rom": "fpga_cw340",
+    },
     slow_test = True,
     test_args = MLKEM_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/mlkem_kat:harness",

--- a/sw/device/tests/crypto/cryptotest/cryptotest.bzl
+++ b/sw/device/tests/crypto/cryptotest/cryptotest.bzl
@@ -52,7 +52,7 @@ FIRMWARE_DEPS = [
     "//sw/device/tests/crypto/cryptotest/json:commands",
 ]
 
-def cryptotest(name, test_vectors, test_args, test_harness, slow_test = False):
+def cryptotest(name, test_vectors, test_args, test_harness, slow_test = False, extra_exec_envs = {}):
     """A macro for defining a CryptoTest test case.
 
     Args:
@@ -61,8 +61,11 @@ def cryptotest(name, test_vectors, test_args, test_harness, slow_test = False):
         test_args: additional arguments to pass to the test.
         test_harness: the test harness to use.
         slow_test: indicate if the test should be run in the nightly CI.
+        extra_exec_envs: additional exec_env entries merged into the defaults.
     """
     tags = ["slow_test"] if slow_test else []
+    exec_env = dict(CRYPTOTEST_EXEC_ENVS)
+    exec_env.update(extra_exec_envs)
     pavona_test(
         name = name,
         srcs = ["//sw/device/tests/crypto/cryptotest/firmware:firmware.c"],
@@ -84,7 +87,7 @@ def cryptotest(name, test_vectors, test_args, test_harness, slow_test = False):
             """ + test_args,
             test_harness = test_harness,
         ),
-        exec_env = CRYPTOTEST_EXEC_ENVS,
+        exec_env = exec_env,
         silicon = silicon_params(
             timeout = "eternal",
             tags = tags,


### PR DESCRIPTION
- Depends on #269 

Builds a PQC-enabled CW340 bitstream (`chip_egret_cw340_pqc`, synthesized with `AccPQCEn=1`) and runs the ACC ML-KEM KAT against it in CI, so the ACC's PQC datapath is exercised on hardware.

- `AccPQCEn` is forwarded through the egret chip wrapper as a chip-level parameter (default 0). The PQC bitstream is a separate cached design.
- It's built and cached like the others, so it's reusable locally without a local Vivado build.
- `mlkem_kat` opts into the `fpga_cw340_pqc_test_rom` exec_env and runs with `--define=acc_has_pqc=true` in the PR and nightly CW340 jobs, selected by the `cw340_pqc_test_rom` tag.

Test on CW340:
```
./bazelisk.sh test \
  //sw/device/tests/crypto/cryptotest:mlkem_kat_fpga_cw340_pqc_test_rom \
  --define=acc_has_pqc=true --define=bitstream=vivado \
  --test_arg=--usb-serial=<serial> --test_output=streamed
```