### PR TITLE
[hw,prim_alert_sender,dv] Fix Ack seq copy/paste error

### DIFF
--- a/hw/ip/prim/rtl/prim_alert_sender.sv
+++ b/hw/ip/prim/rtl/prim_alert_sender.sv
@@ -306,7 +306,7 @@ module prim_alert_sender
       alert_rx_i.ping_p == alert_rx_i.ping_n [*2];
     endsequence
     sequence AckSigInt_S;
-      alert_rx_i.ping_p == alert_rx_i.ping_n [*2];
+      alert_rx_i.ack_p == alert_rx_i.ack_n [*2];
     endsequence
 
   `ifndef FPV_ALERT_NO_SIGINT_ERR
@@ -340,7 +340,7 @@ module prim_alert_sender
       alert_rx_i.ping_p == alert_rx_i.ping_n;
     endsequence
     sequence AckSigInt_S;
-      alert_rx_i.ping_p == alert_rx_i.ping_n;
+      alert_rx_i.ack_p == alert_rx_i.ack_n;
     endsequence
 
   `ifndef FPV_ALERT_NO_SIGINT_ERR


### PR DESCRIPTION
Fix a copy/paste error for the AckSigInt sequence. Correctly use the alert_*_i.ack signal instead of the ping signal.