### PR TITLE
[ci,fix] Correct finding repo top in gitless

### DIFF
--- a/ci/scripts/target-location.sh
+++ b/ci/scripts/target-location.sh
@@ -6,7 +6,7 @@
 # Use Bazel to query for the location of targets instead of searching
 
 set -e
-REPO_TOP=$(git rev-parse --show-toplevel) || REPO_TOP=$(realpath $0/../../..)
+REPO_TOP=$(git rev-parse --show-toplevel) || REPO_TOP=$(realpath "$(dirname "$0")"/../../..)
 readonly REPO_TOP
 
 verbose='false'


### PR DESCRIPTION
Typo in `ci/scripts/target-location.sh`.