### PR TITLE
[hw,prim_flop_2sync] Model CDC race-through in 2-flop synchronizers

### DIFF
--- a/hw/ip/prim/rtl/prim_cdc_rand_delay.sv
+++ b/hw/ip/prim/rtl/prim_cdc_rand_delay.sv
@@ -6,13 +6,24 @@
 // and allows DV to model real CDC delays within simulations, especially useful at the chip level
 // or in IPs that communicate across clock domains.
 //
-// The instrumentation is very simple: when this is enabled the input into the first
-// synchronizer flop has a mux where the select is randomly set. One of the mux inputs is the input
-// of this module, and the other is the output of the first flop: selecting the latter models the
-// effect of the first flop missing the input transition.
+// Models three physical outcomes per bit when a signal crosses clock domains:
 //
-// Notice the delay should cause the input to be skipped by at most a single cycle. As a perhaps
-// unnecessary precaution, the select will only be allowed to be random when the input changes.
+//   Normal capture: The input meets FF1's setup time. FF1 captures cleanly.
+//                   dst_data_o = src_data_i, race_through_o = 0. Synchronizer delay = 2 cycles.
+//
+//   Missed capture: The input arrives too late for FF1. FF1 retains its old value for one cycle
+//                   and captures on the next edge.
+//                   dst_data_o = prev_data_i, race_through_o = 0. Synchronizer delay = 3 cycles.
+//
+//   Race-through:   The input arrives during FF1's setup/hold violation window. Because there is
+//                   no STA closure across asynchronous clock domains, the input can race through
+//                   FF1's internal latch structure and appear at its output combinationally. FF2
+//                   captures it on the next edge.
+//                   dst_data_o = src_data_i, race_through_o = 1, Synchronizer delay = 1 cycle.
+//                   The consumer (prim_flop_2sync) uses race_through_o to bypass FF1.
+//
+// Each bit independently selects one of these three outcomes on every input transition.
+// The select is randomized when the input changes and cleared on the next clock edge.
 
 module prim_cdc_rand_delay #(
     parameter int DataWidth = 1,
@@ -22,7 +33,8 @@ module prim_cdc_rand_delay #(
     input logic                   rst_ni,
     input logic [DataWidth-1:0]   prev_data_i,
     input logic [DataWidth-1:0]   src_data_i,
-    output logic [DataWidth-1:0]  dst_data_o
+    output logic [DataWidth-1:0]  dst_data_o,
+    output logic [DataWidth-1:0]  race_through_o
 );
 `ifdef SIMULATION
   if (Enable) begin : gen_enable
@@ -30,38 +42,45 @@ module prim_cdc_rand_delay #(
     // This controls dst_data_o: any bit with its data_sel set uses prev_data_i, others use
     // src_data_i.
     bit [DataWidth-1:0] data_sel;
+    bit [DataWidth-1:0] race_sel;
     bit                 cdc_instrumentation_enabled;
-
-    function automatic bit [DataWidth-1:0] fast_randomize();
-      bit [DataWidth-1:0] data;
-      if (DataWidth <= 32) begin
-        data = $urandom();
-      end else begin
-        if (!std::randomize(data)) $fatal(1, "%t: [%m] Failed to randomize data", $time);
-      end
-      return data;
-    endfunction
 
     initial begin
       void'($value$plusargs("cdc_instrumentation_enabled=%d", cdc_instrumentation_enabled));
       data_sel = '0;
     end
 
-    // Set data_sel at random combinationally when the input changes.
+    // Randomize the synchronizer delay independently per bit when the input changes
     always @(src_data_i) begin
-      data_sel = cdc_instrumentation_enabled ? fast_randomize() : 0;
+      if (cdc_instrumentation_enabled) begin
+        for (int i = 0; i < DataWidth; i++) begin
+          case ($urandom_range(1, 3))
+            1: begin data_sel[i] = 1'b0; race_sel[i] = 1'b1; end // race-through
+            2: begin data_sel[i] = 1'b0; race_sel[i] = 1'b0; end // normal capture
+            3: begin data_sel[i] = 1'b1; race_sel[i] = 1'b0; end // missed capture
+            default: begin data_sel[i] = 1'b0; race_sel[i] = 1'b0; end
+          endcase
+        end
+      end else begin
+        data_sel = '0;
+        race_sel = '0;
+      end
     end
 
     // Clear data_del on any cycle start.
     always @(posedge clk_i or negedge rst_ni) begin
       data_sel <= 0;
+      race_sel <= 0;
     end
 
     always_comb dst_data_o = (prev_data_i & data_sel) | (src_data_i & ~data_sel);
+    assign race_through_o = race_sel;
   end else begin : gen_no_enable
     assign dst_data_o = src_data_i;
+    assign race_through_o = '0;
   end
 `else  // SIMULATION
     assign dst_data_o = src_data_i;
+    assign race_through_o = '0;
 `endif  // SIMULATION
 endmodule

--- a/hw/ip/prim/rtl/prim_lc_sync.sv
+++ b/hw/ip/prim/rtl/prim_lc_sync.sv
@@ -67,9 +67,14 @@ module prim_lc_sync #(
       always_ff @(posedge clk_i) begin
         lc_en_in_sva_q <= lc_en_i;
       end
+    // The 2-flop synchronizer has a per-bit delay in {1,2,3} cycles (race-through,
+    // normal capture, missed capture). This assertion  checks at D_max=3. The two escape
+    // clauses span the 2-cycle uncertainty window [D_min, D_max): if the input changed
+    // anywhere in that window, different bits may have captured different values.
     `ASSERT(OutputDelay_A,
             rst_ni |-> ##3 lc_en_o == {NumCopies{$past(lc_en_in_sva_q, 2)}} ||
-                           ($past(lc_en_in_sva_q, 2) != $past(lc_en_in_sva_q, 1)))
+                           ($past(lc_en_in_sva_q, 2) != $past(lc_en_in_sva_q, 1)) ||
+                           ($past(lc_en_in_sva_q, 1) != lc_en_in_sva_q))
 `endif
   end else begin : gen_no_flops
     //VCS coverage off

--- a/hw/ip/prim/rtl/prim_mubi12_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi12_sync.sv
@@ -117,8 +117,11 @@ module prim_mubi12_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
+      // With stability check the data path is: 2-flop sync (D in {1,2,3}) + 1 stability
+      // flop, giving a total delay in {2,3,4}. The range ##[2:4] covers the full window.
+      // sig_unstable fires while the value is still propagating through the stability stage.
       `ASSERT(OutputDelay_A,
-              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+              rst_ni |-> ##[2:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -127,9 +130,14 @@ module prim_mubi12_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
+      // The 2-flop synchronizer has a per-bit delay in {1,2,3} cycles (race-through,
+      // normal capture, missed capture). This assertion  checks at D_max=3. The two escape
+      // clauses span the 2-cycle uncertainty window [D_min, D_max): if the input changed
+      // anywhere in that window, different bits may have captured different values.
       `ASSERT(OutputDelay_A,
               rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
-                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
+                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1) ||
+                              $past(mubi_in_sva_q, 1) != mubi_in_sva_q))
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim/rtl/prim_mubi16_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi16_sync.sv
@@ -117,8 +117,11 @@ module prim_mubi16_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
+      // With stability check the data path is: 2-flop sync (D in {1,2,3}) + 1 stability
+      // flop, giving a total delay in {2,3,4}. The range ##[2:4] covers the full window.
+      // sig_unstable fires while the value is still propagating through the stability stage.
       `ASSERT(OutputDelay_A,
-              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+              rst_ni |-> ##[2:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -127,9 +130,14 @@ module prim_mubi16_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
+      // The 2-flop synchronizer has a per-bit delay in {1,2,3} cycles (race-through,
+      // normal capture, missed capture). This assertion  checks at D_max=3. The two escape
+      // clauses span the 2-cycle uncertainty window [D_min, D_max): if the input changed
+      // anywhere in that window, different bits may have captured different values.
       `ASSERT(OutputDelay_A,
               rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
-                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
+                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1) ||
+                              $past(mubi_in_sva_q, 1) != mubi_in_sva_q))
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim/rtl/prim_mubi20_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi20_sync.sv
@@ -117,8 +117,11 @@ module prim_mubi20_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
+      // With stability check the data path is: 2-flop sync (D in {1,2,3}) + 1 stability
+      // flop, giving a total delay in {2,3,4}. The range ##[2:4] covers the full window.
+      // sig_unstable fires while the value is still propagating through the stability stage.
       `ASSERT(OutputDelay_A,
-              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+              rst_ni |-> ##[2:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -127,9 +130,14 @@ module prim_mubi20_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
+      // The 2-flop synchronizer has a per-bit delay in {1,2,3} cycles (race-through,
+      // normal capture, missed capture). This assertion  checks at D_max=3. The two escape
+      // clauses span the 2-cycle uncertainty window [D_min, D_max): if the input changed
+      // anywhere in that window, different bits may have captured different values.
       `ASSERT(OutputDelay_A,
               rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
-                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
+                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1) ||
+                              $past(mubi_in_sva_q, 1) != mubi_in_sva_q))
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim/rtl/prim_mubi24_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi24_sync.sv
@@ -117,8 +117,11 @@ module prim_mubi24_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
+      // With stability check the data path is: 2-flop sync (D in {1,2,3}) + 1 stability
+      // flop, giving a total delay in {2,3,4}. The range ##[2:4] covers the full window.
+      // sig_unstable fires while the value is still propagating through the stability stage.
       `ASSERT(OutputDelay_A,
-              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+              rst_ni |-> ##[2:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -127,9 +130,14 @@ module prim_mubi24_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
+      // The 2-flop synchronizer has a per-bit delay in {1,2,3} cycles (race-through,
+      // normal capture, missed capture). This assertion  checks at D_max=3. The two escape
+      // clauses span the 2-cycle uncertainty window [D_min, D_max): if the input changed
+      // anywhere in that window, different bits may have captured different values.
       `ASSERT(OutputDelay_A,
               rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
-                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
+                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1) ||
+                              $past(mubi_in_sva_q, 1) != mubi_in_sva_q))
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim/rtl/prim_mubi28_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi28_sync.sv
@@ -117,8 +117,11 @@ module prim_mubi28_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
+      // With stability check the data path is: 2-flop sync (D in {1,2,3}) + 1 stability
+      // flop, giving a total delay in {2,3,4}. The range ##[2:4] covers the full window.
+      // sig_unstable fires while the value is still propagating through the stability stage.
       `ASSERT(OutputDelay_A,
-              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+              rst_ni |-> ##[2:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -127,9 +130,14 @@ module prim_mubi28_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
+      // The 2-flop synchronizer has a per-bit delay in {1,2,3} cycles (race-through,
+      // normal capture, missed capture). This assertion  checks at D_max=3. The two escape
+      // clauses span the 2-cycle uncertainty window [D_min, D_max): if the input changed
+      // anywhere in that window, different bits may have captured different values.
       `ASSERT(OutputDelay_A,
               rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
-                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
+                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1) ||
+                              $past(mubi_in_sva_q, 1) != mubi_in_sva_q))
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim/rtl/prim_mubi32_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi32_sync.sv
@@ -117,8 +117,11 @@ module prim_mubi32_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
+      // With stability check the data path is: 2-flop sync (D in {1,2,3}) + 1 stability
+      // flop, giving a total delay in {2,3,4}. The range ##[2:4] covers the full window.
+      // sig_unstable fires while the value is still propagating through the stability stage.
       `ASSERT(OutputDelay_A,
-              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+              rst_ni |-> ##[2:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -127,9 +130,14 @@ module prim_mubi32_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
+      // The 2-flop synchronizer has a per-bit delay in {1,2,3} cycles (race-through,
+      // normal capture, missed capture). This assertion  checks at D_max=3. The two escape
+      // clauses span the 2-cycle uncertainty window [D_min, D_max): if the input changed
+      // anywhere in that window, different bits may have captured different values.
       `ASSERT(OutputDelay_A,
               rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
-                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
+                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1) ||
+                              $past(mubi_in_sva_q, 1) != mubi_in_sva_q))
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim/rtl/prim_mubi4_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi4_sync.sv
@@ -117,8 +117,11 @@ module prim_mubi4_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
+      // With stability check the data path is: 2-flop sync (D in {1,2,3}) + 1 stability
+      // flop, giving a total delay in {2,3,4}. The range ##[2:4] covers the full window.
+      // sig_unstable fires while the value is still propagating through the stability stage.
       `ASSERT(OutputDelay_A,
-              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+              rst_ni |-> ##[2:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -127,9 +130,14 @@ module prim_mubi4_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
+      // The 2-flop synchronizer has a per-bit delay in {1,2,3} cycles (race-through,
+      // normal capture, missed capture). This assertion  checks at D_max=3. The two escape
+      // clauses span the 2-cycle uncertainty window [D_min, D_max): if the input changed
+      // anywhere in that window, different bits may have captured different values.
       `ASSERT(OutputDelay_A,
               rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
-                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
+                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1) ||
+                              $past(mubi_in_sva_q, 1) != mubi_in_sva_q))
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim/rtl/prim_mubi8_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi8_sync.sv
@@ -117,8 +117,11 @@ module prim_mubi8_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
+      // With stability check the data path is: 2-flop sync (D in {1,2,3}) + 1 stability
+      // flop, giving a total delay in {2,3,4}. The range ##[2:4] covers the full window.
+      // sig_unstable fires while the value is still propagating through the stability stage.
       `ASSERT(OutputDelay_A,
-              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+              rst_ni |-> ##[2:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -127,9 +130,14 @@ module prim_mubi8_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
+      // The 2-flop synchronizer has a per-bit delay in {1,2,3} cycles (race-through,
+      // normal capture, missed capture). This assertion  checks at D_max=3. The two escape
+      // clauses span the 2-cycle uncertainty window [D_min, D_max): if the input changed
+      // anywhere in that window, different bits may have captured different values.
       `ASSERT(OutputDelay_A,
               rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
-                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
+                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1) ||
+                              $past(mubi_in_sva_q, 1) != mubi_in_sva_q))
 `endif
     end
   end else begin : gen_no_flops

--- a/hw/ip/prim_generic/rtl/prim_flop_2sync.sv
+++ b/hw/ip/prim_generic/rtl/prim_flop_2sync.sv
@@ -17,6 +17,8 @@ module prim_flop_2sync #(
 
   logic [Width-1:0] d_o;
   logic [Width-1:0] intq;
+  logic [Width-1:0] ff2_in;
+  logic [Width-1:0] race_through;
 
 `ifdef SIMULATION
 
@@ -28,12 +30,28 @@ module prim_flop_2sync #(
     .rst_ni,
     .src_data_i(d_i),
     .prev_data_i(intq),
-    .dst_data_o(d_o)
+    .dst_data_o(d_o),
+    .race_through_o(race_through)
   );
+
+  // Race-through bypass mux for the first synchronizer flop.
+  //
+  // When race_through is set for a bit, FF2 sees d_o (the input) instead of intq (FF1's
+  // registered output), modeling the physical scenario where setup/hold violoation causes
+  // the input to race through FF1 combinationally. See prim_cdc_rand_delay for details.
+  //
+  // Per bit synchronizer delay:
+  //   D=1 Race-though:    race_through=1 -> ff2_in=d_o -> FF2 captures input directly.
+  //   D=2 Normal capture: race_through=0 -> ff2_in=intq -> standard 2-flop path.
+  //   D=3 Missed capture: race_through=0, d_o=intq -> ff2_in=intq, FF1 delayed by 1.
+  assign ff2_in = (d_o & race_through) | (intq & ~race_through);
+
 `else // !`ifdef SIMULATION
   logic unused_sig;
   assign unused_sig = EnablePrimCdcRand;
   always_comb d_o = d_i;
+  assign ff2_in = intq;
+  assign race_through = '0;
 `endif // !`ifdef SIMULATION
 
   prim_flop #(
@@ -52,7 +70,7 @@ module prim_flop_2sync #(
   ) u_sync_2 (
     .clk_i,
     .rst_ni,
-    .d_i(intq),
+    .d_i(ff2_in),
     .q_o
   );
 

--- a/util/design/data/prim_mubi_sync.sv.tpl
+++ b/util/design/data/prim_mubi_sync.sv.tpl
@@ -117,8 +117,11 @@ module prim_mubi${n_bits}_sync
         mubi_in_sva_q <= mubi_i;
       end
       `ASSERT(OutputIfUnstable_A, sig_unstable |-> mubi_o == {NumCopies{reset_value}})
+      // With stability check the data path is: 2-flop sync (D in {1,2,3}) + 1 stability
+      // flop, giving a total delay in {2,3,4}. The range ##[2:4] covers the full window.
+      // sig_unstable fires while the value is still propagating through the stability stage.
       `ASSERT(OutputDelay_A,
-              rst_ni |-> ##[3:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
+              rst_ni |-> ##[2:4] sig_unstable || mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}})
 `endif
     end else begin : gen_no_stable_chks
       assign mubi = mubi_sync;
@@ -127,9 +130,14 @@ module prim_mubi${n_bits}_sync
       always_ff @(posedge clk_i) begin
         mubi_in_sva_q <= mubi_i;
       end
+      // The 2-flop synchronizer has a per-bit delay in {1,2,3} cycles (race-through,
+      // normal capture, missed capture). This assertion  checks at D_max=3. The two escape
+      // clauses span the 2-cycle uncertainty window [D_min, D_max): if the input changed
+      // anywhere in that window, different bits may have captured different values.
       `ASSERT(OutputDelay_A,
               rst_ni |-> ##3 (mubi_o == {NumCopies{$past(mubi_in_sva_q, 2)}} ||
-                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1)))
+                              $past(mubi_in_sva_q, 2) != $past(mubi_in_sva_q, 1) ||
+                              $past(mubi_in_sva_q, 1) != mubi_in_sva_q))
 `endif
     end
   end else begin : gen_no_flops


### PR DESCRIPTION
This updates the CDC random delay instrumentation to model three possible per-bit outcomes when a signal crosses into a destination clock domain:

- normal capture, where FF1 captures the new value and the synchronizer has the usual 2-cycle delay

- missed capture, where FF1 retains the previous value for one cycle and the synchronizer delay extends to 3 cycles

- race-through, where the input races through FF1 during a setup/hold violation window and FF2 can capture it after only 1 cycle

To support the race-through case, prim_cdc_rand_delay now emits a race_through_o mask alongside the delayed data, and prim_flop_2sync uses that mask to bypass FF1 on a per-bit basis in simulation. Non-simulation behavior remains unchanged.

The LC and MuBi synchronizer assertions are updated to account for the new 1-3 cycle synchronization window. For MuBi synchronizers with stability checking enabled, the expected output delay range is adjusted to include the additional stability flop on top of the randomized synchronizer delay.

This also updates the MuBi sync template so regenerated MuBi synchronizer variants keep the same assertion behavior.