### PR TITLE
[mlkem,mldsa] Update mlkem-native/mldsa-native to v2.0.0

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -607,7 +607,7 @@
     },
     "//third_party/mlkem_native:extensions.bzl%mlkem_native": {
       "general": {
-        "bzlTransitiveDigest": "pJZ7cksmmU0acXS7UEUWnuncG4ItXOS6p+tdQ+n5dhw=",
+        "bzlTransitiveDigest": "6rzCxRBO+d89Gb0ov9/V2lkgO10mjO1P0CB+NJq/Gf0=",
         "usagesDigest": "wrmyTg8v0YnST2GEFD1/vEGe+hfW4yrjxgMt8EEb7ho=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -617,10 +617,10 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//third_party/mlkem_native:BUILD.mlkem_native.bazel",
-              "sha256": "fb1eeb64974ea13cdbec8d1e6ae7e69316dc959926c5660437dabf8462c965bf",
-              "strip_prefix": "mlkem-native-1.2.0",
+              "sha256": "76bf71771f09a25f30463218974ae10752d72bca34bbc470c7f6f8655f51d622",
+              "strip_prefix": "mlkem-native-2.0.0",
               "urls": [
-                "https://github.com/pq-code-package/mlkem-native/archive/v1.2.0.tar.gz"
+                "https://github.com/pq-code-package/mlkem-native/archive/v2.0.0.tar.gz"
               ]
             }
           }

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -578,7 +578,7 @@
     },
     "//third_party/mldsa_native:extensions.bzl%mldsa_native": {
       "general": {
-        "bzlTransitiveDigest": "JXWwls/UX0FppzTPIxvBkNEWdRjjdl9Kyqiwb6JQ0cM=",
+        "bzlTransitiveDigest": "EHhp8IV9QMml8INBW8b1mIH9xov9Q1ppyZ+E7tVfX0w=",
         "usagesDigest": "u4wmpsW8xRNXUJxQAEu2V94rpike0oJR5U4wylT/dU8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -588,10 +588,10 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//third_party/mldsa_native:BUILD.mldsa_native.bazel",
-              "sha256": "722f0c778cfb33ad24e1877c3c9c6e169428393b863a00492c1e0a4dcea39465",
-              "strip_prefix": "mldsa-native-1.0.0-beta2",
+              "sha256": "97a7305c32b62cbcae97891823176e18ca96d9eaafc3728587d75bb113862a40",
+              "strip_prefix": "mldsa-native-2.0.0",
               "urls": [
-                "https://github.com/pq-code-package/mldsa-native/archive/v1.0.0-beta2.tar.gz"
+                "https://github.com/pq-code-package/mldsa-native/archive/v2.0.0.tar.gz"
               ]
             }
           }

--- a/sw/device/lib/crypto/impl/mldsa.c
+++ b/sw/device/lib/crypto/impl/mldsa.c
@@ -196,9 +196,8 @@ otcrypto_status_t otcrypto_mldsa44_sign_derand(
     memcpy(pre + 2, context.data, context.len);
   }
 
-  size_t signature_len;
   int result = mldsa44_signature_internal(
-      (uint8_t *)signature.data, &signature_len, message.data, message.len, pre,
+      (uint8_t *)signature.data, message.data, message.len, pre,
       2 + context.len, (const uint8_t *)rnd.data, (const uint8_t *)sk_share0, 0,
       &ctx);
 
@@ -248,9 +247,9 @@ otcrypto_status_t otcrypto_mldsa44_verify(
   mld_alloc_ctx_t ctx = {.base = work,
                          .size_words = kOtcryptoMldsa44WorkBufferVerifyWords,
                          .offset_words = 0};
-  int result = mldsa44_verify(
-      (const uint8_t *)signature.data, signature.len, message.data, message.len,
-      context.data, context.len, (const uint8_t *)public_key->key, &ctx);
+  int result = mldsa44_verify((const uint8_t *)signature.data, message.data,
+                              message.len, context.data, context.len,
+                              (const uint8_t *)public_key->key, &ctx);
 
   *verification_result = (result == 0) ? kHardenedBoolTrue : kHardenedBoolFalse;
 #endif
@@ -402,9 +401,8 @@ otcrypto_status_t otcrypto_mldsa65_sign_derand(
     memcpy(pre + 2, context.data, context.len);
   }
 
-  size_t signature_len;
   int result = mldsa65_signature_internal(
-      (uint8_t *)signature.data, &signature_len, message.data, message.len, pre,
+      (uint8_t *)signature.data, message.data, message.len, pre,
       2 + context.len, (const uint8_t *)rnd.data, (const uint8_t *)sk_share0, 0,
       &ctx);
 
@@ -454,9 +452,9 @@ otcrypto_status_t otcrypto_mldsa65_verify(
   mld_alloc_ctx_t ctx = {.base = work,
                          .size_words = kOtcryptoMldsa65WorkBufferVerifyWords,
                          .offset_words = 0};
-  int result = mldsa65_verify(
-      (const uint8_t *)signature.data, signature.len, message.data, message.len,
-      context.data, context.len, (const uint8_t *)public_key->key, &ctx);
+  int result = mldsa65_verify((const uint8_t *)signature.data, message.data,
+                              message.len, context.data, context.len,
+                              (const uint8_t *)public_key->key, &ctx);
 
   *verification_result = (result == 0) ? kHardenedBoolTrue : kHardenedBoolFalse;
 #endif
@@ -608,9 +606,8 @@ otcrypto_status_t otcrypto_mldsa87_sign_derand(
     memcpy(pre + 2, context.data, context.len);
   }
 
-  size_t signature_len;
   int result = mldsa87_signature_internal(
-      (uint8_t *)signature.data, &signature_len, message.data, message.len, pre,
+      (uint8_t *)signature.data, message.data, message.len, pre,
       2 + context.len, (const uint8_t *)rnd.data, (const uint8_t *)sk_share0, 0,
       &ctx);
 
@@ -660,9 +657,9 @@ otcrypto_status_t otcrypto_mldsa87_verify(
   mld_alloc_ctx_t ctx = {.base = work,
                          .size_words = kOtcryptoMldsa87WorkBufferVerifyWords,
                          .offset_words = 0};
-  int result = mldsa87_verify(
-      (const uint8_t *)signature.data, signature.len, message.data, message.len,
-      context.data, context.len, (const uint8_t *)public_key->key, &ctx);
+  int result = mldsa87_verify((const uint8_t *)signature.data, message.data,
+                              message.len, context.data, context.len,
+                              (const uint8_t *)public_key->key, &ctx);
 
   *verification_result = (result == 0) ? kHardenedBoolTrue : kHardenedBoolFalse;
 #endif

--- a/sw/device/lib/crypto/impl/mldsa/mldsa-native/mldsa_native_config.h
+++ b/sw/device/lib/crypto/impl/mldsa/mldsa-native/mldsa_native_config.h
@@ -63,19 +63,6 @@
 #define MLD_CONFIG_NO_RANDOMIZED_API
 
 /******************************************************************************
- * Name:        MLD_CONFIG_NO_SUPERCOP
- *
- * Description: By default, mldsa_native.h exposes the mldsa-native API in the
- *              SUPERCOP naming convention (crypto_sign_xxx). If you don't need
- *              this, set MLD_CONFIG_NO_SUPERCOP.
- *
- *              NOTE: You must set this for a multi-level build as the SUPERCOP
- *              naming does not disambiguate between the parameter sets.
- *
- *****************************************************************************/
-#define MLD_CONFIG_NO_SUPERCOP
-
-/******************************************************************************
  * Name:        MLD_CONFIG_INTERNAL_API_QUALIFIER
  *
  * Description: If set, this option provides an additional function

--- a/sw/device/lib/crypto/impl/mlkem/mlkem-native/mlkem_native_config.h
+++ b/sw/device/lib/crypto/impl/mlkem/mlkem-native/mlkem_native_config.h
@@ -62,19 +62,6 @@
 #define MLK_CONFIG_NO_RANDOMIZED_API
 
 /******************************************************************************
- * Name:        MLK_CONFIG_NO_SUPERCOP
- *
- * Description: By default, mlkem_native.h exposes the mlkem-native API in the
- *              SUPERCOP naming convention (crypto_kem_xxx). If you don't need
- *              this, set MLK_CONFIG_NO_SUPERCOP.
- *
- *              NOTE: You must set this for a multi-level build as the SUPERCOP
- *              naming does not disambiguate between the parameter sets.
- *
- *****************************************************************************/
-#define MLK_CONFIG_NO_SUPERCOP
-
-/******************************************************************************
  * Name:        MLK_CONFIG_INTERNAL_API_QUALIFIER
  *
  * Description: If set, this option provides an additional function

--- a/sw/device/tests/crypto/mldsa_functest.c
+++ b/sw/device/tests/crypto/mldsa_functest.c
@@ -55,10 +55,11 @@ OTTF_DEFINE_TEST_CONFIG();
 
 // FIPS 204 expected iteration counts for signing (scaled by 100)
 // From FIPS 204 Table 1: Expected number of iterations of the
-// main loop in Algorithm 2 (ML-DSA.Sign)
-#define FIPS204_EXPECTED_ITERS_44 425  // 4.25
-#define FIPS204_EXPECTED_ITERS_65 510  // 5.1
-#define FIPS204_EXPECTED_ITERS_87 385  // 3.85
+// main loop in Algorithm 2 (ML-DSA.Sign), as revised by the FIPS 204 errata:
+// https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx
+#define FIPS204_EXPECTED_ITERS_44 436  // 4.36
+#define FIPS204_EXPECTED_ITERS_65 514  // 5.14
+#define FIPS204_EXPECTED_ITERS_87 391  // 3.91
 
 #define TEST_MSG_LEN (sizeof(TEST_MSG) - 1)
 
@@ -217,11 +218,11 @@ static void test_mldsa44_derand(void) {
   LOG_INFO("1-iteration message signing time: %u cycles", (uint32_t)time_1iter);
 
 #ifdef MLDSA_BENCHMARK_MODE
-  // Calculate expected runtime for expected iterations (4.25)
+  // Calculate expected runtime for expected iterations (4.36)
   uint32_t time_per_iter = (uint32_t)(time_2iter - time_1iter);
   uint64_t expected_time =
       time_1iter + ((FIPS204_EXPECTED_ITERS_44 - 100) * time_per_iter) / 100;
-  LOG_INFO("Expected signing time (4.25 iterations): %u cycles",
+  LOG_INFO("Expected signing time (4.36 iterations): %u cycles",
            (uint32_t)expected_time);
 #endif
 
@@ -317,11 +318,11 @@ static void test_mldsa65_derand(void) {
   LOG_INFO("1-iteration message signing time: %u cycles", (uint32_t)time_1iter);
 
 #ifdef MLDSA_BENCHMARK_MODE
-  // Calculate expected runtime for expected iterations (5.1)
+  // Calculate expected runtime for expected iterations (5.14)
   uint32_t time_per_iter = (uint32_t)(time_2iter - time_1iter);
   uint64_t expected_time =
       time_1iter + ((FIPS204_EXPECTED_ITERS_65 - 100) * time_per_iter) / 100;
-  LOG_INFO("Expected signing time (5.1 iterations): %u cycles",
+  LOG_INFO("Expected signing time (5.14 iterations): %u cycles",
            (uint32_t)expected_time);
 #endif
 
@@ -417,11 +418,11 @@ static void test_mldsa87_derand(void) {
   LOG_INFO("1-iteration message signing time: %u cycles", (uint32_t)time_1iter);
 
 #ifdef MLDSA_BENCHMARK_MODE
-  // Calculate expected runtime for expected iterations (3.85)
+  // Calculate expected runtime for expected iterations (3.91)
   uint32_t time_per_iter = (uint32_t)(time_2iter - time_1iter);
   uint64_t expected_time =
       time_1iter + ((FIPS204_EXPECTED_ITERS_87 - 100) * time_per_iter) / 100;
-  LOG_INFO("Expected signing time (3.85 iterations): %u cycles",
+  LOG_INFO("Expected signing time (3.91 iterations): %u cycles",
            (uint32_t)expected_time);
 #endif
 

--- a/third_party/mldsa_native/BUILD.mldsa_native.bazel
+++ b/third_party/mldsa_native/BUILD.mldsa_native.bazel
@@ -12,6 +12,7 @@ cc_library(
         "mldsa/mldsa_native.h",
         "mldsa/src/cbmc.h",
         "mldsa/src/common.h",
+        "mldsa/src/context.h",
         "mldsa/src/randombytes.h",
         "mldsa/src/debug.h",
         "mldsa/src/debug.c",

--- a/third_party/mldsa_native/extensions.bzl
+++ b/third_party/mldsa_native/extensions.bzl
@@ -13,9 +13,9 @@ def _mldsa_native_repos():
     http_archive(
         name = "mldsa_native",
         build_file = Label("//third_party/mldsa_native:BUILD.mldsa_native.bazel"),
-        sha256 = "722f0c778cfb33ad24e1877c3c9c6e169428393b863a00492c1e0a4dcea39465",
-        strip_prefix = "mldsa-native-1.0.0-beta2",
+        sha256 = "97a7305c32b62cbcae97891823176e18ca96d9eaafc3728587d75bb113862a40",
+        strip_prefix = "mldsa-native-2.0.0",
         urls = [
-            "https://github.com/pq-code-package/mldsa-native/archive/v1.0.0-beta2.tar.gz",
+            "https://github.com/pq-code-package/mldsa-native/archive/v2.0.0.tar.gz",
         ],
     )

--- a/third_party/mlkem_native/BUILD.mlkem_native.bazel
+++ b/third_party/mlkem_native/BUILD.mlkem_native.bazel
@@ -12,6 +12,7 @@ cc_library(
         "mlkem/mlkem_native.h",
         "mlkem/src/cbmc.h",
         "mlkem/src/common.h",
+        "mlkem/src/context.h",
         "mlkem/src/randombytes.h",
         "mlkem/src/debug.h",
         "mlkem/src/debug.c",

--- a/third_party/mlkem_native/extensions.bzl
+++ b/third_party/mlkem_native/extensions.bzl
@@ -13,9 +13,9 @@ def _mlkem_native_repos():
     http_archive(
         name = "mlkem_native",
         build_file = Label("//third_party/mlkem_native:BUILD.mlkem_native.bazel"),
-        sha256 = "fb1eeb64974ea13cdbec8d1e6ae7e69316dc959926c5660437dabf8462c965bf",
-        strip_prefix = "mlkem-native-1.2.0",
+        sha256 = "76bf71771f09a25f30463218974ae10752d72bca34bbc470c7f6f8655f51d622",
+        strip_prefix = "mlkem-native-2.0.0",
         urls = [
-            "https://github.com/pq-code-package/mlkem-native/archive/v1.2.0.tar.gz",
+            "https://github.com/pq-code-package/mlkem-native/archive/v2.0.0.tar.gz",
         ],
     )


### PR DESCRIPTION
The first stable release of mldsa-native has landed last weekend:
https://github.com/pq-code-package/mldsa-native/releases/tag/v2.0.0

Alongside a new mlkem-native release landed that shares the same configuration options and API conventions: 
https://github.com/pq-code-package/mlkem-native/releases/tag/v2.0.0

This PR updates both and adjust our integration to the new configs.
While at it, fix the expected iteration counts for ML-DSA. See the [FIPS 204 errata](https://csrc.nist.gov/files/pubs/fips/204/final/docs/fips-204-potential-updates.xlsx) and the corresponding [discussion](https://groups.google.com/a/list.nist.gov/g/pqc-forum/c/BF7a9So7-1Y) on the pqc-forum.

Below are the new performance results (which is marginally slower than the previous version). 

## ML-DSA performance (Ibex)
|                                | Cycles   |
|-- |-- |
|mldsa44_keypair_derand          |   757977 |
mldsa44 sign, 2 iterations      |  2629500 |
mldsa44 sign, 1 iteration       |  1809176 |
mldsa44 sign, expected (4.36)   |  4565464 |
mldsa44_verify                  |   911075 |
mldsa65_keypair_derand          |  1207754 |
mldsa65 sign, 2 iterations      |  3903806 |
mldsa65 sign, 1 iteration       |  2670095 |
mldsa65 sign, expected (5.14)   |  7777658 |
mldsa65_verify                  |  1412130 |
mldsa87_keypair_derand          |  1912049 |
mldsa87 sign, 2 iterations      |  5793557 |
mldsa87 sign, 1 iteration       |  3883986 |
mldsa87 sign, expected (3.91)   |  9440837 |
mldsa87_verify                  |  2172447 |

## ML-KEM performance (Ibex)

Measurement                  | Cycles  |
| - | - |
mlkem512_keygen_derand       |  251786 |
mlkem512_encapsulate_derand  |  362644 |
mlkem512_decapsulate         |  488231 |
mlkem768_keygen_derand       |  406456 |
mlkem768_encapsulate_derand  |  540562 |
mlkem768_decapsulate         |  698384 |
mlkem1024_keygen_derand      |  586963 |
mlkem1024_encapsulate_derand |  747776 |
mlkem1024_decapsulate        |  942941 |

