### PR TITLE
[fusesoc] fix syntax error in core files

### DIFF
--- a/hw/ip/tlul/adapter_dmi.core
+++ b/hw/ip/tlul/adapter_dmi.core
@@ -21,8 +21,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files: []
-      # - lint/tlul_adapter_dmi.vlt
     file_type: vlt
 
   files_ascentlint_waiver:

--- a/hw/ip/tlul/jtag_dtm.core
+++ b/hw/ip/tlul/jtag_dtm.core
@@ -20,8 +20,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files: []
-      # - lint/tlul_jtag_dtm.vlt
     file_type: vlt
 
   files_ascentlint_waiver:


### PR DESCRIPTION
Some versions of FuseSoC will complain about the empty `files` array and ignore the core file altogether, resulting in dependency errors. Simply removing the files section should be fine.