### PR TITLE
[util] Fix dual-copyright header order

### DIFF
--- a/util/gen_doc_hw_summary_table.py
+++ b/util/gen_doc_hw_summary_table.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# Copyright zeroRISC Inc.
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 """Collect the one-line summaries of all hardware blocks and output them as

--- a/util/reggen/gen_selfdoc.py
+++ b/util/reggen/gen_selfdoc.py
@@ -1,5 +1,5 @@
-# Copyright zeroRISC Inc.
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/util/topgen/selfdoc.py
+++ b/util/topgen/selfdoc.py
@@ -1,5 +1,5 @@
-# Copyright zeroRISC Inc.
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/util/uvmdvgen/__init__.py
+++ b/util/uvmdvgen/__init__.py
@@ -1,5 +1,5 @@
-# Copyright zeroRISC Inc.
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
./bazelisk.sh test //quality:license_check was failing due to wrongly ordered dual copyright headers.

This didn't surface in CI's check-license-headers.sh because that only checks the changed files.

This commit swaps the copyright lines to make the
license check happy.