### PR TITLE
[dvsim] Count license timeout separately

### DIFF
--- a/hw/data/common_project_cfg.hjson
+++ b/hw/data/common_project_cfg.hjson
@@ -17,6 +17,15 @@
   // TODO: Add back FuseSoC fail pattern
   build_fail_patterns: []
 
+  // Patterns whose first appearance in a job's log marks where it stopped
+  // queueing for a license and started work. The timeout is measured from there.
+  // Empty means nothing to wait for, so the job is timed from its launch.
+  //
+  // These are the neutral defaults; each tool cfg adds what it prints. Imported
+  // lists concatenate, so a tool can add a marker but not take one away.
+  build_started_patterns: []
+  run_started_patterns: []
+
   exports: [
     { SCRATCH_PATH: "{scratch_path}" },
     { proj_root: "{proj_root}" }

--- a/hw/data/common_project_cfg.hjson
+++ b/hw/data/common_project_cfg.hjson
@@ -26,6 +26,12 @@
   build_started_patterns: []
   run_started_patterns: []
 
+  // Patterns saying a job died because the license server would not serve it,
+  // rather than because of the design or the testbench. Such a job is reported
+  // as killed, so a license outage does not read as a DV failure. Every tool
+  // words these differently, so they live with the tool cfg that prints them.
+  license_error_patterns: []
+
   exports: [
     { SCRATCH_PATH: "{scratch_path}" },
     { proj_root: "{proj_root}" }

--- a/hw/dv/tools/dvsim/dsim.hjson
+++ b/hw/dv/tools/dvsim/dsim.hjson
@@ -93,6 +93,10 @@
   build_fail_patterns: ["^=E:"]
   run_fail_patterns:   ["^=E:"]
 
+  // A UVM report appears only once the simulator holds a license and has
+  // elaborated, so the first one marks the run as under way.
+  run_started_patterns: ["^UVM_(INFO|WARNING|ERROR|FATAL)"]
+
   // waveform
   probe_file: "dsim.probe"
 

--- a/hw/dv/tools/dvsim/questa.hjson
+++ b/hw/dv/tools/dvsim/questa.hjson
@@ -73,6 +73,10 @@
                         "^\\*\\* Error.*$"]
   run_fail_patterns:   ["^\\*\\* Error.*$"]
 
+  // A UVM report appears only once the simulator holds a license and has
+  // elaborated, so the first one marks the run as under way.
+  run_started_patterns: ["^UVM_(INFO|WARNING|ERROR|FATAL)"]
+
   build_modes: [
    {
       name: questa_gui

--- a/hw/dv/tools/dvsim/riviera.hjson
+++ b/hw/dv/tools/dvsim/riviera.hjson
@@ -62,6 +62,10 @@
   build_fail_patterns: ["\\*E.*$"]
   run_fail_patterns:   ["\\*E.*$"] // Null pointer error
 
+  // A UVM report appears only once the simulator holds a license and has
+  // elaborated, so the first one marks the run as under way.
+  run_started_patterns: ["^UVM_(INFO|WARNING|ERROR|FATAL)"]
+
   build_modes: [
     {
       name: riviera_gui

--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -279,6 +279,10 @@
   build_fail_patterns: ["^Error-.*$"]
   run_fail_patterns:   ["^Error-.*$"] // Null pointer error
 
+  // A UVM report appears only once the simulator holds a license and has
+  // elaborated, so the first one marks the run as under way.
+  run_started_patterns: ["^UVM_(INFO|WARNING|ERROR|FATAL)"]
+
   build_modes: [
     {
       name: vcs_gui

--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -283,6 +283,11 @@
   // elaborated, so the first one marks the run as under way.
   run_started_patterns: ["^UVM_(INFO|WARNING|ERROR|FATAL)"]
 
+  // What VCS prints when the server rereads its license file.
+  license_error_patterns: ["Feature removed during lmreread",
+                           "SERVER line hostid",
+                           "Check your license file"]
+
   build_modes: [
     {
       name: vcs_gui

--- a/hw/dv/tools/dvsim/verilator.hjson
+++ b/hw/dv/tools/dvsim/verilator.hjson
@@ -99,6 +99,9 @@
                         "^TEST FAILED CHECKS$"
                         ]
 
+  // Verilator checks out no license, so there is nothing to wait for.
+  // run_started_patterns is left empty: a run is timed from its launch.
+
   // Coverage related.
   cov_db_dir: ""
   cov_db_test_dir: ""

--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -196,6 +196,10 @@
   build_fail_patterns: ["\\*E.*$"]
   run_fail_patterns:   ["\\*E.*$"] // Null pointer error
 
+  // A UVM report appears only once the simulator holds a license and has
+  // elaborated, so the first one marks the run as under way.
+  run_started_patterns: ["^UVM_(INFO|WARNING|ERROR|FATAL)"]
+
   build_modes: [
     {
       name: xcelium_gui

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -120,6 +120,7 @@ class Deploy():
             "dry_run": False,
             "exports": False,
             "flow_makefile": False,
+            "license_error_patterns": False,
             "name": False,
         }
 

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -40,6 +40,15 @@ class Deploy():
     # TODO: Allow these to be set in the HJson.
     weight = 1
 
+    # Patterns whose first appearance in the job's log marks where it stopped
+    # waiting for a license and started work. The timeout is measured from there.
+    # Empty means nothing to wait for, so the job is timed from its launch.
+    #
+    # The marker depends on the flow and the tool, so the targets that have one
+    # take it from the HJson, alongside their pass and fail patterns. This is the
+    # fallback for the targets that have none.
+    started_patterns = []
+
     def __str__(self):
         return (pprint.pformat(self.__dict__)
                 if log.getLogger().isEnabledFor(VERBOSE) else self.full_name)
@@ -372,6 +381,7 @@ class CompileSim(Deploy):
         self.mandatory_misc_attrs.update({
             "build_fail_patterns": False,
             "build_pass_patterns": False,
+            "build_started_patterns": False,
             "build_timeout_mins": False,
             "cov_db_dir": False,
         })
@@ -390,6 +400,7 @@ class CompileSim(Deploy):
             self.output_dirs += [self.cov_db_dir]
         self.pass_patterns = self.build_pass_patterns
         self.fail_patterns = self.build_fail_patterns
+        self.started_patterns = self.build_started_patterns
 
         if self.sim_cfg.args.build_timeout_mins is not None:
             self.build_timeout_mins = self.sim_cfg.args.build_timeout_mins
@@ -447,7 +458,8 @@ class CompileOneShot(Deploy):
 
         self.mandatory_misc_attrs.update({
             "build_fail_patterns": False,
-            "build_pass_patterns": False
+            "build_pass_patterns": False,
+            "build_started_patterns": False
         })
 
     def _set_attrs(self):
@@ -459,6 +471,7 @@ class CompileOneShot(Deploy):
         self.job_name += f"_{self.build_mode}"
         self.fail_patterns = self.build_fail_patterns
         self.pass_patterns = self.build_pass_patterns
+        self.started_patterns = self.build_started_patterns
 
         if self.sim_cfg.args.build_timeout_mins is not None:
             self.build_timeout_mins = self.sim_cfg.args.build_timeout_mins
@@ -527,6 +540,7 @@ class RunTest(Deploy):
             "run_dir_name": False,
             "run_fail_patterns": False,
             "run_pass_patterns": False,
+            "run_started_patterns": False,
             "run_timeout_mins": False,
             "run_timeout_multiplier": False,
         })
@@ -544,10 +558,12 @@ class RunTest(Deploy):
         if self.sim_cfg.cov:
             self.output_dirs += [self.cov_db_dir]
 
-        # In GUI mode, the log file is not updated; hence, nothing to check.
+        # In GUI mode, the log file is not updated; hence, nothing to check,
+        # and nothing to wait for either, so the job is timed from its launch.
         if not self.gui:
             self.pass_patterns = self.run_pass_patterns
             self.fail_patterns = self.run_fail_patterns
+            self.started_patterns = self.run_started_patterns
 
         if self.sim_cfg.args.run_timeout_mins is not None:
             self.run_timeout_mins = self.sim_cfg.args.run_timeout_mins

--- a/util/dvsim/Launcher.py
+++ b/util/dvsim/Launcher.py
@@ -66,6 +66,12 @@ class Launcher:
     # more than this many directories.
     max_odirs = 5
 
+    # Give up on a job that has not started doing its work within this many
+    # minutes of being launched, which normally means it is still queueing for a
+    # license. Zero waits indefinitely. This is a separate limit from the job's
+    # own timeout, which only starts counting once the job is under way.
+    max_job_wait_mins = 180
+
     # Flag indicating the workspace preparation steps are complete.
     workspace_prepared = False
     workspace_prepared_for_cfg = set()

--- a/util/dvsim/Launcher.py
+++ b/util/dvsim/Launcher.py
@@ -8,10 +8,36 @@ import logging as log
 import os
 import re
 import sys
+from itertools import islice
 from pathlib import Path
 from typing import Union
 
 from utils import VERBOSE, clean_odirs, mk_symlink, rm_path
+
+
+# Failure message used when a job returns a non-zero exit code without any of
+# its fail patterns matching. _check_status() keys off this to tell a job that
+# fell over before it got going from one that reported a testbench failure
+_EXIT_CODE_FAIL_MSG = "Job returned non-zero exit code"
+
+
+def find_first_match(lines, patterns, context_lines=5):
+    """Find the first of the lines matching any of the patterns.
+
+    `lines` is any iterable, so an open file can be handed in directly and the
+    log is never held whole.
+
+    Returns (line_number, context) with a 1-based line_number and the matching
+    line plus the next context_lines - 1 lines, or None if nothing matches.
+    """
+    lines = iter(lines)
+    for line_number, line in enumerate(lines, start=1):
+        if any(re.search(pattern, line) for pattern in patterns):
+            # Same iterator, so only the lines after the match are ever held.
+            context = [line] + list(islice(lines, context_lines - 1))
+            return line_number, context
+
+    return None
 
 
 class LauncherError(Exception):
@@ -243,11 +269,60 @@ class Launcher:
         raise NotImplementedError
 
     def _check_status(self):
+        """Determine the outcome of the job (P/F/K if it ran to completion).
+
+        Returns (status, err_msg) as _check_log_status() does, except that a job
+        which failed because the license server would not serve it is reported
+        as killed rather than failed.
+        """
+        status, err_msg = self._check_log_status()
+        if status != "F":
+            return status, err_msg
+
+        if err_msg.message != _EXIT_CODE_FAIL_MSG:
+            return status, err_msg
+
+        license_err_msg = self._find_license_error()
+        if license_err_msg:
+            return "K", license_err_msg
+
+        return status, err_msg
+
+    def _find_license_error(self):
+        """Return an ErrorMessage if the job's log shows a license failure.
+
+        Returns None if it does not, or if the log cannot be read.
+        """
+        patterns = self.deploy.license_error_patterns
+        if not patterns:
+            return None
+
+        try:
+            with open(
+                self.deploy.get_log_path(),
+                encoding="UTF-8",
+                errors="surrogateescape",
+            ) as f:
+                match = find_first_match(f, patterns)
+        except OSError:
+            return None
+
+        if not match:
+            return None
+
+        line_number, context = match
+        return ErrorMessage(
+            line_number=line_number,
+            message="Job could not obtain a license",
+            context=context,
+        )
+
+    def _check_log_status(self):
         """Determine the outcome of the job (P/F if it ran to completion).
 
         Returns (status, err_msg) extracted from the log, where the status is
-        "P" if the it passed, "F" otherwise. This is invoked by poll() just
-        after the job finishes. err_msg is an instance of the named tuple
+        "P" if the it passed, "F" otherwise. This is invoked by _check_status()
+        just after the job finishes. err_msg is an instance of the named tuple
         ErrorMessage.
         """
 
@@ -316,7 +391,7 @@ class Launcher:
         if self.exit_code != 0:
             return "F", ErrorMessage(
                 line_number=None,
-                message="Job returned non-zero exit code",
+                message=_EXIT_CODE_FAIL_MSG,
                 context=lines[-10:],
             )
         if chk_passed:

--- a/util/dvsim/LocalLauncher.py
+++ b/util/dvsim/LocalLauncher.py
@@ -5,12 +5,18 @@
 
 import datetime
 import os
+import re
 import shlex
 import subprocess
 from pathlib import Path
 from typing import Union
 
 from Launcher import ErrorMessage, Launcher, LauncherBusy, LauncherError
+
+# How much of the end of each log read to carry over to the next one, so that a
+# start marker split across two reads is still matched. Comfortably longer than
+# the lines being looked for
+_LOG_SCAN_TAIL_CHARS = 256
 
 
 class LocalLauncher(Launcher):
@@ -23,6 +29,15 @@ class LocalLauncher(Launcher):
         # Popen object when launching the job.
         self._process = None
         self._log_file = None
+
+        # When the job started doing its work, as opposed to when it was
+        # launched. None until we see it start. See _detect_job_start().
+        self._run_start_time = None
+
+        # How far through the log we have looked for the job starting, and the
+        # tail of what we read, so a marker split across two reads is not missed.
+        self._log_scan_offset = 0
+        self._log_scan_tail = ""
 
     def _do_launch(self) -> None:
         # Update the shell's env vars with self.exports. Values in exports must
@@ -111,22 +126,9 @@ class LocalLauncher(Launcher):
         elapsed_time = datetime.datetime.now() - self.start_time
         self.job_runtime_secs = elapsed_time.total_seconds()
         if self._process.poll() is None:
-            if (
-                self.timeout_secs
-                and (self.job_runtime_secs > self.timeout_secs)  # noqa: W503
-                and not (self.deploy.gui)  # noqa: W503
-            ):
-                self._kill()
-                timeout_mins = self.deploy.get_timeout_mins()
-                timeout_message = f"Job timed out after {timeout_mins} minutes"
-                self._post_finish(
-                    "K",
-                    ErrorMessage(
-                        line_number=None,
-                        message=timeout_message,
-                        context=[timeout_message],
-                    ),
-                )
+            timeout_reason = self._timeout_reason()
+            if timeout_reason is not None:
+                self._kill_with_reason(timeout_reason)
                 return "K"
 
             return "D"
@@ -136,6 +138,92 @@ class LocalLauncher(Launcher):
         self._post_finish(status, err_msg)
 
         return self.status
+
+    def _kill_with_reason(self, message: str) -> None:
+        """Kill the job and record why dvsim decided to kill it."""
+        self._kill()
+        self._post_finish(
+            "K",
+            ErrorMessage(line_number=None, message=message, context=[message]),
+        )
+
+    def _detect_job_start(self) -> None:
+        """Look for the point in the log where the job started doing its work.
+
+        Sets _run_start_time when one of the deploy's started_patterns turns up.
+        Only the bytes added to the log since the last look are read, so the cost
+        does not grow with the log, and nothing is read at all once the job has
+        started.
+        """
+        patterns = self.deploy.started_patterns
+        if not patterns:
+            # Nothing marks the start for this flow, so treat the job as under
+            # way from the moment it was launched.
+            self._run_start_time = self.start_time
+            return
+
+        try:
+            with open(self.deploy.get_log_path(), "rb") as f:
+                f.seek(self._log_scan_offset)
+                chunk = f.read()
+                self._log_scan_offset = f.tell()
+        except OSError:
+            # The log is not there yet, or cannot be read. Try again next poll.
+            return
+
+        if not chunk:
+            return
+
+        text = self._log_scan_tail + chunk.decode("UTF-8", errors="surrogateescape")
+        for pattern in patterns:
+            if re.search(pattern, text, re.MULTILINE):
+                self._run_start_time = datetime.datetime.now()
+                self._log_scan_tail = ""
+                return
+
+        # Hold on to the tail, so that a marker straddling two reads still
+        # matches when the rest of it arrives
+        self._log_scan_tail = text[-_LOG_SCAN_TAIL_CHARS:]
+
+    def _timeout_reason(self) -> Union[str, None]:
+        """Return why the job ought to be killed for taking too long, or None.
+
+        A job is timed from the point where it starts doing its work rather than
+        from the point where it was launched, because the gap between the two is
+        spent queueing for a license.
+
+        The waiting and the running phases therefore get separate limits and
+        separate messages, so that a report can tell a job that never got a
+        license apart from one that genuinely ran too long.
+        """
+        if self.deploy.gui:
+            # The user is driving, so nothing counts as too slow
+            return None
+
+        if self._run_start_time is None:
+            self._detect_job_start()
+
+        if self._run_start_time is None:
+            wait_mins = Launcher.max_job_wait_mins
+            if wait_mins and self.job_runtime_secs > wait_mins * 60:
+                return (
+                    f"Job did not start running within {wait_mins} minutes of "
+                    f"being launched, so it was most likely still waiting for a "
+                    f"license"
+                )
+            return None
+
+        if not self.timeout_secs:
+            return None
+
+        run_secs = (
+            datetime.datetime.now() - self._run_start_time
+        ).total_seconds()
+        if run_secs > self.timeout_secs:
+            timeout_mins = self.deploy.get_timeout_mins()
+            return f"Job timed out after running for {timeout_mins} minutes"
+
+        return None
 
     def _kill(self) -> None:
         """Kill the running process.

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -388,6 +388,18 @@ def parse_args():
                             'is used. Only applicable when launching jobs '
                             'locally.'))
 
+    disg.add_argument("--run-wait-timeout-mins",
+                      type=int,
+                      default=180,
+                      metavar="MINUTES",
+                      help=('Give up on a run that has not started simulating '
+                            'within MINUTES of being launched, which normally '
+                            'means it is still queueing for a license. This is '
+                            'separate from --run-timeout-mins, which only '
+                            'starts counting once the run is under way, so that '
+                            'a license queue does not eat into it. Pass 0 to '
+                            'wait indefinitely.'))
+
     pathg = parser.add_argument_group('File management')
 
     pathg.add_argument("--scratch-root",
@@ -802,6 +814,7 @@ def main():
     LsfLauncher.LsfLauncher.max_parallel = args.max_parallel
     NcLauncher.NcLauncher.max_parallel = args.max_parallel
     Launcher.Launcher.max_odirs = args.max_odirs
+    Launcher.Launcher.max_job_wait_mins = args.run_wait_timeout_mins
     LauncherFactory.set_launcher_type(args.local)
 
     # Build infrastructure from hjson file and create the list of items to


### PR DESCRIPTION
This PR contains two commits:
- The first one aims to make `dvsim` count the beginning of a run from polling the `run.log` and waiting for certain patterns that might indicate that the run is underway (for e.g. a `UVM_INFO`) , if applicable. This is because originally, `dvsim` would count the `run_timeout` from the moment the `make` file launches `dvsim`, which meant that if the process launched but it's waiting on a license, it might run into a timeout before it even started simulating. It also includes a `dvsim` argument for adjusting the timeout window for license queuing. 
- The second one simply differentiates the failures; a DV timeout should present a different error message from a license timeout.