### PR TITLE
[fusesoc] Prioritize Bazel-provided hermetic Verilator in build

### DIFF
--- a/util/fusesoc_build.py
+++ b/util/fusesoc_build.py
@@ -80,11 +80,13 @@ if __name__ == "__main__":
     make_options += " LDFLAGS='{}'".format(" ".join(ldflags))
 
     # `VERILATOR_BINARY` is passed in as a relative path to the Bazel
-    # `execroot`. Convert this to an absolute path in PATH, if present.
+    # `execroot`. Convert this to an absolute path in PATH, if present, at the
+    # start of PATH to ensure the hermetic Verilator binary is selected over any
+    # locally installed version.
     if "VERILATOR_BINARY" in os.environ:
         verilator_binary = os.environ["VERILATOR_BINARY"]
         verilator_dirname = os.path.dirname(os.path.join(cwd, verilator_binary))
-        path_env += os.pathsep + verilator_dirname
+        path_env = verilator_dirname + os.pathsep + path_env
         # If running verilator, include make options.
         sys.argv = others + ["--make_options=" + make_options]
     os.environ["PATH"] = path_env


### PR DESCRIPTION
This one-commit PR tweaks fusesoc_build.py to always prioritize the `VERILATOR_BINARY`-provided Verilator binary over any pre-existing Verilator binaries in the path, ensuring presence of a separate Verilator version in the path cannot break builds.

As an alternative to modifying `PATH`, I observed that edalize accepts a `VERILATOR_ROOT` environment variable for setting the Verilator root path. Unfortunately, edalize also searches for the Verilator `include` directory in the same place, which is incompatible with how Bazel presently builds the hermetic Verilator; changing how `PATH` was set in fusesoc_build.py was the most reasonable approach I could identify.