### PR TITLE
[acc,mldsa] Test ACC ML-DSA on a PQCEn=1 CW340 bitstream in CI 

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -116,6 +116,9 @@ MLDSA_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "mldsa_kat",
+    extra_exec_envs = {
+        "//hw/top_egret:fpga_cw340_pqc_test_rom": "fpga_cw340",
+    },
     slow_test = True,
     test_args = MLDSA_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/mldsa_kat:harness",


### PR DESCRIPTION
- Depends on #269 
- Depends on #247 
- Depends on #258
- Depends on #280 
- Depends on #284 

Doing this in a separate PR to not introduce the #280 dependency into #284.