### PR TITLE
[dvsim] Keep the information when a run or a job is killed

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -326,8 +326,12 @@ class Deploy():
             time, unit = get_job_runtime(log_text, self.sim_cfg.tool)
             self.job_runtime.set(time, unit)
         except RuntimeError as e:
-            log.warning(f"{self.full_name}: {e} Using dvsim-maintained "
-                        "job_runtime instead.")
+            # A job that was killed never got to print its runtime, so this is
+            # expected rather than noteworthy. Interrupting a large regression
+            # would otherwise bury the report behind one warning per job.
+            level = VERBOSE if self.launcher.status == "K" else log.WARNING
+            log.log(level, f"{self.full_name}: {e} Using dvsim-maintained "
+                           "job_runtime instead.")
             self.job_runtime.set(self.launcher.job_runtime_secs, "s")
 
         # Extract the tool-reported memory footprint if available.

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -97,6 +97,15 @@ class Deploy():
         # does not report it). For VCS this is the design's
         # "data structure size", not the process's peak resident memory.
         self.job_mem = None
+        # Job's peak resident set size in MB, as measured by dvsim rather than
+        # reported by the tool (None if it could not be measured). This is the
+        # real memory the job occupied, and unlike job_mem it is known even for
+        # a job that was killed before the tool printed its summary.
+        self.job_peak_rss = None
+        # Size of the job's output directory in MB when the job finished (None
+        # if it could not be measured). Measured before any post-run cleanup,
+        # so it reflects what the job actually wrote.
+        self.job_odir_size = None
 
     def _define_attrs(self):
         """Defines the attributes this instance needs to have.

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -467,10 +467,21 @@ class FlowCfg():
             sys.exit(1)
 
         scheduler = Scheduler(deploy, get_launcher_cls(), self.interactive)
-        results = scheduler.run()
-        # Stash the run's wall-clock footprint so it can be shown in the report.
-        self.target_runtime = scheduler.target_runtime
-        self.total_runtime = scheduler.total_runtime
+        try:
+            results = scheduler.run()
+        except (Exception, KeyboardInterrupt):
+            # An interrupted or broken run is exactly when the logs and the
+            # per-job numbers matter most, so losing them is not an option.
+            # Hand back the statuses gathered so far and let the caller report
+            # on them. Anything that never ran counts as killed.
+            log.exception("Run did not complete. Reporting on the %d job(s) "
+                          "that finished.", len(scheduler.item_to_status))
+            results = scheduler.item_to_status
+        finally:
+            # Stash the run's wall-clock footprint so it can be shown in the
+            # report, including for a run that was cut short.
+            self.target_runtime = scheduler.target_runtime
+            self.total_runtime = scheduler.total_runtime
         return results
 
     def _gen_results(self, results):

--- a/util/dvsim/Launcher.py
+++ b/util/dvsim/Launcher.py
@@ -268,6 +268,19 @@ class Launcher:
         """Terminate the job."""
         raise NotImplementedError
 
+    def force_kill(self) -> None:
+        """Terminate the job at once, without waiting for it to wind down.
+
+        Invoked when dvsim is force-quit while this job is still running.
+
+        This default implementation simply defers to kill(). That still gives
+        the job a grace period, which is not what a force-quit asks for, but
+        terminating it slowly beats leaving it behind: an abandoned job carries
+        on consuming licenses, memory and disk long after dvsim has exited.
+        Launchers that can terminate a job more abruptly should override this.
+        """
+        self.kill()
+
     def _check_status(self):
         """Determine the outcome of the job (P/F/K if it ran to completion).
 

--- a/util/dvsim/Launcher.py
+++ b/util/dvsim/Launcher.py
@@ -20,6 +20,11 @@ from utils import VERBOSE, clean_odirs, mk_symlink, rm_path
 # fell over before it got going from one that reported a testbench failure
 _EXIT_CODE_FAIL_MSG = "Job returned non-zero exit code"
 
+# Lines kept from the end of a killed job's log when mining it for runtime and
+# simulated time. Every sim_utils parser scans backwards for the last match, so
+# only the end can carry them, and a runaway job's log has no bound.
+_LOG_TAIL_LINES = 10000
+
 
 def find_first_match(lines, patterns, context_lines=5):
     """Find the first of the lines matching any of the patterns.
@@ -201,6 +206,11 @@ class Launcher:
         # The actual job runtime computed by dvsim, in seconds.
         self.job_runtime_secs = 0
 
+        # Whether the job's log has already been mined for information about
+        # the job. Guards against reading it twice, since the job's outcome
+        # decides which of the two code paths gets there first.
+        self._log_parsed = False
+
     def _make_odir(self) -> None:
         """Create the output directory."""
         # If renew_odir flag is True - then move it.
@@ -379,6 +389,7 @@ class Launcher:
         # status, use this opportunity to also extract other pieces of
         # information.
         self.deploy.extract_info_from_log(lines)
+        self._log_parsed = True
 
         if chk_failed or chk_passed:
             for cnt, line in enumerate(lines):
@@ -415,6 +426,40 @@ class Launcher:
             )
         return "P", None
 
+    def _extract_info_from_log(self) -> None:
+        """Have the deploy object mine the job's log, at most once.
+
+        _check_status() already does this for a job that ran to completion,
+        since it has the log open anyway to work out the outcome. A job that was
+        killed never reaches that point, so this is the fallback for it: it is
+        the difference between a killed job reporting how long it ran and how
+        much it simulated, and it reporting nothing at all.
+
+        _check_log_status() needs the whole log for its context quotes; this
+        needs only what the tool prints as it winds up, so it keeps a tail.
+        """
+        if self._log_parsed:
+            return
+        self._log_parsed = True
+
+        log_path = self.deploy.get_log_path()
+        try:
+            with open(log_path, encoding="UTF-8", errors="surrogateescape") as f:
+                # A sequence, because the parsers reverse and index it.
+                lines = list(collections.deque(f, maxlen=_LOG_TAIL_LINES))
+        except OSError as e:
+            log.log(VERBOSE, "Could not read %s to extract the job's "
+                             "info: %s", log_path, e)
+            return
+
+        # This runs while dvsim is shutting down after an interrupt, so it must
+        # not be the thing that brings the shutdown down with it.
+        try:
+            self.deploy.extract_info_from_log(lines)
+        except Exception as e:
+            log.log(VERBOSE, "Could not extract the job's info from %s: %s",
+                    log_path, e)
+
     def _post_finish(self, status, err_msg) -> None:
         """Do post-completion activities, such as preparing the results.
 
@@ -448,3 +493,8 @@ class Launcher:
             assert isinstance(err_msg, ErrorMessage)
             self.fail_msg = err_msg
             log.log(VERBOSE, err_msg.message)
+
+        # A job that was killed never went through _check_status(), so nothing
+        # has read its log yet. Do it now: whatever the tool printed before it
+        # died is the only record of how far the job actually got.
+        self._extract_info_from_log()

--- a/util/dvsim/Launcher.py
+++ b/util/dvsim/Launcher.py
@@ -97,6 +97,11 @@ class Launcher:
     # more than this many directories.
     max_odirs = 5
 
+    # Kill a job whose peak resident set size grows beyond this many GB. None
+    # disables the check. It is only enforced by the launchers that can measure
+    # a running job's memory, which today means LocalLauncher.
+    max_job_mem_gb = None
+
     # Give up on a job that has not started doing its work within this many
     # minutes of being launched, which normally means it is still queueing for a
     # license. Zero waits indefinitely. This is a separate limit from the job's

--- a/util/dvsim/Launcher.py
+++ b/util/dvsim/Launcher.py
@@ -12,7 +12,7 @@ from itertools import islice
 from pathlib import Path
 from typing import Union
 
-from utils import VERBOSE, clean_odirs, mk_symlink, rm_path
+from utils import VERBOSE, clean_odirs, dir_size_mb, mk_symlink, rm_path
 
 
 # Failure message used when a job returns a non-zero exit code without any of
@@ -471,6 +471,12 @@ class Launcher:
         assert status in ["P", "F", "K"]
         self._link_odir(status)
         log.debug("Item %s has completed execution: %s", self, status)
+
+        # Size the output directory now, before the cleanup below runs. That
+        # cleanup deletes artifacts (the coverage database, for one), so
+        # measuring afterwards would hide how much the job actually wrote,
+        # which is the very thing we want to know about a runaway job.
+        self.deploy.job_odir_size = dir_size_mb(self.deploy.odir)
 
         try:
             # Run the target-specific cleanup tasks regardless of the job's

--- a/util/dvsim/LocalLauncher.py
+++ b/util/dvsim/LocalLauncher.py
@@ -7,6 +7,7 @@ import datetime
 import os
 import re
 import shlex
+import signal
 import subprocess
 from pathlib import Path
 from typing import Union
@@ -77,6 +78,12 @@ class LocalLauncher(Launcher):
                     stdout=self._log_file,
                     stderr=self._log_file,
                     env=exports,
+                    # Give the job a process group of its own. The command we
+                    # run is a make wrapper which spawns the simulator as a
+                    # separate process, so a group is what lets us later signal
+                    # the whole job rather than just the wrapper. See
+                    # _signal_job_group().
+                    start_new_session=True,
                 )
 
             except BlockingIOError as e:
@@ -225,21 +232,61 @@ class LocalLauncher(Launcher):
 
         return None
 
-    def _kill(self) -> None:
-        """Kill the running process.
+    def _signal_job_group(self, sig: int) -> None:
+        """Send a signal to every process belonging to the job.
 
-        Try to kill the running process. Send SIGTERM first, wait a bit,
-        and then send SIGKILL if it didn't work.
+        Signaling only the process we launched is not enough: that process is a
+        make wrapper, and the simulator it spawns is a separate process, so the
+        wrapper dies while the simulator carries on holding its license and
+        writing its wave dump. The job has a process group of its own (see
+        _do_launch), so one killpg reaches all of it.
+
+        Falls back to signaling just the process we have a handle on when the
+        group cannot be used, and gives up quietly if that process has gone too,
+        which only happens when the job was on its way out regardless.
+        """
+        if self._process is None:
+            return
+
+        try:
+            pgid = os.getpgid(self._process.pid)
+        except OSError:
+            pgid = None
+
+        # Only signal the group if it really is the job's own. A job launched
+        # without a new session of its own sits in dvsim's group, and signaling
+        # that would take down dvsim itself along with every other running job.
+        # The interactive path deliberately does not start a new session, so
+        # this is reachable rather than theoretical.
+        if pgid is not None and pgid != os.getpgid(0):
+            try:
+                os.killpg(pgid, sig)
+                return
+            except OSError:
+                pass
+
+        try:
+            self._process.send_signal(sig)
+        except OSError:
+            pass
+
+    def _kill(self) -> None:
+        """Kill the running job.
+
+        Try to kill the whole job. Send SIGTERM first, wait a bit, and then send
+        SIGKILL if it didn't work.
         """
         if self._process is None:
             # process already dead or didn't start
             return
 
-        self._process.terminate()
+        self._signal_job_group(signal.SIGTERM)
         try:
+            # The wrapper exiting is the best proxy we have for the job being
+            # done: it does not return until the simulator it spawned has gone.
             self._process.wait(timeout=2)
         except subprocess.TimeoutExpired:
-            self._process.kill()
+            self._signal_job_group(signal.SIGKILL)
 
     def kill(self) -> None:
         """Kill the running process.
@@ -263,7 +310,7 @@ class LocalLauncher(Launcher):
         it has not, leaving a zombie that is cleaned up when dvsim exits.
         """
         if self._process is not None:
-            self._process.kill()
+            self._signal_job_group(signal.SIGKILL)
             self._process.poll()
 
         # Finish the job off properly even though we are in a hurry: this is

--- a/util/dvsim/LocalLauncher.py
+++ b/util/dvsim/LocalLauncher.py
@@ -20,8 +20,89 @@ from Launcher import ErrorMessage, Launcher, LauncherBusy, LauncherError
 _LOG_SCAN_TAIL_CHARS = 256
 
 
+def _read_vmhwm_mb(pid: int) -> Union[float, None]:
+    """Return a process's peak resident set size in MB, read from procfs.
+
+    VmHWM is a high water mark that the kernel maintains from the moment the
+    process starts, so a single read reports the true peak so far. That means
+    there is no need to sample continuously and no way for a spike between two
+    reads to go unnoticed.
+
+    Opening unbuffered and reading once skips the buffering and UTF-8 decoding on
+    a call made for every running job on every poll. VmHWM sits in the first
+    kilobyte, so the long bitmasks at the end of the file do not matter.
+
+    Returns None if the process has already exited or procfs cannot be read. A
+    process with no memory map of its own, such as a kernel thread, reports no
+    VmHWM at all and also comes back as None.
+    """
+    try:
+        with open(f"/proc/{pid}/status", "rb", buffering=0) as f:
+            blob = f.read(4096)
+    except OSError:
+        return None
+
+    start = blob.find(b"VmHWM:")
+    if start < 0:
+        return None
+    end = blob.find(b"kB", start)
+    if end < 0:
+        return None
+
+    try:
+        # The value is in kB, per proc(5).
+        return int(blob[start + len(b"VmHWM:"):end]) / 1024
+    except ValueError:
+        return None
+
+
+def _iter_job_pids(pid: int):
+    """Yield the given process and every descendant of it.
+
+    Descendants are read from /proc/<pid>/task/<tid>/children, which lists a
+    thread's direct children. Walking down from the job costs a couple of reads
+    per process belonging to it, rather than a scan of every process on the
+    machine, which would be orders of magnitude dearer.
+
+    Processes that exit midway through the walk are skipped rather than raising,
+    since a job's process tree changes shape while it runs.
+    """
+    pending = [pid]
+    seen = set()
+
+    while pending:
+        current = pending.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        yield current
+
+        task_dir = f"/proc/{current}/task"
+        try:
+            tids = os.listdir(task_dir)
+        except OSError:
+            continue
+
+        for tid in tids:
+            try:
+                with open(f"{task_dir}/{tid}/children", encoding="UTF-8") as f:
+                    children = f.read().split()
+            except OSError:
+                continue
+
+            for child in children:
+                try:
+                    pending.append(int(child))
+                except ValueError:
+                    continue
+
+
 class LocalLauncher(Launcher):
     """Implementation of Launcher to launch jobs in the user's local workstation."""
+
+    # Re-discover the job's process tree once every this many polls. See
+    # _sample_peak_rss() for why the tree is not walked afresh every time.
+    pid_walk_interval = 30
 
     def __init__(self, deploy) -> None:
         """Initialize common class members."""
@@ -30,6 +111,10 @@ class LocalLauncher(Launcher):
         # Popen object when launching the job.
         self._process = None
         self._log_file = None
+
+        # The job's process tree, and the countdown to re-walking it.
+        self._job_pids = []
+        self._pid_walk_countdown = 0
 
         # When the job started doing its work, as opposed to when it was
         # launched. None until we see it start. See _detect_job_start().
@@ -132,7 +217,8 @@ class LocalLauncher(Launcher):
 
         elapsed_time = datetime.datetime.now() - self.start_time
         self.job_runtime_secs = elapsed_time.total_seconds()
-        if self._process.poll() is None:
+        if self._reap() is None:
+            # Still running.
             timeout_reason = self._timeout_reason()
             if timeout_reason is not None:
                 self._kill_with_reason(timeout_reason)
@@ -140,19 +226,10 @@ class LocalLauncher(Launcher):
 
             return "D"
 
-        self.exit_code = self._process.returncode
         status, err_msg = self._check_status()
         self._post_finish(status, err_msg)
 
         return self.status
-
-    def _kill_with_reason(self, message: str) -> None:
-        """Kill the job and record why dvsim decided to kill it."""
-        self._kill()
-        self._post_finish(
-            "K",
-            ErrorMessage(line_number=None, message=message, context=[message]),
-        )
 
     def _detect_job_start(self) -> None:
         """Look for the point in the log where the job started doing its work.
@@ -232,6 +309,104 @@ class LocalLauncher(Launcher):
 
         return None
 
+    def _reap(self) -> Union[int, None]:
+        """Reap the process if it has finished, returning its exit code.
+
+        Returns None while the process is still running.
+
+        We reap with os.wait4() rather than Popen.poll() so as to receive the
+        rusage that the kernel hands over at reap time. Its ru_maxrss field is
+        the job's peak resident set size, and the moment the process is gone
+        that number is unknowable, so for a job that runs to completion this is
+        the only chance to capture it. The kernel rolls the peak of a reaped
+        descendant into its parent's figure, so this covers the simulator even
+        though the process we launched is only its wrapper.
+        """
+        if self._process.returncode is None:
+            try:
+                pid, wait_status, usage = os.wait4(self._process.pid, os.WNOHANG)
+            except ChildProcessError:
+                # Something else already reaped it, so the rusage is lost. Fall
+                # back to Popen's own bookkeeping for the exit code.
+                self._process.poll()
+            else:
+                if pid == 0:
+                    return None
+
+                # Record the exit code the way Popen would have, which also
+                # tells Popen not to try reaping the child a second time.
+                self._process.returncode = os.waitstatus_to_exitcode(wait_status)
+                # ru_maxrss is in kB on Linux.
+                self._record_peak_rss(usage.ru_maxrss / 1024)
+
+        self.exit_code = self._process.returncode
+        return self.exit_code
+
+    def _record_peak_rss(self, peak_rss_mb: Union[float, None]) -> None:
+        """Keep the largest peak resident set size seen for this job, in MB."""
+        if peak_rss_mb is None:
+            return
+        if (
+            self.deploy.job_peak_rss is None
+            or peak_rss_mb > self.deploy.job_peak_rss  # noqa: W503
+        ):
+            self.deploy.job_peak_rss = peak_rss_mb
+
+    def _sample_peak_rss(self) -> Union[float, None]:
+        """Read the running job's peak resident set size so far, in MB.
+
+        The process dvsim launches is a make wrapper, and the simulator it goes
+        on to spawn is where the memory actually goes, so reading the launched
+        process alone reports a handful of MB and misses the job entirely. Walk
+        the whole tree instead and report the largest peak in it.
+
+        The largest rather than the total, because VmHWM is a per-process high
+        water mark and the peaks of two processes need not coincide, so adding
+        them up would overstate the job. For the shapes dvsim runs, where one
+        simulator dwarfs its wrapper, the largest peak is the job's peak. A job
+        with two large processes running at once would be understated.
+
+        Returns None once the processes have gone, since procfs then has nothing
+        left to tell us about them.
+        """
+        if self._process is None:
+            return None
+
+        # Walking the tree costs a read per thread of every process in the job,
+        # whereas reading the peaks costs one read per process, so the walk is
+        # what to avoid repeating. An EDA job's tree settles as soon as its
+        # simulator is up and does not change shape after that, so re-walk it
+        # only occasionally. Discovering a process late does not lose any of its
+        # peak, because VmHWM covers the whole life of the process.
+        #
+        # Until the job has spawned something below the wrapper, though, keep
+        # walking on every poll: a job can balloon within seconds of starting,
+        # and the memory budget must not be blind while that happens. The walk
+        # is cheap in that window, since a wrapper has a single thread.
+        if len(self._job_pids) < 2 or self._pid_walk_countdown <= 0:
+            self._job_pids = list(_iter_job_pids(self._process.pid))
+            self._pid_walk_countdown = self.pid_walk_interval
+        self._pid_walk_countdown -= 1
+
+        peak_rss_mb = None
+        for pid in self._job_pids:
+            pid_peak_mb = _read_vmhwm_mb(pid)
+            if pid_peak_mb is None:
+                continue
+            if peak_rss_mb is None or pid_peak_mb > peak_rss_mb:
+                peak_rss_mb = pid_peak_mb
+
+        self._record_peak_rss(peak_rss_mb)
+        return peak_rss_mb
+
+    def _kill_with_reason(self, message: str) -> None:
+        """Kill the job and record why dvsim decided to kill it."""
+        self._kill()
+        self._post_finish(
+            "K",
+            ErrorMessage(line_number=None, message=message, context=[message]),
+        )
+
     def _signal_job_group(self, sig: int) -> None:
         """Send a signal to every process belonging to the job.
 
@@ -280,6 +455,11 @@ class LocalLauncher(Launcher):
             # process already dead or didn't start
             return
 
+        # Read the job's peak memory before signaling it. This is the last
+        # moment at which procfs can still tell us, and a killed job is exactly
+        # the case where the tool never gets to report the figure itself.
+        self._sample_peak_rss()
+
         self._signal_job_group(signal.SIGTERM)
         try:
             # The wrapper exiting is the best proxy we have for the job being
@@ -310,12 +490,15 @@ class LocalLauncher(Launcher):
         it has not, leaving a zombie that is cleaned up when dvsim exits.
         """
         if self._process is not None:
+            # One cheap procfs read before it dies, so that even a force-quit
+            # leaves the job's memory figure behind for the report.
+            self._sample_peak_rss()
             self._signal_job_group(signal.SIGKILL)
             self._process.poll()
 
         # Finish the job off properly even though we are in a hurry: this is
-        # what records the job as killed, and it is the whole point of
-        # force-quitting rather than crashing out.
+        # what sizes the output directory and records the job as killed, and
+        # it is the whole point of force-quitting rather than crashing out.
         self._post_finish(
             "K",
             ErrorMessage(

--- a/util/dvsim/LocalLauncher.py
+++ b/util/dvsim/LocalLauncher.py
@@ -224,6 +224,17 @@ class LocalLauncher(Launcher):
                 self._kill_with_reason(timeout_reason)
                 return "K"
 
+            mem_limit_gb = Launcher.max_job_mem_gb
+            if mem_limit_gb is not None:
+                peak_rss_mb = self._sample_peak_rss()
+                if peak_rss_mb is not None and peak_rss_mb > mem_limit_gb * 1024:
+                    self._kill_with_reason(
+                        f"Job exceeded the {mem_limit_gb} GB memory limit "
+                        f"(peak resident set size "
+                        f"{peak_rss_mb / 1024:.2f} GB)",
+                    )
+                    return "K"
+
             return "D"
 
         status, err_msg = self._check_status()

--- a/util/dvsim/LocalLauncher.py
+++ b/util/dvsim/LocalLauncher.py
@@ -253,6 +253,31 @@ class LocalLauncher(Launcher):
             ErrorMessage(line_number=None, message="Job killed!", context=[]),
         )
 
+    def force_kill(self) -> None:
+        """SIGKILL the process without waiting around for it to die.
+
+        We deliberately do not block on the process here. A job that is stuck
+        in uninterruptible IO (writing a large wave dump over NFS, say) does
+        not die the moment SIGKILL lands, and a force-quit must not hang on it.
+        poll() reaps the process if it has already gone and returns at once if
+        it has not, leaving a zombie that is cleaned up when dvsim exits.
+        """
+        if self._process is not None:
+            self._process.kill()
+            self._process.poll()
+
+        # Finish the job off properly even though we are in a hurry: this is
+        # what records the job as killed, and it is the whole point of
+        # force-quitting rather than crashing out.
+        self._post_finish(
+            "K",
+            ErrorMessage(
+                line_number=None,
+                message="Job force-killed when dvsim was force-quit.",
+                context=[],
+            ),
+        )
+
     def _post_finish(self, status: str, err_msg: Union[ErrorMessage, None]) -> None:
         self._close_job_log_file()
         self._process = None

--- a/util/dvsim/Scheduler.py
+++ b/util/dvsim/Scheduler.py
@@ -184,6 +184,15 @@ class Scheduler:
                 # signal.
                 stop_now.wait(timeout=self.launcher_cls.poll_freq)
 
+        except KeyboardInterrupt:
+            # A second SIGINT restored the default handler, so the interrupt
+            # arrived here as an exception. The user does not want to wait for
+            # the jobs to wind down, so kill them outright, but carry on to
+            # return the statuses gathered so far: the caller still needs them
+            # to write the results.
+            log.info("Force-quitting. Killing all remaining jobs.")
+            self._kill(force=True)
+
         finally:
             signal(SIGINT, old_handler)
 
@@ -512,8 +521,13 @@ class Scheduler:
                 self._running[target].append(item)
                 self.item_to_status[item] = "D"
 
-    def _kill(self):
-        """Kill any running items and cancel any that are waiting"""
+    def _kill(self, force=False):
+        """Kill any running items and cancel any that are waiting
+
+        If force is set, the running items are killed outright instead of being
+        given a grace period in which to wind down. Either way, nothing is left
+        running.
+        """
         # Cancel any waiting items. We take a copy of self._queued to avoid
         # iterating over the set as we modify it.
         for target in self._queued:
@@ -524,7 +538,7 @@ class Scheduler:
         # modifying it while iterating over it.
         for target in self._running:
             for item in [item for item in self._running[target]]:
-                self._kill_item(item)
+                self._kill_item(item, force)
 
     def _check_if_done(self, hms):
         """Check if we are done executing all jobs.
@@ -588,9 +602,12 @@ class Scheduler:
         if cancel_successors:
             self._cancel_successors(item)
 
-    def _kill_item(self, item):
+    def _kill_item(self, item, force=False):
         """Kill a running item and cancel all of its successors."""
-        item.launcher.kill()
+        if force:
+            item.launcher.force_kill()
+        else:
+            item.launcher.kill()
         self.item_to_status[item] = "K"
         self._killed[item.target].add(item)
         self._running[item.target].remove(item)

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -792,14 +792,22 @@ class SimCfg(FlowCfg):
         tests_by_name = OrderedDict()
         for r in self.runs:
             start = getattr(r.launcher, "start_time", None)
+            status = run_results.get(r, "K")
             tests_by_name.setdefault(r.name, []).append({
                 'seed': str(r.seed),
-                'status': run_results.get(r, "K"),
+                'status': status,
                 'start': start.isoformat() if start else None,
                 'wall_time_s': _jobtime_val(r.job_wall_time, 's'),
                 'cpu_time_s': _jobtime_val(r.job_runtime, 's'),
                 'simulated_time_us': _jobtime_val(r.simulated_time, 'us'),
                 'data_structure_size_mb': r.job_mem,
+                'peak_rss_mb': r.job_peak_rss,
+                'odir_size_mb': r.job_odir_size,
+                # Why the job failed or was killed. For a killed job this is
+                # the only record of the reason, so it matters most for the
+                # runs that never got to report anything themselves.
+                'fail_msg': (r.launcher.fail_msg.message
+                             if status != "P" else None),
             })
         results['tests'] = [{'name': name, 'seeds': seeds}
                             for name, seeds in tests_by_name.items()]

--- a/util/dvsim/SimResults.py
+++ b/util/dvsim/SimResults.py
@@ -84,7 +84,10 @@ class SimResults:
 
     def _add_item(self, item, results):
         '''Recursively add a single item to the table of results'''
-        status = results[item]
+        # An item that never got dispatched (because the run was cut short) has
+        # no entry in the status map. Treat it as killed rather than letting a
+        # KeyError take down the whole report.
+        status = results.get(item, "K")
         if status in ["F", "K"]:
             bucket = self._bucketize(item.launcher.fail_msg.message)
             self.buckets[bucket].append(

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -388,6 +388,15 @@ def parse_args():
                             'is used. Only applicable when launching jobs '
                             'locally.'))
 
+    disg.add_argument("--max-job-mem-gb",
+                      type=float,
+                      metavar="GB",
+                      help=('Kill any single job whose peak resident set size '
+                            'grows beyond GB gigabytes. Only that job is '
+                            'killed; the rest of the regression carries on, '
+                            'and the report says why it died. Off by default. '
+                            'Only applicable when launching jobs locally.'))
+
     disg.add_argument("--run-wait-timeout-mins",
                       type=int,
                       default=180,
@@ -538,7 +547,7 @@ def parse_args():
 
     rung.add_argument("--no-rerun",
                       action='store_true',
-                      help=("Disable the default behaviour, where failing "
+                      help=("Disable the default behavior, where failing "
                             "tests are automatically rerun with waves "
                             "enabled."))
 
@@ -814,6 +823,7 @@ def main():
     LsfLauncher.LsfLauncher.max_parallel = args.max_parallel
     NcLauncher.NcLauncher.max_parallel = args.max_parallel
     Launcher.Launcher.max_odirs = args.max_odirs
+    Launcher.Launcher.max_job_mem_gb = args.max_job_mem_gb
     Launcher.Launcher.max_job_wait_mins = args.run_wait_timeout_mins
     LauncherFactory.set_launcher_type(args.local)
 

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -263,7 +263,7 @@ def subst_wildcards(var, mdict, ignored_wildcards=[], ignore_error=False):
 
     If a wildcard appears in var but is not in mdict, the environment is
     checked for the variable. If the name still isn't found, the default
-    behaviour is to log an error and exit. If ignore_error is True, the
+    behavior is to log an error and exit. If ignore_error is True, the
     wildcard is ignored (as if it appeared in ignore_wildcards).
 
     If {eval_cmd} appears in the string and 'eval_cmd' is not in
@@ -602,6 +602,29 @@ def mk_path(path):
     except PermissionError as e:
         log.fatal("Failed to create directory {}:\n{}.".format(path, e))
         sys.exit(1)
+
+
+def dir_size_mb(path):
+    '''Return the total apparent size of the files under path, in MB.
+
+    'path' is a Path-like object. Returns None if the path cannot be walked at
+    all. Symlinks are not followed, and files that vanish midway through are
+    skipped rather than raising: a job's output directory may still be
+    changing while it is measured.
+    '''
+    # os.walk() reports nothing at all for a path it cannot read, so check up
+    # front rather than returning a bogus zero for a directory that is missing.
+    if not os.path.isdir(path):
+        return None
+
+    total = 0
+    for dirpath, _, filenames in os.walk(path):
+        for name in filenames:
+            try:
+                total += os.lstat(os.path.join(dirpath, name)).st_size
+            except OSError:
+                continue
+    return total / (1024 * 1024)
 
 
 def mk_symlink(path, link):


### PR DESCRIPTION
Built on top of #368.

Killing a `dvsim` run used to throw away nearly everything. A second Ctrl+C escaped before the report was written, the simulators kept running afterwards, and a killed job reported no runtime, no memory and no disk footprint, which are exactly the numbers wanted when a test has run away.
- An interrupted run still writes its report, seed manifest and summary. A second Ctrl+C force-kills what is left instead of crashing out.
- Killing a job signals its whole process group. The command `dvsim` runs is a `make` wrapper, so signalling only that left `simv` alive holding its license. Interactive Ctrl+C hid this, because the terminal was doing the killing.
- A killed job's log is now read, so its runtime and simulated time survive.
- Every job reports `peak_rss_mb` and `odir_size_mb` in `report.json`, beside a new `fail_msg` saying why it died. The peak comes from the `wait4()` rusage for a job that finished, otherwise from `VmHWM` across the job's process tree, measured before the job is signalled.
- New `--max-job-mem-gb` kills a single runaway job and lets the rest of the regression finish, with the reason recorded in the report. 