### PR TITLE
[dj,sw] Run hello_world binary on Dragonfly + Verilator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,12 +285,31 @@ jobs:
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
       - name: Run fast Verilator tests
-        run: ./ci/scripts/run-verilator-tests.sh
+        run: ./ci/scripts/run-verilator-tests.sh egret
       - name: Publish Bazel test results
         uses: ./.github/actions/publish-bazel-test-results
         if: ${{ !cancelled() }}
         with:
           artifact-name: verilator_egret-test-results
+
+  verilator_dragonfly:
+    name: Dragonfly Verilator tests
+    runs-on:
+      group: pavona-large
+    needs: quick_lint
+    if: ${{ github.event_name != 'merge_group' }}
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+      - name: Run fast Verilator tests
+        run: ./ci/scripts/run-verilator-tests.sh dragonfly
+      - name: Publish Bazel test results
+        uses: ./.github/actions/publish-bazel-test-results
+        if: ${{ !cancelled() }}
+        with:
+          artifact-name: verilator_dragonfly-test-results
 
   chip_egret_cw310:
     name: Egret for CW310

--- a/ci/scripts/run-verilator-tests.sh
+++ b/ci/scripts/run-verilator-tests.sh
@@ -5,9 +5,41 @@
 
 set -e
 
+if [ $# != 1 ]; then
+    echo >&2 "Usage: run-verilator-tests.sh top_name"
+    echo >&2 "E.g. ./run-verilator-tests.sh egret"
+    exit 1
+fi
+
+TOP_NAME=$1
+
+TESTS=(
+    "//sw/device/tests:aes_smoketest_sim_verilator"
+    "//sw/device/tests:uart_smoketest_sim_verilator"
+    "//sw/device/tests:crt_test_sim_verilator"
+    "//sw/device/tests:acc_randomness_test_sim_verilator"
+    "//sw/device/tests:acc_irq_test_sim_verilator"
+    "//sw/device/tests:kmac_mode_cshake_test_sim_verilator"
+    "//sw/device/tests:kmac_mode_kmac_test_sim_verilator"
+    "//sw/device/silicon_creator/lib/drivers:hmac_functest_sim_verilator"
+    "//sw/device/silicon_creator/lib/drivers:uart_functest_sim_verilator"
+    "//sw/device/silicon_creator/lib/drivers:retention_sram_functest_sim_verilator"
+)
+
+if [ "${TOP_NAME}" == "egret" ]; then
+    TESTS+=("//sw/device/silicon_creator/lib/drivers:alert_functest_sim_verilator")
+    TESTS+=("//sw/device/tests:flash_ctrl_test_sim_verilator")
+    TESTS+=("//sw/device/silicon_creator/rom:rom_epmp_test_sim_verilator")
+    TESTS+=("//sw/device/tests:usbdev_test_sim_verilator")
+    # TODO: these two tests hang on Dragonfly.
+    TESTS+=("//sw/device/silicon_creator/lib/drivers:watchdog_functest_sim_verilator")
+    TESTS+=("//sw/device/silicon_creator/lib:irq_asm_functest_sim_verilator")
+fi
+
 # Increase the test_timeout due to slow performance on CI
 
 ./bazelisk.sh test \
+    --//hw/top="${TOP_NAME}" \
     --build_tests_only=true \
     --test_timeout=2400,2400,4000,-1 \
     --local_test_jobs=8 \
@@ -15,19 +47,4 @@ set -e
     --test_tag_filters=verilator,-broken \
     --test_output=errors \
     --//hw:make_options=-j,8 \
-    //sw/device/tests:aes_smoketest_sim_verilator \
-    //sw/device/tests:uart_smoketest_sim_verilator \
-    //sw/device/tests:crt_test_sim_verilator \
-    //sw/device/tests:acc_randomness_test_sim_verilator \
-    //sw/device/tests:acc_irq_test_sim_verilator \
-    //sw/device/tests:kmac_mode_cshake_test_sim_verilator \
-    //sw/device/tests:kmac_mode_kmac_test_sim_verilator \
-    //sw/device/tests:flash_ctrl_test_sim_verilator \
-    //sw/device/tests:usbdev_test_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:hmac_functest_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:uart_functest_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:retention_sram_functest_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:alert_functest_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:watchdog_functest_sim_verilator \
-    //sw/device/silicon_creator/lib:irq_asm_functest_sim_verilator \
-    //sw/device/silicon_creator/rom:rom_epmp_test_sim_verilator
+    "${TESTS[@]}"

--- a/hw/top_dragonfly/BUILD
+++ b/hw/top_dragonfly/BUILD
@@ -56,7 +56,7 @@ sim_verilator(
         "//sw/device/lib/arch:sim_verilator",
         "//hw/top_dragonfly/sw/dt:sim_verilator",
     ],
-    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_virtual",
     otp = "//hw/top_dragonfly/data/otp:img_rma",
     slot_spec = DRAGONFLY_SLOTS,
     test_cmd = "testing-not-supported",
@@ -91,6 +91,17 @@ sim_verilator(
         --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
         no-op
     """,
+)
+
+sim_verilator(
+    name = "sim_verilator_rom_with_fake_keys",
+    testonly = True,
+    base = ":sim_verilator",
+    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:test_key_0_ecdsa_p256": "test_key_0"},
+    exec_env = "sim_verilator_rom_with_fake_keys",
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest",
+    rom = "//sw/device/silicon_creator/rom:base_rom",
+    second_rom = "//sw/device/silicon_creator/rom:second_rom",
 )
 
 ###########################################################################

--- a/hw/top_dragonfly/BUILD
+++ b/hw/top_dragonfly/BUILD
@@ -70,7 +70,8 @@ sim_verilator(
         "--logging=info",
         "--interface=verilator",
         "--verilator-bin=$(rootpath //hw:verilator)",
-        "--verilator-rom={rom}",
+        "--verilator-rom={rom}:0",
+        "--verilator-rom={second_rom}:1",
         "--verilator-otp={otp}",
         "--verilator-ctn-ram={firmware}",
     ],
@@ -85,6 +86,7 @@ sim_verilator(
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
     rom = "//sw/device/lib/testing/test_rom:test_rom",
+    second_rom = "//sw/device/lib/testing/test_second_rom:test_second_rom",
     test_cmd = """
         --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
         no-op

--- a/hw/top_dragonfly/sw/dt/sim_verilator.c
+++ b/hw/top_dragonfly/sw/dt/sim_verilator.c
@@ -6,10 +6,13 @@
 
 #include "hw/top/dt/api.h"  // Generated
 
-// FIXME Are those really fixed in DV? Does it matter?
+// Keep in sync with sw/device/lib/arch/device_sim_verilator.c.
+//
+// These values are important to ensure the correct baud rate in DV, e.g. see
+// the `uartdpi` in hw/top_dragonfly/dv/verilator/chip_sim_tb.sv.
 static const uint32_t clock_freqs[kDtClockCount] = {
     [kDtClockMain] = 500 * 1000,
-    [kDtClockIo] = 250 * 1000,
+    [kDtClockIo] = 500 * 1000,
     [kDtClockAon] = 125 * 1000,
 };
 

--- a/sw/device/examples/hello_world/BUILD
+++ b/sw/device/examples/hello_world/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules/pavona:defs.bzl", "pavona_test")
+load("//rules/pavona:defs.bzl", "pavona_test", "verilator_params")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -16,7 +16,11 @@ pavona_test(
     exec_env = {
         "//hw/top_egret:sim_dv": None,
         "//hw/top_egret:sim_verilator": None,
+        "//hw/top_dragonfly:sim_dv": None,
+        "//hw/top_dragonfly:sim_verilator": None,
+        "//hw/top_dragonfly:sim_verilator_rom_with_fake_keys": None,
     },
+    verilator = verilator_params(timeout = "long"),
     deps = [
         "//hw/top/dt",
         "//sw/device/lib/arch:device",

--- a/sw/device/lib/arch/BUILD
+++ b/sw/device/lib/arch/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:doxygen.bzl", "doxygen_gather_all_package_cc")
-load("//hw/top:defs.bzl", "pavona_if_ip", "pavona_require_ip")
+load("//hw/top:defs.bzl", "pavona_if_ip", "pavona_require_ip", "pavona_select_top")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -120,6 +120,13 @@ cc_library(
 cc_library(
     name = "sim_verilator",
     srcs = ["device_sim_verilator.c"],
+    defines = pavona_select_top(
+        {
+            "egret": ["PAVONA_IS_EGRET"],
+            "dragonfly": ["PAVONA_IS_DRAGONFLY"],
+        },
+        [],
+    ),
     deps = [
         ":device",
         ":stub",

--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -41,7 +41,15 @@ uint64_t to_cpu_cycles(uint64_t usec) {
 
 const uint64_t kClockFreqHiSpeedPeripheralHz = 500 * 1000;  // 500kHz
 
-const uint64_t kClockFreqPeripheralHz = 125 * 1000;  // 125kHz
+// Egret on Verilator uses a 1/4 clock divider for the peripheral clock, but on
+// Dragonfly the peripheral clock is 1:1 with the high-speed domain clock.
+#if defined(PAVONA_IS_EGRET)
+const uint64_t kClockFreqPeripheralHz =
+    kClockFreqHiSpeedPeripheralHz / 4;  // 125kHz
+#elif defined(PAVONA_IS_DRAGONFLY)
+const uint64_t kClockFreqPeripheralHz =
+    kClockFreqHiSpeedPeripheralHz;  // 500kHz
+#endif
 
 const uint64_t kClockFreqUsbHz = 500 * 1000;  // 500kHz
 

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -12,6 +12,7 @@ load("//rules:cross_platform.bzl", "dual_cc_device_library_of", "dual_cc_library
 load("//rules/pavona:defs.bzl", "PAVONA_CPU")
 load(
     "//rules/pavona:defs.bzl",
+    "DRAGONFLY_TEST_ENVS",
     "EGRET_TEST_ENVS",
     "fpga_params",
     "pavona_test",
@@ -247,14 +248,13 @@ cc_library(
 pavona_test(
     name = "irq_asm_functest",
     srcs = ["irq_asm_functest.c"],
-    exec_env = EGRET_TEST_ENVS,
+    exec_env = dicts.add(EGRET_TEST_ENVS, DRAGONFLY_TEST_ENVS),
     verilator = verilator_params(
         timeout = "long",
     ),
     deps = [
         ":error",
         ":irq_asm",
-        "//hw/top_egret/sw/autogen:top_egret",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -14,6 +14,7 @@ load(
 )
 load(
     "//rules/pavona:defs.bzl",
+    "DRAGONFLY_TEST_ENVS",
     "EGRET_CW340_TEST_ENVS",
     "EGRET_SILICON_OWNER_ROM_EXT_ENVS",
     "EGRET_TEST_ENVS",
@@ -280,6 +281,7 @@ pavona_test(
     name = "hmac_functest",
     srcs = ["hmac_functest.c"],
     exec_env = dicts.add(
+        DRAGONFLY_TEST_ENVS,
         EGRET_TEST_ENVS,
         EGRET_CW340_TEST_ENVS,
     ),
@@ -288,7 +290,6 @@ pavona_test(
     ),
     deps = [
         ":hmac",
-        "//hw/top_egret/sw/autogen:top_egret",
         "//sw/device/lib/testing:hexstr",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib:error",
@@ -639,13 +640,12 @@ cc_test(
 pavona_test(
     name = "retention_sram_functest",
     srcs = ["retention_sram_functest.c"],
-    exec_env = EGRET_TEST_ENVS,
+    exec_env = dicts.add(EGRET_TEST_ENVS, DRAGONFLY_TEST_ENVS),
     verilator = verilator_params(
         timeout = "long",
     ),
     deps = [
         ":retention_sram",
-        "//hw/top_egret/sw/autogen:top_egret",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -828,10 +828,9 @@ cc_test(
 pavona_test(
     name = "uart_functest",
     srcs = ["uart_functest.c"],
-    exec_env = EGRET_TEST_ENVS,
+    exec_env = dicts.add(EGRET_TEST_ENVS, DRAGONFLY_TEST_ENVS),
     deps = [
         ":uart",
-        "//hw/top_egret/sw/autogen:top_egret",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib:error",
     ],
@@ -886,7 +885,7 @@ cc_test(
 pavona_test(
     name = "watchdog_functest",
     srcs = ["watchdog_functest.c"],
-    exec_env = EGRET_TEST_ENVS,
+    exec_env = dicts.add(EGRET_TEST_ENVS, DRAGONFLY_TEST_ENVS),
     verilator = verilator_params(
         timeout = "long",
     ),

--- a/sw/device/silicon_creator/lib/drivers/hmac_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac_functest.c
@@ -18,8 +18,6 @@
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
-#include "hw/top_egret/sw/autogen/top_egret.h"
-
 // From: http://www.abrahamlincolnonline.org/lincoln/speeches/gettysburg.htm
 static alignas(uint32_t) const char kGettysburgPrelude[] =
     "Four score and seven years ago our fathers brought forth on this "

--- a/sw/device/silicon_creator/lib/drivers/retention_sram_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram_functest.c
@@ -12,8 +12,6 @@
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
-#include "hw/top_egret/sw/autogen/top_egret.h"
-
 // Variables of type `retention_sram_t` are static to reduce stack usage.
 static retention_sram_t ret;
 static uint64_t raw[sizeof(retention_sram_t) / sizeof(uint64_t)];

--- a/sw/device/silicon_creator/lib/drivers/uart_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/uart_functest.c
@@ -11,8 +11,6 @@
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
-#include "hw/top_egret/sw/autogen/top_egret.h"
-
 OTTF_DEFINE_TEST_CONFIG(.console.test_may_clobber = true);
 
 rom_error_t uart_test(void) {

--- a/sw/device/silicon_creator/lib/irq_asm_functest.c
+++ b/sw/device/silicon_creator/lib/irq_asm_functest.c
@@ -19,8 +19,6 @@
 #include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
-#include "hw/top_egret/sw/autogen/top_egret.h"
-
 /**
  * Exception handler written in assembly.
  *

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -434,6 +434,12 @@ cc_library(
 cc_library(
     name = "sigverify_key_types",
     hdrs = ["sigverify_key_types.h"],
+    defines = pavona_select_top(
+        {
+            "dragonfly": ["OTP_KEY_ROLE"],
+        },
+        [],
+    ),
     deps = [
         "//sw/device/silicon_creator/lib/sigverify:ecdsa_p256_key",
         "//sw/device/silicon_creator/lib/sigverify:rsa_key",

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -312,6 +312,7 @@ pavona_test(
     # loading the default test ROM, or any other ROM that may be specified via
     # Verilator or CW310 params).
     exec_env = {
+        "//hw/top_dragonfly:sim_verilator": None,
         "//hw/top_egret:sim_verilator": None,
     },
     kind = "rom",

--- a/sw/device/silicon_creator/rom/keys/real/otp/BUILD
+++ b/sw/device/silicon_creator/rom/keys/real/otp/BUILD
@@ -58,10 +58,10 @@ otp_json_rot_keys(
             otp_partition(
                 name = "ROT_OWNER_AUTH_SLOT0",
                 items = {
-                    # //sw/device/silicon_creator/rom/keys/real/spx:test_key_0_spx
-                    "ROT_OWNER_AUTH_SLOT0_NON_RAW_MFW_CODESIGN_KEY_TYPE": otp_hex(CONST.SIGVERIFY.KEY_TYPE.TEST),
+                    # //sw/device/silicon_creator/rom/keys/real/spx:prod_key_0_spx
+                    "ROT_OWNER_AUTH_SLOT0_NON_RAW_MFW_CODESIGN_KEY_TYPE": otp_hex(CONST.SIGVERIFY.KEY_TYPE.PROD),
                     "ROT_OWNER_AUTH_SLOT0_NON_RAW_MFW_CODESIGN_KEY_ROLE": otp_hex(CONST.SIGVERIFY.KEY_ROLE.FIRMWARE_SIGNING),
-                    "ROT_OWNER_AUTH_SLOT0_NON_RAW_MFW_CODESIGN_KEY": "0x2BB062EECDAFCD22015BA9BB38E0A97FFD0F8D4CD416672ABE0FA6069D629D35",
+                    "ROT_OWNER_AUTH_SLOT0_NON_RAW_MFW_CODESIGN_KEY": 0xAA68F9D4D64FF84C32185CB4F80EBA3924E9351B3C0A258DCE66247AC310E733,
                 },
             ),
         ],

--- a/sw/device/silicon_creator/rom/sigverify_key_types.h
+++ b/sw/device/silicon_creator/rom/sigverify_key_types.h
@@ -157,6 +157,12 @@ typedef struct sigverify_rom_key_header {
    * Type of the key.
    */
   sigverify_key_type_t key_type;
+#ifdef OTP_KEY_ROLE
+  /**
+   * Role of the key.
+   */
+  sigverify_key_role_t key_role;
+#endif
   /**
    * ID of the key.
    */
@@ -164,8 +170,14 @@ typedef struct sigverify_rom_key_header {
 } sigverify_rom_key_header_t;
 
 OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_type, 0);
+#ifdef OTP_KEY_ROLE
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_role, 4);
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_id, 8);
+OT_ASSERT_SIZE(sigverify_rom_key_header_t, 12);
+#else
 OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_id, 4);
 OT_ASSERT_SIZE(sigverify_rom_key_header_t, 8);
+#endif
 
 /**
  * An ECDSA P256 public key stored in ROM.
@@ -179,16 +191,32 @@ typedef struct sigverify_rom_ecdsa_p256_key_entry {
    * Type of the key.
    */
   sigverify_key_type_t key_type;
+#ifdef OTP_KEY_ROLE
+  /**
+   * Role of the key.
+   */
+  sigverify_key_role_t key_role;
+#endif
   /**
    * An ECDSA P256 public key.
    */
   ecdsa_p256_public_key_t key;
 } sigverify_rom_ecdsa_p256_key_entry_t;
 OT_ASSERT_MEMBER_OFFSET(sigverify_rom_ecdsa_p256_key_entry_t, key_type, 0);
+#ifdef OTP_KEY_ROLE
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_ecdsa_p256_key_entry_t, key_role, 4);
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_ecdsa_p256_key_entry_t, key.x[0], 8);
+#else
 OT_ASSERT_MEMBER_OFFSET(sigverify_rom_ecdsa_p256_key_entry_t, key.x[0], 4);
+#endif
 static_assert(offsetof(sigverify_rom_key_header_t, key_type) ==
                   offsetof(sigverify_rom_ecdsa_p256_key_entry_t, key_type),
               "Invalid key_type offset.");
+#ifdef OTP_KEY_ROLE
+static_assert(offsetof(sigverify_rom_key_header_t, key_role) ==
+                  offsetof(sigverify_rom_ecdsa_p256_key_entry_t, key_role),
+              "Invalid key_role offset.");
+#endif
 static_assert(offsetof(sigverify_rom_key_header_t, key_id) ==
                   offsetof(sigverify_rom_ecdsa_p256_key_entry_t, key.x[0]),
               "Invalid key_id offset.");
@@ -224,16 +252,32 @@ typedef struct sigverify_rom_rsa_key_entry {
    * Type of the key.
    */
   sigverify_key_type_t key_type;
+#ifdef OTP_KEY_ROLE
+  /**
+   * Role of the key.
+   */
+  sigverify_key_role_t key_role;
+#endif
   /**
    * An RSA public key.
    */
   sigverify_rsa_key_t key;
 } sigverify_rom_rsa_key_entry_t;
 OT_ASSERT_MEMBER_OFFSET(sigverify_rom_rsa_key_entry_t, key_type, 0);
+#ifdef OTP_KEY_ROLE
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_rsa_key_entry_t, key_role, 4);
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_rsa_key_entry_t, key.n.data[0], 8);
+#else
 OT_ASSERT_MEMBER_OFFSET(sigverify_rom_rsa_key_entry_t, key.n.data[0], 4);
+#endif
 static_assert(offsetof(sigverify_rom_key_header_t, key_type) ==
                   offsetof(sigverify_rom_rsa_key_entry_t, key_type),
               "Invalid key_type offset.");
+#ifdef OTP_KEY_ROLE
+static_assert(offsetof(sigverify_rom_key_header_t, key_role) ==
+                  offsetof(sigverify_rom_rsa_key_entry_t, key_role),
+              "Invalid key_role offset.");
+#endif
 static_assert(offsetof(sigverify_rom_key_header_t, key_id) ==
                   offsetof(sigverify_rom_rsa_key_entry_t, key.n.data[0]),
               "Invalid key_id offset.");
@@ -268,6 +312,12 @@ typedef struct sigverify_rom_spx_key_entry {
    * Type of the key.
    */
   sigverify_key_type_t key_type;
+#ifdef OTP_KEY_ROLE
+  /**
+   * Role of the key.
+   */
+  sigverify_key_role_t key_role;
+#endif
   /**
    * An SPX public key.
    */
@@ -279,10 +329,20 @@ typedef struct sigverify_rom_spx_key_entry {
 } sigverify_rom_spx_key_entry_t;
 
 OT_ASSERT_MEMBER_OFFSET(sigverify_rom_spx_key_entry_t, key_type, 0);
+#ifdef OTP_KEY_ROLE
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_spx_key_entry_t, key_role, 4);
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_spx_key_entry_t, key.data[0], 8);
+#else
 OT_ASSERT_MEMBER_OFFSET(sigverify_rom_spx_key_entry_t, key.data[0], 4);
+#endif
 static_assert(offsetof(sigverify_rom_key_header_t, key_type) ==
                   offsetof(sigverify_rom_spx_key_entry_t, key_type),
               "Invalid key_type offset.");
+#ifdef OTP_KEY_ROLE
+static_assert(offsetof(sigverify_rom_key_header_t, key_role) ==
+                  offsetof(sigverify_rom_spx_key_entry_t, key_role),
+              "Invalid key_role offset.");
+#endif
 static_assert(offsetof(sigverify_rom_key_header_t, key_id) ==
                   offsetof(sigverify_rom_spx_key_entry_t, key.data[0]),
               "Invalid key_id offset.");

--- a/sw/device/silicon_creator/rom/sigverify_otp_keys.h
+++ b/sw/device/silicon_creator/rom/sigverify_otp_keys.h
@@ -17,6 +17,7 @@
 extern "C" {
 #endif  // __cplusplus
 
+#ifdef DISCRETE_OTP_MMAP
 enum {
   /**Maximum number of ECDSA keys supported in OTP. */
   kSigVerifyOtpKeysEcdsaCount = 4,
@@ -47,6 +48,32 @@ typedef struct sigverify_otp_keys {
    */
   hmac_digest_t integrity_measurement;
 } sigverify_otp_keys_t;
+
+#elif INTEGRATED_OTP_MMAP
+/*
+ * In the integrated OTP memory map, the OTP stores a single key whose algorithm
+ * is untagged. The key contains an additional key_role field after the key_type
+ * (see sigverify_key_types.h).
+ */
+enum {
+  /**Maximum number of ECDSA keys supported in OTP. */
+  kSigVerifyOtpKeysEcdsaCount = 1,
+  /**Maximum number of SPX keys supported in OTP. */
+  kSigVerifyOtpKeysSpxCount = 1,
+};
+
+typedef union sigverify_otp_keys {
+  /**
+   * ECDSA P-256 keys.
+   */
+  sigverify_rom_ecdsa_p256_key_t ecdsa[1];
+  /**
+   * SPX keys.
+   */
+  sigverify_rom_spx_key_t spx[1];
+} sigverify_otp_keys_t;
+
+#endif
 
 /**
  * SRAM representation of the OTP `ROT_CREATOR_AUTH_STATE` partition.


### PR DESCRIPTION
This PR builds on the tooling introduced in previous PRs (#179, #221, #222, #245) to run an end-to-end software test for Dragonfly on Verilator.

This PR also contains a few miscellaneous improvements that did not fit well in the previous PRs:
- Enable `sigverify` support on Dragonfly as part of the `rom1` in #222 using the OTP signing keys in #245.
- Fix an issue with the clock settings for Dragonfly/Verilator.

Duplicate of #189 as a result of the repository becoming public.