### PR TITLE
[top,dv] Updated sim_cfg comments for loading SW images into slots

### DIFF
--- a/hw/top_dragonfly/dv/chip_dragonfly_sim_cfg.hjson
+++ b/hw/top_dragonfly/dv/chip_dragonfly_sim_cfg.hjson
@@ -403,9 +403,13 @@
   // followed by an index separated with a ':', which is used by the testbench
   // to know what type of image is it:
   // - 0 for Boot ROM,
-  // - 1 for SW test (loaded in flash),
-  // - 2 for ACC test, and
-  // - 3 for OTP.
+  // - 1 for SW test (loaded in flash slot A),
+  // - 2 for SW test (loaded in flash slot B),
+  // - 3 for ACC test,
+  // - 4 for OTP,
+  // - 5 for Debug SW (injected into SRAM),
+  // - 6 for Ibex SW (test SW in CTN SRAM),
+  // - 7 for Ibex SW (second stage boot ROM).
   // This allows an arbitrary number of SW images to be supplied to the TB.
   //
   // For example, if the Bazel label for a test is:

--- a/hw/top_dragonfly/dv/chip_rom_tests.hjson
+++ b/hw/top_dragonfly/dv/chip_rom_tests.hjson
@@ -6,6 +6,25 @@
   # Please see chip_dragonfly_sim_cfg.hjson for full setup details.
 
   # Note: Please maintain alphabetical order.
+
+  // If you are adding a test that has been generated from a Bazel
+  // `pavona_functest` macro, you can specify the test using its Bazel label
+  // followed by an index separated with a ':', which is used by the testbench
+  // to know what type of image is it:
+  // - 0 for Boot ROM,
+  // - 1 for SW test (loaded in flash slot A),
+  // - 2 for SW test (loaded in flash slot B),
+  // - 3 for ACC test,
+  // - 4 for OTP,
+  // - 5 for Debug SW (injected into SRAM),
+  // - 6 for Ibex SW (test SW in CTN SRAM),
+  // - 7 for Ibex SW (second stage boot ROM).
+  // This allows an arbitrary number of SW images to be supplied to the TB.
+  //
+  // For example, if the Bazel label for a test is:
+  // `//sw/device/tests:example_test_from_flash`, then you would specify this as
+  // `//sw/device/tests:example_test_from_flash:1`.
+
   tests: [
     // ROM E2E tests.
     {

--- a/hw/top_dragonfly/dv/env/chip_env_pkg.sv
+++ b/hw/top_dragonfly/dv/env/chip_env_pkg.sv
@@ -110,7 +110,7 @@ package chip_env_pkg;
     SwTypeRom       = 0, // Ibex SW - first stage boot ROM.
     SwTypeTestSlotA = 1, // Ibex SW - test SW in (flash) slot A.
     SwTypeTestSlotB = 2, // Ibex SW - test SW in (flash) slot B.
-    SwTypeAcc      = 3, // Acc SW
+    SwTypeAcc       = 3, // Acc SW
     SwTypeOtp       = 4, // Customized OTP image
     SwTypeDebug     = 5, // Debug SW - injected into SRAM.
     SwTypeCtn       = 6, // Ibex SW - test SW in CTN SRAM.

--- a/hw/top_egret/dv/chip_egret_sim_cfg.hjson
+++ b/hw/top_egret/dv/chip_egret_sim_cfg.hjson
@@ -415,9 +415,11 @@
   // followed by an index separated with a ':', which is used by the testbench
   // to know what type of image is it:
   // - 0 for Boot ROM,
-  // - 1 for SW test (loaded in flash),
-  // - 2 for ACC test, and
-  // - 3 for OTP.
+  // - 1 for SW test (loaded in flash slot A),
+  // - 2 for SW test (loaded in flash slot B),
+  // - 3 for ACC test,
+  // - 4 for OTP,
+  // - 5 for Debug SW (injected into SRAM).
   // This allows an arbitrary number of SW images to be supplied to the TB.
   //
   // For example, if the Bazel label for a test is:

--- a/hw/top_egret/dv/chip_rom_tests.hjson
+++ b/hw/top_egret/dv/chip_rom_tests.hjson
@@ -6,6 +6,23 @@
   # Please see chip_egret_sim_cfg.hjson for full setup details.
 
   # Note: Please maintain alphabetical order.
+
+  // If you are adding a test that has been generated from a Bazel
+  // `pavona_test` macro, you can specify the test using its Bazel label
+  // followed by an index separated with a ':', which is used by the testbench
+  // to know what type of image is it:
+  // - 0 for Boot ROM,
+  // - 1 for SW test (loaded in flash slot A),
+  // - 2 for SW test (loaded in flash slot B),
+  // - 3 for ACC test,
+  // - 4 for OTP,
+  // - 5 for Debug SW (injected into SRAM).
+  // This allows an arbitrary number of SW images to be supplied to the TB.
+  //
+  // For example, if the Bazel label for a test is:
+  // `//sw/device/tests:example_test_from_flash`, then you would specify this as
+  // `//sw/device/tests:example_test_from_flash:1`.
+
   tests: [
     // ROM E2E tests.
     {

--- a/hw/top_egret/dv/env/chip_env_pkg.sv
+++ b/hw/top_egret/dv/env/chip_env_pkg.sv
@@ -108,7 +108,7 @@ package chip_env_pkg;
     SwTypeRom       = 0, // Ibex SW - first stage boot ROM.
     SwTypeTestSlotA = 1, // Ibex SW - test SW in (flash) slot A.
     SwTypeTestSlotB = 2, // Ibex SW - test SW in (flash) slot B.
-    SwTypeAcc      = 3, // Acc SW
+    SwTypeAcc       = 3, // Acc SW
     SwTypeOtp       = 4, // Customized OTP image
     SwTypeDebug     = 5  // Debug SW - injected into SRAM.
   } sw_type_e;


### PR DESCRIPTION
The comments for loading a Bazel generated SW test into a Dragonfly or Egret image slot were outdated. Both Egret and Dragonfly have been updated, the comment has also been included in the ROM sim_cfg to make it easier to identify.