### PR TITLE
[hw,kmac,rtl] Fix EncodedOutLenMask index

### DIFF
--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -762,7 +762,7 @@ module kmac_app
 
   // Encoded output length
   assign encoded_outlen      = EncodedOutLen[SelDigSize];
-  assign encoded_outlen_mask = EncodedOutLenMask[SelKeySize];
+  assign encoded_outlen_mask = EncodedOutLenMask[SelDigSize];
 
   // Data mux
   // This is the main part of the KeyMgr interface logic.


### PR DESCRIPTION
Indexing works today because SelKeySize and SelDigSize resolve to the same value. Fix that to prevent future bugs.