### PR TITLE
[ac_range_check,dv] Fix syntax error

### DIFF
--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_predictor.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_predictor.sv.tpl
@@ -378,7 +378,7 @@ function void ${module_instance_name}_predictor::update_log(tl_seq_item item, in
 
   if (`gmv(log_config_csr.log_enable)) begin
     if (`gmv(log_status_csr.deny_cnt) == 0 && !overflow_flag &&
-        `gmv(range_attr_csr.log_denied_access || no_match) == MuBi4True) begin
+        (`gmv(range_attr_csr.log_denied_access) == MuBi4True || no_match)) begin
       deny_cnt = deny_cnt + 8'd1;
       `uvm_info(`gfn, $sformatf({"First deny log information:\n",
               " - deny_range_index: %0d\n",

--- a/hw/top_dragonfly/ip_autogen/ac_range_check/dv/env/ac_range_check_predictor.sv
+++ b/hw/top_dragonfly/ip_autogen/ac_range_check/dv/env/ac_range_check_predictor.sv
@@ -378,7 +378,7 @@ function void ac_range_check_predictor::update_log(tl_seq_item item, int index, 
 
   if (`gmv(log_config_csr.log_enable)) begin
     if (`gmv(log_status_csr.deny_cnt) == 0 && !overflow_flag &&
-        `gmv(range_attr_csr.log_denied_access || no_match) == MuBi4True) begin
+        (`gmv(range_attr_csr.log_denied_access) == MuBi4True || no_match)) begin
       deny_cnt = deny_cnt + 8'd1;
       `uvm_info(`gfn, $sformatf({"First deny log information:\n",
               " - deny_range_index: %0d\n",


### PR DESCRIPTION
This commit fixes an error that stops `ac_range_check` from building its suite of tests.