### PR TITLE
[racl_ctrl] Gate ALERT_TEST.recov_ctrl_update_err by shadow register support

### DIFF
--- a/hw/ip_templates/racl_ctrl/data/racl_ctrl.hjson.tpl
+++ b/hw/ip_templates/racl_ctrl/data/racl_ctrl.hjson.tpl
@@ -198,10 +198,12 @@
           name: "fatal_fault",
           desc: "'Write 1 to trigger one alert event of this kind.'",
         }
+      % if enable_shadow_reg:
         { bits: "1",
           name: "recov_ctrl_update_err",
           desc: "'Write 1 to trigger one alert event of this kind.'",
         }
+      % endif
       ],
     }
     { name: "ERROR_LOG"


### PR DESCRIPTION
Only generate when shadow registers are enabled, since the corresponding recovery alert is only present in that configuration. The alert definition is already gated but not the manual implementation of the ALERT_TEST register.