### PR TITLE
[doc] Move the Python setup out of the getting started guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -9,6 +9,7 @@
 
 # Using Pavona
 
+- [Python Environment Setup](./doc/getting_started/setup_python.md)
 - [Verilator Setup](./doc/getting_started/setup_verilator.md)
 - [FPGA Setup](./doc/getting_started/setup_fpga.md)
   - [Vivado Setup](./doc/getting_started/install_vivado/README.md)

--- a/doc/contributing/doc/README.md
+++ b/doc/contributing/doc/README.md
@@ -12,9 +12,7 @@ The `util/site/build-docs.sh` script is used to build this book as well as the g
 Rules for how to write correct Markdown files can be found in the [reference manual](../style_guides/markdown_usage_style.md).
 
 In order to run them, you'll need some dependencies.
-Most are mentioned in two steps of the Getting Started guide:
-- [Install dependencies using the package manager](../../getting_started/README.md#step-2-install-dependencies-using-the-package-manager)
-- [Install Python libraries needed](../../getting_started/README.md#step-3-install-python-libraries-needed)
+Most are covered by [Install system dependencies](../../getting_started/README.md#install-system-dependencies) in the Getting Started guide, along with the packages in `python-requirements.txt`.
 
 Since the creation of documentation is based around the conversion from Markdown to HTML files, you also need
 - [Cargo](https://doc.rust-lang.org/cargo/), the Rust package manager

--- a/doc/contributing/style_guides/python_coding_style.md
+++ b/doc/contributing/style_guides/python_coding_style.md
@@ -117,12 +117,7 @@ Fixing import ordering errors for a single file can be done with `isort`:
 $ isort file.py
 ```
 
-Yapf and isort are Python packages and should be installed with pip:
-
-```console
-$ pip3 install --user yapt
-$ pip3 install --user isort
-```
+Yapf and isort are both listed in `python-requirements.txt`, so they come with the environment described in [Python Environment Setup](../../getting_started/setup_python.md).
 
 ### File Extensions
 

--- a/doc/getting_started/README.md
+++ b/doc/getting_started/README.md
@@ -114,36 +114,8 @@ The following command processes this file and passes it to apt to install them:
 $ sed '/^#/d' apt-requirements.txt | xargs sudo apt install -y
 ```
 
-You'll also need to set up a Pavona-specific Python environment.
-This process keeps Pavona-specific Python package versions from clashing with others that may already exist on your system.
-
-First, install the python3-venv package from apt, then create your virtual environment:
-
-```shell
-$ sudo apt install python3-venv
-$ python3 -m venv .venv
-```
-
-### Activating your Pavona Python environment
-
-The second step creates a hidden directory called `.venv` in your `pavona/` directory.
-In order to use Pavona's Python-based tools, you'll need to *activate* this environment:
-
-```shell
-$ source .venv/bin/activate
-(.venv) $
-```
-
-The `(.venv)` prepended to your shell prompt indicates that the virtual environment is now activated.
-If you close your terminal and later return to use the Pavona repository, **be sure to re-activate your virtual environment by running the above command**.
-Alternatively, you may activate your environment as part of your shell rc file (e.g. bashrc, cshrc, zshrc).
-
-Once you've activated your Pavona environment, install the Python dependencies.
-You'll need to do this only once.
-
-```shell
-$ pip3 install -r python-requirements.txt --require-hashes
-```
+Anything you build or test with Bazel brings its own Python, so no Python setup is needed here.
+The few tools that run outside Bazel, such as `util/dvsim/dvsim.py` and `util/regtool.py`, do need one; see [Python Environment Setup](setup_python.md).
 
 ## Build and run a test
 

--- a/doc/getting_started/setup_python.md
+++ b/doc/getting_started/setup_python.md
@@ -1,0 +1,16 @@
+# Python Environment Setup
+
+Anything you build or test with Bazel brings its own Python, so this is only needed for the tools that run outside it, such as `util/dvsim/dvsim.py`, `util/regtool.py` and the other generators.
+
+Install their dependencies into a virtual environment, which keeps the versions from clashing with anything else on your system:
+
+```console
+$ sudo apt install python3-venv
+$ python3 -m venv $REPO_TOP/.venv
+$ source $REPO_TOP/.venv/bin/activate
+$ pip3 install -r $REPO_TOP/python-requirements.txt --require-hashes
+```
+
+We recommend matching the Python version `MODULE.bazel` pins for the Bazel toolchain, so that a tool behaves the same whether you run it or Bazel does.
+
+Re-activate the environment with `source $REPO_TOP/.venv/bin/activate` whenever you return to the repository, or activate it from your shell rc file (e.g. bashrc, cshrc, zshrc).

--- a/util/dvsim/README.md
+++ b/util/dvsim/README.md
@@ -29,13 +29,8 @@ DVSim relies on the following third-party Python libraries:
 * **[Premailer](https://pypi.org/project/premailer/)**: to inline a block of CSS into the generated HTML report.
 * **[Tabulate](https://pypi.org/project/tabulate/)**: to pretty-print tabular data when displaying the report on the console.
 
-These dependencies are already listed in `$REPO_TOP/python_requirements.txt`, which can be installed by running:
-
-```console
-python3 -m pip install --user -r $REPO_TOP/python-requirements.txt
-```
-
-Note that you may have already done this if you followed the getting started steps.
+These dependencies are already listed in `$REPO_TOP/python-requirements.txt`.
+See [Python Environment Setup](../../doc/getting_started/setup_python.md) for how to install them.
 
 ## Other related documents
 

--- a/util/reggen/doc/setup_and_use.md
+++ b/util/reggen/doc/setup_and_use.md
@@ -6,14 +6,7 @@ The example commands assume `$REPO_TOP` is set to the toplevel directory of the 
 
 ### Setup
 
-If packages have not previously been installed you will need to set a few things up.
-First use `pip3` to install some required packages:
-
-```console
-$ pip3 install --user hjson
-$ pip3 install --user mistletoe
-$ pip3 install --user mako
-```
+`regtool.py` runs outside Bazel, so it needs the environment described in [Python Environment Setup](../../../doc/getting_started/setup_python.md).
 
 ### Register JSON Format
 


### PR DESCRIPTION
The guide sets up a virtual environment and installs the requirements before anything else, but Bazel provides its own interpreter for the tools it runs and needs neither. Only the tools run outside it do, and several pages install their packages into the system interpreter with `pip3 install --user`, which is not the environment the guide creates.

Give the setup its own page next to the other setup guides, and link it from the tools that need it.

Context: Our current `python-requirements.txt` is incompatible with anything newer than Python 3.13 (Ubuntu 26 ships 3.14; Debian 13 ships 3.13). Requiring all users to install it even though only a subset of tools will need it feels unnecessary. In the medium term, it would be good to make it compatible (most changes for that seem to be needed for bumping the Python version used within bazel anyway). In the long term, it would be good if we do not rely on the system Python interpreter.