### PR TITLE
[hw,prim_prince,rtl] Correctly index from data_state_lo

### DIFF
--- a/hw/ip/prim/rtl/prim_prince.sv
+++ b/hw/ip/prim/rtl/prim_prince.sv
@@ -159,7 +159,7 @@ module prim_prince #(
     end
   end else begin : gen_middle_d32
     always_comb begin : p_middle_d32
-      data_state_middle_d = prim_cipher_pkg::sbox4_32bit(data_state_middle[NumRoundsHalf],
+      data_state_middle_d = prim_cipher_pkg::sbox4_32bit(data_state_lo[NumRoundsHalf],
           prim_cipher_pkg::PRINCE_SBOX4);
       data_state_middle = prim_cipher_pkg::prince_mult_prime_32bit(data_state_middle_q);
       data_state_middle = prim_cipher_pkg::sbox4_32bit(data_state_middle,


### PR DESCRIPTION
The computation of data_state_middle_d used data_state_middle[NumRoundsHalf] as the sbox input, which is wrong. Correctly change that to data_state_lo[NumRoundsHalf] like it is used in the 64-bit instantiation.

Note, Pavona does not instantiate prim_prince in a 32-bit config, that's why this issue was never observed.