### PR TITLE
[dma] Fix path to RAL spec in sim config

### DIFF
--- a/hw/ip/dma/dv/dma_sim_cfg.hjson
+++ b/hw/ip/dma/dv/dma_sim_cfg.hjson
@@ -21,7 +21,7 @@
   testplan: "{proj_root}/hw/ip/dma/data/dma_testplan.hjson"
 
   // RAL spec - used to generate the RAL model.
-  ral_spec: "{proj_root}/rvscs/rtl/ip/dma/data/dma.hjson"
+  ral_spec: "{proj_root}/hw/ip/dma/data/dma.hjson"
 
   // Import additional common sim cfg files.
   import_cfgs: [// Project wide common sim cfg file


### PR DESCRIPTION
There is no `rvscs` path in Pavona ;-)