### PR TITLE
[top_dragonfly,dv] Updated second ROM linker to avoid overlap in SW logger

### DIFF
--- a/hw/top_dragonfly/dv/tb/tb.sv
+++ b/hw/top_dragonfly/dv/tb/tb.sv
@@ -439,7 +439,7 @@ module tb;
 `endif
           .key   (top_dragonfly_rnd_cnst_pkg::RndCnstRomCtrl1ScrKey),
           .nonce (top_dragonfly_rnd_cnst_pkg::RndCnstRomCtrl1ScrNonce),
-          .system_base_addr    (top_dragonfly_pkg::TOP_DRAGONFLY_ROM_CTRL0_ROM_BASE_ADDR));
+          .system_base_addr    (top_dragonfly_pkg::TOP_DRAGONFLY_ROM_CTRL1_ROM_BASE_ADDR));
       m_mem_bkdr_util[Rom1] = rom1;
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Rom1], `ROM1_MEM_HIER)
 

--- a/sw/device/lib/testing/test_second_rom/test_second_rom.ld
+++ b/sw/device/lib/testing/test_second_rom/test_second_rom.ld
@@ -49,7 +49,7 @@ _rom_digest_size = 32;
 _chip_info_start = ORIGIN(test_second_rom) + LENGTH(test_second_rom) - _rom_digest_size - _chip_info_size;
 
 /* DV Log offset (has to be different to other boot stages). */
-_dv_log_offset = 0x0;
+_dv_log_offset = 0x8000;
 
 /**
  * We define an entry point only for documentation purposes (and to stop LLD

--- a/sw/device/silicon_creator/rom/second_rom.ld
+++ b/sw/device/silicon_creator/rom/second_rom.ld
@@ -32,7 +32,7 @@ ASSERT((_rom_ext_virtual_size <= (LENGTH(ram_ctn))),
   "Error: rom ext is bigger than slot.");
 
 /* DV Log offset (has to be different to other boot stages). */
-_dv_log_offset = 0x0;
+_dv_log_offset = 0x8000;
 
 /**
  * This symbol is used as a jump target when an error is detected by the


### PR DESCRIPTION
This PR fixes a bug with chip-level Dragonfly tests that use two ROMs previously resulting in test failures.

The ROM boot sequence was operating correctly, but UVM tests experienced an early termination due to a `UVM_ERROR` originating from the `sw_logger_if.sv` interface. The second ROM linker did not have a unique `_dv_log_offset` which led to address collisions with the `sw_logger_if.sv`. Anytime an address intended for the `test_rom` was used, the logger was reading from both the `test_rom` and `test_second_rom` mappings. This would occasionally result in reading a DIF failure, despite the ROM code having never been actually executed.

> UVM_ERROR @ 135.294000 us: (sw_logger_if.sv:526) [test_second_rom_sim_dv(sw/device/lib/testing/test_second_rom/test_second_rom.c:105)] DIF-fail: dif_rv_core_ibex_enable_addr_translation( &ibex, kDifRvCoreIbexAddrTranslationSlot_0, kDifRvCoreIbexAddrTranslationIBus) returns 4 