### PR TITLE
[spi,work-around] Fix workaround for wait statement

### DIFF
--- a/hw/dv/sv/spi_agent/spi_monitor.sv
+++ b/hw/dv/sv/spi_agent/spi_monitor.sv
@@ -47,12 +47,7 @@ class spi_monitor extends dv_base_monitor#(
     bit flash_opcode_received;
 
     wait (cfg.en_monitor);
-    // It would be simpler to just do `wait (&cfg.vif.csb === 1'b0);` but for some
-    // simulators that wait can be erroneously satisfied even when csb is all 1's.
-    if (&cfg.vif.csb !== 1'b0) begin
-      @cfg.vif.csb;
-      if (&cfg.vif.csb !== 1'b0) return;
-    end
+    wait (cfg.vif.csb == '0);
     active_csb = cfg.vif.get_active_csb();
 
     cfg.vif.sck_polarity = cfg.sck_polarity[active_csb];

--- a/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
@@ -313,13 +313,7 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
       txt = "\n\t byte      actual     expected";
       for (int i=0; i < exp_segment.command_reg.len+1; i++) begin
 
-        // It would be simpler to just do `wait (&cfg.vif.csb === 1'b0);` but for some
-        // simulators that wait can be erroneously satisfied even when csb is all 1's.
-        if (&cfg.m_spi_agent_cfg.vif.csb !== 1'b0) begin
-          do
-            @cfg.m_spi_agent_cfg.vif.csb;
-          while (&cfg.m_spi_agent_cfg.vif.csb !== 1'b0);
-        end
+        wait (cfg.m_spi_agent_cfg.vif.csb == '0);
         // After the sampling edge the plain_item should've been populated
         cfg.m_spi_agent_cfg.wait_sck_edge(SamplingEdge, cfg.m_spi_agent_cfg.vif.get_active_csb());
 


### PR DESCRIPTION
Replace the work-around for VCS faulty handling of `wait (&cfg.vif.csb===1'b0)` by `wait (cfg.vif.csb == '0)`, as suggested by VCS support. The work-around was put in place in #71.

Fixes #28