### PR TITLE
[hw,pwrmgr,rtl] Correctly report escalation reset status

### DIFF
--- a/hw/ip_templates/pwrmgr/rtl/pwrmgr.sv.tpl
+++ b/hw/ip_templates/pwrmgr/rtl/pwrmgr.sv.tpl
@@ -574,7 +574,7 @@ module pwrmgr
   end
 
   assign hw2reg.escalate_reset_status.de = 1'b1;
-  assign hw2reg.escalate_reset_status.d = peri_reqs_masked.rstreqs[NumRstReqs];
+  assign hw2reg.escalate_reset_status.d = peri_reqs_masked.rstreqs[ResetEscIdx];
 
 
   ////////////////////////////

--- a/hw/top_dragonfly/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_dragonfly/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -536,7 +536,7 @@ module pwrmgr
   end
 
   assign hw2reg.escalate_reset_status.de = 1'b1;
-  assign hw2reg.escalate_reset_status.d = peri_reqs_masked.rstreqs[NumRstReqs];
+  assign hw2reg.escalate_reset_status.d = peri_reqs_masked.rstreqs[ResetEscIdx];
 
 
   ////////////////////////////

--- a/hw/top_egret/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_egret/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -543,7 +543,7 @@ module pwrmgr
   end
 
   assign hw2reg.escalate_reset_status.de = 1'b1;
-  assign hw2reg.escalate_reset_status.d = peri_reqs_masked.rstreqs[NumRstReqs];
+  assign hw2reg.escalate_reset_status.d = peri_reqs_masked.rstreqs[ResetEscIdx];
 
 
   ////////////////////////////

--- a/hw/top_scafi_deprecated/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_scafi_deprecated/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -543,7 +543,7 @@ module pwrmgr
   end
 
   assign hw2reg.escalate_reset_status.de = 1'b1;
-  assign hw2reg.escalate_reset_status.d = peri_reqs_masked.rstreqs[NumRstReqs];
+  assign hw2reg.escalate_reset_status.d = peri_reqs_masked.rstreqs[ResetEscIdx];
 
 
   ////////////////////////////


### PR DESCRIPTION
Previously, the escalation reset status CSR was sourced by the main-power-glitch reset bit, instead of rstreqs[ResetEscIdx]. The reset behavior was correct but the reporting was wrong.

This PR changes that to correctly index via ResetEscIdx.