### PR TITLE
[ci] Bump libtinfo5 to 6.3-2ubuntu0.2

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -59,15 +59,15 @@ runs:
           sudo apt update --fix-missing
           grep '^[^#]' apt-requirements.txt | xargs sudo apt install -y
           sudo apt install wget
-          # TODO: Remove once the prebuilt RISC-V toolchain no longer needs libtinfo5.
+          # TODO: Remove once Vivado no longer needs libtinfo5.
           ARCH="$(dpkg --print-architecture)"
           if [ "$ARCH" = "amd64" ]; then
             POOL_URL=http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses
           else
             POOL_URL=http://ports.ubuntu.com/ubuntu-ports/pool/universe/n/ncurses
           fi
-          wget "${POOL_URL}/libtinfo5_6.3-2ubuntu0.1_${ARCH}.deb"
-          sudo apt install "./libtinfo5_6.3-2ubuntu0.1_${ARCH}.deb"
+          wget "${POOL_URL}/libtinfo5_6.3-2ubuntu0.2_${ARCH}.deb"
+          sudo apt install "./libtinfo5_6.3-2ubuntu0.2_${ARCH}.deb"
         else
           # Install Extra Packages for Enterprise Linux first
           sudo yum install -y epel-release


### PR DESCRIPTION
The Ubuntu pool only keeps the latest version, so the 6.3-2ubuntu0.1 URL now returns 404. Also correct the TODO comment: the libtinfo5 dependency comes from Vivado not the RISC-V toolchain.

