### PR TITLE
[ci] Stop installing libtinfo5 in prepare-env

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -61,16 +61,6 @@ runs:
         if command -v apt > /dev/null; then
           sudo apt update --fix-missing
           grep '^[^#]' apt-requirements.txt | xargs sudo apt install -y
-          sudo apt install wget
-          # TODO: Remove once Vivado no longer needs libtinfo5.
-          ARCH="$(dpkg --print-architecture)"
-          if [ "$ARCH" = "amd64" ]; then
-            POOL_URL=http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses
-          else
-            POOL_URL=http://ports.ubuntu.com/ubuntu-ports/pool/universe/n/ncurses
-          fi
-          wget "${POOL_URL}/libtinfo5_6.3-2ubuntu0.3_${ARCH}.deb"
-          sudo apt install "./libtinfo5_6.3-2ubuntu0.3_${ARCH}.deb"
         else
           # Install Extra Packages for Enterprise Linux first
           sudo yum install -y epel-release

--- a/doc/getting_started/install_vivado/README.md
+++ b/doc/getting_started/install_vivado/README.md
@@ -16,6 +16,21 @@ Then click on 'Vivado Archive' in the Version list and locate version {{#tool-ve
 
 See [Download and Installation](https://docs.xilinx.com/r/{{#tool-version vivado }}-English/ug973-vivado-release-notes-install-license/Download-and-Installation) for installation instructions.
 
+Vivado also needs system libraries that are not part of the Pavona dependencies, most notably `libtinfo5`.
+AMD ships an `installLibs.sh` script at the root of the installer image to install them; see [Checking Required Libraries](https://docs.amd.com/r/{{#tool-version vivado }}-English/ug973-vivado-release-notes-install-license/Checking-Required-Libraries).
+That script installs `libtinfo5` with `apt-get`, which fails from Ubuntu 24.04 onwards, where only `libtinfo6` is packaged.
+As a workaround, install the Ubuntu 22.04 ("jammy") package manually:
+
+```sh
+echo 'deb http://archive.ubuntu.com/ubuntu jammy universe' \
+  | sudo tee /etc/apt/sources.list.d/jammy.list >/dev/null
+sudo apt-get update
+sudo apt-get download libtinfo5
+sudo dpkg -i libtinfo5_*.deb
+sudo rm -f libtinfo5_*.deb /etc/apt/sources.list.d/jammy.list
+sudo apt-get update
+```
+
 When asked what edition to install, choose "Vivado HL Design Edition".
 _Note: If you are only developing software, you may select the "Lab Edition" instead._
 On the feature selection screen, select at least the following features:


### PR DESCRIPTION
libtinfo5 is only required by Vivado. The installation for CI has been moved into the the runner image.

The following steps work without pinning a specific version:
```
  echo 'deb http://archive.ubuntu.com/ubuntu jammy universe' \
    | sudo tee /etc/apt/sources.list.d/jammy.list >/dev/null
  sudo apt-get update
  sudo apt-get download libtinfo5
  sudo dpkg -i libtinfo5_*.deb
  sudo rm -f libtinfo5_*.deb /etc/apt/sources.list.d/jammy.list
  sudo apt-get update
```

(Tested on Ubuntu 24.04).

 - Fixes https://github.com/pavona/pavona/issues/271
 
I've also updated the documentation to to include the setup for Vivado. However, that section wants a larger overhaul.