### PR TITLE
[ci] Reduce concurrent jobs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,3 +58,4 @@ jobs:
       timeout-minutes: 2880 # 48 hours
       dashboard-private: "git@github.com:pavona/internal-dashboard.git"
       dashboard-public: "git@github.com:pavona/public-dashboard.git"
+      concurrent-jobs: 25

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -28,7 +28,7 @@ jobs:
       dashboard-private: "git@github.com:pavona/internal-dashboard.git"
       dashboard-public: "git@github.com:pavona/public-dashboard.git"
       reseed-source: "hw/dv/grading/grading_report.hjson"
-      concurrent-jobs: 28
+      concurrent-jobs: 25
 
   gitless:
     name: Run gitless check (repo packaging check)


### PR DESCRIPTION
In order to support more internal jobs, we reduce the number of licenses used by the CI on weeklies.