### PR TITLE
[bazel] Add a libxml2.so.2 shim to the prebuilt LLVM toolchain

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -68,11 +68,6 @@ runs:
           fi
           wget "${POOL_URL}/libtinfo5_6.3-2ubuntu0.1_${ARCH}.deb"
           sudo apt install "./libtinfo5_6.3-2ubuntu0.1_${ARCH}.deb"
-          # TODO: Remove once the prebuilt LLVM toolchain no longer links libxml2.so.2.
-          LIBDIR="/usr/lib/$(uname -m)-linux-gnu"
-          if [ -e "${LIBDIR}/libxml2.so.16" ] && [ ! -e "${LIBDIR}/libxml2.so.2" ]; then
-            sudo ln -s libxml2.so.16 "${LIBDIR}/libxml2.so.2"
-          fi
         else
           # Install Extra Packages for Enterprise Linux first
           sudo yum install -y epel-release

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -74,6 +74,19 @@ single_version_override(
     version = "0.9.0",
 )
 
+single_version_override(
+    module_name = "toolchains_llvm",
+    patch_strip = 1,
+    patches = [
+        # Patch to make the prebuilt lld and lldb run on distros that ship
+        # libxml2 >= 2.14, where the libxml2.so.2 soname no longer exists.
+        # Drop once the prebuilt binaries stop linking libxml2. See upstream
+        # issue: https://github.com/llvm/llvm-project/issues/113696
+        "@pavona_pavona//third_party/llvm/patches:toolchains_llvm.libxml2_shim.patch",
+    ],
+    version = "1.7.0",
+)
+
 archive_override(
     module_name = "lowrisc_misc_linters",
     integrity = "sha256-eRFiSjD638NuOjDDScMuEKVYpmotDY0yX3jxYL/d3ac=",

--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -32,6 +32,7 @@ libssl-dev
 libtool
 libudev-dev
 libusb-1.0-0
+libxml2-dev
 libzstd-dev
 lrzsz
 lsb-release

--- a/third_party/llvm/patches/BUILD
+++ b/third_party/llvm/patches/BUILD
@@ -1,0 +1,5 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])

--- a/third_party/llvm/patches/toolchains_llvm.libxml2_shim.patch
+++ b/third_party/llvm/patches/toolchains_llvm.libxml2_shim.patch
@@ -1,0 +1,31 @@
+Add a libxml2.so.2 shim for distros shipping libxml2 >= 2.14
+
+diff --git a/toolchain/internal/repo.bzl b/toolchain/internal/repo.bzl
+--- a/toolchain/internal/repo.bzl
++++ b/toolchain/internal/repo.bzl
+@@ -13,6 +13,7 @@
+ # limitations under the License.
+ load(
+     "//toolchain/internal:common.bzl",
++    _arch = "arch",
+     _attr_dict = "attr_dict",
+     _os = "os",
+     _supported_os_arch_keys = "supported_os_arch_keys",
+@@ -460,6 +461,17 @@
+     # do want to make changes, then we should do it through a patch file, and
+     # document it for users of toolchain_roots attribute.
+ 
++    # The prebuilt lld and lldb link libxml2.so.2, which distros shipping
++    # libxml2 >= 2.14 (soname libxml2.so.16) no longer provide. If the host
++    # has libxml2.so.16, add a shim to lib/, which the prebuilt binaries
++    # resolve through their $ORIGIN/../lib RUNPATH. The watch re-runs this
++    # rule whenever the host libxml2.so.16 appears, disappears, or changes.
++    if os == "linux":
++        libxml2 = rctx.path("/usr/lib/{}-linux-gnu/libxml2.so.16".format(_arch(rctx)))
++        rctx.watch(libxml2)
++        if libxml2.exists:
++            rctx.symlink(libxml2, "lib/libxml2.so.2")
++
+     if hasattr(rctx, "repo_metadata"):
+         if updated_attrs == _attr_dict(rctx.attr):
+             return rctx.repo_metadata(reproducible = True)

--- a/yum-requirements.txt
+++ b/yum-requirements.txt
@@ -34,6 +34,7 @@ python3-setuptools
 python3-wheel
 time
 tree
+libxml2
 libxslt
 zlib-devel
 xz-libs


### PR DESCRIPTION
Distros shipping libxml2 >= 2.14 (e.g. Ubuntu 26.04) no longer provide the libxml2.so.2 soname that the prebuilt lld and lldb link. Patch toolchains_llvm to symlink the host libxml2.so.16 into the toolchain's lib/ directory, where the binaries resolve it through their $ORIGIN/../lib RUNPATH. Add libxml2 to the package requirements and drop the CI symlink workaround.

- Resolves #272