### PR TITLE
[acc,util] Fix parsing of a comment before a mnemonic

### DIFF
--- a/hw/ip/acc/util/acc_as.py
+++ b/hw/ip/acc/util/acc_as.py
@@ -974,7 +974,7 @@ class Transformer:
             pos += end
 
         # Return if at EOL
-        if pos == len(line):
+        if pos >= len(line):
             return pos
 
         # Spot a line comment ('#'). In that case, eat to EOL and return.
@@ -1129,8 +1129,10 @@ class Transformer:
                 self.macros.append(line_match.group(1))
 
         def perform_replacement(line: str, symbol_table: Dict[str, List[str]]) -> str:
-            # Remove comment (only works single-line comments)
-            line_new = re.sub(r"/\*.*\*/", "", line)
+            # Blank out single-line comments. The length must be preserved:
+            # the caller resumes parsing at an offset into this line.
+            line_new = re.sub(r"/\*.*?\*/", lambda m: " " * len(m.group(0)),
+                              line)
             # Check if the token is a symbol in the symbol table
             for sym in symbol_table:
                 # Replace the token with the value from the most recent definition


### PR DESCRIPTION
acc_as deleted block comments from a line before parsing it, but then carried on parsing at an offset computed against the original line. A comment to the left of the mnemonic shifted the operands out from under the parser, giving either a bogus syntax error, an IndexError, or silently dropped operands on a data directive.

Blank the comments out in place instead, so that the offset stays valid.

- Fixes #345.