### PR TITLE
[ci, verilator] Add a `PQCEn=1` verilator execution environment and exercise in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,24 @@ jobs:
         with:
           artifact-name: verilator_egret-test-results
 
+  verilator_egret_pqc:
+    name: Egret Verilator PQC Tests
+    runs-on:
+      group: pavona-large
+    needs: quick_lint
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@v7
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+      - name: Run fast Verilator tests
+        run: ./ci/scripts/run-verilator-tests.sh --pqc
+      - name: Publish Bazel test results
+        uses: ./.github/actions/publish-bazel-test-results
+        if: ${{ !cancelled() }}
+        with:
+          artifact-name: verilator_egret_pqc-test-results
+
   chip_egret_cw310:
     name: Egret for CW310
     needs: quick_lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,6 @@ jobs:
       - name: Run fast Verilator tests
         run: ./ci/scripts/run-verilator-tests.sh
       - name: Run slow Verilator tests
-        if: ${{ github.event_name != 'pull_request' }}
         run: ./ci/scripts/run-verilator-tests.sh --slow
       - name: Publish Bazel test results
         uses: ./.github/actions/publish-bazel-test-results
@@ -308,7 +307,6 @@ jobs:
       - name: Run fast Verilator tests
         run: ./ci/scripts/run-verilator-tests.sh --pqc
       - name: Run slow Verilator tests
-        if: ${{ github.event_name != 'pull_request' }}
         run: ./ci/scripts/run-verilator-tests.sh --pqc --slow
       - name: Publish Bazel test results
         uses: ./.github/actions/publish-bazel-test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,9 @@ jobs:
         uses: ./.github/actions/prepare-env
       - name: Run fast Verilator tests
         run: ./ci/scripts/run-verilator-tests.sh
+      - name: Run slow Verilator tests
+        if: ${{ github.event_name != 'pull_request' }}
+        run: ./ci/scripts/run-verilator-tests.sh --slow
       - name: Publish Bazel test results
         uses: ./.github/actions/publish-bazel-test-results
         if: ${{ !cancelled() }}
@@ -304,6 +307,9 @@ jobs:
         uses: ./.github/actions/prepare-env
       - name: Run fast Verilator tests
         run: ./ci/scripts/run-verilator-tests.sh --pqc
+      - name: Run slow Verilator tests
+        if: ${{ github.event_name != 'pull_request' }}
+        run: ./ci/scripts/run-verilator-tests.sh --pqc --slow
       - name: Publish Bazel test results
         uses: ./.github/actions/publish-bazel-test-results
         if: ${{ !cancelled() }}

--- a/ci/scripts/run-verilator-tests.sh
+++ b/ci/scripts/run-verilator-tests.sh
@@ -5,7 +5,40 @@
 
 set -e
 
-# Increase the test_timeout due to slow performance on CI
+suffix="sim_verilator"
+defines=()
+
+for arg in "$@"; do
+    case "${arg}" in
+        --pqc)
+            suffix="sim_verilator_pqc"
+            defines=(--define=acc_has_pqc=true)
+            ;;
+        *)
+            echo "Unknown argument: ${arg}" >&2
+            exit 1
+            ;;
+    esac
+done
+
+targets=(
+    "//sw/device/tests:aes_smoketest_${suffix}"
+    "//sw/device/tests:uart_smoketest_${suffix}"
+    "//sw/device/tests:crt_test_${suffix}"
+    "//sw/device/tests:acc_randomness_test_${suffix}"
+    "//sw/device/tests:acc_irq_test_${suffix}"
+    "//sw/device/tests:kmac_mode_cshake_test_${suffix}"
+    "//sw/device/tests:kmac_mode_kmac_test_${suffix}"
+    "//sw/device/tests:flash_ctrl_test_${suffix}"
+    "//sw/device/tests:usbdev_test_${suffix}"
+    "//sw/device/silicon_creator/lib/drivers:hmac_functest_${suffix}"
+    "//sw/device/silicon_creator/lib/drivers:uart_functest_${suffix}"
+    "//sw/device/silicon_creator/lib/drivers:retention_sram_functest_${suffix}"
+    "//sw/device/silicon_creator/lib/drivers:alert_functest_${suffix}"
+    "//sw/device/silicon_creator/lib/drivers:watchdog_functest_${suffix}"
+    "//sw/device/silicon_creator/lib:irq_asm_functest_${suffix}"
+    "//sw/device/silicon_creator/rom:rom_epmp_test_${suffix}"
+)
 
 ./bazelisk.sh test \
     --build_tests_only=true \
@@ -15,19 +48,5 @@ set -e
     --test_tag_filters=verilator,-broken \
     --test_output=errors \
     --//hw:make_options=-j,8 \
-    //sw/device/tests:aes_smoketest_sim_verilator \
-    //sw/device/tests:uart_smoketest_sim_verilator \
-    //sw/device/tests:crt_test_sim_verilator \
-    //sw/device/tests:acc_randomness_test_sim_verilator \
-    //sw/device/tests:acc_irq_test_sim_verilator \
-    //sw/device/tests:kmac_mode_cshake_test_sim_verilator \
-    //sw/device/tests:kmac_mode_kmac_test_sim_verilator \
-    //sw/device/tests:flash_ctrl_test_sim_verilator \
-    //sw/device/tests:usbdev_test_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:hmac_functest_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:uart_functest_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:retention_sram_functest_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:alert_functest_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:watchdog_functest_sim_verilator \
-    //sw/device/silicon_creator/lib:irq_asm_functest_sim_verilator \
-    //sw/device/silicon_creator/rom:rom_epmp_test_sim_verilator
+    "${defines[@]}" \
+    "${targets[@]}"

--- a/ci/scripts/run-verilator-tests.sh
+++ b/ci/scripts/run-verilator-tests.sh
@@ -7,12 +7,16 @@ set -e
 
 suffix="sim_verilator"
 defines=()
+slow=false
 
 for arg in "$@"; do
     case "${arg}" in
         --pqc)
             suffix="sim_verilator_pqc"
             defines=(--define=acc_has_pqc=true)
+            ;;
+        --slow)
+            slow=true
             ;;
         *)
             echo "Unknown argument: ${arg}" >&2
@@ -21,24 +25,31 @@ for arg in "$@"; do
     esac
 done
 
-targets=(
-    "//sw/device/tests:aes_smoketest_${suffix}"
-    "//sw/device/tests:uart_smoketest_${suffix}"
-    "//sw/device/tests:crt_test_${suffix}"
-    "//sw/device/tests:acc_randomness_test_${suffix}"
-    "//sw/device/tests:acc_irq_test_${suffix}"
-    "//sw/device/tests:kmac_mode_cshake_test_${suffix}"
-    "//sw/device/tests:kmac_mode_kmac_test_${suffix}"
-    "//sw/device/tests:flash_ctrl_test_${suffix}"
-    "//sw/device/tests:usbdev_test_${suffix}"
-    "//sw/device/silicon_creator/lib/drivers:hmac_functest_${suffix}"
-    "//sw/device/silicon_creator/lib/drivers:uart_functest_${suffix}"
-    "//sw/device/silicon_creator/lib/drivers:retention_sram_functest_${suffix}"
-    "//sw/device/silicon_creator/lib/drivers:alert_functest_${suffix}"
-    "//sw/device/silicon_creator/lib/drivers:watchdog_functest_${suffix}"
-    "//sw/device/silicon_creator/lib:irq_asm_functest_${suffix}"
-    "//sw/device/silicon_creator/rom:rom_epmp_test_${suffix}"
-)
+if [[ "${slow}" == "true" ]]; then
+    targets=(
+        "//sw/device/tests/crypto:mlkem_functest_${suffix}"
+        "//sw/device/tests/crypto:mldsa_functest_${suffix}"
+    )
+else
+    targets=(
+        "//sw/device/tests:aes_smoketest_${suffix}"
+        "//sw/device/tests:uart_smoketest_${suffix}"
+        "//sw/device/tests:crt_test_${suffix}"
+        "//sw/device/tests:acc_randomness_test_${suffix}"
+        "//sw/device/tests:acc_irq_test_${suffix}"
+        "//sw/device/tests:kmac_mode_cshake_test_${suffix}"
+        "//sw/device/tests:kmac_mode_kmac_test_${suffix}"
+        "//sw/device/tests:flash_ctrl_test_${suffix}"
+        "//sw/device/tests:usbdev_test_${suffix}"
+        "//sw/device/silicon_creator/lib/drivers:hmac_functest_${suffix}"
+        "//sw/device/silicon_creator/lib/drivers:uart_functest_${suffix}"
+        "//sw/device/silicon_creator/lib/drivers:retention_sram_functest_${suffix}"
+        "//sw/device/silicon_creator/lib/drivers:alert_functest_${suffix}"
+        "//sw/device/silicon_creator/lib/drivers:watchdog_functest_${suffix}"
+        "//sw/device/silicon_creator/lib:irq_asm_functest_${suffix}"
+        "//sw/device/silicon_creator/rom:rom_epmp_test_${suffix}"
+    )
+fi
 
 ./bazelisk.sh test \
     --build_tests_only=true \

--- a/hw/BUILD
+++ b/hw/BUILD
@@ -151,6 +151,47 @@ alias(
     visibility = ["//visibility:public"],
 )
 
+# Verilated model with the ACC PQC vector ISA enabled (AccPQCEn=1).
+fusesoc_build(
+    name = "verilator_real_pqc",
+    srcs = [
+        ":dpi_files",
+        ":dv_common_files",
+        ":rtl_files",
+        ":verilator_files",
+    ],
+    cores = [
+        ":cores",
+    ],
+    data = ["//hw/ip/acc:rtl_files"],
+    flags = ["--AccPQCEn=1"],
+    make_options = ":make_options",
+    output_groups = pavona_select_top_attr("top_verilator_binary"),
+    systems = pavona_select_top_attr("top_verilator_core"),
+    tags = [
+        "manual",
+        "verilator",
+    ],
+    target = "sim",
+    verilator_options = ":verilator_options",
+)
+
+filegroup(
+    name = "verilator_bin_pqc",
+    srcs = [":verilator_real_pqc"],
+    output_group = "binary",
+)
+
+alias(
+    name = "verilator_pqc",
+    actual = select({
+        ":disable_verilator_build": ":verilator_stub",
+        "//conditions:default": ":verilator_bin_pqc",
+    }),
+    tags = ["verilator"],
+    visibility = ["//visibility:public"],
+)
+
 genrule(
     name = "fusesoc_ignore",
     outs = ["FUSESOC_IGNORE"],

--- a/hw/dv/dpi/gpiodpi/gpiodpi.sv
+++ b/hw/dv/dpi/gpiodpi/gpiodpi.sv
@@ -34,7 +34,7 @@ module gpiodpi
                                      input logic [N_GPIO-1:0] gpio_en_d2p,
                                      input logic [N_GPIO-1:0] gpio_pull_en,
                                      input logic [N_GPIO-1:0] gpio_pull_sel,
-                                     output bit req_exit);
+                                     inout bit req_exit);
 
    bit req_exit;
    chandle ctx;

--- a/hw/top_egret/BUILD
+++ b/hw/top_egret/BUILD
@@ -515,6 +515,36 @@ sim_verilator(
     """,
 )
 
+# Same as sim_verilator, but against the PQC-enabled model (//hw:verilator_pqc).
+sim_verilator(
+    name = "sim_verilator_pqc",
+    testonly = True,
+    args = [
+        "--rcfile=",
+        "--logging=info",
+        "--interface=verilator",
+        "--verilator-bin=$(rootpath //hw:verilator_pqc)",
+        "--verilator-rom={rom}",
+        "--verilator-otp={otp}",
+        "--verilator-flash={firmware}",
+    ],
+    base = ":sim_verilator_base",
+    data = [
+        "//hw:fusesoc_ignore",
+        "//hw:verilator_pqc",
+    ],
+    exec_env = "sim_verilator_pqc",
+    param = {
+        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
+        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
+    },
+    rom = "//sw/device/lib/testing/test_rom:test_rom",
+    test_cmd = """
+        --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+        no-op
+    """,
+)
+
 sim_verilator(
     name = "sim_verilator_rom_with_fake_keys",
     testonly = True,

--- a/hw/top_egret/chip_egret_verilator.core
+++ b/hw/top_egret/chip_egret_verilator.core
@@ -21,6 +21,11 @@ filesets:
       - rtl/chip_egret_verilator.sv: { file_type: systemVerilogSource }
 
 parameters:
+  AccPQCEn:
+    datatype: int
+    description: Enable the PQC vector ISA extension in the ACC
+    default: 0
+    paramtype: vlogparam
   AST_BYPASS_CLK:
     datatype: bool
     paramtype: vlogdefine
@@ -30,6 +35,7 @@ targets:
     filesets:
       - files_sim_verilator
     parameters:
+      - AccPQCEn
       - AST_BYPASS_CLK=true
     toplevel: chip_egret_verilator
     tools:

--- a/hw/top_egret/dv/verilator/chip_sim_tb.sv
+++ b/hw/top_egret/dv/verilator/chip_sim_tb.sv
@@ -3,7 +3,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-module chip_sim_tb (
+module chip_sim_tb #(
+  parameter bit AccPQCEn = 0
+) (
   // Clock and Reset
   input clk_i,
   input rst_ni
@@ -27,7 +29,9 @@ module chip_sim_tb (
   logic cio_usbdev_dp_p2d, cio_usbdev_dp_d2p, cio_usbdev_dp_en_d2p;
   logic cio_usbdev_dn_p2d, cio_usbdev_dn_d2p, cio_usbdev_dn_en_d2p;
 
-  chip_egret_verilator u_dut (
+  chip_egret_verilator #(
+    .AccPQCEn(AccPQCEn)
+  ) u_dut (
     .clk_i,
     .rst_ni,
 

--- a/hw/top_egret/rtl/chip_egret_verilator.sv
+++ b/hw/top_egret/rtl/chip_egret_verilator.sv
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-module chip_egret_verilator (
+module chip_egret_verilator #(
+  parameter bit AccPQCEn = 0
+) (
   // Clock and Reset
   input clk_i,
   input rst_ni,
@@ -497,7 +499,8 @@ module chip_egret_verilator (
     .PinmuxAonTargetCfg(PinmuxTargetCfg),
     .SecAesAllowForcingMasks(1'b1),
     .SramCtrlMainInstrExec(1),
-    .SramCtrlRetAonInstrExec(0)
+    .SramCtrlRetAonInstrExec(0),
+    .AccAccPQCEn(AccPQCEn)
   ) top_egret (
     // update por / reset connections, this is not quite right here
     .por_n_i                      (por_n                ),

--- a/rules/pavona/defs.bzl
+++ b/rules/pavona/defs.bzl
@@ -123,6 +123,7 @@ EGRET_TEST_ENVS = {
     "//hw/top_egret:fpga_cw340_rom_with_fake_keys": None,
     "//hw/top_egret:sim_dv": None,
     "//hw/top_egret:sim_verilator": None,
+    "//hw/top_egret:sim_verilator_pqc": None,
     "//hw/top_egret:sim_qemu_rom_with_fake_keys": None,
 }
 

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -313,6 +313,7 @@ pavona_test(
     # Verilator or CW310 params).
     exec_env = {
         "//hw/top_egret:sim_verilator": None,
+        "//hw/top_egret:sim_verilator_pqc": None,
     },
     kind = "rom",
     linker_script = ":linker_script",


### PR DESCRIPTION
- Depends on #334 

This PR does 3 things (each in a separate commit):
1) It wires up the PQCEn parameter to the verilator model exposed as `//hw:verilator_pqc`  and registers it as a new egret execution environment.
2) It adds a CI run that duplicates the current verilator job to run the same fast tests on the PQCEn=1 model
3) It extends the nightly Verilator jobs to additionally run ML-KEM and ML-DSA functests (those take around an hour each) against both models.

Still work in progress if any timeouts need to be extended. 