### PR TITLE
[verilator] Depend on full Verilator install for FuseSoC builds

### DIFF
--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -95,7 +95,7 @@ def _fusesoc_build_impl(ctx):
             ctx.executable._ar,
             ctx.executable._cc,
             ctx.executable._cxx,
-        ]) if ctx.attr.target != "synth" else [],
+        ] + ctx.files._verilator_install) if ctx.attr.target != "synth" else [],
         arguments = [args],
         executable = ctx.executable._fusesoc,
         use_default_shell_env = False,
@@ -165,6 +165,12 @@ fusesoc_build = rule(
             executable = True,
             default = "//third_party/verilator",
             doc = "Verilator binary target",
+            cfg = "exec",
+        ),
+        "_verilator_install": attr.label(
+            allow_files = True,
+            default = "//third_party/verilator:verilator_install",
+            doc = "Full Verilator installation staged alongside the wrapper.",
             cfg = "exec",
         ),
         "_ar": attr.label(

--- a/third_party/verilator/BUILD
+++ b/third_party/verilator/BUILD
@@ -38,3 +38,9 @@ filegroup(
     output_group = "verilator",
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "verilator_install",
+    srcs = [":build_verilator"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
The FuseSoC action declares only the `verilator` wrapper as its verilator tool, but the wrapper exec()s `verilator_bin` from the same configure_make output. Bazel only materializes the output group a consumer references on a cache restore, so when the toolchain is restored from a cache only the wrapper lands on disk and the build fails with `Can't exec "verilator_bin"`. A fresh build materializes the whole install, so this only surfaces on a cache restore combined with a model cache miss resulting in a FuseSoC invocation.

Depend on the full installation instead of just the wrapper.

 - Resolves https://github.com/pavona/pavona/issues/320