### PR TITLE
[dvsim] Record per-seed telemetry in report.json

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -11,7 +11,7 @@ from typing import List
 
 from JobTime import JobTime
 from LauncherFactory import get_launcher
-from sim_utils import (get_cov_summary_table, get_job_runtime,
+from sim_utils import (get_cov_summary_table, get_job_mem, get_job_runtime,
                        get_simulated_time)
 from tabulate import tabulate
 from utils import (VERBOSE, clean_odirs, find_and_substitute_wildcards,
@@ -84,6 +84,10 @@ class Deploy():
         # Job's wall-clock time from dispatch to completion, as measured by
         # dvsim (includes infra/setup/IO overhead the tool runtime omits).
         self.job_wall_time = JobTime()
+        # Job's tool-reported memory footprint in MB (None if the tool/log
+        # does not report it). For VCS this is the design's
+        # "data structure size", not the process's peak resident memory.
+        self.job_mem = None
 
     def _define_attrs(self):
         """Defines the attributes this instance needs to have.
@@ -315,6 +319,14 @@ class Deploy():
             log.warning(f"{self.full_name}: {e} Using dvsim-maintained "
                         "job_runtime instead.")
             self.job_runtime.set(self.launcher.job_runtime_secs, "s")
+
+        # Extract the tool-reported memory footprint if available.
+        try:
+            mem, mem_unit = get_job_mem(log_text, self.sim_cfg.tool)
+            self.job_mem = mem * {"K": 1 / 1024, "M": 1, "G": 1024}[mem_unit]
+        except (RuntimeError, NotImplementedError) as e:
+            log.log(VERBOSE, f"{self.full_name}: {e}")
+            self.job_mem = None
 
     def create_launcher(self):
         """Creates the launcher instance.

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -768,11 +768,35 @@ class SimCfg(FlowCfg):
                     'failing_tests': fts,
                 })
 
+        # Per-seed telemetry, grouped by test name. Unlike 'results' (which is
+        # aggregated and mapped to the testplan), this is the raw record: one
+        # entry per seed. It is emitted to report.json only and is deliberately
+        # not added to the Markdown/HTML report (see _gen_results).
+        def _jobtime_val(jt, unit):
+            """JobTime -> float in `unit`, or None when unset (0)."""
+            val = jt.with_unit(unit).get()[0]
+            return val if val else None
+
+        tests_by_name = OrderedDict()
+        for r in self.runs:
+            start = getattr(r.launcher, "start_time", None)
+            tests_by_name.setdefault(r.name, []).append({
+                'seed': str(r.seed),
+                'status': run_results.get(r, "K"),
+                'start': start.isoformat() if start else None,
+                'wall_time_s': _jobtime_val(r.job_wall_time, 's'),
+                'cpu_time_s': _jobtime_val(r.job_runtime, 's'),
+                'simulated_time_us': _jobtime_val(r.simulated_time, 'us'),
+                'data_structure_size_mb': r.job_mem,
+            })
+        results['tests'] = [{'name': name, 'seeds': seeds}
+                            for name, seeds in tests_by_name.items()]
+
         # Store the `results` dictionary in this object.
         self.results_dict = results
 
         # Return the `results` dictionary as json string.
-        return json.dumps(self.results_dict)
+        return json.dumps(self.results_dict, indent=2)
 
     def _gen_results(self, run_results):
         '''

--- a/util/dvsim/sim_utils.py
+++ b/util/dvsim/sim_utils.py
@@ -124,6 +124,26 @@ def get_job_runtime(log_text: List, tool: str) -> Tuple[float, str]:
                                   "extraction.")
 
 
+def get_job_mem(log_text: List, tool: str) -> Tuple[float, str]:
+    """Returns the job's peak memory usage along with its units.
+
+    EDA tools report the memory footprint of the job in the log file. This
+    method invokes the tool specific method which parses the log text and
+    returns the memory as a floating point value followed by its units (a
+    single-letter magnitude prefix, e.g. 'K', 'M', 'G') as a tuple.
+
+    `log_text` is the job's log file contents as a list of lines.
+    `tool` is the EDA tool used to run the job.
+    Returns the memory, units as a tuple.
+    Raises NotImplementedError exception if the EDA tool is not supported.
+    """
+    if tool == 'vcs':
+        return vcs_job_mem(log_text)
+    else:
+        raise NotImplementedError(f"{tool} is unsupported for job memory "
+                                  "extraction.")
+
+
 def vcs_job_runtime(log_text: List) -> Tuple[float, str]:
     """Returns the VCS job runtime (wall clock time) along with its units.
 
@@ -141,6 +161,24 @@ def vcs_job_runtime(log_text: List) -> Tuple[float, str]:
         if m:
             return float(m.group(1)), m.group(2)[0]
     raise RuntimeError("Job runtime not found in the log.")
+
+
+def vcs_job_mem(log_text: List) -> Tuple[float, str]:
+    """Returns the VCS job's data structure size (memory) with its units.
+
+    This is VCS's reported footprint of the design's data structures, not the
+    process's peak resident memory. Search pattern example:
+    CPU Time:      0.610 seconds;       Data structure size:   1.6Mb
+
+    Returns the memory value and its single-letter magnitude prefix as a tuple.
+    Raises RuntimeError exception if the search pattern is not found.
+    """
+    pattern = r"Data structure size:\s*(\d+\.?\d*)\s*([KMG])b"
+    for line in reversed(log_text):
+        m = re.search(pattern, line)
+        if m:
+            return float(m.group(1)), m.group(2)
+    raise RuntimeError("Job memory not found in the log.")
 
 
 def xcelium_job_runtime(log_text: List) -> Tuple[float, str]:


### PR DESCRIPTION
Add a "tests" section to `report.json` (generated on each run) that captures per-seed run data such as: status, start time, `dvsim` wall time, tool-reported CPU time, simulated time, and tool-reported memory footprint. This would improve access to data for resource allocation.