### PR TITLE
[hw,racl_ctrl,rtl] Fix clearing of ERROR_LOG

### DIFF
--- a/hw/ip_templates/racl_ctrl/data/racl_ctrl.hjson.tpl
+++ b/hw/ip_templates/racl_ctrl/data/racl_ctrl.hjson.tpl
@@ -207,7 +207,8 @@
     { name: "ERROR_LOG"
       desc: "Error logging registers"
       swaccess: "ro"
-      hwaccess: "hwo"
+      hwaccess: "hrw"
+      hwext: "true"
       hwqe: "true"
       fields: [
         { bits: "0"
@@ -265,7 +266,8 @@
                This register gets cleared when SW writes `1` to the `valid` field of the !!ERROR_LOG register.
             '''
       swaccess: "ro"
-      hwaccess: "hwo"
+      hwaccess: "hrw"
+      hwext: "true"
       fields: [
         { bits: "29:0"
           name: "address"

--- a/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
+++ b/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
@@ -178,33 +178,45 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   logic first_error;
   assign first_error = ~reg2hw.error_log.valid.q & racl_error_arb.valid;
 
-  // Writing 1 to the error valid bit clears the log and log address again
+  // Writing 1 to the error valid bit clears the log and log address again.
   logic clear_log;
   assign clear_log = reg2hw.error_log.valid.q & reg2hw.error_log.valid.qe;
 
-  assign hw2reg.error_log.valid.d  = ~clear_log;
-  assign hw2reg.error_log.valid.de = racl_error_arb.valid | clear_log;
+  racl_error_log_t error_log_d, error_log_q;
+  always_comb begin
+    error_log_d = error_log_q;
 
-  // Overflow is raised when error is valid and a new error is coming in or more than one
-  // error is coming in at the same time
-  assign hw2reg.error_log.overflow.d  = ~clear_log;
-  assign hw2reg.error_log.overflow.de = (reg2hw.error_log.valid.q & racl_error_arb.valid) |
-                                        racl_error_arb.overflow                           |
-                                        clear_log;
+    if (clear_log) begin
+      error_log_d = '0;
+    end
 
-  assign hw2reg.error_log.read_access.d  = clear_log ? '0 : racl_error_arb.read_access;
-  assign hw2reg.error_log.read_access.de = first_error | clear_log;
+    if (racl_error_arb.valid) begin
+      if (!error_log_q.valid || clear_log) begin
+        error_log_d = racl_error_arb;
+        error_log_d.overflow = racl_error_arb.overflow | (clear_log & error_log_q.valid);
+      end else begin
+        error_log_d.overflow = 1'b1;
+      end
+    end
+  end
 
-  assign hw2reg.error_log.role.d  = clear_log ? '0 : racl_error_arb.racl_role;
-  assign hw2reg.error_log.role.de = first_error | clear_log;
+  prim_flop #(
+    .Width      ( $bits{racl_error_log_t} ),
+    .ResetValue ( '0                      )
+  ) u_error_log_q (
+    .clk_i,
+    .rst_ni,
+    .d_i ( {error_log_d} ),
+    .d_o ( {error_log_q} )
+  );
 
-  assign hw2reg.error_log.ctn_uid.d  = clear_log ? '0 : racl_error_arb.ctn_uid;
-  assign hw2reg.error_log.ctn_uid.de = first_error | clear_log;
+  assign hw2reg.error_log.valid.d       = error_log_q.valid;
+  assign hw2reg.error_log.overflow.d     = error_log_q.overflow;
+  assign hw2reg.error_log.read_access.d = error_log_q.read_access;
+  assign hw2reg.error_log.role.d        = error_log_q.racl_role;
+  assign hw2reg.error_log.ctn_uid.d     = error_log_q.ctn_uid;
 
-  assign hw2reg.error_log_address.d  = clear_log
-                                       ? '0
-                                       : racl_error_arb.request_address[top_pkg::TL_AW-1:2];
-  assign hw2reg.error_log_address.de = first_error | clear_log;
+  assign hw2reg.error_log_address.d     = error_log_q.request_address[top_pkg::TL_AW-1:2];
 
   // unused request_address bits
   logic unused_request_address;

--- a/hw/top_dragonfly/ip_autogen/racl_ctrl/data/racl_ctrl.hjson
+++ b/hw/top_dragonfly/ip_autogen/racl_ctrl/data/racl_ctrl.hjson
@@ -253,7 +253,8 @@
     { name: "ERROR_LOG"
       desc: "Error logging registers"
       swaccess: "ro"
-      hwaccess: "hwo"
+      hwaccess: "hrw"
+      hwext: "true"
       hwqe: "true"
       fields: [
         { bits: "0"
@@ -311,7 +312,8 @@
                This register gets cleared when SW writes `1` to the `valid` field of the !!ERROR_LOG register.
             '''
       swaccess: "ro"
-      hwaccess: "hwo"
+      hwaccess: "hrw"
+      hwext: "true"
       fields: [
         { bits: "29:0"
           name: "address"

--- a/hw/top_dragonfly/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
+++ b/hw/top_dragonfly/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
@@ -157,33 +157,45 @@ module racl_ctrl import racl_ctrl_reg_pkg::*; #(
   logic first_error;
   assign first_error = ~reg2hw.error_log.valid.q & racl_error_arb.valid;
 
-  // Writing 1 to the error valid bit clears the log and log address again
+  // Writing 1 to the error valid bit clears the log and log address again.
   logic clear_log;
   assign clear_log = reg2hw.error_log.valid.q & reg2hw.error_log.valid.qe;
 
-  assign hw2reg.error_log.valid.d  = ~clear_log;
-  assign hw2reg.error_log.valid.de = racl_error_arb.valid | clear_log;
+  racl_error_log_t error_log_d, error_log_q;
+  always_comb begin
+    error_log_d = error_log_q;
 
-  // Overflow is raised when error is valid and a new error is coming in or more than one
-  // error is coming in at the same time
-  assign hw2reg.error_log.overflow.d  = ~clear_log;
-  assign hw2reg.error_log.overflow.de = (reg2hw.error_log.valid.q & racl_error_arb.valid) |
-                                        racl_error_arb.overflow                           |
-                                        clear_log;
+    if (clear_log) begin
+      error_log_d = '0;
+    end
 
-  assign hw2reg.error_log.read_access.d  = clear_log ? '0 : racl_error_arb.read_access;
-  assign hw2reg.error_log.read_access.de = first_error | clear_log;
+    if (racl_error_arb.valid) begin
+      if (!error_log_q.valid || clear_log) begin
+        error_log_d = racl_error_arb;
+        error_log_d.overflow = racl_error_arb.overflow | (clear_log & error_log_q.valid);
+      end else begin
+        error_log_d.overflow = 1'b1;
+      end
+    end
+  end
 
-  assign hw2reg.error_log.role.d  = clear_log ? '0 : racl_error_arb.racl_role;
-  assign hw2reg.error_log.role.de = first_error | clear_log;
+  prim_flop #(
+    .Width      ( $bits{racl_error_log_t} ),
+    .ResetValue ( '0                      )
+  ) u_error_log_q (
+    .clk_i,
+    .rst_ni,
+    .d_i ( {error_log_d} ),
+    .d_o ( {error_log_q} )
+  );
 
-  assign hw2reg.error_log.ctn_uid.d  = clear_log ? '0 : racl_error_arb.ctn_uid;
-  assign hw2reg.error_log.ctn_uid.de = first_error | clear_log;
+  assign hw2reg.error_log.valid.d       = error_log_q.valid;
+  assign hw2reg.error_log.overflow.d     = error_log_q.overflow;
+  assign hw2reg.error_log.read_access.d = error_log_q.read_access;
+  assign hw2reg.error_log.role.d        = error_log_q.racl_role;
+  assign hw2reg.error_log.ctn_uid.d     = error_log_q.ctn_uid;
 
-  assign hw2reg.error_log_address.d  = clear_log
-                                       ? '0
-                                       : racl_error_arb.request_address[top_pkg::TL_AW-1:2];
-  assign hw2reg.error_log_address.de = first_error | clear_log;
+  assign hw2reg.error_log_address.d     = error_log_q.request_address[top_pkg::TL_AW-1:2];
 
   // unused request_address bits
   logic unused_request_address;

--- a/hw/top_dragonfly/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
+++ b/hw/top_dragonfly/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
@@ -78,10 +78,30 @@ package racl_ctrl_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic [4:0]  q;
+      logic        qe;
+    } ctn_uid;
+    struct packed {
+      logic [3:0]  q;
+      logic        qe;
+    } role;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } read_access;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } overflow;
+    struct packed {
       logic        q;
       logic        qe;
     } valid;
   } racl_ctrl_reg2hw_error_log_reg_t;
+
+  typedef struct packed {
+    logic [29:0] q;
+  } racl_ctrl_reg2hw_error_log_address_reg_t;
 
   typedef struct packed {
     logic        d;
@@ -91,48 +111,43 @@ package racl_ctrl_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [4:0]  d;
-      logic        de;
     } ctn_uid;
     struct packed {
       logic [3:0]  d;
-      logic        de;
     } role;
     struct packed {
       logic        d;
-      logic        de;
     } read_access;
     struct packed {
       logic        d;
-      logic        de;
     } overflow;
     struct packed {
       logic        d;
-      logic        de;
     } valid;
   } racl_ctrl_hw2reg_error_log_reg_t;
 
   typedef struct packed {
     logic [29:0] d;
-    logic        de;
   } racl_ctrl_hw2reg_error_log_address_reg_t;
 
   // Register -> HW type
   typedef struct packed {
-    racl_ctrl_reg2hw_policy_all_rd_wr_shadowed_reg_t policy_all_rd_wr_shadowed; // [105:74]
-    racl_ctrl_reg2hw_policy_rot_private_shadowed_reg_t policy_rot_private_shadowed; // [73:42]
-    racl_ctrl_reg2hw_policy_soc_rot_shadowed_reg_t policy_soc_rot_shadowed; // [41:10]
-    racl_ctrl_reg2hw_intr_state_reg_t intr_state; // [9:9]
-    racl_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [8:8]
-    racl_ctrl_reg2hw_intr_test_reg_t intr_test; // [7:6]
-    racl_ctrl_reg2hw_alert_test_reg_t alert_test; // [5:2]
-    racl_ctrl_reg2hw_error_log_reg_t error_log; // [1:0]
+    racl_ctrl_reg2hw_policy_all_rd_wr_shadowed_reg_t policy_all_rd_wr_shadowed; // [150:119]
+    racl_ctrl_reg2hw_policy_rot_private_shadowed_reg_t policy_rot_private_shadowed; // [118:87]
+    racl_ctrl_reg2hw_policy_soc_rot_shadowed_reg_t policy_soc_rot_shadowed; // [86:55]
+    racl_ctrl_reg2hw_intr_state_reg_t intr_state; // [54:54]
+    racl_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [53:53]
+    racl_ctrl_reg2hw_intr_test_reg_t intr_test; // [52:51]
+    racl_ctrl_reg2hw_alert_test_reg_t alert_test; // [50:47]
+    racl_ctrl_reg2hw_error_log_reg_t error_log; // [46:30]
+    racl_ctrl_reg2hw_error_log_address_reg_t error_log_address; // [29:0]
   } racl_ctrl_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    racl_ctrl_hw2reg_intr_state_reg_t intr_state; // [49:48]
-    racl_ctrl_hw2reg_error_log_reg_t error_log; // [47:31]
-    racl_ctrl_hw2reg_error_log_address_reg_t error_log_address; // [30:0]
+    racl_ctrl_hw2reg_intr_state_reg_t intr_state; // [43:42]
+    racl_ctrl_hw2reg_error_log_reg_t error_log; // [41:30]
+    racl_ctrl_hw2reg_error_log_address_reg_t error_log_address; // [29:0]
   } racl_ctrl_hw2reg_t;
 
   // Register offsets
@@ -149,6 +164,14 @@ package racl_ctrl_reg_pkg;
   // Reset values for hwext registers and their fields
   parameter logic [0:0] RACL_CTRL_INTR_TEST_RESVAL = 1'h 0;
   parameter logic [1:0] RACL_CTRL_ALERT_TEST_RESVAL = 2'h 0;
+  parameter logic [11:0] RACL_CTRL_ERROR_LOG_RESVAL = 12'h 0;
+  parameter logic [0:0] RACL_CTRL_ERROR_LOG_VALID_RESVAL = 1'h 0;
+  parameter logic [0:0] RACL_CTRL_ERROR_LOG_OVERFLOW_RESVAL = 1'h 0;
+  parameter logic [0:0] RACL_CTRL_ERROR_LOG_READ_ACCESS_RESVAL = 1'h 0;
+  parameter logic [3:0] RACL_CTRL_ERROR_LOG_ROLE_RESVAL = 4'h 0;
+  parameter logic [4:0] RACL_CTRL_ERROR_LOG_CTN_UID_RESVAL = 5'h 0;
+  parameter logic [29:0] RACL_CTRL_ERROR_LOG_ADDRESS_RESVAL = 30'h 0;
+  parameter logic [29:0] RACL_CTRL_ERROR_LOG_ADDRESS_ADDRESS_RESVAL = 30'h 0;
 
   // Register index
   typedef enum int {

--- a/hw/top_dragonfly/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
+++ b/hw/top_dragonfly/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
@@ -172,6 +172,7 @@ module racl_ctrl_reg_top
   logic alert_test_we;
   logic alert_test_fatal_fault_wd;
   logic alert_test_recov_ctrl_update_err_wd;
+  logic error_log_re;
   logic error_log_we;
   logic error_log_valid_qs;
   logic error_log_valid_wd;
@@ -179,6 +180,7 @@ module racl_ctrl_reg_top
   logic error_log_read_access_qs;
   logic [3:0] error_log_role_qs;
   logic [4:0] error_log_ctn_uid_qs;
+  logic error_log_address_re;
   logic [29:0] error_log_address_qs;
 
   // Register instances
@@ -517,179 +519,106 @@ module racl_ctrl_reg_top
   assign reg2hw.alert_test.recov_ctrl_update_err.qe = alert_test_qe;
 
 
-  // R[error_log]: V(False)
+  // R[error_log]: V(True)
   logic error_log_qe;
   logic [4:0] error_log_flds_we;
-  prim_flop #(
-    .Width(1),
-    .ResetValue(0)
-  ) u_error_log0_qe (
-    .clk_i(clk_i),
-    .rst_ni(rst_ni),
-    .d_i(&(error_log_flds_we | 5'h1e)),
-    .q_o(error_log_qe)
-  );
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_error_log_flds_we;
+  assign unused_error_log_flds_we = ^(error_log_flds_we & 5'h1e);
+  assign error_log_qe = &(error_log_flds_we | 5'h1e);
   //   F[valid]: 0:0
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+  prim_subreg_ext #(
+    .DW    (1)
   ) u_error_log_valid (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
+    .re     (error_log_re),
     .we     (error_log_we),
     .wd     (error_log_valid_wd),
-
-    // from internal hardware
-    .de     (hw2reg.error_log.valid.de),
     .d      (hw2reg.error_log.valid.d),
-
-    // to internal hardware
+    .qre    (),
     .qe     (error_log_flds_we[0]),
     .q      (reg2hw.error_log.valid.q),
     .ds     (),
-
-    // to register interface (read)
     .qs     (error_log_valid_qs)
   );
   assign reg2hw.error_log.valid.qe = error_log_qe;
 
   //   F[overflow]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+  prim_subreg_ext #(
+    .DW    (1)
   ) u_error_log_overflow (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
+    .re     (error_log_re),
     .we     (1'b0),
     .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.error_log.overflow.de),
     .d      (hw2reg.error_log.overflow.d),
-
-    // to internal hardware
+    .qre    (),
     .qe     (error_log_flds_we[1]),
-    .q      (),
+    .q      (reg2hw.error_log.overflow.q),
     .ds     (),
-
-    // to register interface (read)
     .qs     (error_log_overflow_qs)
   );
+  assign reg2hw.error_log.overflow.qe = error_log_qe;
 
   //   F[read_access]: 2:2
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+  prim_subreg_ext #(
+    .DW    (1)
   ) u_error_log_read_access (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
+    .re     (error_log_re),
     .we     (1'b0),
     .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.error_log.read_access.de),
     .d      (hw2reg.error_log.read_access.d),
-
-    // to internal hardware
+    .qre    (),
     .qe     (error_log_flds_we[2]),
-    .q      (),
+    .q      (reg2hw.error_log.read_access.q),
     .ds     (),
-
-    // to register interface (read)
     .qs     (error_log_read_access_qs)
   );
+  assign reg2hw.error_log.read_access.qe = error_log_qe;
 
   //   F[role]: 6:3
-  prim_subreg #(
-    .DW      (4),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+  prim_subreg_ext #(
+    .DW    (4)
   ) u_error_log_role (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
+    .re     (error_log_re),
     .we     (1'b0),
     .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.error_log.role.de),
     .d      (hw2reg.error_log.role.d),
-
-    // to internal hardware
+    .qre    (),
     .qe     (error_log_flds_we[3]),
-    .q      (),
+    .q      (reg2hw.error_log.role.q),
     .ds     (),
-
-    // to register interface (read)
     .qs     (error_log_role_qs)
   );
+  assign reg2hw.error_log.role.qe = error_log_qe;
 
   //   F[ctn_uid]: 11:7
-  prim_subreg #(
-    .DW      (5),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+  prim_subreg_ext #(
+    .DW    (5)
   ) u_error_log_ctn_uid (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
+    .re     (error_log_re),
     .we     (1'b0),
     .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.error_log.ctn_uid.de),
     .d      (hw2reg.error_log.ctn_uid.d),
-
-    // to internal hardware
+    .qre    (),
     .qe     (error_log_flds_we[4]),
-    .q      (),
+    .q      (reg2hw.error_log.ctn_uid.q),
     .ds     (),
-
-    // to register interface (read)
     .qs     (error_log_ctn_uid_qs)
   );
+  assign reg2hw.error_log.ctn_uid.qe = error_log_qe;
 
 
-  // R[error_log_address]: V(False)
-  prim_subreg #(
-    .DW      (30),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+  // R[error_log_address]: V(True)
+  prim_subreg_ext #(
+    .DW    (30)
   ) u_error_log_address (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
+    .re     (error_log_address_re),
     .we     (1'b0),
     .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.error_log_address.de),
     .d      (hw2reg.error_log_address.d),
-
-    // to internal hardware
+    .qre    (),
     .qe     (),
-    .q      (),
+    .q      (reg2hw.error_log_address.q),
     .ds     (),
-
-    // to register interface (read)
     .qs     (error_log_address_qs)
   );
 
@@ -809,9 +738,11 @@ module racl_ctrl_reg_top
   assign alert_test_fatal_fault_wd = reg_wdata[0];
 
   assign alert_test_recov_ctrl_update_err_wd = reg_wdata[1];
+  assign error_log_re = racl_addr_hit_read[7] & reg_re & !reg_error;
   assign error_log_we = racl_addr_hit_write[7] & reg_we & !reg_error;
 
   assign error_log_valid_wd = reg_wdata[0];
+  assign error_log_address_re = racl_addr_hit_read[8] & reg_re & !reg_error;
 
   // Assign write-enables to checker logic vector.
   always_comb begin


### PR DESCRIPTION
racl_ctrl used `valid.q & valid.qe` to detect when software cleared
`ERROR_LOG.valid`. However, `valid.qe` is asserted after `valid.q` has
already been cleared, causing the pulse to be missed and leaving the
error log registers stale.

Fix this by converting the log to `hwext` storage and keeping the log
state in `racl_ctrl`. This allows `valid.q & valid.qe` to be interpreted
as "software wrote 1", so the log can be cleared correctly.