### PR TITLE
[hw,verilator] Change gpiodpi.sv `req_exit` C DPI argument to inout

### DIFF
--- a/hw/dv/dpi/gpiodpi/gpiodpi.sv
+++ b/hw/dv/dpi/gpiodpi/gpiodpi.sv
@@ -34,7 +34,7 @@ module gpiodpi
                                      input logic [N_GPIO-1:0] gpio_en_d2p,
                                      input logic [N_GPIO-1:0] gpio_pull_en,
                                      input logic [N_GPIO-1:0] gpio_pull_sel,
-                                     output bit req_exit);
+                                     inout bit req_exit);
 
    bit req_exit;
    chandle ctx;


### PR DESCRIPTION
This PR is intended to fix occasional Verilator early simulation exits.

Prior to this commit, the `req_exit` bit in the Verilator GPIO DPI module was listed as an output from the DPI function `gpiodpi_host_to_device_tick`, as `gpiodpi_host_to_device_tick` only ever sets this bit.

The details regarding DPI arguments in IEEE Standard for SystemVerilog subsection 35.6.1 specify that input and inout arguments must be implemented to behave as "copy-in" arguments, whereas outputs are only required to have "copy-out" behavior.

Inspection of a verilated Egret test binary verified that when `gpiodpi_host_to_device_tick` was called, the local `req_exit` variable was indeed never initialized. This led to occasional early exits when the memory pointed to by `req_exit` happened to have its LSB set on function entry, as the usual control paths for `gpiodpi_host_to_device_tick` never set `req_exit`, causing the LSB of this uninitialized value to be copied out into the actual `req_exit` signal and triggering an early simulation exit.

By changing `req_exit` in `gpiodpi_host_to_device_tick` to an inout argument, the resulting "copy-in" behavior now ensures that the value of `req_exit` local variable on function entry is set to the corresponding `req_exit` signal value in the GPIO DPI module, resolving this issue.