### PR TITLE
Revert "[hw,prim_alert_sender,dv] Fix Ack seq copy/paste error"

### DIFF
--- a/hw/ip/prim/rtl/prim_alert_sender.sv
+++ b/hw/ip/prim/rtl/prim_alert_sender.sv
@@ -306,7 +306,7 @@ module prim_alert_sender
       alert_rx_i.ping_p == alert_rx_i.ping_n [*2];
     endsequence
     sequence AckSigInt_S;
-      alert_rx_i.ack_p == alert_rx_i.ack_n [*2];
+      alert_rx_i.ping_p == alert_rx_i.ping_n [*2];
     endsequence
 
   `ifndef FPV_ALERT_NO_SIGINT_ERR
@@ -340,7 +340,7 @@ module prim_alert_sender
       alert_rx_i.ping_p == alert_rx_i.ping_n;
     endsequence
     sequence AckSigInt_S;
-      alert_rx_i.ack_p == alert_rx_i.ack_n;
+      alert_rx_i.ping_p == alert_rx_i.ping_n;
     endsequence
 
   `ifndef FPV_ALERT_NO_SIGINT_ERR


### PR DESCRIPTION
The [July 14, 2026 nightly regression](https://dashboards.pavona.org/all_tops_batch_nightly_sim/all_tops_batch_nightly_sim_26.07.15_13.38.33/chip_dragonfly-sim-vcs/reports/latest/report.html) showed that chip_dragonfly gets SigIntAck_A tripped. This is the only commit in the interim that changed alerting.

This reverts commit 3c1676bcc6c2e6a40f97ae0bae6ec214f3c665c6.