### PR TITLE
 [acc] Fix ACCSim profiler per-function cycle counts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
         run: ruff check
       - name: Validate testplans with schema
         run: ./ci/scripts/validate_testplans.sh
+      - name: ACC assembly lint
+        run: ./ci/scripts/check-acc-asm.py
       - name: C/C++ formatting
         run: ./bazelisk.sh test //quality:clang_format_check
       - name: Rust formatting

--- a/ci/jobs/quick-lint.sh
+++ b/ci/jobs/quick-lint.sh
@@ -52,6 +52,9 @@ ci/scripts/mypy.sh $tgt_branch
 echo -e "\n### Validate testplans with schema."
 ci/scripts/validate_testplans.sh
 
+echo -e "\n### Check ACC assembly lint"
+ci/scripts/check-acc-asm.py
+
 echo -e "\n### Use clang-format to check C/C++ coding style"
 ci/scripts/clang-format.sh $tgt_branch
 

--- a/ci/scripts/check-acc-asm.py
+++ b/ci/scripts/check-acc-asm.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""Lint checks for ACC assembly.
+
+Each check is a function that takes a file's path and its lines and
+yields (lineno, message) violations. Register a check in CHECKS together
+with a predicate selecting the files it applies to.
+"""
+
+import re
+import subprocess
+import sys
+from typing import Callable, Iterator, List, Tuple
+
+Violation = Tuple[int, str]
+Check = Callable[[str, List[str]], Iterator[Violation]]
+Predicate = Callable[[str], bool]
+
+LABEL_RE = re.compile(r'^\s*([A-Za-z_.$][A-Za-z0-9_.$]*)\s*:')
+TYPE_RE = re.compile(r'\.type\s+([A-Za-z_.$][A-Za-z0-9_.$]*)\s*,\s*@function\b')
+
+
+def _iter_text_labels(lines: List[str]) -> Iterator[Tuple[int, str]]:
+    """Yield (lineno, label) for labels defined in an executable section."""
+    in_text = True
+    in_comment = False
+    for lineno, line in enumerate(lines, 1):
+        if in_comment:
+            if '*/' not in line:
+                continue
+            line = line.split('*/', 1)[1]
+            in_comment = False
+        line = re.sub(r'/\*.*?\*/', '', line)
+        if '/*' in line:
+            line = line.split('/*', 1)[0]
+            in_comment = True
+
+        stripped = line.strip()
+        if stripped.startswith('.section'):
+            in_text = '.text' in stripped
+        elif stripped.startswith('.text'):
+            in_text = True
+        elif stripped.startswith(('.data', '.bss', '.rodata')):
+            in_text = False
+
+        m = LABEL_RE.match(line)
+        if m and in_text:
+            yield lineno, m.group(1)
+
+
+def check_function_types(path: str, lines: List[str]) -> Iterator[Violation]:
+    """Function labels must carry a '.type <name>, @function' directive.
+
+    The ACC simulator's profiler attributes cycles to @function symbols, so
+    every function entry point needs the annotation to appear in the
+    per-function breakdown. Labels internal to a function (_ prefixed)
+    are exempt by convention, as are .L* assembler-local labels.
+    """
+    typed = set()
+    for line in lines:
+        m = TYPE_RE.search(line)
+        if m:
+            typed.add(m.group(1))
+
+    for lineno, name in _iter_text_labels(lines):
+        if name.startswith('_') or name.startswith('.L'):
+            continue
+        if name not in typed:
+            yield lineno, (f"function label '{name}' has no "
+                           f"'.type {name}, @function' annotation")
+
+
+def _is_crypto_lib(path: str) -> bool:
+    """Crypto library sources, excluding test programs."""
+    return (path.startswith('sw/acc/crypto/') and
+            not path.startswith('sw/acc/crypto/tests/'))
+
+
+CHECKS: List[Tuple[str, Check, Predicate]] = [
+    ('function-types', check_function_types, _is_crypto_lib),
+]
+
+
+def main() -> int:
+    files = subprocess.run(['git', 'ls-files', '--', 'sw/acc/*.s'],
+                           check=True, stdout=subprocess.PIPE,
+                           text=True).stdout.split()
+
+    ret = 0
+    for path in files:
+        with open(path) as f:
+            lines = f.read().splitlines()
+        for _name, check, applies in CHECKS:
+            if not applies(path):
+                continue
+            for lineno, msg in check(path, lines):
+                print(f"::error::{path}:{lineno}: {msg}")
+                ret = 1
+
+    return ret
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/hw/ip/acc/dv/accsim/sim/stats.py
+++ b/hw/ip/acc/dv/accsim/sim/stats.py
@@ -209,7 +209,9 @@ def _get_addr_symbol_map(elf_file: ELFFile) -> Dict[int, str]:
         return {}
 
     return {sym.entry.st_value: sym.name
-            for sym in section.iter_symbols() if sym.entry['st_shndx'] == 1}
+            for sym in section.iter_symbols()
+            if sym.entry['st_shndx'] == 1 and
+            sym.entry['st_info']['type'] == 'STT_FUNC'}
 
 
 class ExecutionStatAnalyzer:
@@ -233,14 +235,21 @@ class ExecutionStatAnalyzer:
         else:
             # |func_addr| is the largest possible |sym_addr| which is at most
             # |address|.
-            func_addr = 0
+            func_addr = -1
             for sym_addr in self._addr_symbol_map.keys():
                 if sym_addr <= address and sym_addr > func_addr:
                     func_addr = sym_addr
-            func_name = self._addr_symbol_map[func_addr]
-            if name_only:
-                return func_name
-            symbol_name = func_name + f"+{address - func_addr:#x}"
+            if func_addr >= 0:
+                func_name = self._addr_symbol_map[func_addr]
+                if name_only:
+                    return func_name
+                symbol_name = func_name + f"+{address - func_addr:#x}"
+            else:
+                # No function symbol precedes this address (e.g. code not
+                # annotated with .type); group it under a single label.
+                if name_only:
+                    return "<no function>"
+                symbol_name = "<no function>"
 
         file_line = None
         if self._elf_file.has_dwarf_info():
@@ -372,7 +381,8 @@ class ExecutionStatAnalyzer:
             has_one_callsite = False
             func = self._describe_imem_addr(rev_callee_func)
             callee = func
-            callee_func_only = re.findall(r'\(([^]]*)\)', callee)[0]
+            callee_matches = re.findall(r'\(([^]]*)\)', callee)
+            callee_func_only = callee_matches[0] if callee_matches else callee
             if callee_func_only not in self.func_calls:
                 self.func_calls[callee_func_only] = defaultdict(lambda: 0, {})
             out += f"Function {func}\n"

--- a/sw/acc/crypto/boot.s
+++ b/sw/acc/crypto/boot.s
@@ -63,6 +63,7 @@
 .equ MODE_ATTESTATION_KEY_SAVE, 0x64d
 
 .section .text.start
+.type start, @function
 start:
   /* Read the mode and tail-call the requested operation. */
   la    x2, mode
@@ -81,7 +82,7 @@ start:
   beq   x2, x3, attestation_key_save
 
   /* Invalid mode; fail. */
-start_failed:
+_start_failed:
   unimp
   unimp
   unimp
@@ -106,6 +107,7 @@ start_failed:
  * @param[out] dmem[ok]:  success/failure of basic checks (32 bits)
  * @param[out] dmem[x_r]: dmem buffer for reduced affine x_r-coordinate (x_1)
  */
+.type sigverify, @function
 sigverify:
   /* Validate the public key (ends the program on failure). */
   jal      x1, p256_check_public_key
@@ -127,6 +129,7 @@ sigverify:
  * @param[out]  dmem[x]: Public key x-coordinate.
  * @param[out]  dmem[y]: Public key y-coordinate.
  */
+.type attestation_keygen, @function
 attestation_keygen:
   /* Initialize all-zero register. */
   bn.xor   w31, w31, w31
@@ -185,6 +188,7 @@ attestation_keygen:
  * @param[out]   dmem[r]: Buffer for r component of signature (256 bits)
  * @param[out]   dmem[s]: Buffer for s component of signature (256 bits)
  */
+.type attestation_endorse, @function
 attestation_endorse:
   /* Generate a fresh random scalar for signing.
        dmem[k0] <= first share of k
@@ -218,6 +222,7 @@ attestation_endorse:
  * @param[out]  dmem[d0]: First share of private key (320 bits).
  * @param[out]  dmem[d1]: Second share of private key (320 bits).
  */
+.type attestation_key_save, @function
 attestation_key_save:
   /* Initialize all-zero register. */
   bn.xor   w31, w31, w31
@@ -262,6 +267,7 @@ attestation_key_save:
  * clobbered registers: x2, x3, x20, w1 to w4, w10, w11, w20 to w29
  * clobbered flag groups: FG0
  */
+.type attestation_secret_key_from_seed, @function
 attestation_secret_key_from_seed:
   /* Load keymgr seeds from WSRs.
        w20,w21 <= seed0

--- a/sw/acc/crypto/div.s
+++ b/sw/acc/crypto/div.s
@@ -28,6 +28,7 @@
  * clobbered registers: x2, x3, w23, w24
  * clobbered flag groups: none
  */
+.type bignum_rshift1, @function
 bignum_rshift1:
    /* Get a pointer to the end of the input.
         x3 <= x3 + x30 << 5 = dptr_a + n*32 */
@@ -78,6 +79,7 @@ bignum_rshift1:
  * clobbered registers: x3, w23, w24
  * clobbered flag groups: none
  */
+.type bignum_lshift256, @function
 bignum_lshift256:
   /* Loop invariants for iteration i:
        x3 = dptr_a + i*32
@@ -145,6 +147,7 @@ bignum_lshift256:
  * clobbered registers: x2 to x5, w23 to w25
  * clobbered flag groups: FG0
  */
+.type cond_sub_shifted, @function
 cond_sub_shifted:
   /* x3 <= x8 << 5 = i*32 */
   slli     x3, x8, 5
@@ -274,6 +277,7 @@ cond_sub_shifted:
  * clobbered registers: x2 to x5, x8, x23 to x25, w23 to w27
  * clobbered flag groups: FG0
  */
+.type div, @function
 div:
   /* Initialize quotient to zero.
        dmem[dptr_q..dptr_q+n*32] = 0  */
@@ -402,6 +406,7 @@ div:
  * clobbered registers: x2 to x5, x8, w23 to w25, w27
  * clobbered flag groups: FG0
  */
+.type mod, @function
 mod:
   /* Initialize loop counter.
        x8 <= x30 = n */

--- a/sw/acc/crypto/ed25519.s
+++ b/sw/acc/crypto/ed25519.s
@@ -75,6 +75,7 @@
  * clobbered flag groups: FG0
  */
 .globl ed25519_verify_var
+.type ed25519_verify_var, @function
 ed25519_verify_var:
   /* Set up for scalar arithmetic.
        [w15:w14] <= mu
@@ -110,7 +111,7 @@ ed25519_verify_var:
 
   /* Fail if S >= L. */
   li       x3, 1
-  bne      x2, x3, verify_fail
+  bne      x2, x3, _verify_fail
 
   /* Compute (8 * S) mod L.
        w1 <= (2 * (2 * (2 * w1) mod L) mod L) mod L = (8 * S) mod L */
@@ -144,7 +145,7 @@ ed25519_verify_var:
 
   /* If R was not a valid point (x20 != SUCCESS), fail. */
   li      x21, 0xf77fe650
-  bne     x20, x21, verify_fail
+  bne     x20, x21, _verify_fail
 
   /* Save R (in affine coordinates) for later.
        [w5:w4] <= [w11:w10] = R */
@@ -163,7 +164,7 @@ ed25519_verify_var:
   jal      x1, affine_decode_var
 
   /* If A was not a valid point (x20 != SUCCESS), fail. */
-  bne      x20, x21, verify_fail
+  bne      x20, x21, _verify_fail
 
   /* Convert A to extended coordinates.
       [w9:w6] <= extended(A) = (A.X, A.Y, A.Z, A.T) */
@@ -229,7 +230,7 @@ ed25519_verify_var:
 
   ret
 
-  verify_fail:
+  _verify_fail:
   /* Write the FAILURE magic value.
        dmem[ed25519_verify_result] <= x23 = FAILURE */
   li       x22, 0xeda2bfaf
@@ -270,6 +271,7 @@ ed25519_verify_var:
  * clobbered flag groups: FG0
  */
 .globl ed25519_sign_prehashed
+.type ed25519_sign_prehashed, @function
 ed25519_sign_prehashed:
   /* Initialize all-zero register. */
   bn.xor   w31, w31, w31
@@ -350,6 +352,7 @@ ed25519_sign_prehashed:
  * clobbered flag groups: FG0
  */
 .globl ed25519_sign_pure_init
+.type ed25519_sign_pure_init, @function
 ed25519_sign_pure_init:
   bn.xor   w31, w31, w31
   jal      x1, sha512_init
@@ -381,6 +384,7 @@ ed25519_sign_pure_init:
  * clobbered flag groups: FG0
  */
 .globl ed25519_sign_pure_update
+.type ed25519_sign_pure_update, @function
 ed25519_sign_pure_update:
   bn.xor   w31, w31, w31
   la       x18, ed25519_message_len
@@ -410,6 +414,7 @@ ed25519_sign_pure_update:
  * clobbered flag groups: FG0
  */
 .globl ed25519_sign_pure_mid
+.type ed25519_sign_pure_mid, @function
 ed25519_sign_pure_mid:
   bn.xor   w31, w31, w31
 
@@ -450,6 +455,7 @@ ed25519_sign_pure_mid:
  * clobbered flag groups: FG0
  */
 .globl ed25519_sign_pure_final
+.type ed25519_sign_pure_final, @function
 ed25519_sign_pure_final:
   bn.xor   w31, w31, w31
 
@@ -701,6 +707,7 @@ _ed25519_sign_compute_s:
  * clobbered registers: w16, w17
  * clobbered flag groups: FG0
  */
+.type sc_clamp, @function
 sc_clamp:
   /* w16 <= w16 >> 3 = h[255:3] */
   bn.rshi  w16, w31, w16 >> 3
@@ -755,6 +762,7 @@ sc_clamp:
  * clobbered registers: w6 to w9, w18, w20 to w23
  * clobbered flag groups: FG0
  */
+.type affine_to_ext, @function
 affine_to_ext:
   /* w8 <= 1 = Z */
   bn.addi  w8, w31, 1
@@ -801,6 +809,7 @@ affine_to_ext:
  * clobbered registers: w10, w11, w14 to w18, w20 to w23
  * clobbered flag groups: FG0
  */
+.type ext_to_affine, @function
 ext_to_affine:
   /* w22 <= (Z^-1) mod p */
   bn.mov  w16, w12
@@ -850,6 +859,7 @@ ext_to_affine:
  * clobbered flag groups: FG0
  */
 .globl affine_encode
+.type affine_encode, @function
 affine_encode:
   /* w10 <= lsb(x) << 255 */
   bn.rshi  w10, w10, w31 >> 1
@@ -895,6 +905,7 @@ affine_encode:
  * clobbered flag groups: FG0
  */
 .globl affine_decode_var
+.type affine_decode_var, @function
 affine_decode_var:
   /* Extract lsb(x) from the encoded point.
        w24 <= w11 >> 255 = lsb(x) */
@@ -912,7 +923,7 @@ affine_decode_var:
   bn.cmp   w11, w14
   li       x3, 8
   csrrs    x2, FG0, x0
-  beq      x2, x3, decode_y_ok
+  beq      x2, x3, _decode_y_ok
 
   /* If we get here, then y >= p; reject the point. */
   li       x20, 0xeda2bfaf
@@ -920,7 +931,7 @@ affine_decode_var:
   bn.mov   w11, w31
   ret
 
-  decode_y_ok:
+  _decode_y_ok:
 
   /* Solve the curve equation to get a candidate root. From RFC 8032,
      section 5.1.3, step 2:
@@ -1055,7 +1066,7 @@ affine_decode_var:
   and      x2, x2, x3
 
   /* Go to step 3, case 1 if we are in case 1. */
-  beq      x2, x3, decode_step3_case1
+  beq      x2, x3, _decode_step3_case1
 
   /* Check for case 2: (r^2 * v) mod p == (- u) mod p */
 
@@ -1069,7 +1080,7 @@ affine_decode_var:
   and      x2, x2, x3
 
   /* Go to step 3, case 2 if we are in case 2. */
-  beq      x2, x3, decode_step3_case2
+  beq      x2, x3, _decode_step3_case2
 
   /* If we get here, then r^2 was not equal to either (u/v) or - (u/v), so we
      are in case 3, (u/v) is nonsquare mod p, and point decoding fails. */
@@ -1078,7 +1089,7 @@ affine_decode_var:
   bn.mov   w11, w31
   ret
 
-  decode_step3_case2:
+  _decode_step3_case2:
   /* Multiply r by sqrt(-1) = 2^((p-1)/4). */
 
   /* w23 <= dmem[ed25519_sqrt_m1] = sqrt(-1) mod p */
@@ -1093,7 +1104,7 @@ affine_decode_var:
 
   /* From here, r^2 = x^2 and we can proceed with the same steps as case 1. */
 
-  decode_step3_case1:
+  _decode_step3_case1:
   /* Once we're here, we know that r^2 = x^2, and therefore r is either x or
      -x. Following RFC 8032, section 5.1.3, step 4, we set the resulting
      point's x coordinate to r if lsb(x) from the encoded point matches lsb(r),
@@ -1127,7 +1138,7 @@ affine_decode_var:
   bn.xor   w14, w10, w24
   csrrs    x2, FG0, x0
   andi     x2, x2, 4
-  beq      x2, x0, decode_success
+  beq      x2, x0, _decode_success
 
   /* Exit with FAILURE. */
   li       x20, 0xeda2bfaf
@@ -1135,7 +1146,7 @@ affine_decode_var:
   bn.mov   w11, w31
   ret
 
-  decode_success:
+  _decode_success:
   /* TODO: add an extra check that the curve equation is satisfied to protect
      against glitching? */
 
@@ -1185,6 +1196,7 @@ affine_decode_var:
  * clobbered flag groups: FG0
  */
 .globl ext_scmul
+.type ext_scmul, @function
 ext_scmul:
   /* Initialize the intermediate result P to the origin point.
        [w13:w10] <= (0, 1, 1, 0) */
@@ -1291,6 +1303,7 @@ ext_scmul:
  * clobbered flag groups: FG0
  */
 .globl ext_scmul_var
+.type ext_scmul_var, @function
 ext_scmul_var:
   /* Initialize the intermediate result P to the origin point.
        [w13:w10] <= (0, 1, 1, 0) */
@@ -1388,6 +1401,7 @@ ext_scmul_var:
  * clobbered flag groups: FG0
  */
 .globl ext_double
+.type ext_double, @function
 ext_double:
   /* w24 = (X1^2) = A */
   bn.mov    w22, w10
@@ -1491,6 +1505,7 @@ ext_double:
  * clobbered flag groups: FG0
  */
 .globl ext_add
+.type ext_add, @function
 ext_add:
   /* Compute A = (Y1 - X1) * (Y2 - X2). */
 
@@ -1617,6 +1632,7 @@ ext_add:
  * clobbered registers: w14 to w17
  * clobbered flag groups: FG0
  */
+.type ext_equal_var, @function
 ext_equal_var:
   /* x22 <= FAILURE */
   li       x22, 0xeda2bfaf
@@ -1653,7 +1669,7 @@ ext_equal_var:
 
   /* Fail if the FG0.Z flag was unset. */
   li       x3, 8
-  bne      x2, x3, ext_equal_var_fail
+  bne      x2, x3, _ext_equal_var_fail
 
   /* Compute (Y1 * Z2). */
 
@@ -1685,7 +1701,7 @@ ext_equal_var:
 
   /* Fail if the FG0.Z flag was unset. */
   li       x3, 8
-  bne      x2, x3, ext_equal_var_fail
+  bne      x2, x3, _ext_equal_var_fail
 
   /* If we got here, both checks passed; write the SUCCESS value to DMEM.
 
@@ -1701,7 +1717,7 @@ ext_equal_var:
 
   ret
 
-  ext_equal_var_fail:
+  _ext_equal_var_fail:
   /* Write the FAILURE magic value.
        dmem[ed25519_verify_result] <= x22 = FAILURE */
   la       x4, ed25519_verify_result
@@ -1733,6 +1749,7 @@ ext_equal_var:
  * clobbered registers: w14, w15, w17, w18, w20 to w23
  * clobbered flag groups: FG0
  */
+.type fe_pow_2252m3, @function
 fe_pow_2252m3:
   /* w22 <= w16^2 = a^2 */
   bn.mov  w22, w16

--- a/sw/acc/crypto/ed25519_scalar.s
+++ b/sw/acc/crypto/ed25519_scalar.s
@@ -30,6 +30,7 @@
  * clobbered flag groups: FG0
  */
 .globl sc_init
+.type sc_init, @function
 sc_init:
   /* Load modulus L into the MOD register. */
   li      x2, 14
@@ -126,6 +127,7 @@ sc_init:
  * clobbered flag groups: FG0
  */
 .globl sc_reduce
+.type sc_reduce, @function
 sc_reduce:
   /* First, compute q3 = (x * mu) >> 512.
 
@@ -257,6 +259,7 @@ sc_reduce:
  * clobbered flag groups: FG0
  */
 .globl sc_mul
+.type sc_mul, @function
 sc_mul:
   /* Compute the raw 512-bit product.
      [w17:w16] <= a * b */

--- a/sw/acc/crypto/field25519.s
+++ b/sw/acc/crypto/field25519.s
@@ -25,6 +25,7 @@
  * clobbered flag groups: FG0
  */
 .globl fe_init
+.type fe_init, @function
 fe_init:
   /* Load modulus p into the MOD register. */
   li      x2, 19
@@ -59,6 +60,7 @@ fe_init:
  * clobbered flag groups: FG0
  */
 .globl fe_mul
+.type fe_mul, @function
 fe_mul:
   /* Partial products for multiply-reduce:
 
@@ -171,6 +173,7 @@ fe_mul:
  * clobbered flag groups: FG0
  */
 .globl fe_square
+.type fe_square, @function
 fe_square:
   /* Partial products for square:
 
@@ -299,6 +302,7 @@ fe_square:
  * clobbered flag groups: FG0
  */
 .globl fe_inv
+.type fe_inv, @function
 fe_inv:
   /* w22 <= w16^2 = a^2 */
   bn.mov  w22, w16

--- a/sw/acc/crypto/gcd.s
+++ b/sw/acc/crypto/gcd.s
@@ -24,6 +24,7 @@
  * clobbered registers: x3, x4, x5, w23, w24
  * clobbered flag groups: FG0
  */
+.type gcd_cond_sub, @function
 gcd_cond_sub:
   /* Clear flags. */
   bn.add    w31, w31, w31
@@ -63,6 +64,7 @@ gcd_cond_sub:
  * clobbered registers: x3, x4, x22, x23, x24, w23, w24
  * clobbered flag groups: FG0
  */
+.type gcd_cond_rshift1, @function
 gcd_cond_rshift1:
   /* x22 <= x30 - 1 = n - 1 */
   addi      x22, x0, 1
@@ -127,6 +129,7 @@ gcd_cond_rshift1:
  * clobbered registers: x3, x22, w20, w23, w24, w25
  * clobbered flag groups: FG0
  */
+.type gcd_cond_lshift1, @function
 gcd_cond_lshift1:
   /* Check if counter is zero.
        FG0.Z <= ctr != 0 */
@@ -200,6 +203,7 @@ gcd_cond_lshift1:
  * clobbered flag groups: FG0, FG1
  */
 .globl gcd
+.type gcd, @function
 gcd:
   /* Initialize the shift to 0.
        w20 <= 0 = shift */

--- a/sw/acc/crypto/handwritten/rsa_verify_3072.s
+++ b/sw/acc/crypto/handwritten/rsa_verify_3072.s
@@ -23,6 +23,7 @@
  * clobbered registers: w26, w27
  * clobbered flag groups: none
  */
+.type mul256_w30xw25, @function
 mul256_w30xw25:
   bn.mulqacc.z          w30.0, w25.0,  0
   bn.mulqacc            w30.1, w25.0, 64
@@ -58,6 +59,7 @@ mul256_w30xw25:
  * clobbered registers: w26, w27
  * clobbered flag groups: none
  */
+.type mul256_w30xw2, @function
 mul256_w30xw2:
   bn.mulqacc.z          w30.0, w2.0,  0
   bn.mulqacc            w30.1, w2.0, 64
@@ -113,6 +115,7 @@ mul256_w30xw2:
  *                      w24, w25, w26, w27, w28, w29, w30, w4 to w15
  * clobbered Flag Groups: FG0, FG1
  */
+.type mont_loop, @function
 mont_loop:
   /* save pointer to modulus */
   addi      x22, x16, 0
@@ -231,7 +234,7 @@ mont_loop:
   /* No subtracion if carry bit of addition of carry words not set. */
   csrrs     x2, FG1, x0
   andi      x2, x2, 1
-  beq       x2, x0, mont_loop_no_sub
+  beq       x2, x0, _mont_loop_no_sub
 
   /* limb-wise subtraction */
   li        x12, 30
@@ -245,7 +248,7 @@ mont_loop:
     bn.movr   x8++, x13
 
 
-  mont_loop_no_sub:
+  _mont_loop_no_sub:
 
   /* restore pointers */
   li        x8, 4
@@ -280,6 +283,7 @@ mont_loop:
  * clobbered Flag Groups: FG0, FG1
  */
 .globl montmul
+.type montmul, @function
 montmul:
   /* load Montgomery constant: w3 = dmem[x17] = dmem[dptr_m0d] = m0' */
   bn.lid    x9, 0(x17)
@@ -340,6 +344,7 @@ montmul:
  * clobbered Flag Groups: FG0, FG1
  */
  .globl modexp_var_3072_f4
+.type modexp_var_3072_f4, @function
 modexp_var_3072_f4:
   /* Prepare all-zero reg. */
   bn.xor    w31, w31, w31
@@ -394,10 +399,10 @@ modexp_var_3072_f4:
             alert. */
   andi      x2, x2, 1
   li        x8, 4
-  bne       x2, x0, f4_no_sub
+  bne       x2, x0, _f4_no_sub
   li        x8, 16
 
-  f4_no_sub:
+  _f4_no_sub:
 
   /* Store result in output buffer. */
   addi      x21, x24, 0

--- a/sw/acc/crypto/lcm.s
+++ b/sw/acc/crypto/lcm.s
@@ -25,6 +25,7 @@
  * clobbered registers: x2 to x8, x20 to x25, w20 to w25
  * clobbered flag groups: FG0
  */
+.type lcm, @function
 lcm:
   /* Initialize wide-register pointers. */
   li       x20, 20

--- a/sw/acc/crypto/mldsa/intt.s
+++ b/sw/acc/crypto/mldsa/intt.s
@@ -26,6 +26,7 @@
  * clobbered registers: x5-x7, x10-x12, w0-w15, w17-w21, w24-w30
  */
 .global intt
+.type intt, @function
 intt:
 
     /* Load twiddle factors. */

--- a/sw/acc/crypto/mldsa/kmac_send_msg.s
+++ b/sw/acc/crypto/mldsa/kmac_send_msg.s
@@ -30,6 +30,7 @@
  * clobbered flag groups: None
  */
 .globl keccak_send_message
+.type keccak_send_message, @function
 keccak_send_message:
   /* Compute the number of full 256-bit message chunks.
   t0 <= x11 >> 5 = floor(len / 32) */

--- a/sw/acc/crypto/mldsa/mldsa_keypair.s
+++ b/sw/acc/crypto/mldsa/mldsa_keypair.s
@@ -84,6 +84,7 @@
  * clobbered registers: a0-a6, t0-t5, s1, w0-w30
  */
 .globl crypto_sign_keypair
+.type crypto_sign_keypair, @function
 crypto_sign_keypair:
     la   s11, mldsa_params
     lw   s10, MLDSA_PARAM_K_OFFSET(s11)

--- a/sw/acc/crypto/mldsa/mldsa_sign.s
+++ b/sw/acc/crypto/mldsa/mldsa_sign.s
@@ -108,6 +108,7 @@
  *
  */
 .global crypto_sign_signature_internal
+.type crypto_sign_signature_internal, @function
 crypto_sign_signature_internal:
     /* Store pointer parameters. */
     la  t0, dptr_sig

--- a/sw/acc/crypto/mldsa/mldsa_verify.s
+++ b/sw/acc/crypto/mldsa/mldsa_verify.s
@@ -100,6 +100,7 @@
  *
  */
 .globl crypto_sign_verify_internal
+.type crypto_sign_verify_internal, @function
 crypto_sign_verify_internal:
     la   s11, mldsa_params
 

--- a/sw/acc/crypto/mldsa/ntt.s
+++ b/sw/acc/crypto/mldsa/ntt.s
@@ -26,6 +26,7 @@
  * clobbered registers: x5-x7, x10-x12, w0-w15, w17-w19, w24-w30
  */
 .globl ntt
+.type ntt, @function
 ntt:
     /* Load twiddle factors. */
     la   x11, twiddles_fwd

--- a/sw/acc/crypto/mldsa/poly.s
+++ b/sw/acc/crypto/mldsa/poly.s
@@ -88,6 +88,7 @@
  */
 
 .global polyt1_unpack
+.type polyt1_unpack, @function
 polyt1_unpack:
 
     /* Setup WDR */
@@ -185,6 +186,7 @@ _inner_polyt1_unpack:
  * clobbered registers: a0-a1, t0-t6
  */
 .global polyz_unpack
+.type polyz_unpack, @function
 polyz_unpack:
     /* Dispatch on x14 (K): K==4 means GAMMA1=2^17, otherwise 2^19. */
     li  t0, 4
@@ -192,6 +194,7 @@ polyz_unpack:
     jal x0, polyz_unpack_19
 
 .global polyz_unpack_17
+.type polyz_unpack_17, @function
 polyz_unpack_17:
      /* Load gamma1 as a vector into w4 */
     li t2, 4
@@ -285,6 +288,7 @@ _inner_polyz_unpack_17:
     ret
 
 .global polyz_unpack_19
+.type polyz_unpack_19, @function
 polyz_unpack_19:
     /* Load gamma1 as a vector into w4 */
     li t2, 4
@@ -371,6 +375,7 @@ _inner_polyz_unpack_19:
  * clobbered registers: a0, a2, t0-t2, w0-w4
  */
  .global poly_chknorm
+.type poly_chknorm, @function
 poly_chknorm:
     /* Load the bound into a wide register. */
     la      t2, poly_wdr2gpr
@@ -444,6 +449,7 @@ poly_chknorm:
  * clobbered registers: a0-a5, t0-t4, w0-w3
  */
 .global poly_challenge
+.type poly_challenge, @function
 poly_challenge:
     /* save output pointer */
     addi a4, a0, 0
@@ -580,6 +586,7 @@ _loop_inner_skip_load_poly_challenge:
  * clobbered registers: a0-a3, t0-t6, w0, w8-w15, w21
  */
 .global poly_uniform
+.type poly_uniform, @function
 poly_uniform:
     /* Define temporary registers. */
     #define shake_reg w8
@@ -1193,6 +1200,7 @@ _poly_uniform_recompute_first_bad_index:
  *
  * clobbered registers: w10, w21
  */
+.type poly_uniform_mask_and_check_vectors, @function
 poly_uniform_mask_and_check_vectors:
     loop  t1, 8
       /* Load the next vector. */
@@ -1225,6 +1233,7 @@ poly_uniform_mask_and_check_vectors:
  * clobbered registers: a1, a3-a5, w8-w15, w20, t0-t6
  */
 .global poly_uniform_eta
+.type poly_uniform_eta, @function
 poly_uniform_eta:
     /* Dispatch on x14 (K): K==6 means ETA=4, otherwise ETA=2. */
     li  t0, 6
@@ -1232,6 +1241,7 @@ poly_uniform_eta:
     jal x0, poly_uniform_eta_eta_2
 
 .global poly_uniform_eta_eta_2
+.type poly_uniform_eta_eta_2, @function
 poly_uniform_eta_eta_2:
     /* Save nonce to memory (use poly tmp buffer). */
     la t0, poly_wdr2gpr
@@ -1328,6 +1338,7 @@ _rej_eta_sample_loop_continue_eta_2:
 
 
 .global poly_uniform_eta_eta_4
+.type poly_uniform_eta_eta_4, @function
 poly_uniform_eta_eta_4:
     /* Save nonce to memory (use poly tmp buffer). */
     la t0, poly_wdr2gpr
@@ -1468,6 +1479,7 @@ _poly_uniform_eta_arithmetic_eta_4:
  * clobbered registers: a0-a2, t0-t1, w0-w15, w30
  */
 .global poly_use_hint
+.type poly_use_hint, @function
 poly_use_hint:
     /* Dispatch on x14 (K): K==4 means GAMMA2=(Q-1)/88, otherwise (Q-1)/32. */
     li  t0, 4
@@ -1475,6 +1487,7 @@ poly_use_hint:
     jal x0, poly_use_hint_32
 
 .global poly_use_hint_88
+.type poly_use_hint_88, @function
 poly_use_hint_88:
     la t0, decompose_127_const
     li t1, 5
@@ -1527,6 +1540,7 @@ poly_use_hint_88:
     ret
 
 .global poly_use_hint_32
+.type poly_use_hint_32, @function
 poly_use_hint_32:
     la t0, decompose_127_const
     li t1, 5
@@ -1593,6 +1607,7 @@ poly_use_hint_32:
  * clobbered registers: a0-a1, t0-t2
  */
 .global polyt1_pack
+.type polyt1_pack, @function
 polyt1_pack:
     li t1, 1
     li t4, 4
@@ -1710,6 +1725,7 @@ _inner_polyt1_pack:
  * clobbered registers: a0-a1, t0-t3, w1, w2
  */
 .global polyeta_pack
+.type polyeta_pack, @function
 polyeta_pack:
     /* Dispatch on x14 (K): K==6 means ETA=4, otherwise ETA=2. */
     li  t0, 6
@@ -1717,6 +1733,7 @@ polyeta_pack:
     jal x0, polyeta_pack_eta_2
 
 .global polyeta_pack_eta_2
+.type polyeta_pack_eta_2, @function
 polyeta_pack_eta_2:
     /* Compute ETA - coeff */
     /* Setup WDRs */
@@ -1790,6 +1807,7 @@ _inner_polyeta_pack_eta_2:
     ret
 
 .global polyeta_pack_eta_4
+.type polyeta_pack_eta_4, @function
 polyeta_pack_eta_4:
     /* Compute ETA - coeff */
     /* Setup WDRs */
@@ -1843,6 +1861,7 @@ _inner_polyeta_pack_eta_4:
  * clobbered registers: a0-a1, t0-t3, w1, w2
  */
 .global polyt0_pack
+.type polyt0_pack, @function
 polyt0_pack:
     /* Compute (1 << (D-1)) - coeff */
     /* Setup WDRs */
@@ -1969,6 +1988,7 @@ _inner_polyt0_pack:
  * clobbered registers: a0, t0, w0-w4
  */
 .global poly_nonzero_encode
+.type poly_nonzero_encode, @function
 poly_nonzero_encode:
     /* Initialize accumulator to zero. */
     bn.mov w0, w31
@@ -2012,6 +2032,7 @@ poly_nonzero_encode:
  * clobbered registers: a0-a1, t0-t2
  */
 .global polyw1_pack
+.type polyw1_pack, @function
 polyw1_pack:
     /* Dispatch on x14 (K): K==4 means GAMMA2=(Q-1)/88, otherwise (Q-1)/32. */
     li  t0, 4
@@ -2019,6 +2040,7 @@ polyw1_pack:
     jal x0, polyw1_pack_32
 
 .global polyw1_pack_88
+.type polyw1_pack_88, @function
 polyw1_pack_88:
 
     /* Setup WDRs */
@@ -2061,6 +2083,7 @@ _inner_polyw1_pack_88:
     ret
 
 .global polyw1_pack_32
+.type polyw1_pack_32, @function
 polyw1_pack_32:
 
     /* Setup WDRs */
@@ -2095,6 +2118,7 @@ _inner_polyw1_pack_32:
  * clobbered registers: a0-a1, t0-t2, w1-w2
  */
 .global polyeta_unpack
+.type polyeta_unpack, @function
 polyeta_unpack:
     /* Dispatch on x14 (K): K==6 means ETA=4, otherwise ETA=2. */
     li  t0, 6
@@ -2102,6 +2126,7 @@ polyeta_unpack:
     jal x0, polyeta_unpack_eta_2
 
 .global polyeta_unpack_eta_2
+.type polyeta_unpack_eta_2, @function
 polyeta_unpack_eta_2:
     /* Setup WDR */
     li t1, 1
@@ -2166,6 +2191,7 @@ _inner_polyeta_unpack_eta_2:
     ret
 
 .global polyeta_unpack_eta_4
+.type polyeta_unpack_eta_4, @function
 polyeta_unpack_eta_4:
     /* Setup WDR */
     li t1, 1
@@ -2247,6 +2273,7 @@ _inner_polyeta_unpack_eta_4:
  * clobbered registers: a0-a7, t0-t6
  */
 .global poly_decode_h
+.type poly_decode_h, @function
 poly_decode_h:
     /* Initialize h[i] to zero */
     add t1, zero, a0
@@ -2388,6 +2415,7 @@ _ret1_decode_h:
  * clobbered registers: a0-a1, t2, t3, t5, t6, w1-w2
  */
 .global polyt0_unpack
+.type polyt0_unpack, @function
 polyt0_unpack:
     /* Load (1 << (D-1)) as a vector into w4 */
     li t2, 4
@@ -2515,6 +2543,7 @@ _inner_polyt0_unpack:
  * clobbered registers: a1, t0-t3, w1-w6
  */
 .global poly_uniform_gamma_1
+.type poly_uniform_gamma_1, @function
 poly_uniform_gamma_1:
     /* Dispatch on x14 (K): K==4 means GAMMA1=2^17, otherwise 2^19. */
     li  t0, 4
@@ -2522,6 +2551,7 @@ poly_uniform_gamma_1:
     jal x0, poly_uniform_gamma_1_19
 
 .global poly_uniform_gamma_1_17
+.type poly_uniform_gamma_1_17, @function
 poly_uniform_gamma_1_17:
     /* copy output pointer */
     addi t1, a0, 0
@@ -2642,6 +2672,7 @@ _inner_poly_uniform_gamma_1_17:
     ret
 
 .global poly_uniform_gamma_1_19
+.type poly_uniform_gamma_1_19, @function
 poly_uniform_gamma_1_19:
     /* copy output pointer */
     addi t1, a0, 0
@@ -2751,6 +2782,7 @@ _inner_poly_uniform_gamma_1_19:
  * clobbered registers: w0-w11, a0-a2, t0-t4
  */
 .global poly_decompose
+.type poly_decompose, @function
 poly_decompose:
     /* Dispatch on x14 (K): K==4 means GAMMA2=(Q-1)/88, otherwise (Q-1)/32. */
     li  t0, 4
@@ -2758,6 +2790,7 @@ poly_decompose:
     jal x0, poly_decompose_32
 
 .global poly_decompose_88
+.type poly_decompose_88, @function
 poly_decompose_88:
     la t0, decompose_127_const
     li t1, 5
@@ -2800,6 +2833,7 @@ poly_decompose_88:
     ret
 
 .global poly_decompose_32
+.type poly_decompose_32, @function
 poly_decompose_32:
     la t0, decompose_127_const
     li t1, 5
@@ -2862,6 +2896,7 @@ poly_decompose_32:
  * clobbered registers: t0-t2, t5-t6, a0-a2, a4-a7
  */
 .global poly_make_hint
+.type poly_make_hint, @function
 poly_make_hint:
     li   t2, 0
     li   t4, 1
@@ -2929,6 +2964,7 @@ _loop_end_poly_make_hint:
  * clobbered registers: a0-a1, t0-t2, w0-w1
  */
 .global polyz_pack
+.type polyz_pack, @function
 polyz_pack:
     /* Dispatch on x14 (K): K==4 means GAMMA1=2^17, otherwise 2^19. */
     li  t0, 4
@@ -2936,6 +2972,7 @@ polyz_pack:
     jal x0, polyz_pack_19
 
 .global polyz_pack_17
+.type polyz_pack_17, @function
 polyz_pack_17:
     la t1, gamma1_vec_const_17
     li t3, 3
@@ -3122,6 +3159,7 @@ _inner_polyz_pack_17:
     ret
 
 .global polyz_pack_19
+.type polyz_pack_19, @function
 polyz_pack_19:
     la t1, gamma1_vec_const_19
     li t3, 3
@@ -3199,6 +3237,7 @@ _inner_polyz_pack_19:
  * clobbered registers: a1-a2, t0-t6
  */
 .global poly_encode_h
+.type poly_encode_h, @function
 poly_encode_h:
     /* Masking constant for alignment */
     li t0, 0xFFFFFFFC
@@ -3253,6 +3292,7 @@ _skip_store_poly_encode_h:
  * clobbered registers: x4-x7, x10-x11, w2-w6
  */
 .globl poly_reduce32
+.type poly_reduce32, @function
 poly_reduce32:
     /* Set up constants for input/state */
     li t1, 3
@@ -3306,6 +3346,7 @@ poly_reduce32:
  * clobbered registers: x4-x7, w2-w4
  */
 .global poly_power2round
+.type poly_power2round, @function
 poly_power2round:
     #define D 13
     /* Set up constants for input/state */

--- a/sw/acc/crypto/mldsa/poly_add.s
+++ b/sw/acc/crypto/mldsa/poly_add.s
@@ -27,6 +27,7 @@
  * clobbered registers: x4-x6, w2-w4
  */
 .global poly_add
+.type poly_add, @function
 poly_add:
     /* Set up constants for input/state */
     li x4, 1

--- a/sw/acc/crypto/mldsa/poly_pointwise.s
+++ b/sw/acc/crypto/mldsa/poly_pointwise.s
@@ -27,6 +27,7 @@
  * clobbered registers: x4-x6, w2-w4
  */
 .globl poly_pointwise
+.type poly_pointwise, @function
 poly_pointwise:
     /* Set up constants for input/state */
     li x4, 1
@@ -65,6 +66,7 @@ poly_pointwise:
  * clobbered registers: x4-x6, w2-w4
  */
 .globl poly_pointwise_acc
+.type poly_pointwise_acc, @function
 poly_pointwise_acc:
     /* Set up constants for input/state */
     li x4, 1

--- a/sw/acc/crypto/mldsa/poly_sub.s
+++ b/sw/acc/crypto/mldsa/poly_sub.s
@@ -28,6 +28,7 @@
  *                      w2 to w3
  */
 .globl poly_sub
+.type poly_sub, @function
 poly_sub:
     /* Set up constants for input/state */
     li x4, 1

--- a/sw/acc/crypto/mldsa/rounding.s
+++ b/sw/acc/crypto/mldsa/rounding.s
@@ -31,6 +31,7 @@
  * clobbered registers: w1-w4, w30
  */
 .global decompose_88
+.type decompose_88, @function
 decompose_88:
     /* "a", "a{0,1}" refer to the variable names from the reference code */
 
@@ -62,6 +63,7 @@ decompose_88:
     ret
 
 .global decompose_32
+.type decompose_32, @function
 decompose_32:
     /* "a", "a{0,1}" refer to the variable names from the reference code */
 

--- a/sw/acc/crypto/mlkem/basemul.s
+++ b/sw/acc/crypto/mlkem/basemul.s
@@ -28,6 +28,7 @@
  */
 
 .globl basemul
+.type basemul, @function
 basemul:
   /* Set up wide registers for inputs*/
   li x4, 0
@@ -251,6 +252,7 @@ basemul:
  */
 
 .globl basemul_acc
+.type basemul_acc, @function
 basemul_acc:
   /* Set up wide registers for inputs*/
   li x4, 0

--- a/sw/acc/crypto/mlkem/cbd.s
+++ b/sw/acc/crypto/mlkem/cbd.s
@@ -27,6 +27,7 @@
  */
 
 .globl cbd2
+.type cbd2, @function
 cbd2:
     /* Set up wide registers for input and intermediate states */
     li x4, 0
@@ -83,6 +84,7 @@ cbd2:
  */
 
 .globl cbd3
+.type cbd3, @function
 cbd3:
     /* Set up wide registers for input and intermediate states */
     li x4, 0

--- a/sw/acc/crypto/mlkem/intt.s
+++ b/sw/acc/crypto/mlkem/intt.s
@@ -29,6 +29,7 @@
  */
 
 .globl intt
+.type intt, @function
 intt:
   /* Empty w18 */
   bn.xor w18, w18, w18

--- a/sw/acc/crypto/mlkem/kmac_send_msg.s
+++ b/sw/acc/crypto/mlkem/kmac_send_msg.s
@@ -27,6 +27,7 @@
  * clobbered flag groups: None
  */
 .globl keccak_send_message
+.type keccak_send_message, @function
 keccak_send_message:
   /* Compute the number of full 256-bit message chunks.
   t0 <= x11 >> 5 = floor(len / 32) */

--- a/sw/acc/crypto/mlkem/mlkem_decap.s
+++ b/sw/acc/crypto/mlkem/mlkem_decap.s
@@ -86,6 +86,7 @@
  * clobbered registers: a0-a4, t0-t5, w8, w16
  */
 .globl indcpa_dec
+.type indcpa_dec, @function
 indcpa_dec:
   /* Stack layout (worst-case K=4). V and SKPV follow B contiguously:
    *   STACK_DEC_B + K*512    : poly v
@@ -190,6 +191,7 @@ indcpa_dec:
  * clobbered registers: a0-a4, t0-t5, w8, w16
  */
 .globl crypto_kem_dec
+.type crypto_kem_dec, @function
 crypto_kem_dec:
   #define STACK_KEM_DEC_KEYA_ADDR -8
   #define STACK_KEM_DEC_H_ADDR   -12

--- a/sw/acc/crypto/mlkem/mlkem_encap.s
+++ b/sw/acc/crypto/mlkem/mlkem_encap.s
@@ -85,6 +85,7 @@
  * clobbered flag groups: FG0
  */
 .globl crypto_kem_enc
+.type crypto_kem_enc, @function
 crypto_kem_enc:
 
   /*** hash_h(pk) ***/

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_enc.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_enc.s
@@ -91,6 +91,7 @@
  * clobbered flag groups: FG0
  */
 .globl indcpa_enc
+.type indcpa_enc, @function
 indcpa_enc:
   /* Store parameters to save registers or memory. */
   addi t2, a1, 0

--- a/sw/acc/crypto/mlkem/mlkem_keypair.s
+++ b/sw/acc/crypto/mlkem/mlkem_keypair.s
@@ -84,6 +84,7 @@
  * clobbered registers: a0-a4, t0-t5, w8, w16
  */
 
+.type indcpa_keypair, @function
 indcpa_keypair:
   /* Stack address mapping. Worst-case (K=4) sizes throughout. */
   #define STACK_PK_ADDR        -32
@@ -290,6 +291,7 @@ indcpa_keypair:
  */
 
 .globl crypto_kem_keypair
+.type crypto_kem_keypair, @function
 crypto_kem_keypair:
   /* Set frame pointer */
   addi fp, sp, 0

--- a/sw/acc/crypto/mlkem/ntt.s
+++ b/sw/acc/crypto/mlkem/ntt.s
@@ -28,6 +28,7 @@
  */
 
 .globl ntt
+.type ntt, @function
 ntt:
   /* Set up wide registers for input and intermediate states */
   li x4, 0

--- a/sw/acc/crypto/mlkem/pack_ciphertext.s
+++ b/sw/acc/crypto/mlkem/pack_ciphertext.s
@@ -30,6 +30,7 @@
  * clobbered registers: x0-x30, w0-w31
  */
 
+.type poly_compress_dv4, @function
 poly_compress_dv4:
   /* Multiply the constant 80635 with 2**4 so that later we shift to the right
    * 32 bits instead of 28 bits. This means we can return the high parts of
@@ -74,6 +75,7 @@ poly_compress_dv4:
  * clobbered registers: x0-x30, w0-w31
  */
 
+.type poly_compress_dv5, @function
 poly_compress_dv5:
   bn.shv.8S w3, w2 >> 17 /* w3 = (0x340)^8 */
   bn.shv.8S w3, w3 << 1 /* w3 = (0x680)^8 */
@@ -213,6 +215,7 @@ poly_compress_dv5:
  * clobbered registers:
  */
 
+.type poly_compress_16, @function
 poly_compress_16:
   bn.trn1.16H          w1, w0, w31 /* Put even coeffs to 32-bit slots */
   bn.shv.8S            w1, w1 << 5 /* << 5 */
@@ -245,6 +248,7 @@ poly_compress_16:
  *
  * clobbered registers: x0-x30, w0-w31
  */
+.type polyvec_compress_du10, @function
 polyvec_compress_du10:
   bn.shv.8S w3, w2 >> 16 /* w2 = (0x681)^8 */
   bn.mov    w16, w5 /* w16 = (1290167) */
@@ -366,6 +370,7 @@ polyvec_compress_du10:
  *
  * clobbered registers: x0-x30, w0-w31
  */
+.type polyvec_compress_du11, @function
 polyvec_compress_du11:
   bn.shv.8S w3, w2 >> 17 /* w3 = (0x340)^8 */
   bn.shv.8S w3, w3 << 1 /* w3 = (0x680)^8 */
@@ -597,6 +602,7 @@ polyvec_compress_du11:
  * clobbered registers:
  */
 
+.type polyvec_compress_16_du10, @function
 polyvec_compress_16_du10:
   bn.trn1.16H          w1, w0, w31 /* Put even coeffs to 32-bit slots */
   bn.shv.8S            w1, w1 << 10 /* << 10 */
@@ -626,6 +632,7 @@ polyvec_compress_16_du10:
  * clobbered registers:
  */
 
+.type polyvec_compress_16_du11, @function
 polyvec_compress_16_du11:
   bn.trn1.16H          w1, w0, w31 /* Put even coeffs to 32-bit slots */
   bn.shv.8S            w1, w1 << 11 /* << 11 */
@@ -665,6 +672,7 @@ polyvec_compress_16_du11:
  */
 
 .globl pack_ciphertext
+.type pack_ciphertext, @function
 pack_ciphertext:
   /* Set up registers for input and output */
   li x4, 4
@@ -711,6 +719,7 @@ _pack_ciphertext_k4:
  * clobbered registers: x0-x30, w0-w31
  */
 
+.type poly_decompress_dv4, @function
 poly_decompress_dv4:
   bn.shv.16H w2, w2 >> 8 /* 0xf */
   LOOPI 4, 11
@@ -745,6 +754,7 @@ poly_decompress_dv4:
  * clobbered registers: x0-x30, w0-w31
  */
 
+.type poly_decompress_dv5, @function
 poly_decompress_dv5:
   /* Before, we used bn.mulv.l.8S.{even,odd}.lo to compute 16 16x16-bit
    * multiplications, because we need the full 32-bit results to shift them by
@@ -867,6 +877,7 @@ poly_decompress_dv5:
  *
  * clobbered registers:
  */
+.type poly_decompress_16, @function
 poly_decompress_16:
   bn.shv.16H           w1, w1 << 11 /* << 11 */
   bn.wsrw              0x3, w3 /* Write w3 to ACC */
@@ -895,6 +906,7 @@ poly_decompress_16:
  * clobbered registers: x0-x30, w0-w31
  */
 
+.type polyvec_decompress_du10, @function
 polyvec_decompress_du10:
   /* Before, we used bn.mulv.l.8S.{even,odd}.lo to compute 16 16x16-bit
    * multiplications, because we need the full 32-bit results to shift them by
@@ -1016,6 +1028,7 @@ polyvec_decompress_du10:
  * clobbered registers: x0-x30, w0-w31
  */
 
+.type polyvec_decompress_du11, @function
 polyvec_decompress_du11:
   LOOPI 4, 149
     /* First WDR: 176 bits */
@@ -1212,6 +1225,7 @@ polyvec_decompress_du11:
  *
  * clobbered registers:
  */
+.type polyvec_decompress_16_du10, @function
 polyvec_decompress_16_du10:
   bn.shv.16H           w1, w1 << 6 /* *(2**6) */
   bn.wsrw              0x3, w3 /* Write w3 to ACC */
@@ -1231,6 +1245,7 @@ polyvec_decompress_16_du10:
  *
  * clobbered registers:
  */
+.type polyvec_decompress_16_du11, @function
 polyvec_decompress_16_du11:
   bn.shv.16H           w1, w1 << 5 /* *(2**5) */
   bn.wsrw              0x3, w3 /* Write w3 to ACC */
@@ -1259,6 +1274,7 @@ polyvec_decompress_16_du11:
  */
 
 .globl unpack_ciphertext
+.type unpack_ciphertext, @function
 unpack_ciphertext:
   /* Set up registers for input and output */
   li x4, 1

--- a/sw/acc/crypto/mlkem/pack_keys.s
+++ b/sw/acc/crypto/mlkem/pack_keys.s
@@ -27,6 +27,7 @@
  * clobbered registers: x4-x9, w0-w5, w31
  */
 
+.type poly_tobytes, @function
 poly_tobytes:
   LOOPI 4, 37
     /* Load inputs */
@@ -102,6 +103,7 @@ poly_tobytes:
  */
 
 .globl pack_pk
+.type pack_pk, @function
 pack_pk:
   /* Set up wide registers for input and output */
   li x4, 0
@@ -144,6 +146,7 @@ pack_pk:
  */
 
 .globl pack_sk
+.type pack_sk, @function
 pack_sk:
   /* Set up wide registers for input and output */
   li x4, 0
@@ -179,6 +182,7 @@ pack_sk:
  * clobbered registers: x4-x8, w0-w4, w31
  */
 
+.type poly_frombytes, @function
 poly_frombytes:
   LOOPI 4, 35
     /* Load inputs */
@@ -249,6 +253,7 @@ poly_frombytes:
  */
 
 .globl unpack_pk
+.type unpack_pk, @function
 unpack_pk:
   /* Set up wide registers for input and output */
   li x4, 0
@@ -292,6 +297,7 @@ unpack_pk:
  */
 
 .globl unpack_sk
+.type unpack_sk, @function
 unpack_sk:
   /* Set up wide registers for input and output */
   li x4, 0

--- a/sw/acc/crypto/mlkem/poly.s
+++ b/sw/acc/crypto/mlkem/poly.s
@@ -41,6 +41,7 @@
  */
 
 .globl poly_frommsg
+.type poly_frommsg, @function
 poly_frommsg:
   /* Set up wide registers for input and output */
   li x4, 0
@@ -83,6 +84,7 @@ poly_frommsg:
  */
 
 .globl poly_tomsg
+.type poly_tomsg, @function
 poly_tomsg:
   /* Set up registers for input and output */
   li x4, 0
@@ -135,6 +137,7 @@ poly_tomsg:
  */
 
 .globl poly_getnoise_eta_init
+.type poly_getnoise_eta_init, @function
 poly_getnoise_eta_init:
   /* Initialize a SHAKE256 operation. */
   addi  x5, x0, 33
@@ -176,6 +179,7 @@ poly_getnoise_eta_init:
  */
 
 .globl poly_getnoise_eta_1
+.type poly_getnoise_eta_1, @function
 poly_getnoise_eta_1:
   /* eta1 = 3 for ML-KEM-512 (K=2), eta1 = eta2 = 2 for ML-KEM-768/1024
    * (K=3,4). Dispatch on x14 to the matching CBD sampler. */
@@ -199,6 +203,7 @@ poly_getnoise_eta_1:
  * clobbered registers: x4 to x6, x10 to x11, x17, x19 to x21, w0 to w9, w11, w20 to w21
  * clobbered flag groups: FG0
  */
+.type poly_getnoise_cbd3, @function
 poly_getnoise_cbd3:
   addi x10, x6, 0
 
@@ -237,7 +242,9 @@ poly_getnoise_cbd3:
  */
 
 .globl poly_getnoise_eta_2
+.type poly_getnoise_eta_2, @function
 poly_getnoise_eta_2:
+.type poly_getnoise_cbd2, @function
 poly_getnoise_cbd2:
   addi x10, x6, 0
 
@@ -268,6 +275,7 @@ poly_getnoise_cbd2:
  * clobbered flag groups: none
  */
 .globl poly_add
+.type poly_add, @function
 poly_add:
   li x4, 1
 
@@ -295,6 +303,7 @@ poly_add:
  * clobbered flag groups: none
  */
 .globl poly_sub
+.type poly_sub, @function
 poly_sub:
   li x4, 1
 
@@ -323,6 +332,7 @@ poly_sub:
  * clobbered flag groups: none
  */
 .globl poly_tomont
+.type poly_tomont, @function
 poly_tomont:
   /* Load const_tomont */
   li     x4, 0

--- a/sw/acc/crypto/mlkem/poly_gen_matrix.s
+++ b/sw/acc/crypto/mlkem/poly_gen_matrix.s
@@ -70,6 +70,7 @@
  */
 
 .globl poly_gen_matrix_init
+.type poly_gen_matrix_init, @function
 poly_gen_matrix_init:
   /* Initialize a SHAKE128 operation. */
   addi  t0, zero, 34
@@ -107,6 +108,7 @@ poly_gen_matrix_init:
  */
 
 .globl poly_gen_matrix
+.type poly_gen_matrix, @function
 poly_gen_matrix:
   /* t0 = 508, a1 + 508 is the last valid address */
   addi t0, a1, 512

--- a/sw/acc/crypto/modexp.s
+++ b/sw/acc/crypto/modexp.s
@@ -32,6 +32,7 @@
  * clobbered registers: x8, x21, w0, w2
  * clobbered Flag Groups: FG1
  */
+.type sel_sqr_or_sqrmul, @function
 sel_sqr_or_sqrmul:
   /* iterate over all limbs */
   loop      x30, 8
@@ -92,6 +93,7 @@ sel_sqr_or_sqrmul:
  *                      w4 to w[4+N-1]
  * clobbered Flag Groups: FG0, FG1
  */
+.type modexp, @function
 modexp:
   /* prepare pointers to temp regs */
   li         x8, 4
@@ -226,6 +228,7 @@ modexp:
  *                      w4 to w[4+N-1]
  * clobbered Flag Groups: FG0, FG1
  */
+.type modexp_crt, @function
 modexp_crt:
   /* temporarially halve the limb count to copy a cofactor
        x30 <= N >> 1 = N / 2 */
@@ -606,6 +609,7 @@ modexp_crt:
  *                      w4 to w[4+N-1]
  * clobbered Flag Groups: FG0, FG1
  */
+.type modexp_65537, @function
 modexp_65537:
   /* prepare pointers to temp regs */
   li         x8, 4
@@ -737,6 +741,7 @@ modexp_65537:
  * clobbered registers: x8, x16, x21, w2, w3
  * clobbered Flag Groups: FG0
  */
+.type cond_sub_to_dmem, @function
 cond_sub_to_dmem:
   /* iterate over all limbs for conditional limb-wise subtraction */
   loop      x30, 5
@@ -787,6 +792,7 @@ cond_sub_to_dmem:
  *                      w2, w3, w4 to w[4+N-1], w24 to w30
  * clobbered Flag Groups: FG0, FG1
  */
+.type montmul_mul1, @function
 montmul_mul1:
   /* load Montgomery constant: w3 = dmem[x17] = dmem[dptr_m0d] = m0' */
   bn.lid    x9, 0(x17)

--- a/sw/acc/crypto/modinv.s
+++ b/sw/acc/crypto/modinv.s
@@ -137,6 +137,7 @@
  * clobbered registers: x2 to x6, x31, w20 to w26
  * clobbered flag groups: FG0, FG1
  */
+.type modinv, @function
 modinv:
   /* Zero the intermediate buffers.
        dmem[dptr_A..dptr_A+(plen*32)] <= 0
@@ -659,6 +660,7 @@ _modinv_u_ok:
  * clobbered registers: x2, x3, x4, w20, w21
  * clobbered flag groups: FG0
  */
+.type bignum_rshift1_if_not_fg1L, @function
 bignum_rshift1_if_not_fg1L:
   /* Calculate number of loop iterations for bignum shifts.
        x2 <= n - 1 */

--- a/sw/acc/crypto/montmul.s
+++ b/sw/acc/crypto/montmul.s
@@ -44,6 +44,7 @@
  * clobbered registers: w0, w1, w29
  * clobbered flag groups: FG0
  */
+.type m0inv, @function
 m0inv:
   /* w0 keeps track of loop iterations in one-hot encoding, i.e.
      w0 = 2^i in the loop body below and initialized here with w0 = 1
@@ -113,6 +114,7 @@ m0inv:
  *                      w2, w3, w4 to w(4+N-1), w24, w29, w30
  * clobbered Flag Groups: FG0, FG1
  */
+.type double_and_reduce, @function
 double_and_reduce:
   /* Clear carry flags. */
   bn.sub    w31, w31, w31
@@ -196,6 +198,7 @@ double_and_reduce:
 *                      w0, w2, w3, w4, w5 to w20 depending on N
 * clobbered flag groups: FG0, FG1
 */
+.type compute_rr, @function
 compute_rr:
   /* Prepare all-zero register and clear FG0.C. */
   bn.sub    w31, w31, w31
@@ -271,6 +274,7 @@ compute_rr:
  * clobbered registers: w26, w27
  * clobbered flag groups: none
  */
+.type mul256_w30xw25, @function
 mul256_w30xw25:
   bn.mulqacc.z          w30.0, w25.0,  0
   bn.mulqacc            w30.1, w25.0, 64
@@ -306,6 +310,7 @@ mul256_w30xw25:
  * clobbered registers: w26, w27
  * clobbered flag groups: none
  */
+.type mul256_w30xw2, @function
 mul256_w30xw2:
   bn.mulqacc.z          w30.0, w2.0,  0
   bn.mulqacc            w30.1, w2.0, 64
@@ -352,6 +357,7 @@ mul256_w30xw2:
  * clobbered registers: x8, x12, x13, x16, w24, w29, w30, w[x8] to w[x8+N-1]
  * clobbered Flag Groups: FG0
  */
+.type cond_sub_to_reg, @function
 cond_sub_to_reg:
 
   /* load pointers to temp regs */
@@ -413,6 +419,7 @@ cond_sub_to_reg:
  *                      w24, w25, w26, w27, w28, w29, w30, w4 to w[4+N-1]
  * clobbered Flag Groups: FG0, FG1
  */
+.type mont_loop, @function
 mont_loop:
   /* save pointer to modulus */
   addi      x22, x16, 0
@@ -574,6 +581,7 @@ mont_loop:
  *                      w2, w3, w4 to w[4+N-1], w24 to w30
  * clobbered Flag Groups: FG0, FG1
  */
+.type montmul, @function
 montmul:
   /* set pointers to allow static analysis constant propagation */
   /* TODO (#137): find a way to elide this while allowing instruction count
@@ -633,6 +641,7 @@ montmul:
  * @param[out] [dmem[dptr_m0d+31]:dmem[dptr_m0d]] computed m0'
  * @param[out] [dmem[dptr_RR+N*32-1]:dmem[dptr_RR]] computed RR
  */
+.type modload, @function
 modload:
   /* load lowest limb of modulus to w28 */
   li       x8, 28

--- a/sw/acc/crypto/mul.s
+++ b/sw/acc/crypto/mul.s
@@ -39,6 +39,7 @@
  * clobbered registers: x2 to x8, x20 to x23, w20 to w23
  * clobbered flag groups: FG0
  */
+.type bignum_mul, @function
 bignum_mul:
   /* Zeroize output buffer.
        dmem[dptr_c..dptr_c+(n*2*32)] <= 0 */
@@ -158,6 +159,7 @@ bignum_mul:
  * clobbered registers: x2, x3, x20, x21, x22, x23, w20, w21, w22, w23
  * clobbered flag groups: FG0
  */
+.type bignum_mul256, @function
 bignum_mul256:
   /* Zeroize first word of output buffer.
        dmem[dptr_c] <= 0 */
@@ -212,6 +214,7 @@ bignum_mul256:
  * clobbered registers: w22, w23
  * clobbered flag groups: None
  */
+.type mul256_w20xw21, @function
 mul256_w20xw21:
   bn.mulqacc.z          w20.0, w21.0,  0
   bn.mulqacc            w20.1, w21.0, 64

--- a/sw/acc/crypto/p256_base.s
+++ b/sw/acc/crypto/p256_base.s
@@ -77,6 +77,7 @@
  * clobbered registers: w19, w20, w21, w22, w23, w24, w25
  * clobbered flag groups: FG0
  */
+.type p256_reduce, @function
 p256_reduce:
   /* Compute q1' = q1[255:0] = x >> 255
      w21 = q1' = [w20, w19] >> 255 */
@@ -222,6 +223,7 @@ p256_reduce:
  * clobbered registers: w19, w20, w21, w22, w23, w24, w25
  * clobbered flag groups: FG0
  */
+.type mod_mul_256x256, @function
 mod_mul_256x256:
   /* Compute the integer product of the operands x = a * b
      x = [w20, w19] = a * b = w24 * w25
@@ -283,6 +285,7 @@ mod_mul_256x256:
  * clobbered registers: w19, w20, w21, w22, w23, w24, w25
  * clobbered flag groups: FG0
  */
+.type mod_mul_320x128, @function
 mod_mul_320x128:
   /* Compute the integer product of the operands x = a * b
      x = [w20, w19] = a * b = w24 * w25
@@ -344,6 +347,7 @@ mod_mul_320x128:
  * clobbered registers: w19, w20, w21, w22, w23, w24, w25
  * clobbered flag groups: FG0
  */
+.type mul_modp, @function
 mul_modp:
   /* First, compute the high partial products (coefficient 2^192 or higher).
        w19,w20.U <= 2^192*(a0b3 + a1b2 + a2b1 + a3b0)
@@ -505,6 +509,7 @@ mul_modp:
  * clobbered registers: w28, w29
  * clobbered flag groups: FG0
  */
+.type setup_modp, @function
 setup_modp:
   /* Load the modulus p from DMEM and store it in MOD.
      MOD <= w29 <= p = dmem[p256_p] */
@@ -567,6 +572,7 @@ setup_modp:
  * clobbered registers: w11 to w25
  * clobbered flag groups: FG0
  */
+.type proj_add, @function
 proj_add:
   /* mapping of parameters to symbols of [2] (Algorithm 4):
      X1 = x_p; Y1 = y_p; Z1 = z_p; X2 = x_q; Y2 = y_q; Z2 = z_q
@@ -783,6 +789,7 @@ proj_add:
  * clobbered registers: w10 to w19, w24, w25
  * clobbered flag groups: FG0
  */
+.type proj_to_affine, @function
 proj_to_affine:
 
   /* Fully reduce z. */
@@ -948,6 +955,7 @@ proj_to_affine:
  * clobbered registers: w1, w2, w3, w19, w24, w25
  * clobbered flag groups: FG0
  */
+.type mod_inv, @function
 mod_inv:
 
   /* subtract 2 from modulus for Fermat's little theorem
@@ -975,7 +983,7 @@ mod_inv:
     bn.sel    w1, w1, w3, C
     csrrs     x2, FG0, x0
     andi      x2, x2, 1
-    beq       x2, x0, nomul
+    beq       x2, x0, _nomul
 
     /* multiply: w1 = w19 = w24*w25 = w3*w0  mod m */
     bn.mov    w24, w3
@@ -983,7 +991,7 @@ mod_inv:
     jal       x1, mod_mul_256x256
     bn.mov    w1, w19
 
-    nomul:
+    _nomul:
     nop
 
   ret
@@ -1021,6 +1029,7 @@ mod_inv:
  * clobbered registers: w14 to w16, w19 to w26
  * clobbered flag groups: FG0
  */
+.type fetch_proj_randomize, @function
 fetch_proj_randomize:
 
   /* get random number from URND */
@@ -1099,6 +1108,7 @@ fetch_proj_randomize:
  * clobbered registers: w14 to w25
  * clobbered flag groups: FG0
  */
+.type proj_double, @function
 proj_double:
   /* w14 <= 3 * (w8 - w10) * (w8 + w10) = 3 * (X1 - Z1) * (X1 + Z1) = w */
   bn.subm   w24, w8, w10
@@ -1218,6 +1228,7 @@ proj_double:
  * clobbered registers: x2, x3, x10, w0 to w30
  * clobbered flag groups: FG0
  */
+.type scalar_mult_int, @function
 scalar_mult_int:
   /* Set up for coordinate arithmetic.
        MOD <= p
@@ -1465,6 +1476,7 @@ scalar_mult_int:
  * clobbered registers: x2, x3, x16, x17, x19, x20, x21, x22, w0 to w29
  * clobbered flag groups: FG0
  */
+.type p256_base_mult, @function
 p256_base_mult:
 
   /* init all-zero register */
@@ -1560,6 +1572,7 @@ p256_base_mult:
  * clobbered registers: x2, x3, x20, w12 to w29
  * clobbered flag groups: FG0
  */
+.type p256_random_scalar, @function
 p256_random_scalar:
   /* Load the curve order n.
      w29 <= dmem[p256_n] = n */
@@ -1576,7 +1589,7 @@ p256_random_scalar:
   la        x3, p256_u_n
   bn.lid    x2, 0(x3)
 
-  random_scalar_retry:
+  _random_scalar_retry:
   /* Obtain 768 bits of randomness from RND. */
   bn.wsrr   w15, RND
   bn.wsrr   w16, RND
@@ -1631,7 +1644,7 @@ p256_random_scalar:
   andi      x2, x2, 8
 
   /* Retry if x2 != 0. */
-  bne       x2, x0, random_scalar_retry
+  bne       x2, x0, _random_scalar_retry
 
   /* If we get here, then (seed0 + seed1) mod n is nonzero mod n; return. */
 
@@ -1648,6 +1661,7 @@ p256_random_scalar:
  * clobbered registers: x2, x3, x20, w20, w21, w29
  * clobbered flag groups: FG0
  */
+.type p256_generate_random_key, @function
 p256_generate_random_key:
   /* Init all-zero register. */
   bn.xor    w31, w31, w31
@@ -1686,6 +1700,7 @@ p256_generate_random_key:
  * clobbered registers: x2, x3, x20, w20, w21, w29
  * clobbered flag groups: FG0
  */
+.type p256_generate_k, @function
 p256_generate_k:
   /* Init all-zero register. */
   bn.xor    w31, w31, w31
@@ -1761,6 +1776,7 @@ p256_generate_k:
  * clobbered registers: w1 to w5, w20 to w23
  * clobbered flag groups: FG0
  */
+.type boolean_to_arithmetic, @function
 boolean_to_arithmetic:
   /* Mask out excess bits from seed shares.
        [w21, w20] <= s0 mod 2^320
@@ -1875,6 +1891,7 @@ boolean_to_arithmetic:
  * clobbered registers: x2, x3, w1 to w4, w20 to w29
  * clobbered flag groups: FG0
  */
+.type p256_key_from_seed, @function
 p256_key_from_seed:
   /* Convert from a boolean to an arithmetic mask using Goubin's algorithm.
        [w21, w20] <= ((seed0 ^ seed1) - seed1) mod 2^321 = x0 */
@@ -1992,6 +2009,7 @@ p256_key_from_seed:
  * clobbered registers: x3-x4, x10-x11, w1-w11, w31
  * clobbered flag groups: none
  */
+.type p256_scalar_remask, @function
 p256_scalar_remask:
   /* Initialize all-zero register. */
   bn.xor    w31, w31, w31

--- a/sw/acc/crypto/p256_ecdsa_sca.s
+++ b/sw/acc/crypto/p256_ecdsa_sca.s
@@ -10,6 +10,7 @@
 
 .section .text.start
 .globl start
+.type start, @function
 start:
   /* Read mode, then tail-call either p256_ecdsa_sign or p256_ecdsa_verify */
   la    x2, mode
@@ -25,10 +26,12 @@ start:
   unimp
 
 .text
+.type p256_ecdsa_sign, @function
 p256_ecdsa_sign:
   jal      x1, p256_sign
   ecall
 
+.type p256_ecdsa_verify, @function
 p256_ecdsa_verify:
   jal      x1, p256_verify
   ecall

--- a/sw/acc/crypto/p256_isoncurve.s
+++ b/sw/acc/crypto/p256_isoncurve.s
@@ -44,6 +44,7 @@
  * clobbered registers: x2, x3, x19, x20, w0, w18 to w29
  * clobbered flag groups: FG0
  */
+.type p256_isoncurve, @function
 p256_isoncurve:
   /* Set up for coordinate arithmetic.
        MOD <= p
@@ -116,6 +117,7 @@ p256_isoncurve:
  * clobbered registers: x2, x3, x19, x20, w0, w2, w18 to w29
  * clobbered flag groups: FG0
  */
+.type p256_check_public_key, @function
 p256_check_public_key:
   /* Init all-zero register. */
   bn.xor   w31, w31, w31
@@ -194,6 +196,7 @@ p256_check_public_key:
  *
  * @param[out] dmem[ok] Set to HARDENED_BOOL_FALSE.
  */
+.type p256_invalid_input, @function
 p256_invalid_input:
   /* Set the `ok` code to false. */
   la       x2, ok

--- a/sw/acc/crypto/p256_isoncurve_proj.s
+++ b/sw/acc/crypto/p256_isoncurve_proj.s
@@ -35,6 +35,7 @@
  * clobbered registers: x2, x3, x19, x20, w0, w18 to w29
  * clobbered flag groups: FG0
  */
+.type p256_isoncurve_proj, @function
 p256_isoncurve_proj:
   /* Set up for coordinate arithmetic.
        MOD <= p

--- a/sw/acc/crypto/p256_key_from_seed_sca.s
+++ b/sw/acc/crypto/p256_key_from_seed_sca.s
@@ -12,6 +12,7 @@
 
 .section .text.start
 
+.type start, @function
 start:
   /* Read mode, then tail-call either p256_gen_secret_key or p256_gen_keypair */
   la    x2, mode
@@ -26,6 +27,7 @@ start:
   /* Invalid mode; fail. */
   unimp
 
+.type p256_gen_secret_key, @function
 p256_gen_secret_key:
   /* First, generate the masked secret key d and write to DMEM.
        dmem[d0] <= d0
@@ -34,6 +36,7 @@ p256_gen_secret_key:
 
   ecall
 
+.type p256_gen_keypair, @function
 p256_gen_keypair:
   /* First, generate the masked secret key d and write to DMEM.
        dmem[d0] <= d0
@@ -47,6 +50,7 @@ p256_gen_keypair:
 
   ecall
 
+.type run_gen_secret_key, @function
 run_gen_secret_key:
   /* Init all-zero register. */
   bn.xor    w31, w31, w31

--- a/sw/acc/crypto/p256_mod_inv_sca.s
+++ b/sw/acc/crypto/p256_mod_inv_sca.s
@@ -11,6 +11,7 @@
 
 .section .text.start
 
+.type main, @function
 main:
   /* Initialize all-zero register. */
   bn.xor    w31, w31, w31

--- a/sw/acc/crypto/p256_shared_key.s
+++ b/sw/acc/crypto/p256_shared_key.s
@@ -37,6 +37,7 @@
  * clobbered registers: x2, x3, x16, x17, x21, x22, w0 to w25
  * clobbered flag groups: FG0
  */
+.type p256_shared_key, @function
 p256_shared_key:
   /* Init all-zero register. */
   bn.xor    w31, w31, w31
@@ -188,6 +189,7 @@ p256_shared_key:
  * clobbered registers: w1 to w6, w11, w12, w18, w20 to w27, and w29
  * clobbered flag groups: FG0
  */
+.type arithmetic_to_boolean_mod, @function
 arithmetic_to_boolean_mod:
   /* First step: calculate A2B from reduced values. */
 
@@ -313,6 +315,7 @@ arithmetic_to_boolean_mod:
  * clobbered registers: w1 - w6, w11, w12, and w18 - w21
  * clobbered flag groups: FG0
  */
+.type arithmetic_to_boolean, @function
 arithmetic_to_boolean:
   /* Initialize inputs: in case of randomness in upper part of inputs
      truncate to 257 bits. Also, fetch 257 bits of randomness.

--- a/sw/acc/crypto/p256_sign.s
+++ b/sw/acc/crypto/p256_sign.s
@@ -67,6 +67,7 @@
  * clobbered registers: x2, x3, x16 to x23, w0 to w29
  * clobbered flag groups: FG0
  */
+.type p256_sign, @function
 p256_sign:
 
   /* init all-zero register */

--- a/sw/acc/crypto/p256_verify.s
+++ b/sw/acc/crypto/p256_verify.s
@@ -55,6 +55,7 @@
  * clobbered registers: x2, x3, x11, x12, x13, x14, x17 to x24, w0 to w25
  * clobbered flag groups: FG0
  */
+.type p256_verify, @function
 p256_verify:
 
   /* init all-zero register */
@@ -186,11 +187,11 @@ p256_verify:
     bn.mov    w10, w13
     jal       x1, proj_add
 
-    /* if either  u_1[i] == 0 or u_2[i] == 0 jump to 'no_both' */
+    /* if either  u_1[i] == 0 or u_2[i] == 0 jump to '_no_both' */
     bn.add    w2, w2, w2
     csrrs     x2, FG0, x0
     andi      x2, x2, 1
-    beq       x2, x0, no_both
+    beq       x2, x0, _no_both
 
     /* hardening: this block should only be reachable if x2=1, so this should
        have no effect */
@@ -202,21 +203,21 @@ p256_verify:
     bn.mov    w9, w4
     bn.mov    w10, w5
     jal       x1, proj_add
-    jal       x0, no_q
+    jal       x0, _no_q
     unimp
     unimp
 
     /* either u1[i] or u2[i] is set, but not both */
-    no_both:
+    _no_both:
     /* hardening: this block should only be reachable if x2=0, so this should
        have no effect */
     srl       x11, x11, x2
 
-    /* if u2[i] is not set jump to 'no_g' */
+    /* if u2[i] is not set jump to '_no_g' */
     bn.add    w6, w0, w0
     csrrs     x2, FG0, x0
     andi      x2, x2, 1
-    beq       x2, x0, no_g
+    beq       x2, x0, _no_g
 
     /* hardening: this block should only be reachable if x2=1, so this should
        have no effect */
@@ -228,12 +229,12 @@ p256_verify:
     bn.addi   w10, w31, 1
     jal       x1, proj_add
 
-    no_g:
-    /* if u1[i] is not set jump to 'no_q' */
+    _no_g:
+    /* if u1[i] is not set jump to '_no_q' */
     bn.add    w6, w1, w1
     csrrs     x2, FG0, x0
     andi      x2, x2, 1
-    beq       x2, x0, no_q
+    beq       x2, x0, _no_q
 
     /* hardening: this block should only be reachable if x2=1, so this should
        have no effect */
@@ -248,7 +249,7 @@ p256_verify:
     bn.addi   w10, w31, 1
     jal       x1, proj_add
 
-    no_q:
+    _no_q:
     /* left shift w0 and w1 to decrease index */
     bn.add    w0, w0, w0
     bn.add    w1, w1, w1
@@ -317,6 +318,7 @@ p256_verify:
  * clobbered registers: x2, w2, w3, w4, w7
  * clobbered flag groups: FG0
  */
+.type mod_inv_var, @function
 mod_inv_var:
   /* Check if the input is zero. */
   bn.cmp    w0, w31
@@ -337,12 +339,12 @@ mod_inv_var:
   /* w5 = v = w0 */
   bn.mov    w5, w0
 
-  ebgcd_loop:
+  _ebgcd_loop:
   /* test if u is odd */
   bn.or     w4, w4, w4
   csrrs     x2, FG0, x0
   andi      x2, x2, 4
-  bne       x2, x0, ebgcd_u_odd
+  bne       x2, x0, _ebgcd_u_odd
 
   /* u is even: */
   /* w4 = u <= u/2 = w4 >> 1 */
@@ -352,26 +354,26 @@ mod_inv_var:
   bn.or     w2, w2, w2
   csrrs     x2, FG0, x0
   andi      x2, x2, 4
-  bne       x2, x0, ebgcd_r_odd
+  bne       x2, x0, _ebgcd_r_odd
 
   /* r is even: */
   /* w2 = r <= r/2 = w2 >> 1 */
   bn.rshi   w2, w31, w2 >> 1
-  jal       x0, ebgcd_loop
+  jal       x0, _ebgcd_loop
 
-  ebgcd_r_odd:
+  _ebgcd_r_odd:
   /* w2 = r <= (r + m)/2 = (w2 + w7) >> 1 */
   bn.add    w2, w7, w2
   bn.addc   w6, w31, w31
   bn.rshi   w2, w6, w2 >> 1
-  jal       x0, ebgcd_loop
+  jal       x0, _ebgcd_loop
 
-  ebgcd_u_odd:
+  _ebgcd_u_odd:
   /* test if v is odd */
   bn.or     w5, w5, w5
   csrrs     x2, FG0, x0
   andi      x2, x2, 4
-  bne       x2, x0, ebgcd_uv_odd
+  bne       x2, x0, _ebgcd_uv_odd
 
   /* v is even: */
   /* w5 = v <= v/2 = w5 >> 1 */
@@ -381,26 +383,26 @@ mod_inv_var:
   bn.or     w3, w3, w3
   csrrs     x2, FG0, x0
   andi      x2, x2, 4
-  bne       x2, x0, ebgcd_s_odd
+  bne       x2, x0, _ebgcd_s_odd
 
   /* s is even: */
   /* w3 = s <= s/2 = w3 >> 1 */
   bn.rshi   w3, w31, w3 >> 1
-  jal       x0, ebgcd_loop
+  jal       x0, _ebgcd_loop
 
-  ebgcd_s_odd:
+  _ebgcd_s_odd:
   /* w3 = s <= (s + m)/2 = (w3 + w7) >> 1 */
   bn.add    w3, w7, w3
   bn.addc   w6, w31, w31
   bn.rshi   w3, w6, w3 >> 1
-  jal       x0, ebgcd_loop
+  jal       x0, _ebgcd_loop
 
-  ebgcd_uv_odd:
+  _ebgcd_uv_odd:
   /* test if v >= u */
   bn.cmp    w5, w4
   csrrs     x2, FG0, x0
   andi      x2, x2, 1
-  beq       x2, x0, ebgcd_v_gte_u
+  beq       x2, x0, _ebgcd_v_gte_u
 
   /* u > v: */
   /* w2 = r <= r - s = w2 - w3; if (r < 0): r <= r + m */
@@ -408,9 +410,9 @@ mod_inv_var:
 
   /* w4 = u <= u - v = w4 - w5 */
   bn.sub    w4, w4, w5
-  jal       x0, ebgcd_loop
+  jal       x0, _ebgcd_loop
 
-  ebgcd_v_gte_u:
+  _ebgcd_v_gte_u:
   /* w3 = s <= s - r = w3 - w2; if (s < 0) s <= s + m */
   bn.subm   w3, w3, w2
 
@@ -420,7 +422,7 @@ mod_inv_var:
   /* if v > 0 go back to start of loop */
   csrrs     x2, FG0, x0
   andi      x2, x2, 8
-  beq       x2, x0, ebgcd_loop
+  beq       x2, x0, _ebgcd_loop
 
   /* v <= 0: */
   /* if (r > m): w1 = a = r - m = w2 - MOD else: w1 = a = r = w2 */

--- a/sw/acc/crypto/p384_a2b.s
+++ b/sw/acc/crypto/p384_a2b.s
@@ -42,6 +42,7 @@
  * clobbered registers: w1 to w6, w10 to w12, w20, w21, w23 to w28
  * clobbered flag groups: FG0
  */
+.type p384_arithmetic_to_boolean_mod, @function
 p384_arithmetic_to_boolean_mod:
   /* First step: calculate A2B from reduced values. */
 
@@ -143,6 +144,7 @@ p384_arithmetic_to_boolean_mod:
  * clobbered registers: w1 to w6, w11, w12, and w18 to w21
  * clobbered flag groups: FG0
  */
+.type p384_arithmetic_to_boolean, @function
 p384_arithmetic_to_boolean:
   /* Fetch 385 bits of randomness.
      [w2,w1] = gamma    <= URND */

--- a/sw/acc/crypto/p384_b2a.s
+++ b/sw/acc/crypto/p384_b2a.s
@@ -47,6 +47,7 @@
  * clobbered registers: w1 to w4, w20 to w23
  * clobbered flag groups: FG0
  */
+.type p384_boolean_to_arithmetic, @function
 p384_boolean_to_arithmetic:
   /* Fetch 385 bits of randomness from URND.
        [w2, w1] <= gamma */

--- a/sw/acc/crypto/p384_base.s
+++ b/sw/acc/crypto/p384_base.s
@@ -29,6 +29,7 @@
  * Clobbered flag groups: FG0
  */
 .globl mul384
+.type mul384, @function
 mul384:
   bn.mulqacc.z          w10.0, w16.0,   0
   bn.mulqacc            w10.0, w16.1,  64
@@ -89,6 +90,7 @@ mul384:
  * Clobbered registers: w18 to w20
  * Clobbered flag groups: FG0
  */
+.type mul448x128, @function
 mul448x128:
   bn.mulqacc.z          w10.0, w16.0, 0
   bn.mulqacc            w10.0, w16.1, 64
@@ -143,6 +145,7 @@ mul448x128:
  * Clobbered flag groups: FG0
  */
 .globl p384_reduce_p
+.type p384_reduce_p, @function
 p384_reduce_p:
   /* Solinas reduction step. Based on the observation that:
      (x + 2^384 * y) mod (2^384 - K) = (x + K * y) mod (2^384 - K).
@@ -268,6 +271,7 @@ p384_reduce_p:
  * Clobbered flag groups: FG0
  */
 .globl p384_reduce_n
+.type p384_reduce_n, @function
 p384_reduce_n:
   /* Extract the high 128 bits from the middle term and the low 128 bits from
      the high term:
@@ -401,6 +405,7 @@ p384_reduce_n:
  * Clobbered flag groups: FG0
  */
 .globl p384_mulmod_p
+.type p384_mulmod_p, @function
 p384_mulmod_p:
   /* Compute the raw 768-bit product:
        ab = [w20:w18] <= a * b */
@@ -434,6 +439,7 @@ p384_mulmod_p:
  * Clobbered flag groups: FG0
  */
 .globl p384_mulmod_n
+.type p384_mulmod_n, @function
 p384_mulmod_n:
   /* Compute the raw 768-bit product:
        ab = [w20:w18] <= a * b */
@@ -467,6 +473,7 @@ p384_mulmod_n:
  * Clobbered flag groups: FG0
  */
 .globl p384_mulmod448x128_n
+.type p384_mulmod448x128_n, @function
 p384_mulmod448x128_n:
   /* Compute the raw 768-bit product:
        ab = [w20:w18] <= a * b */
@@ -518,6 +525,7 @@ p384_mulmod448x128_n:
  * clobbered flag groups: FG0
  */
 .globl proj_add_p384
+.type proj_add_p384, @function
 proj_add_p384:
   /* mapping of parameters to symbols of [2] (Algorithm 4):
      X1 = x_p; Y1 = y_p; Z1 = z_p; X2 = x_q; Y2 = y_q; Z2 = z_q
@@ -918,6 +926,7 @@ proj_add_p384:
  * clobbered flag groups: FG0
  */
 .globl proj_double_p384
+.type proj_double_p384, @function
 proj_double_p384:
   /* 1: [w1, w0] = t0 <= X1-Z1 */
   bn.sub    w16, w25, w29
@@ -1126,6 +1135,7 @@ proj_double_p384:
  * clobbered flag groups: FG0
  */
  .globl proj_to_affine_p384
+.type proj_to_affine_p384, @function
 proj_to_affine_p384:
 
   /* Exp: 0b10 = 2*0b1
@@ -1359,6 +1369,7 @@ proj_to_affine_p384:
  * clobbered flag groups: none
  */
 .globl p384_scalar_remask
+.type p384_scalar_remask, @function
 p384_scalar_remask:
   /* Initialize all-zero register. */
   bn.xor    w31, w31, w31

--- a/sw/acc/crypto/p384_base_mult.s
+++ b/sw/acc/crypto/p384_base_mult.s
@@ -36,6 +36,7 @@
  * clobbered flag groups: FG0
  */
 .globl p384_base_mult_checked
+.type p384_base_mult_checked, @function
 p384_base_mult_checked:
   jal       x1, p384_base_mult
 
@@ -72,6 +73,7 @@ p384_base_mult_checked:
  * clobbered flag groups: FG0
  */
 .globl p384_base_mult
+.type p384_base_mult, @function
 p384_base_mult:
 
   /* set dmem pointer to x-coordinate of base point*/

--- a/sw/acc/crypto/p384_curve_point_valid.s
+++ b/sw/acc/crypto/p384_curve_point_valid.s
@@ -14,6 +14,7 @@
  */
 
 .section .text.start
+.type start, @function
 start:
   /* Init all-zero register. */
   bn.xor    w31, w31, w31
@@ -25,6 +26,7 @@ start:
   unimp
   unimp
 
+.type validate_point, @function
 validate_point:
   /* Call curve point validation function */
   jal       x1, p384_curve_point_valid

--- a/sw/acc/crypto/p384_ecdsa_sca.s
+++ b/sw/acc/crypto/p384_ecdsa_sca.s
@@ -10,6 +10,7 @@
 
 .section .text.start
 .globl start
+.type start, @function
 start:
   /* Read mode, then tail-call either p384_ecdsa_sign or p384_ecdsa_verify */
   la    x2, mode
@@ -25,10 +26,12 @@ start:
   unimp
 
 .text
+.type p384_ecdsa_sign, @function
 p384_ecdsa_sign:
   jal      x1, p384_sign
   ecall
 
+.type p384_ecdsa_verify, @function
 p384_ecdsa_verify:
   /*jal      x1, p384_verify*/
   ecall

--- a/sw/acc/crypto/p384_internal_mult.s
+++ b/sw/acc/crypto/p384_internal_mult.s
@@ -45,6 +45,7 @@
  * clobbered flag groups: FG0
  */
  .globl store_proj_randomize
+.type store_proj_randomize, @function
 store_proj_randomize:
 
   /* get a 384-bit random number from URND
@@ -163,6 +164,7 @@ store_proj_randomize:
  * clobbered flag groups: FG0, FG1
  */
  .globl scalar_mult_int_p384
+.type scalar_mult_int_p384, @function
 scalar_mult_int_p384:
 
   /* set regfile pointers to in/out regs of mulmod routine. Set here to avoid

--- a/sw/acc/crypto/p384_isoncurve.s
+++ b/sw/acc/crypto/p384_isoncurve.s
@@ -52,6 +52,7 @@
  * clobbered flag groups: FG0
  */
  .globl p384_isoncurve
+.type p384_isoncurve, @function
 p384_isoncurve:
 
   /* setup all-zero reg */
@@ -154,6 +155,7 @@ p384_isoncurve:
  * clobbered flag groups: FG0
  */
  .globl p384_isoncurve_check
+.type p384_isoncurve_check, @function
 p384_isoncurve_check:
   /* Fill gpp registers with pointers to variables */
   la        x22, rhs
@@ -210,6 +212,7 @@ p384_isoncurve_check:
  * clobbered flag groups: FG0
  */
  .globl p384_check_public_key
+.type p384_check_public_key, @function
 p384_check_public_key:
   /* Init all-zero register. */
   bn.xor    w31, w31, w31
@@ -308,6 +311,7 @@ p384_check_public_key:
  * clobbered registers: x2
  * clobbered flag groups: none
  */
+.type trigger_input_error_if_fg0_not_z, @function
 trigger_input_error_if_fg0_not_z:
   /* Fail if FG0.Z is false. */
   csrrs     x2, FG0, x0
@@ -333,6 +337,7 @@ trigger_input_error_if_fg0_not_z:
  * @param[out] dmem[ok] Set to HARDENED_BOOL_FALSE.
  */
 .global p384_invalid_input
+.type p384_invalid_input, @function
 p384_invalid_input:
   /* Set the `ok` code to false. */
   la       x2, ok

--- a/sw/acc/crypto/p384_isoncurve_proj.s
+++ b/sw/acc/crypto/p384_isoncurve_proj.s
@@ -37,6 +37,7 @@
  * clobbered flag groups: FG0
  */
  .globl p384_isoncurve_proj_check
+.type p384_isoncurve_proj_check, @function
 p384_isoncurve_proj_check:
 
   jal       x1, p384_isoncurve_proj
@@ -94,6 +95,7 @@ p384_isoncurve_proj_check:
  * clobbered flag groups: FG0
  */
  .globl p384_isoncurve_proj
+.type p384_isoncurve_proj, @function
 p384_isoncurve_proj:
 
   /* load domain parameter b from dmem

--- a/sw/acc/crypto/p384_keygen.s
+++ b/sw/acc/crypto/p384_keygen.s
@@ -51,6 +51,7 @@
  * clobbered registers: x2, x3, w4 to w11, w14, w16 to w28
  * clobbered flag groups: FG0
  */
+.type p384_random_scalar, @function
 p384_random_scalar:
   /* Load the curve order n.
      [w13,w12] <= dmem[p384_n] = n */
@@ -59,7 +60,7 @@ p384_random_scalar:
   bn.lid    x2++, 0(x3)
   bn.lid    x2++, 32(x3)
 
-  random_scalar_retry:
+  _random_scalar_retry:
   /* Obtain 1024 bits of randomness from RND. */
   bn.wsrr   w6, RND
   bn.wsrr   w7, RND
@@ -164,7 +165,7 @@ p384_random_scalar:
   or        x2, x2, x3
 
   /* Retry if x2 != 0. */
-  bne       x2, x0, random_scalar_retry
+  bne       x2, x0, _random_scalar_retry
 
   /* If we get here, then (seed0 + seed1) mod n is nonzero mod n; return. */
 
@@ -182,6 +183,7 @@ p384_random_scalar:
  * clobbered flag groups: FG0
  */
 .globl p384_generate_random_key
+.type p384_generate_random_key, @function
 p384_generate_random_key:
   /* Init all-zero register. */
   bn.xor    w31, w31, w31
@@ -222,6 +224,7 @@ p384_generate_random_key:
  * clobbered flag groups: FG0
  */
 .globl p384_generate_k
+.type p384_generate_k, @function
 p384_generate_k:
   /* Init all-zero register. */
   bn.xor    w31, w31, w31

--- a/sw/acc/crypto/p384_keygen_from_seed.s
+++ b/sw/acc/crypto/p384_keygen_from_seed.s
@@ -58,6 +58,7 @@
  * clobbered flag groups: FG0
  */
 .globl p384_key_from_seed
+.type p384_key_from_seed, @function
 p384_key_from_seed:
   /* Convert from a boolean to an arithmetic mask using Goubin's algorithm.
        [w21, w20] <= ((seed0 ^ seed1) - seed1) mod 2^385 = x0 */

--- a/sw/acc/crypto/p384_modinv.s
+++ b/sw/acc/crypto/p384_modinv.s
@@ -50,6 +50,7 @@
  * clobbered flag groups: FG0
  */
  .globl mod_inv_p384
+.type mod_inv_p384, @function
 mod_inv_p384:
 
   /* subtract 2 from modulus for Fermat's little theorem
@@ -79,14 +80,14 @@ mod_inv_p384:
     /* skip multiplication if C flag not set */
     csrrs     x2, 0x7c0, x0
     andi      x2, x2, 1
-    beq       x2, x0, nomul
+    beq       x2, x0, _nomul
 
     /* multiply: [w17,w16] <= [w17, w16]*[w30,w29] mod [w13, w12] */
     bn.mov    w10, w29
     bn.mov    w11, w30
     jal       x1, p384_mulmod_n
 
-    nomul:
+    _nomul:
     nop
 
   ret

--- a/sw/acc/crypto/p384_scalar_mult.s
+++ b/sw/acc/crypto/p384_scalar_mult.s
@@ -42,6 +42,7 @@
  * clobbered flag groups: FG0
  */
 .globl p384_scalar_mult
+.type p384_scalar_mult, @function
 p384_scalar_mult:
 
   /* Init all-zero register. */

--- a/sw/acc/crypto/p384_sign.s
+++ b/sw/acc/crypto/p384_sign.s
@@ -42,6 +42,7 @@
  * clobbered flag groups: FG0
  */
 .globl p384_sign
+.type p384_sign, @function
 p384_sign:
   /* init all-zero reg */
   bn.xor    w31, w31, w31

--- a/sw/acc/crypto/p384_verify.s
+++ b/sw/acc/crypto/p384_verify.s
@@ -45,6 +45,7 @@
  * clobbered registers: x2, x12, w6 to w11
  * clobbered flag groups: FG0
  */
+.type store_aff_proj, @function
 store_aff_proj:
 
   /* load point */
@@ -85,6 +86,7 @@ store_aff_proj:
  * clobbered registers: x2, x12
  * clobbered flag groups: none
  */
+.type store_proj, @function
 store_proj:
   li        x2, 25
   loopi 6, 2
@@ -123,6 +125,7 @@ store_proj:
  * clobbered flag groups: FG0
  */
 .globl p384_verify
+.type p384_verify, @function
 p384_verify:
 
   /* init all-zero reg */
@@ -369,30 +372,30 @@ p384_verify:
     jal       x1, proj_double_p384
 
     /* no addition if x5 = u1[i] | u2[i] == 0 */
-    beq       x5, x0, ver_end_loop
+    beq       x5, x0, _ver_end_loop
 
     /* check if u1[i] is set */
-    bne       x3, x0, u1_set
+    bne       x3, x0, _u1_set
 
     /* only u2[i] is set: do C <= C + Q */
     addi      x27, x18, 0
-    jal       x0, ver_do_add
+    jal       x0, _ver_do_add
 
-    u1_set:
+    _u1_set:
     /* check if u2[i] is set as well, if so do C <= C + (G + Q) */
     addi      x27, x19, 0
-    bne       x4, x0, ver_do_add
+    bne       x4, x0, _ver_do_add
 
     /* only u1[i] is set: do C <= C + G */
     add       x27, x17, 0
-    jal       x0, ver_do_add
+    jal       x0, _ver_do_add
 
-    ver_do_add:
+    _ver_do_add:
     /* Add selected point.
          [w30:w25] <= [w30:w25] + dmem[x27] */
     jal       x1, proj_add_p384
 
-    ver_end_loop:
+    _ver_end_loop:
     /* increment counter */
     addi     x15, x15, 1
 

--- a/sw/acc/crypto/primality.s
+++ b/sw/acc/crypto/primality.s
@@ -45,6 +45,7 @@
  *                      w2, w3, w4..w[4+(n-1)], w20 to w30
  * clobbered flag groups: FG0, FG1
  */
+.type miller_rabin, @function
 miller_rabin:
   /* Initialize w21 (can be any nonzero value with a high Hamming distance from
      the sensitive "w is prime" value). */
@@ -107,6 +108,7 @@ miller_rabin:
  *                      w2, w3, w4..w[4+(n-1)], w20 to w30
  * clobbered flag groups: FG0, FG1
  */
+.type miller_rabin_round, @function
 miller_rabin_round:
   /* Generate a new random number to test. We take input from RND but xor with
      URND as an extra protection (since it is fast and can only strengthen the
@@ -230,6 +232,7 @@ miller_rabin_round:
  *                      w2, w3, w4..w[4+(n-1)], w20 to w30
  * clobbered flag groups: FG0, FG1
  */
+.type test_witness, @function
 test_witness:
   /* Initialize constants for montgomery multiplication. */
   li         x8, 4
@@ -399,6 +402,7 @@ test_witness:
  * clobbered registers: x2, x3, w23, w25
  * clobbered flag groups: FG0, FG1
  */
+.type reduce_modw, @function
 reduce_modw:
   /* Clear flags in group 1. */
   bn.sub    w31, w31, w31, FG1
@@ -450,6 +454,7 @@ reduce_modw:
  * clobbered registers: x2, x3, w23, w25, w26
  * clobbered flag groups: FG0
  */
+.type is_mont1, @function
 is_mont1:
   /* Clear flags and initialize return value.
        w26 <= 2^256 - 1
@@ -508,6 +513,7 @@ is_mont1:
  * clobbered registers: x2, x3, w23, w25, w26
  * clobbered flag groups: FG0
  */
+.type is_mont_minus1, @function
 is_mont_minus1:
   /* Clear flags. */
   bn.sub   w31, w31, w31

--- a/sw/acc/crypto/rsa.s
+++ b/sw/acc/crypto/rsa.s
@@ -4,6 +4,7 @@
 
 .section .text.start
 .globl start
+.type start, @function
 start:
   /* Init all-zero register. */
   bn.xor  w31, w31, w31
@@ -35,6 +36,7 @@ start:
 /**
  * RSA encryption
  */
+.type rsa_encrypt, @function
 rsa_encrypt:
   /* Compute Montgomery constants. */
   jal      x1, modload
@@ -52,6 +54,7 @@ rsa_encrypt:
 /**
  * RSA decryption
  */
+.type rsa_decrypt, @function
 rsa_decrypt:
   /* Compute Montgomery constants. */
   jal      x1, modload
@@ -72,6 +75,7 @@ rsa_decrypt:
  *
  * clobbered registers: x3, w0
  */
+.type zero_work_buf, @function
 zero_work_buf:
   la     x3, work_buf
   bn.xor w0, w0, w0
@@ -85,6 +89,7 @@ zero_work_buf:
  *
  * clobbered registers: x2, x3, x4, w0
  */
+.type cp_work_buf, @function
 cp_work_buf:
   la    x2, n_limbs
   lw    x30, 0(x2)

--- a/sw/acc/crypto/rsa_keygen.s
+++ b/sw/acc/crypto/rsa_keygen.s
@@ -54,6 +54,7 @@
  *                      w2, w3, w4..w[4+(plen-1)], w20 to w30
  * clobbered flag groups: FG0, FG1
  */
+.type rsa_keygen, @function
 rsa_keygen:
   /* Compute (<# of limbs> - 1), a helpful constant for later computations.
        x31 <= x30 - 1 */
@@ -190,6 +191,7 @@ rsa_keygen:
  * clobbered registers: x2 to x8, x10 to x14, x20 to x25, w20 to w25, w27
  * clobbered flag groups: FG0, FG1
  */
+.type rsa_check_key, @function
 rsa_check_key:
   /* Compute (<# of limbs> - 1), a helpful constant for later computations.
        x31 <= x30 - 1 */
@@ -260,6 +262,7 @@ rsa_check_key:
  * clobbered registers: x2 to x5, x8, x10 to x12, x21 to x23, w20 to w25, w27
  * clobbered flag groups: FG0
  */
+.type check_crt_component, @function
 check_crt_component:
   /* Multiply e * d_p, storing result in tmp_scratchpad. */
   addi     x10, x13, 0
@@ -321,6 +324,7 @@ check_crt_component:
  * clobbered registers: x2 to x8, x10 to x12, x21 to x23, w20 to w25, w27
  * clobbered flag groups: FG0
  */
+.type check_crt_coeff, @function
 check_crt_coeff:
   /* Multiply q * i_q, storing result in tmp_scratchpad. */
   la       x10, rsa_q
@@ -385,6 +389,7 @@ check_crt_coeff:
  * clobbered registers: x2 to x8, x10 to x12, x22 to x25, w20 to w25, w27
  * clobbered flag groups: FG0, FG1
  */
+.type recover_d_from_crt, @function
 recover_d_from_crt:
   /* Multiply d_p * d_q, storing result in rsa_n */
   la       x10, rsa_d_p
@@ -553,6 +558,7 @@ recover_d_from_crt:
  * clobbered registers: x2, x10, w20 to w23
  * clobbered flag groups: FG0
  */
+.type check_recovered_d, @function
 check_recovered_d:
   /* Get a pointer to the second half of d.
        x3 <= rsa_d + plen*32 */
@@ -599,6 +605,7 @@ check_recovered_d:
  * clobbered registers: x10, x11, w20
  * clobbered flag groups: none
  */
+.type prepare_pm1qm1, @function
 prepare_pm1qm1:
   /* Subtract 1 from p (no carry from lowest limb since p is odd).
        dmem[rsa_pm1..rsa_pm1+(plen*32)] <= p - 1 */
@@ -653,6 +660,7 @@ prepare_pm1qm1:
  * clobbered registers: x2 to x8, x10 to x15, x20 to x26, x31, w20 to w28
  * clobbered flag groups: FG0, FG1
  */
+.type derive_d, @function
 derive_d:
   /* Prepare p - 1 and q - 1 */
   jal      x1, prepare_pm1qm1
@@ -702,6 +710,7 @@ derive_d:
  * clobbered registers: x2 to x5, x8, x11 to x13, x23 to x25, w20, w23 to w27
  * clobbered flag groups: FG0
  */
+.type derive_crt_component, @function
 derive_crt_component:
   /* Copy (cofactor - 1) to the start of the scratchpad to zero-extend it. */
   la       x12, tmp_scratchpad
@@ -751,6 +760,7 @@ derive_crt_component:
  * clobbered registers: x2, x3, w20, w23
  * clobbered flag groups: FG0, FG1
  */
+.type check_d, @function
 check_d:
   /* Get a pointer to the second half of d.
        x3 <= rsa_d + plen*32 */
@@ -813,6 +823,7 @@ check_d:
  * clobbered registers: x2 to x8, x10 to x15, x20 to x26, x31, w3, w20 to w28
  * clobbered flag groups: FG0, FG1
  */
+.type rsa_key_from_cofactor, @function
 rsa_key_from_cofactor:
   /* Initialize wide-register pointers.
        x20 <= 20
@@ -994,6 +1005,7 @@ rsa_key_from_cofactor:
  * clobbered registers: MOD, x2 to x4, x31, w20 to w28
  * clobbered flag groups: FG0, FG1
  */
+.type modinv_f4, @function
 modinv_f4:
   /* Zero the intermediate buffers.
        dmem[dptr_A..dptr_A+(nlen*32)] <= 0
@@ -1361,6 +1373,7 @@ modinv_f4:
  * clobbered registers: x2, x3, x4, w20, w21
  * clobbered flag groups: FG0
  */
+.type bignum_rshift1_if_not_fg1L, @function
 bignum_rshift1_if_not_fg1L:
   /* Calculate number of loop iterations for bignum shifts.
        x2 <= n - 1 */
@@ -1413,6 +1426,7 @@ bignum_rshift1_if_not_fg1L:
  *                      w2, w3, w4..w[4+(plen-1)], w20 to w30
  * clobbered flag groups: FG0, FG1
  */
+.type generate_p, @function
 generate_p:
   /* Compute nlen, the bit-length of the RSA modulus based on the number of
      limbs for p.
@@ -1484,6 +1498,7 @@ _generate_p_counter_nonzero:
  *                      w2, w3, w4..w[4+(plen-1)], w20 to w30
  * clobbered flag groups: FG0, FG1
  */
+.type generate_q, @function
 generate_q:
   /* Compute nlen, the bit-length of the RSA modulus based on the number of
      limbs for q.
@@ -1570,6 +1585,7 @@ _generate_q_counter_nonzero:
  *                      w2, w3, w4..w[4+(plen-1)], w20 to w30
  * clobbered flag groups: FG0, FG1
  */
+.type check_p, @function
 check_p:
   /* Set the output to the "check passed" value (all 1s) by default.
        w24 <= 2^256 - 1 */
@@ -1708,6 +1724,7 @@ _check_prime_fail:
  *                      w2, w3, w4..w[4+(plen-1)], w20 to w30
  * clobbered flag groups: FG0, FG1
  */
+.type check_q, @function
 check_q:
   /* Clear flags for both groups. */
   bn.sub   w31, w31, w31, FG0
@@ -1777,6 +1794,7 @@ check_q:
  * clobbered registers: x2, x3, w20, w21
  * clobbered flag groups: FG0
  */
+.type generate_prime_candidate, @function
 generate_prime_candidate:
   /* Generate random 256-bit limbs.
        dmem[x16..x16+(plen*32)] <= RND(n*32) ^ URND(n*32)  */
@@ -1844,6 +1862,7 @@ generate_prime_candidate:
  * clobbered registers: x2, w22, w23
  * clobbered flag groups: FG0
  */
+.type fold_bignum, @function
 fold_bignum:
   /* Initialize constants for loop. */
   li      x22, 22
@@ -1931,6 +1950,7 @@ fold_bignum:
  * clobbered registers: x2, x3, w22, w23, w25
  * clobbered flag groups: FG0
  */
+.type fold_bignum_pow2_32_equiv_4, @function
 fold_bignum_pow2_32_equiv_4:
   /* Initialize constants for loop. */
   li      x3, 32
@@ -2062,6 +2082,7 @@ fold_bignum_pow2_32_equiv_4:
  * clobbered registers: x2, w22, w23
  * clobbered flag groups: FG0
  */
+.type relprime_f4, @function
 relprime_f4:
   /* Load F4 into the modulus register for later.
        MOD <= 2^16 + 1 */
@@ -2137,6 +2158,7 @@ relprime_f4:
  * clobbered registers: x2, w22, w23, w24, w25, w26
  * clobbered flag groups: FG0
  */
+.type relprime_small_primes, @function
 relprime_small_primes:
   /* Generate a 256-bit mask.
        w24 <= 2^256 - 1 */
@@ -2266,6 +2288,7 @@ __relprime_small_primes_fail:
  * clobbered registers: x2, w22, w25, w26
  * clobbered flag groups: FG0
  */
+.type is_zero_mod_small_prime, @function
 is_zero_mod_small_prime:
   /* Copy input. */
   bn.mov  w25, w23

--- a/sw/acc/crypto/run_ed25519.s
+++ b/sw/acc/crypto/run_ed25519.s
@@ -48,6 +48,7 @@
 
 .section .text.start
 .globl start
+.type start, @function
 start:
   /* Init all-zero register. */
   bn.xor  w31, w31, w31
@@ -91,6 +92,7 @@ start:
  * @param[out] dmem[ed25519_sig_R]: R component of signature (256 bits)
  * @param[out] dmem[ed25519_sig_S]: S component of signature (256 bits)
  */
+.type ed25519_sign_hash_top, @function
 ed25519_sign_hash_top:
   jal x1, ed25519_sign_prehashed
   ecall
@@ -100,6 +102,7 @@ ed25519_sign_hash_top:
  *
  * See documentation for ed25519_sign_pure_init in ed25519.s for details.
  */
+.type ed25519_sign_pure_init_top, @function
 ed25519_sign_pure_init_top:
   jal x1, ed25519_sign_pure_init
   ecall
@@ -109,6 +112,7 @@ ed25519_sign_pure_init_top:
  *
  * See documentation for ed25519_sign_pure_update in ed25519.s for details.
  */
+.type ed25519_sign_pure_update_top, @function
 ed25519_sign_pure_update_top:
   jal x1, ed25519_sign_pure_update
   ecall
@@ -118,6 +122,7 @@ ed25519_sign_pure_update_top:
  *
  * See documentation for ed25519_sign_pure_mid in ed25519.s for details.
  */
+.type ed25519_sign_pure_mid_top, @function
 ed25519_sign_pure_mid_top:
   jal x1, ed25519_sign_pure_mid
   ecall
@@ -127,6 +132,7 @@ ed25519_sign_pure_mid_top:
  *
  * See documentation for ed25519_sign_pure_final in ed25519.s for details.
  */
+.type ed25519_sign_pure_final_top, @function
 ed25519_sign_pure_final_top:
   jal x1, ed25519_sign_pure_final
   ecall
@@ -144,6 +150,7 @@ ed25519_sign_pure_final_top:
  * @param[in]  dmem[ed25519_public_key]: encoded public key A_, 256 bits
  * @param[out] dmem[ed25519_verify_result]: SUCCESS or FAILURE
  */
+.type ed25519_verify_top, @function
 ed25519_verify_top:
   jal x1, ed25519_verify_var
   ecall

--- a/sw/acc/crypto/run_mlkem.s
+++ b/sw/acc/crypto/run_mlkem.s
@@ -40,6 +40,7 @@
 
 .section .text.start
 .globl start
+.type start, @function
 start:
   /* All-zero register. */
   bn.xor  w31, w31, w31

--- a/sw/acc/crypto/run_p256.s
+++ b/sw/acc/crypto/run_p256.s
@@ -61,6 +61,7 @@
 
 .section .text.start
 .globl start
+.type start, @function
 start:
   /* Read the mode and tail-call the requested operation. */
   la    x2, mode
@@ -124,6 +125,7 @@ start:
  * clobbered registers: x10, w10
  * clobbered flag groups: none
  */
+.type copy_share, @function
 copy_share:
   /* Randomize the content of w10 to prevent leakage. */
   bn.wsrr  w10, URND
@@ -145,6 +147,7 @@ copy_share:
  * @param[out]  dmem[x]: Public key x-coordinate.
  * @param[out]  dmem[y]: Public key y-coordinate.
  */
+.type random_keygen, @function
 random_keygen:
   /* Generate secret key d in shares.
        dmem[d0] <= d0
@@ -175,6 +178,7 @@ random_keygen:
  * @param[in] dmem[y]: Public key y-coordinate.
  * @param[out] dmem[ok]: success/failure of basic checks (32 bits)
  */
+.type public_key_check, @function
 public_key_check:
   /* Validate the public key (ends the program on failure). */
   jal      x1, p256_check_public_key
@@ -195,6 +199,7 @@ public_key_check:
  * @param[in]  dmem[d0]:  first share of private key d (320 bits)
  * @param[in]  dmem[d1]:  second share of private key d (320 bits)
  */
+.type ecdsa_sign, @function
 ecdsa_sign:
   /* Generate a fresh random scalar for signing.
        dmem[k0] <= first share of k
@@ -226,6 +231,7 @@ ecdsa_sign:
  * @param[out] dmem[ok]:  success/failure of basic checks (32 bits)
  * @param[out] dmem[x_r]: dmem buffer for reduced affine x_r-coordinate (x_1)
  */
+.type ecdsa_verify, @function
 ecdsa_verify:
   /* Validate the public key (ends the program on failure). */
   jal      x1, p256_check_public_key
@@ -257,6 +263,7 @@ ecdsa_verify:
  * @param[out]  dmem[x]: x0, first share of shared key.
  * @param[out]  dmem[y]: x1, second share of shared key.
  */
+.type shared_key, @function
 shared_key:
   /* Validate the public key (ends the program on failure). */
   jal      x1, p256_check_public_key
@@ -281,6 +288,7 @@ shared_key:
  * @param[out]  dmem[x]: Public key x-coordinate.
  * @param[out]  dmem[y]: Public key y-coordinate.
  */
+.type sideload_keygen, @function
 sideload_keygen:
   /* Generate secret key d in shares.
        dmem[d0] <= d0
@@ -301,6 +309,7 @@ sideload_keygen:
  * @param[in]  dmem[r]:   dmem buffer for r component of signature (256 bits)
  * @param[in]  dmem[s]:   dmem buffer for s component of signature (256 bits)
  */
+.type sideload_ecdsa_sign, @function
 sideload_ecdsa_sign:
   /* Generate secret key d in shares.
        dmem[d0] <= d0
@@ -330,6 +339,7 @@ sideload_ecdsa_sign:
  * @param[out]  dmem[x]: x0, first share of shared key.
  * @param[out]  dmem[y]: x1, second share of shared key.
  */
+.type shared_key_from_seed, @function
 shared_key_from_seed:
   /* Generate secret key d in shares.
        dmem[d0] <= d0
@@ -345,6 +355,7 @@ shared_key_from_seed:
  * @param[out] dmem[d0]: First share of secret key.
  * @param[out] dmem[d0]: Second share of secret key.
  */
+.type secret_key_from_seed, @function
 secret_key_from_seed:
   /* Load keymgr seeds from WSRs.
        w20,w21 <= seed0

--- a/sw/acc/crypto/run_p384.s
+++ b/sw/acc/crypto/run_p384.s
@@ -60,6 +60,7 @@
 
 .section .text.start
 .globl start
+.type start, @function
 start:
   /* Read the mode and tail-call the requested operation. */
   la    x2, mode
@@ -123,6 +124,7 @@ start:
  * clobbered registers: x10, w10
  * clobbered flag groups: none
  */
+.type copy_share, @function
 copy_share:
   /* Randomize the content of w10 to prevent leakage. */
   bn.wsrr  w10, URND
@@ -154,6 +156,7 @@ copy_share:
  * clobbered registers: x2, x3, x9 to x13, x18 to x23, x26 to x30, w0 to w30
  * clobbered flag groups: FG0
  */
+.type keypair_random, @function
 keypair_random:
   /* Generate secret key d in shares.
        dmem[d0] <= d0
@@ -184,6 +187,7 @@ keypair_random:
  * @param[in] dmem[y]: Public key y-coordinate.
  * @param[out] dmem[ok]: success/failure of basic checks (32 bits)
  */
+.type public_key_check, @function
 public_key_check:
   /* Validate the public key (ends the program on failure). */
   jal      x1, p384_check_public_key
@@ -205,6 +209,7 @@ public_key_check:
  * @param[out]   dmem[r]: r component of signature
  * @param[out]   dmem[s]: s component of signature
  */
+.type ecdsa_sign, @function
 ecdsa_sign:
   /* Generate a fresh random scalar for signing.
        dmem[k0] <= first share of k
@@ -226,6 +231,7 @@ ecdsa_sign:
  * @param[out]   dmem[r]: r component of signature
  * @param[out]   dmem[s]: s component of signature
  */
+.type ecdsa_sign_sideloaded, @function
 ecdsa_sign_sideloaded:
   /* Load keymgr seeds from WSRs.
        w20,w21 <= seed0
@@ -259,6 +265,7 @@ ecdsa_sign_sideloaded:
  * @param[in]    dmem[y]: y-coordinate of public key
  * @param[out] dmem[x_r]: x1 coordinate to be compared to rs
  */
+.type ecdsa_verify, @function
 ecdsa_verify:
   /* Validate the public key (ends the program on failure). */
   jal      x1, p384_check_public_key
@@ -289,6 +296,7 @@ ecdsa_verify:
  * clobbered registers: x2, x3, x9 to x13, x17 to x21, x26 to x30, w0 to w30
  * clobbered flag groups: FG0
  */
+.type shared_key, @function
 shared_key:
   /* Validate the public key (ends the program on failure). */
   jal      x1, p384_check_public_key
@@ -354,6 +362,7 @@ shared_key:
  * clobbered registers: x2, x3, x9 to x13, x18 to x23, x26 to x30, w0 to w30
  * clobbered flag groups: FG0
  */
+.type keypair_from_seed, @function
 keypair_from_seed:
   /* Load keymgr seeds from WSRs.
        w20,w21 <= seed0
@@ -394,6 +403,7 @@ keypair_from_seed:
  * clobbered registers: x2, x3, x9 to x13, x18 to x21, x26 to x30, w0 to w30
  * clobbered flag groups: FG0
  */
+.type shared_key_from_seed, @function
 shared_key_from_seed:
   /* Load keymgr seeds from WSRs.
        w20,w21 <= seed0

--- a/sw/acc/crypto/run_rsa_keygen.s
+++ b/sw/acc/crypto/run_rsa_keygen.s
@@ -49,6 +49,7 @@
 .globl MODE_CHECK_RSA_4096
 
 .section .text.start
+.type start, @function
 start:
   /* Init all-zero register. */
   bn.xor  w31, w31, w31
@@ -89,6 +90,7 @@ start:
   unimp
   unimp
 
+.type rsa_keygen_2048, @function
 rsa_keygen_2048:
   /* Set the number of limbs for the primes (2048 / 2 / 256). */
   li      x30, 4
@@ -97,6 +99,7 @@ rsa_keygen_2048:
   jal     x1, rsa_keygen
   ecall
 
+.type rsa_keygen_3072, @function
 rsa_keygen_3072:
   /* Set the number of limbs for the primes (3072 / 2 / 256). */
   li      x30, 6
@@ -105,6 +108,7 @@ rsa_keygen_3072:
   jal     x1, rsa_keygen
   ecall
 
+.type rsa_keygen_4096, @function
 rsa_keygen_4096:
   /* Set the number of limbs for the primes (4096 / 2 / 256). */
   li      x30, 8
@@ -113,6 +117,7 @@ rsa_keygen_4096:
   jal     x1, rsa_keygen
   ecall
 
+.type rsa_key_from_cofactor_2048, @function
 rsa_key_from_cofactor_2048:
   /* Set the number of limbs for the primes (2048 / 2 / 256). */
   li      x30, 4
@@ -121,6 +126,7 @@ rsa_key_from_cofactor_2048:
   jal     x1, rsa_key_from_cofactor
   ecall
 
+.type rsa_key_from_cofactor_3072, @function
 rsa_key_from_cofactor_3072:
   /* Set the number of limbs for the primes (3072 / 2 / 256). */
   li      x30, 6
@@ -129,6 +135,7 @@ rsa_key_from_cofactor_3072:
   jal     x1, rsa_key_from_cofactor
   ecall
 
+.type rsa_key_from_cofactor_4096, @function
 rsa_key_from_cofactor_4096:
   /* Set the number of limbs for the primes (4096 / 2 / 256). */
   li      x30, 8
@@ -137,6 +144,7 @@ rsa_key_from_cofactor_4096:
   jal     x1, rsa_key_from_cofactor
   ecall
 
+.type rsa_check_key_2048, @function
 rsa_check_key_2048:
   /* Set the number of limbs for the primes (2048 / 2 / 256). */
   li      x30, 4
@@ -146,6 +154,7 @@ rsa_check_key_2048:
   jal     x1, rsa_check_key
   ecall
 
+.type rsa_check_key_3072, @function
 rsa_check_key_3072:
   /* Set the number of limbs for the primes (3072 / 2 / 256). */
   li      x30, 6
@@ -155,6 +164,7 @@ rsa_check_key_3072:
   jal     x1, rsa_check_key
   ecall
 
+.type rsa_check_key_4096, @function
 rsa_check_key_4096:
   /* Set the number of limbs for the primes (4096 / 2 / 256). */
   li      x30, 8

--- a/sw/acc/crypto/run_rsa_modexp.s
+++ b/sw/acc/crypto/run_rsa_modexp.s
@@ -58,6 +58,7 @@
 .globl MODE_RSA_4096_MODEXP_F4
 
 .section .text.start
+.type start, @function
 start:
   /* Init all-zero register. */
   bn.xor  w31, w31, w31
@@ -98,6 +99,7 @@ start:
   unimp
   unimp
 
+.type rsa_2048_modexp, @function
 rsa_2048_modexp:
   /* Set the number of limbs for the modulus (2048 / 256 = 8). */
   li      x30, 8
@@ -105,6 +107,7 @@ rsa_2048_modexp:
   /* Tail-call modexp. */
   jal     x0, do_modexp
 
+.type rsa_2048_modexp_crt, @function
 rsa_2048_modexp_crt:
   /* Set the number of limbs for the modulus (2048 / 256 = 8). */
   li      x30, 8
@@ -112,6 +115,7 @@ rsa_2048_modexp_crt:
   /* Tail-call modexp_crt. */
   jal     x0, do_modexp_crt
 
+.type rsa_2048_modexp_f4, @function
 rsa_2048_modexp_f4:
   /* Set the number of limbs for the modulus (2048 / 256 = 8). */
   li      x30, 8
@@ -119,6 +123,7 @@ rsa_2048_modexp_f4:
   /* Tail-call modexp_f4. */
   jal     x0, do_modexp_f4
 
+.type rsa_3072_modexp, @function
 rsa_3072_modexp:
   /* Set the number of limbs for the modulus (3072 / 256 = 12). */
   li      x30, 12
@@ -126,6 +131,7 @@ rsa_3072_modexp:
   /* Tail-call modexp. */
   jal     x0, do_modexp
 
+.type rsa_3072_modexp_crt, @function
 rsa_3072_modexp_crt:
   /* Set the number of limbs for the modulus (3072 / 256 = 12). */
   li      x30, 12
@@ -133,6 +139,7 @@ rsa_3072_modexp_crt:
   /* Tail-call modexp_crt. */
   jal     x0, do_modexp_crt
 
+.type rsa_3072_modexp_f4, @function
 rsa_3072_modexp_f4:
   /* Set the number of limbs for the modulus (3072 / 256 = 12). */
   li      x30, 12
@@ -140,6 +147,7 @@ rsa_3072_modexp_f4:
   /* Tail-call modexp_f4. */
   jal     x0, do_modexp_f4
 
+.type rsa_4096_modexp, @function
 rsa_4096_modexp:
   /* Set the number of limbs for the modulus (4096 / 256 = 16). */
   li      x30, 16
@@ -147,6 +155,7 @@ rsa_4096_modexp:
   /* Tail-call modexp. */
   jal     x0, do_modexp
 
+.type rsa_4096_modexp_crt, @function
 rsa_4096_modexp_crt:
   /* Set the number of limbs for the modulus (4096 / 256 = 16). */
   li      x30, 16
@@ -154,6 +163,7 @@ rsa_4096_modexp_crt:
   /* Tail-call modexp_crt. */
   jal     x0, do_modexp_crt
 
+.type rsa_4096_modexp_f4, @function
 rsa_4096_modexp_f4:
   /* Set the number of limbs for the modulus (4096 / 256 = 16). */
   li      x30, 16
@@ -173,6 +183,7 @@ rsa_4096_modexp_f4:
  * @param[in]  dmem[inout]: a, base for exponentiation
  * @param[out] dmem[inout]: result, a^d mod n
  */
+.type do_modexp, @function
 do_modexp:
   /* Load pointers to modulus and Montgomery constant buffers. */
   la    x16, n
@@ -213,6 +224,7 @@ do_modexp:
  * @param[in]  dmem[inout]: a, base for exponentiation
  * @param[out] dmem[inout]: result, a^d mod n
  */
+.type do_modexp_crt, @function
 do_modexp_crt:
   /* Load pointers to modulus and Montgomery constant buffers. */
   la    x17, m0d
@@ -255,6 +267,7 @@ do_modexp_crt:
  * @param[in]  dmem[inout]: a, base for exponentiation
  * @param[out] dmem[inout]: result, a^65537 mod n
  */
+.type do_modexp_f4, @function
 do_modexp_f4:
   /* Load pointers to modulus and Montgomery constant buffers. */
   la    x16, n

--- a/sw/acc/crypto/run_sha256.s
+++ b/sw/acc/crypto/run_sha256.s
@@ -3,6 +3,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 .section .text.start
+.type main, @function
 main:
   /* Load the number of message chunks.
        x30 <= dmem[num_msg_chunks] */

--- a/sw/acc/crypto/run_sha512.s
+++ b/sw/acc/crypto/run_sha512.s
@@ -3,6 +3,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 .section .text.start
+.type main, @function
 main:
   /* Set the state pointer. */
   la      x2, state

--- a/sw/acc/crypto/sha256.s
+++ b/sw/acc/crypto/sha256.s
@@ -26,6 +26,7 @@
  * clobbered registers: x2, x3, x10 to x12, x21 to x23, w20 to w30
  * clobbered flag groups: FG0
  */
+.type sha256, @function
 sha256:
   /* Init all-zero register. */
   bn.xor   w31, w31, w31
@@ -96,6 +97,7 @@ sha256:
  * clobbered registers: w23 to w27
  * clobbered flag groups: FG0
  */
+.type bswap32_w23, @function
 bswap32_w23:
   /* Isolate each byte of each 32-bit word.
        w24 <= byte 0 of each word = a
@@ -183,6 +185,7 @@ bswap32_w23:
  * clobbered registers: x11, x12, w21 to w28, w30
  * clobbered flag groups: FG0
  */
+.type sha256_process_block, @function
 sha256_process_block:
   /* Copy the message into the first 512 bits of the message schedule.
        dmem[sha256_W..sha256_W+64] <= w22 || w21 */

--- a/sw/acc/crypto/sha3_shake.s
+++ b/sw/acc/crypto/sha3_shake.s
@@ -35,6 +35,7 @@
  * clobbered flag groups: none
  */
 .global sha3_init
+.type sha3_init, @function
 sha3_init:
   addi x5, x10, 0
   addi x6, x0, 31
@@ -72,6 +73,7 @@ sha3_init:
  * clobbered flag groups: FG0
  */
 .global sha3_update
+.type sha3_update, @function
 sha3_update:
   /* Load pt as j */
   lw x5, 200(x10)
@@ -153,6 +155,7 @@ _sha3_update_skip_loop:
  * clobbered flag groups: FG0
  */
 .global sha3_final
+.type sha3_final, @function
 sha3_final:
   /* Load constant for address alignment */
   li   x12, 0xFFFFFFFC
@@ -211,6 +214,7 @@ sha3_final:
  * clobbered flag groups: FG0
  */
 .global shake_xof
+.type shake_xof, @function
 shake_xof:
   /* Load constant for address alignment */
   li   x12, 0xFFFFFFFC
@@ -262,6 +266,7 @@ shake_xof:
  * clobbered flag groups: FG0
  */
 .global shake_out
+.type shake_out, @function
 shake_out:
   /* Load pt as j */
   lw   x5, 200(x10)
@@ -341,6 +346,7 @@ _shake_out_skip_loop:
  */
 
 .global keccakf
+.type keccakf, @function
 keccakf:
   /* Copy context pointer */
   add     x5, x0, x10

--- a/sw/acc/crypto/sha512.s
+++ b/sw/acc/crypto/sha512.s
@@ -79,6 +79,7 @@
  * clobbered flag groups: FG0
  */
 .globl sha512
+.type sha512, @function
 sha512:
 
   /* w31 = 0 */

--- a/sw/acc/crypto/sha512_compact.s
+++ b/sw/acc/crypto/sha512_compact.s
@@ -78,6 +78,7 @@
  * clobbered flag groups: FG0
  */
 .globl sha512_compact
+.type sha512_compact, @function
 sha512_compact:
 
   /* w31 = 0 */

--- a/sw/acc/crypto/sha512_interface.s
+++ b/sw/acc/crypto/sha512_interface.s
@@ -28,6 +28,7 @@
  * clobbered registers: x2, x3, x20, w20
  * clobbered flag groups: FG0
  */
+.type sha512_init, @function
 sha512_init:
   /* Copy the initial state into the working buffer.
        dmem[state..state+256] <= dmem[init_state..init_state+256] */
@@ -89,6 +90,7 @@ sha512_init:
  *                      w0 to w7, w10, w11, w15 to w29
  * clobbered flag groups: FG0
  */
+.type sha512_update, @function
 sha512_update:
   /* Load the least significant 32 bits of the current message byte-length.
        x14 <= dmem[len][31:0] */
@@ -184,6 +186,7 @@ sha512_update:
  *                      w0 to w7, w10, w15 to w30
  * clobbered flag groups: FG0
  */
+.type sha512_final, @function
 sha512_final:
   /* Load the least significant 32 bits of the current message byte-length.
        x14 <= dmem[len][31:0] */
@@ -271,6 +274,7 @@ sha512_final:
  * clobbered registers: x2, x10, x11, x13, x16, x17, x19 to x21, w20, w21
  * clobbered flag groups: FG0
  */
+.type copy, @function
 copy:
   /* Continue only if the length of new data is nonzero; otherwise return. */
   bne      x0, x13, _copy_len_nonzero
@@ -382,6 +386,7 @@ copy:
  * clobbered registers: w20 to w28
  * clobbered flag groups: FG0
  */
+.type reverse_bytes, @function
 reverse_bytes:
   /* Select the 64-bit chunks of the word.
        w20 <= w28[ 63:  0]
@@ -421,6 +426,7 @@ reverse_bytes:
  * clobbered registers: x2, x3, x12, x28, w20 to w29
  * clobbered flag groups: FG0
  */
+.type sha512_format_blocks, @function
 sha512_format_blocks:
   /* Load constants.
        x28 <= 28
@@ -454,6 +460,7 @@ sha512_format_blocks:
  * clobbered registers: w20 to w28
  * clobbered flag groups: FG0
  */
+.type bswap64, @function
 bswap64:
   /* Isolate each byte of each 64-bit word.
        w20 <= byte 0 of each word = a

--- a/sw/acc/crypto/sha512_padding.s
+++ b/sw/acc/crypto/sha512_padding.s
@@ -41,6 +41,7 @@
  * clobbered flag groups: FG0
  */
 .globl sha512_pad_message
+.type sha512_pad_message, @function
 sha512_pad_message:
   /* Align the address and compute the offset.
        x20 <= dptr_pad % 4
@@ -137,6 +138,7 @@ sha512_pad_message:
  * clobbered registers: x2, x3, x23
  * clobbered flag groups: FG0
  */
+.type bswap32, @function
 bswap32:
   /* x2 <= w[0] << 24 */
   andi    x2, x23, 255

--- a/sw/acc/crypto/tests/boot_mode_invalid.hjson
+++ b/sw/acc/crypto/tests/boot_mode_invalid.hjson
@@ -9,7 +9,7 @@
   }
   "output": {
     "regs": {
-      "STOP_PC": "start_failed"
+      "STOP_PC": "_start_failed"
       "ERR_BITS": "0x00000008"  # unimp trap
     }
   }

--- a/sw/acc/crypto/trigger_fault_if_fg0_z.s
+++ b/sw/acc/crypto/trigger_fault_if_fg0_z.s
@@ -20,6 +20,7 @@
  * clobbered flag groups: none
  */
 .globl trigger_fault_if_fg0_z
+.type trigger_fault_if_fg0_z, @function
 trigger_fault_if_fg0_z:
   /* Read the FG0.Z flag (position 3).
        x2 <= FG0.Z << 3 */

--- a/sw/acc/crypto/trigger_fault_if_not_fg0_z.s
+++ b/sw/acc/crypto/trigger_fault_if_not_fg0_z.s
@@ -20,6 +20,7 @@
  * clobbered flag groups: none
  */
 .globl trigger_fault_if_not_fg0_z
+.type trigger_fault_if_not_fg0_z, @function
 trigger_fault_if_not_fg0_z:
   /* Read the FG0.Z flag (position 3).
        x2 <= FG0.Z << 3 */

--- a/sw/acc/crypto/x25519.s
+++ b/sw/acc/crypto/x25519.s
@@ -26,6 +26,7 @@
  * clobbered flag groups: FG0
  */
 .globl X25519
+.type X25519, @function
 X25519:
   /* Prepare all-zero register. */
   bn.xor   w31, w31, w31
@@ -110,6 +111,7 @@ X25519:
  * clobbered registers: w2 to w7, w10 to w18, w20 to w24
  * clobbered flag groups: FG0
  */
+.type scalar_mult, @function
 scalar_mult:
 
   /* Load the constant a24:
@@ -273,6 +275,7 @@ scalar_mult:
  * clobbered registers: w2 to w5, w10 to w13, w17, w18, w20 to w23
  * clobbered flag groups: FG0
  */
+.type ladderstep, @function
 ladderstep:
   /* First, compute the new x_2 and z_2:
        A = x_2 + z_2

--- a/sw/acc/crypto/x25519_sideload.s
+++ b/sw/acc/crypto/x25519_sideload.s
@@ -20,6 +20,7 @@
 
 .section .text.start
 
+.type main, @function
 main:
   /* w7 <= KEY_S0_L */
   bn.wsrr w7, 4


### PR DESCRIPTION
The profiler built its address->symbol map from every symbol in the
imem section, sweeping in the LLVM's $x/$d mapping symbols and
.L* labels. These outnumber real labels, so most instructions were
attributed to the nearest preceding mapping symbol.

One could filter such labels, but this commit instead takes the
more robust route and marks function labels using
`.type xxx, @function`, such that the profiler can filter for
such labels.

Additionally, this commit adds linting infrastructure for ACC asm
in ci/scripts/check-acc-asm.py currently consisting of a single
check: Every non-local (not .L or _ prefixed) needs to have a
corresponding .type annotation.

A few non-function labels get a _ prefix to pass the linting.

- Fixes https://github.com/pavona/pavona/issues/296.