### PR TITLE
[dvsim] Publish report.json privately

### DIFF
--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -581,6 +581,12 @@ class FlowCfg():
 
             if mode == "private":
                 self._publish_native_artifacts(item, repo_dir, test)
+                latest_json = os.path.join(item.scratch_path, 'reports', 'latest', 'report.json')
+                if os.path.exists(latest_json):
+                    shutil.copy2(latest_json, os.path.join(dest_dir, 'report.json'))
+                else:
+                    log.warning("No report.json found for %s at %s, skipping.",
+                                item.name, latest_json)
             else:
                 self._strip_native_cov_link(Path(os.path.join(dest_dir, 'report.html')))
             log.info("Copied report for %s", item.name)


### PR DESCRIPTION
This JSON file gets generated at the end of a run. It can be used for grading later and to store information about the run. With this commit, now it can be publishable with `--publish-mode private`.