### PR TITLE
[acc,dv] Run the ACC smoke tests as hermetic bazel tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,9 +251,9 @@ jobs:
       - name: ACC ISS test
         run: make -C hw/ip/acc/dv/accsim test
       - name: ACC smoke test
-        run: ./hw/ip/acc/dv/smoke/run_smoke.sh
+        run: ./bazelisk.sh test --test_output=errors //hw/ip/acc/dv/smoke:run_smoke_test
       - name: ACC PQC smoke test
-        run: ./hw/ip/acc/dv/smoke_pqc/run_smoke.sh
+        run: ./bazelisk.sh test --test_output=errors //hw/ip/acc/dv/smoke_pqc:run_smoke_test
       - name: Assemble & link code snippets
         run: make -C hw/ip/acc/util asm-check
 

--- a/hw/ip/acc/doc/developing_acc.md
+++ b/hw/ip/acc/doc/developing_acc.md
@@ -87,13 +87,19 @@ The generated binaries, a Verilated model and the output from running them can a
 ### Run the smoke test
 
 A smoke test which exercises some functionality of ACC can be found, together with its expected outputs (in the form of final register values), in `./hw/ip/acc/dv/smoke`.
-The test can be run using a script.
+The test can be run with Bazel.
 
 ```sh
-hw/ip/acc/dv/smoke/run_smoke.sh
+./bazelisk.sh test --test_output=errors //hw/ip/acc/dv/smoke:run_smoke_test
 ```
 
 This will build the standalone simulation, build the smoke test binary, run it and check the results are as expected.
+
+`./hw/ip/acc/dv/smoke_pqc` holds the equivalent test for ACC with the PQC instructions enabled.
+
+```sh
+./bazelisk.sh test --test_output=errors //hw/ip/acc/dv/smoke_pqc:run_smoke_test
+```
 
 ### Run the ISS on its own
 

--- a/hw/ip/acc/dv/accsim/BUILD
+++ b/hw/ip/acc/dv/accsim/BUILD
@@ -21,3 +21,13 @@ py_binary(
         "//hw/ip/acc/util/shared:testcase",
     ],
 )
+
+py_binary(
+    name = "stepped",
+    srcs = ["stepped.py"],
+    deps = [
+        "//hw/ip/acc/dv/accsim/sim",
+        "//hw/ip/acc/dv/accsim/sim:decode",
+        "//hw/ip/acc/dv/accsim/sim:load_elf",
+    ],
+)

--- a/hw/ip/acc/dv/model/iss_wrapper.cc
+++ b/hw/ip/acc/dv/model/iss_wrapper.cc
@@ -190,7 +190,14 @@ static std::string find_repo_top() {
 
 // Find the acc Python model. On failure, throw a std::runtime_error with a
 // description of what went wrong.
+//
+// If ACC_ISS is defined, it names an ISS executable that brings its own Python
+// environment, such as the bazel-built //hw/ip/acc/dv/accsim:stepped.
 static std::string find_acc_model() {
+  const char *from_env = getenv("ACC_ISS");
+  if (from_env)
+    return std::string(from_env);
+
   std::string path = find_repo_top() + "/hw/ip/acc/dv/accsim/stepped.py";
   c_str_ptr abs_path(realpath(path.c_str(), NULL));
   if (!abs_path) {
@@ -317,11 +324,9 @@ ISSWrapper::ISSWrapper() : tmpdir(new TmpDir()) {
 
 // Finally, exec the ISS
 #ifdef PQC_EN
-    execl("/usr/bin/env", "/usr/bin/env", "python3", "-u", model_path.c_str(),
-          "--pqc", NULL);
+    execl(model_path.c_str(), model_path.c_str(), "--pqc", NULL);
 #else
-    execl("/usr/bin/env", "/usr/bin/env", "python3", "-u", model_path.c_str(),
-          NULL);
+    execl(model_path.c_str(), model_path.c_str(), NULL);
 #endif
   }
 

--- a/hw/ip/acc/dv/smoke/BUILD
+++ b/hw/ip/acc/dv/smoke/BUILD
@@ -56,3 +56,37 @@ fusesoc_build(
     target = "sim",
     verilator_options = "//hw:verilator_options",
 )
+
+filegroup(
+    name = "verilator_acc_bin",
+    srcs = [":verilator_acc"],
+    output_group = "binary",
+)
+
+filegroup(
+    name = "smoke_test_nondeterministic_elf",
+    srcs = [":smoke_test_nondeterministic"],
+    output_group = "elf",
+)
+
+sh_test(
+    name = "run_smoke_test",
+    size = "small",
+    srcs = ["//hw/ip/acc/util:run_smoke_test.sh"],
+    args = [
+        "$(rootpath :verilator_acc_bin)",
+        "$(rootpath :smoke_test_nondeterministic_elf)",
+        "$(rootpath smoke_expected.txt)",
+        "$(rootpath //hw/ip/acc/dv/accsim:stepped)",
+    ],
+    data = [
+        "smoke_expected.txt",
+        ":smoke_test_nondeterministic_elf",
+        ":verilator_acc_bin",
+        "//hw/ip/acc/dv/accsim:stepped",
+    ],
+    tags = [
+        "manual",
+        "verilator",
+    ],
+)

--- a/hw/ip/acc/dv/smoke/run_smoke.sh
+++ b/hw/ip/acc/dv/smoke/run_smoke.sh
@@ -6,50 +6,9 @@
 # Runs the ACC smoke test (builds software, build simulation, runs simulation
 # and checks expected output)
 
-fail() {
-    echo >&2 "ACC SMOKE FAILURE: $*"
-    exit 1
-}
-
-set -o pipefail
 set -e
 
-SCRIPT_DIR="$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")"
-ROOT_DIR="$(readlink -e "$SCRIPT_DIR/../../../../..")" || \
-  fail "Can't find repository root dir"
-UTIL_DIR="$(readlink -e "$ROOT_DIR/util")" || \
-  fail "Can't find repository util dir"
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.."
 
-source "$UTIL_DIR/build_consts.sh"
-
-SMOKE_SRC_DIR=$ROOT_DIR/hw/ip/acc/dv/smoke
-
-./bazelisk.sh build \
-  //hw/ip/acc/dv/smoke:verilator_acc \
-  //hw/ip/acc/dv/smoke:smoke_test_nondeterministic
-SIM_BINARY=$(./bazelisk.sh cquery --output=files //hw/ip/acc/dv/smoke:verilator_acc)
-SMOKE_ELF=$(./bazelisk.sh cquery --output=files //hw/ip/acc/dv/smoke:smoke_test_nondeterministic | grep "\\.elf$" | head -1)
-
-RUN_LOG=`mktemp`
-readonly RUN_LOG
-# shellcheck disable=SC2064 # The RUN_LOG tempfile path should not change
-trap "rm -rf $RUN_LOG" EXIT
-
-timeout 5s ${SIM_BINARY} --load-elf=${SMOKE_ELF} -t | tee $RUN_LOG
-
-if [ $? -eq 124 ]; then
-  fail "Simulation timeout"
-fi
-
-if [ $? -ne 0 ]; then
-  fail "Simulator run failed"
-fi
-
-had_diff=0
-grep -A 74 "Call Stack:" $RUN_LOG | diff -U3 $SMOKE_SRC_DIR/smoke_expected.txt - || had_diff=1
-
-if [ $had_diff == 0 ]; then
-  echo "ACC SMOKE PASS"
-else
-  fail "Simulator output does not match expected output"
-fi
+exec ./bazelisk.sh test --test_output=errors \
+  //hw/ip/acc/dv/smoke:run_smoke_test "$@"

--- a/hw/ip/acc/dv/smoke_pqc/BUILD
+++ b/hw/ip/acc/dv/smoke_pqc/BUILD
@@ -53,3 +53,37 @@ fusesoc_build(
     target = "sim",
     verilator_options = "//hw:verilator_options",
 )
+
+filegroup(
+    name = "verilator_acc_bin",
+    srcs = [":verilator_acc"],
+    output_group = "binary",
+)
+
+filegroup(
+    name = "smoke_test_nondeterministic_elf",
+    srcs = [":smoke_test_nondeterministic"],
+    output_group = "elf",
+)
+
+sh_test(
+    name = "run_smoke_test",
+    size = "small",
+    srcs = ["//hw/ip/acc/util:run_smoke_test.sh"],
+    args = [
+        "$(rootpath :verilator_acc_bin)",
+        "$(rootpath :smoke_test_nondeterministic_elf)",
+        "$(rootpath smoke_expected.txt)",
+        "$(rootpath //hw/ip/acc/dv/accsim:stepped)",
+    ],
+    data = [
+        "smoke_expected.txt",
+        ":smoke_test_nondeterministic_elf",
+        ":verilator_acc_bin",
+        "//hw/ip/acc/dv/accsim:stepped",
+    ],
+    tags = [
+        "manual",
+        "verilator",
+    ],
+)

--- a/hw/ip/acc/dv/smoke_pqc/run_smoke.sh
+++ b/hw/ip/acc/dv/smoke_pqc/run_smoke.sh
@@ -7,50 +7,9 @@
 # Runs the ACC smoke test (builds software, build simulation, runs simulation
 # and checks expected output)
 
-fail() {
-    echo >&2 "ACC SMOKE FAILURE: $*"
-    exit 1
-}
-
-set -o pipefail
 set -e
 
-SCRIPT_DIR="$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")"
-ROOT_DIR="$(readlink -e "$SCRIPT_DIR/../../../../..")" || \
-  fail "Can't find repository root dir"
-UTIL_DIR="$(readlink -e "$ROOT_DIR/util")" || \
-  fail "Can't find repository util dir"
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.."
 
-source "$UTIL_DIR/build_consts.sh"
-
-SMOKE_SRC_DIR=$ROOT_DIR/hw/ip/acc/dv/smoke_pqc
-
-./bazelisk.sh build \
-  //hw/ip/acc/dv/smoke_pqc:verilator_acc \
-  //hw/ip/acc/dv/smoke_pqc:smoke_test_nondeterministic
-SIM_BINARY=$(./bazelisk.sh cquery --output=files //hw/ip/acc/dv/smoke_pqc:verilator_acc)
-SMOKE_ELF=$(./bazelisk.sh cquery --output=files //hw/ip/acc/dv/smoke_pqc:smoke_test_nondeterministic | grep "\\.elf$" | head -1)
-
-RUN_LOG=`mktemp`
-readonly RUN_LOG
-# shellcheck disable=SC2064 # The RUN_LOG tempfile path should not change
-trap "rm -rf $RUN_LOG" EXIT
-
-timeout 5s ${SIM_BINARY} --load-elf=${SMOKE_ELF} -t | tee $RUN_LOG
-
-if [ $? -eq 124 ]; then
-  fail "Simulation timeout"
-fi
-
-if [ $? -ne 0 ]; then
-  fail "Simulator run failed"
-fi
-
-had_diff=0
-grep -A 74 "Call Stack:" $RUN_LOG | diff -U3 $SMOKE_SRC_DIR/smoke_expected.txt - || had_diff=1
-
-if [ $had_diff == 0 ]; then
-  echo "ACC SMOKE PASS"
-else
-  fail "Simulator output does not match expected output"
-fi
+exec ./bazelisk.sh test --test_output=errors \
+  //hw/ip/acc/dv/smoke_pqc:run_smoke_test "$@"

--- a/hw/ip/acc/util/BUILD
+++ b/hw/ip/acc/util/BUILD
@@ -8,6 +8,8 @@ load("@ot_python_deps//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["run_smoke_test.sh"])
+
 py_binary(
     name = "acc_as",
     srcs = ["acc_as.py"],

--- a/hw/ip/acc/util/run_smoke_test.sh
+++ b/hw/ip/acc/util/run_smoke_test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Runs an ACC smoke test (runs the simulation and checks expected output). The
+# wrapping sh_test passes the paths of everything this needs, relative to the
+# runfiles directory.
+
+fail() {
+    echo >&2 "ACC SMOKE FAILURE: $*"
+    exit 1
+}
+
+set -euo pipefail
+
+SIM_BINARY=$1
+SMOKE_ELF=$2
+SMOKE_EXPECTED=$3
+# Keep the ISS path inside the runfiles tree, so that the launcher finds the
+# Python libraries it was built with.
+export ACC_ISS=$PWD/$4
+
+RUN_LOG=$TEST_TMPDIR/smoke.log
+
+if ! "$SIM_BINARY" --load-elf="$SMOKE_ELF" -t | tee "$RUN_LOG"; then
+  fail "Simulator run failed"
+fi
+
+# The expected output is the "Call Stack:" line and everything after it.
+expected_lines=$(wc -l < "$SMOKE_EXPECTED")
+if grep -A "$((expected_lines - 1))" "Call Stack:" "$RUN_LOG" \
+  | diff -U3 "$SMOKE_EXPECTED" -; then
+  echo "ACC SMOKE PASS"
+else
+  fail "Simulator output does not match expected output"
+fi


### PR DESCRIPTION
Thus far the ACC smoke tests spawn the ISS with the system
Python interpreter requiring the user to install Python
dependencies locally.
This feels unnecessary as we might as well run the ISS through
bazel.

Add a `py_binary` ISS (`stepped.py`) to use Bazel's pinned Python
environment with the pinned dependencies, and let `ACC_ISS` name an
ISS executable to run instead of the model in the source tree.
Both smoke tests become `sh_test`s that pass the launcher,
the Verilated model and the ELF from their runfiles, so neither
the interpreter nor the repository path is taken from the environment.

Keep the fallback so other tools (e.g., dvsim) do not break:
If ACC_ISS is unset, the iss_wrapper stays unchanged.

The scripts also avoid `readlink -e` and `timeout`, neither of which
macOS provides. The wrappers only need to reach the repository root,
and Bazel already bounds the runtime of the `sh_test`.

Both tests can be run with:
```
  ./bazelisk.sh test --test_output=errors //hw/ip/acc/dv/smoke:run_smoke_test //hw/ip/acc/dv/smoke_pqc:run_smoke_test
```