### PR TITLE
[prim] correctly derive IdxW for small arbiters

### DIFF
--- a/hw/ip/prim/rtl/prim_arbiter_fixed.sv
+++ b/hw/ip/prim/rtl/prim_arbiter_fixed.sv
@@ -22,7 +22,7 @@ module prim_arbiter_fixed #(
   parameter bit EnDataPort = 1,
 
   // Derived parameters
-  localparam int IdxW = $clog2(N)
+  localparam int IdxW = prim_util_pkg::vbits(N)
 ) (
   // used for assertions only
   input clk_i,

--- a/hw/ip/prim/rtl/prim_arbiter_tree.sv
+++ b/hw/ip/prim/rtl/prim_arbiter_tree.sv
@@ -40,7 +40,7 @@ module prim_arbiter_tree #(
   parameter bit EnDataPort = 1,
 
   // Derived parameters
-  localparam int IdxW = $clog2(N)
+  localparam int IdxW = prim_util_pkg::vbits(N)
 ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/prim/rtl/prim_arbiter_tree_dup.sv
+++ b/hw/ip/prim/rtl/prim_arbiter_tree_dup.sv
@@ -24,7 +24,7 @@ module prim_arbiter_tree_dup #(
   parameter bit FixedArb = 0,
 
   // Derived parameters
-  localparam int IdxW = $clog2(N)
+  localparam int IdxW = prim_util_pkg::vbits(N)
 ) (
   input clk_i,
   input rst_ni,


### PR DESCRIPTION
Using `$clog2` yields the wrong result if N is 1.