### PR TITLE
[dvsim] Propagate configuration from batch-level to tests

### DIFF
--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -47,6 +47,11 @@ class FlowCfg():
         self.items = list(dict.fromkeys(args.items))
         self.list_items = args.list
         self.select_cfgs = args.select_cfgs
+        self.cfg_group_sel = args.cfg_groups
+        self.cfg_groups = None
+        # Scalar overrides captured from the selected cfg_groups entry, stamped
+        # onto each selected child cfg (see prune_selected_cfgs).
+        self.group_overrides = {}
         self.flow_cfg_file = flow_cfg_file
         self.args = args
         self.scratch_root = args.scratch_root
@@ -371,8 +376,36 @@ class FlowCfg():
         # This should run after self.cfgs has been set
         assert self.cfgs
 
-        # If the user didn't pass --select-cfgs, we don't do anything.
-        if self.select_cfgs is None:
+        select = self.select_cfgs
+
+        # --cfg-groups selects the named groups' cfgs and captures their scalar
+        # overrides. This is separate from -i, which selects tests/regressions.
+        # Each entry is a dict with a 'cfgs' list plus optional overrides.
+        if select is None and self.cfg_group_sel:
+            if not self.is_primary_cfg:
+                log.error("--cfg-groups was passed, but {!r} is not a primary "
+                          "config.".format(self.flow_cfg_file))
+                sys.exit(1)
+            grouped = []
+            for name in self.cfg_group_sel:
+                entry = (self.cfg_groups or {}).get(name)
+                if entry is None:
+                    log.error("Requested cfg_group %r is not defined in %r.",
+                              name, self.flow_cfg_file)
+                    sys.exit(1)
+                if not isinstance(entry, dict):
+                    log.error("cfg_groups entry %r must be a dict with a "
+                              "'cfgs' list.", name)
+                    sys.exit(1)
+                grouped += entry.get("cfgs", [])
+                for key, value in entry.items():
+                    if key != "cfgs":
+                        self.group_overrides[key] = value
+            if grouped:
+                select = list(dict.fromkeys(grouped))
+
+        # If nothing selected either way, we don't do anything.
+        if select is None:
             return
 
         # If the user passed --select-cfgs, but this isn't a primary config
@@ -386,7 +419,7 @@ class FlowCfg():
         # Filter configurations
         filtered_cfgs = []
         for c in self.cfgs:
-            for s in self.select_cfgs:
+            for s in select:
                 if s == c.name:
                     filtered_cfgs.append(c)
                     break
@@ -395,6 +428,10 @@ class FlowCfg():
                     break
 
         self.cfgs = filtered_cfgs
+
+        # Make the group overrides visible to each selected child cfg.
+        for c in self.cfgs:
+            c.group_overrides = self.group_overrides
 
     def _create_deploy_objects(self):
         '''Create deploy objects from items that were passed on for being run.

--- a/util/dvsim/Regression.py
+++ b/util/dvsim/Regression.py
@@ -18,6 +18,10 @@ class Regression(Mode):
     # Maintain a list of tests str
     item_names = []
 
+    # Scalars that override the matching test attribute when set on a
+    # regression (see merge_regression_opts).
+    test_overrides = ("reseed", "run_timeout_mins", "run_timeout_multiplier")
+
     def __init__(self, regdict):
         self.name = ""
 
@@ -32,6 +36,8 @@ class Regression(Mode):
         self.test_names = []
 
         self.reseed = None
+        self.run_timeout_mins = None
+        self.run_timeout_multiplier = None
         self.excl_tests = []  # TODO: add support for this
         self.en_sim_modes = []
         self.en_run_modes = []
@@ -172,6 +178,8 @@ class Regression(Mode):
             test.post_run_cmds.extend(self.post_run_cmds)
             test.run_opts.extend(self.run_opts)
 
-            # Override reseed if available.
-            if self.reseed is not None:
-                test.reseed = self.reseed
+            # Scalar knobs set on the regression override the test's value.
+            for attr in Regression.test_overrides:
+                regr_val = getattr(self, attr)
+                if regr_val is not None:
+                    setattr(test, attr, regr_val)

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -389,9 +389,21 @@ class SimCfg(FlowCfg):
                                self.run_opts, self.sw_images,
                                self.sw_build_opts)
 
+        # Validate cfg_group override keys against the allowlist.
+        for attr in self.group_overrides:
+            if attr not in Regression.test_overrides:
+                log.error("cfg_groups override %r is not one of %s.",
+                          attr, list(Regression.test_overrides))
+                sys.exit(1)
+
         # Process reseed override and create the build_list
         build_list_names = []
         for test in self.run_list:
+            # Apply cfg_group overrides (above regression/test, below flags).
+            for attr in Regression.test_overrides:
+                if attr in self.group_overrides:
+                    setattr(test, attr, self.group_overrides[attr])
+
             # Override reseed if available.
             if self.reseed_ovrd is not None:
                 test.reseed = self.reseed_ovrd

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -353,6 +353,14 @@ def parse_args():
                              'not used, dvsim will process all configs listed '
                              'in a primary config.'))
 
+    whatg.add_argument("--cfg-groups",
+                       nargs="*",
+                       metavar="GROUP",
+                       help=('The .hjson file is a primary config. Only run '
+                             'the configs in the named cfg_groups and apply '
+                             'each group\'s overrides. Independent of -i, '
+                             'which still selects the tests/regressions.'))
+
     disg = parser.add_argument_group('Dispatch options')
 
     disg.add_argument("--job-prefix",


### PR DESCRIPTION
This PR is composed of two commits:
- The first commit aims to allow `run_timeout_mins` to be set within a run mode for a regression and to be downstreamed to the tests, overriding their run timeout. This is done so that separate regressions might have different timeouts. It's also useful at the batch level: we might want a single block to have a certain timeout whereas the rest run with the default.
- The second commit introduces the concept of `cfg_groups`: similar to how `regressions` allows the user to set up particular configuration parameters for multiple tests, this concept allows parameters to be set for a particular subset of blocks, which can then be called with the `--cfg-groups` argument.

For an illustration, this allows batch `sim_cfgs` to be shaped as follows:
```
{ 
    name: test_batch
    import_cfgs: ["{proj_root}/hw/data/common_project_cfg.hjson"]
    flow: sim 
    rel_path: "hw/dv/summary"
    overrides: [
      { name: scratch_path, value: "{scratch_base_path}/{name}-{flow}" }
    ]

    // Pool of cfgs the groups draw from — batchgroups untouched, exactly the
    // all_sim_cfgs shape (copy or subset).
    use_cfgs: {
      ip: [
        "{proj_root}/hw/ip/acc/dv/uvm/acc_standard_sim_cfg.hjson",
        "{proj_root}/hw/ip/uart/dv/uart_sim_cfg.hjson",
        "{proj_root}/hw/ip/aes/dv/aes_masked_sim_cfg.hjson",
        "{proj_root}/hw/ip/hmac/dv/hmac_sim_cfg.hjson",
      ]
    }
    
    // Named groups: subset + per-group scalar overrides.
    cfg_groups: {
      group1: {
        cfgs: ["acc_standard", "uart"]
        run_timeout_mins: 360
        reseed: 3
      }
      crypto: {
        cfgs: ["aes_masked", "hmac"]
        run_timeout_multiplier: 2
      }                                                                                                                                                                                                             
    }                                                                                                                                                                                                               
  }     

```