### PR TITLE
[hw,ac_range_check,rtl] Fix deny logging for unmatched address ranges

### DIFF
--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_predictor.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_predictor.sv.tpl
@@ -378,7 +378,7 @@ function void ${module_instance_name}_predictor::update_log(tl_seq_item item, in
 
   if (`gmv(log_config_csr.log_enable)) begin
     if (`gmv(log_status_csr.deny_cnt) == 0 && !overflow_flag &&
-        `gmv(range_attr_csr.log_denied_access) == MuBi4True) begin
+        `gmv(range_attr_csr.log_denied_access || no_match) == MuBi4True) begin
       deny_cnt = deny_cnt + 8'd1;
       `uvm_info(`gfn, $sformatf({"First deny log information:\n",
               " - deny_range_index: %0d\n",
@@ -416,7 +416,7 @@ function void ${module_instance_name}_predictor::update_log(tl_seq_item item, in
           (.value(deny_cnt), .kind(UVM_PREDICT_DIRECT)));
       void'(env_cfg.ral.log_address.predict
           (.value(log_address), .kind(UVM_PREDICT_DIRECT)));
-    end else if (`gmv(range_attr_csr.log_denied_access) == MuBi4True) begin
+    end else if (`gmv(range_attr_csr.log_denied_access) == MuBi4True || no_match) begin
       overflow_flag = (deny_cnt == (1 << DenyCountWidth)-1) ? 1'b1 : 1'b0;
       deny_cnt = (overflow_flag) ? (1 << DenyCountWidth)-1 : deny_cnt + 8'd1;
       void'(env_cfg.ral.log_status.deny_cnt.predict

--- a/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
+++ b/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
@@ -296,11 +296,17 @@ module ${module_instance_name}
   // Always clear the log_clear bit from hardware
   assign hw2reg.log_config.log_clear.d  = 1'b0;
 
+  // When no range matches at all, deny_mask is all zeros and deny_index defaults to 0
+  // via prim_leading_one_ppc. In that case, the per-range log_enable_mask check must be
+  // bypasssed so that unmatched denies are always logged (when global logging is enabled).
+  logic no_range_match;
+  assign no_range_match = range_check_fail & (deny_mask == '0);
+
   // Only increment the deny counter if logging is globally enabled and for the particular range,
   // we are not clearing the counter in this cycle, and see a failing range check
-  assign deny_cnt_incr = log_enable_q                &
-                         log_enable_mask[deny_index] &
-                         ~clear_log                  &
+  assign deny_cnt_incr = log_enable_q                                   &
+                         (log_enable_mask[deny_index] | no_range_match) &
+                         ~clear_log                                     &
                          range_check_fail;
   // Determine if we are doing the first log. This one is special, since it also needs to log
   // diagnostics data

--- a/hw/top_dragonfly/ip_autogen/ac_range_check/dv/env/ac_range_check_predictor.sv
+++ b/hw/top_dragonfly/ip_autogen/ac_range_check/dv/env/ac_range_check_predictor.sv
@@ -378,7 +378,7 @@ function void ac_range_check_predictor::update_log(tl_seq_item item, int index, 
 
   if (`gmv(log_config_csr.log_enable)) begin
     if (`gmv(log_status_csr.deny_cnt) == 0 && !overflow_flag &&
-        `gmv(range_attr_csr.log_denied_access) == MuBi4True) begin
+        `gmv(range_attr_csr.log_denied_access || no_match) == MuBi4True) begin
       deny_cnt = deny_cnt + 8'd1;
       `uvm_info(`gfn, $sformatf({"First deny log information:\n",
               " - deny_range_index: %0d\n",
@@ -416,7 +416,7 @@ function void ac_range_check_predictor::update_log(tl_seq_item item, int index, 
           (.value(deny_cnt), .kind(UVM_PREDICT_DIRECT)));
       void'(env_cfg.ral.log_address.predict
           (.value(log_address), .kind(UVM_PREDICT_DIRECT)));
-    end else if (`gmv(range_attr_csr.log_denied_access) == MuBi4True) begin
+    end else if (`gmv(range_attr_csr.log_denied_access) == MuBi4True || no_match) begin
       overflow_flag = (deny_cnt == (1 << DenyCountWidth)-1) ? 1'b1 : 1'b0;
       deny_cnt = (overflow_flag) ? (1 << DenyCountWidth)-1 : deny_cnt + 8'd1;
       void'(env_cfg.ral.log_status.deny_cnt.predict

--- a/hw/top_dragonfly/ip_autogen/ac_range_check/rtl/ac_range_check.sv
+++ b/hw/top_dragonfly/ip_autogen/ac_range_check/rtl/ac_range_check.sv
@@ -296,11 +296,17 @@ module ac_range_check
   // Always clear the log_clear bit from hardware
   assign hw2reg.log_config.log_clear.d  = 1'b0;
 
+  // When no range matches at all, deny_mask is all zeros and deny_index defaults to 0
+  // via prim_leading_one_ppc. In that case, the per-range log_enable_mask check must be
+  // bypasssed so that unmatched denies are always logged (when global logging is enabled).
+  logic no_range_match;
+  assign no_range_match = range_check_fail & (deny_mask == '0);
+
   // Only increment the deny counter if logging is globally enabled and for the particular range,
   // we are not clearing the counter in this cycle, and see a failing range check
-  assign deny_cnt_incr = log_enable_q                &
-                         log_enable_mask[deny_index] &
-                         ~clear_log                  &
+  assign deny_cnt_incr = log_enable_q                                   &
+                         (log_enable_mask[deny_index] | no_range_match) &
+                         ~clear_log                                     &
                          range_check_fail;
   // Determine if we are doing the first log. This one is special, since it also needs to log
   // diagnostics data


### PR DESCRIPTION
When no range matches an access, deny_mask is all zero and prim_leading_one_ppc defaults to deny_index 0. The logging gate checked log_enable_mask[0], so unmatched denies were only logged if range 0 happened to have logging enabled.

Add a no_range signal to bypass the per-range log enable check when deny_mask is empty. Apply the same fix in the DV predictor.