### PR TITLE
[verilator] Link only the C++ runtime statically to fix build on Debian 13

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -82,7 +82,15 @@ runs:
     - name: Install UTF-8 language pack
       run: |
         if command -v apt > /dev/null; then
-          sudo apt install -y language-pack-gnome-en-base
+          # Only Ubuntu ships the language-pack-* packages. On Debian the
+          # locale has to be generated from the `locales` package instead.
+          if apt-cache show language-pack-gnome-en-base > /dev/null 2>&1; then
+            sudo apt install -y language-pack-gnome-en-base
+          else
+            sudo apt install -y locales
+            echo "en_US.UTF-8 UTF-8" | sudo tee -a /etc/locale.gen > /dev/null
+            sudo locale-gen
+          fi
           echo "LANG=en_US.UTF-8" >> "$GITHUB_ENV"
           echo "LANGUAGE=en.UTF-8" >> "$GITHUB_ENV"
         fi

--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -129,8 +129,8 @@ runs:
         VERIBLE_URL="https://github.com/chipsalliance/verible/releases/download/${{ inputs.verible-version }}/${VERIBLE_TAR}"
         source ci/scripts/utils.sh
         sudo mkdir -p "${{ inputs.verible-path }}"
-        retry 5 2 2 curl -sSfL "$VERIBLE_URL" -o "${{ runner.temp }}/${VERIBLE_TAR}"
-        sudo tar -C "${{ inputs.verible-path }}" -xvzf "${{ runner.temp }}/${VERIBLE_TAR}" --strip-components=1
+        retry 5 2 2 curl -sSfL "$VERIBLE_URL" -o "$RUNNER_TEMP/${VERIBLE_TAR}"
+        sudo tar -C "${{ inputs.verible-path }}" -xvzf "$RUNNER_TEMP/${VERIBLE_TAR}" --strip-components=1
         # Fixup bin permission which is broken in tarball.
         sudo chmod 755 "${{ inputs.verible-path }}/bin"
         echo "${{ inputs.verible-path }}/bin" >> "$GITHUB_PATH"
@@ -154,7 +154,7 @@ runs:
       if: github.event_name != 'pull_request'
       run: |
         SOURCE=${{ steps.auth.outputs.credentials_file_path }}
-        TARGET=${{ runner.temp }}/$(basename "$SOURCE")
+        TARGET=$RUNNER_TEMP/$(basename "$SOURCE")
         mv $SOURCE $TARGET
         echo "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=$TARGET" >> $GITHUB_ENV
         echo "GOOGLE_APPLICATION_CREDENTIALS=$TARGET" >> $GITHUB_ENV
@@ -193,8 +193,8 @@ runs:
         MERGE_JUNIT_SHA256="5c6a63063f3a155ea4da912d5cae2ec4a89022df31d7942f2aba463ee4790152"
 
         source ci/scripts/utils.sh
-        retry 5 2 2 curl -fLSs -o "${{ runner.temp }}/${MERGE_JUNIT_TAR}" "$MERGE_JUNIT_URL"
-        HASH=$(sha256sum "/${{ runner.temp }}/$MERGE_JUNIT_TAR" | awk '{print $1}')
+        retry 5 2 2 curl -fLSs -o "$RUNNER_TEMP/${MERGE_JUNIT_TAR}" "$MERGE_JUNIT_URL"
+        HASH=$(sha256sum "$RUNNER_TEMP/$MERGE_JUNIT_TAR" | awk '{print $1}')
         if [[ "$HASH" != "$MERGE_JUNIT_SHA256" ]]; then
           echo "The hash of merge-junit does not match" >&2
           echo "$HASH != $MERGE_JUNIT_SHA256" >&2
@@ -203,9 +203,9 @@ runs:
 
         sudo mkdir -p $MERGE_JUNIT_PATH
         sudo chmod 777 $MERGE_JUNIT_PATH
-        tar -C $MERGE_JUNIT_PATH -xvzf "${{ runner.temp }}/${MERGE_JUNIT_TAR}" --strip-components=1
+        tar -C $MERGE_JUNIT_PATH -xvzf "$RUNNER_TEMP/${MERGE_JUNIT_TAR}" --strip-components=1
         echo $MERGE_JUNIT_PATH >> "$GITHUB_PATH"
-        rm "${{ runner.temp }}/${MERGE_JUNIT_TAR}"
+        rm "$RUNNER_TEMP/${MERGE_JUNIT_TAR}"
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -68,6 +68,42 @@ jobs:
       - name: Run ACC ISS test
         run: make -C hw/ip/acc/dv/accsim test
 
+  container_verilator_smoketest:
+    name: Container Verilator smoketest (${{ matrix.image }}, ${{ matrix.runner }})
+    if: ${{ !github.event.repository.private }}
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - debian:12
+          - debian:13
+        runner:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+    env:
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: Bootstrap container
+        run: apt-get update && apt-get install -y sudo git curl wget ca-certificates
+      - uses: actions/checkout@v4
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+      - name: Build device software
+        run: ./bazelisk.sh build //sw/device/examples/hello_world:hello_world_sim_dv
+      - name: Run UART smoketest on Verilator
+        run: |
+          ./bazelisk.sh test \
+            --build_tests_only=true \
+            --test_timeout=2400,2400,4000,-1 \
+            --test_output=errors \
+            --//hw:make_options=-j,"$(nproc)" \
+            //sw/device/tests:uart_smoketest_sim_verilator
+      - name: Run ACC ISS test
+        run: make -C hw/ip/acc/dv/accsim test
+
   docker_verilator_smoketest:
     name: Docker Verilator smoketest (${{ matrix.runner }})
     if: ${{ !github.event.repository.private }}

--- a/util/fusesoc_build.py
+++ b/util/fusesoc_build.py
@@ -36,9 +36,12 @@ if __name__ == "__main__":
     cxxflags = ["-stdlib=libc++"]
     ldflags = [
         "-fuse-ld=lld",
-        "-static",
+        "-static-libstdc++",
         "-stdlib=libc++",
+        # Static C++ runtime, but dynamic host libraries such as libelf.
+        "-Wl,-Bstatic",
         "-lc++abi",
+        "-Wl,-Bdynamic",
         "-lzstd",
     ]
     if "VERILATOR_AR" in os.environ:


### PR DESCRIPTION
Debian isn't a supported OS, but having at least partial support seems worthwhile regardless and the [actual fix](https://github.com/pavona/pavona/pull/351/commits/b064d8ea5435322f8dedfc2d5b7484da5c314182) is very small. 

- Fixes #350 

Also adds a CI smoketest on Debian 12 and 13.