### PR TITLE
[acc,mldsa] Fix the SecCompress rounding for edge case

### DIFF
--- a/sw/acc/crypto/mldsa/gadgets.s
+++ b/sw/acc/crypto/mldsa/gadgets.s
@@ -1770,8 +1770,8 @@ secboundcheck:
  * k = ell + c = 32).
  * Bitsliced.
  *
- *   z_0 <- round(x_0 * delta * 2^ell / q) + 2^(ell-1)  mod 2^(ell+c)
- *   z_1 <- round(x_1 * delta * 2^ell / q)              mod 2^(ell+c)
+ *   z_0 <- round(x_0 * delta * 2^ell / q) + 2^(ell-1) + 1  mod 2^(ell+c)
+ *   z_1 <- round(x_1 * delta * 2^ell / q)                  mod 2^(ell+c)
  *   Z   <- seca2b((z_0, z_1))
  *   V'  <- Z >> ell                                    (top c = 8 stripes)
  *   V'  <- (V' >= delta) ? V' - delta : V'             (twice; V' in [0, 88])
@@ -1820,15 +1820,16 @@ seccompress:
     bn.rshi  w18, w16, w31 >> 128
     bn.or    w16, w16, w18
 
-    /* BIAS = 2^23 -> w17 (broadcast to all 8 lanes). */
+    /* BIAS = 2^23 + 1 -> w17 (broadcast to all 8 lanes). */
     bn.addi   w17, w31, 1
+    bn.shv.8s w17, w17 << 23
+    bn.addi   w17, w17, 1
     bn.rshi   w18, w17, w31 >> 224
     bn.or     w17, w17, w18
     bn.rshi   w18, w17, w31 >> 192
     bn.or     w17, w17, w18
     bn.rshi   w18, w17, w31 >> 128
     bn.or     w17, w17, w18
-    bn.shv.8s w17, w17 << 23
 
     /* Steps 1-2: z_i = round(x_i*delta*2^ell / q) mod 2^(ell+c) for i in {0,1}. */
     addi     s0, a1, 0
@@ -1848,7 +1849,7 @@ seccompress:
         bn.xor w3, w3, w3
     endloop
 
-    /* Add the rounding bias 2^(ell-1) = 2^23 to share 0. */
+    /* Add the rounding bias 2^(ell-1) + 1 to share 0. */
     lw       s0, 32(sp)
     li       t0, 0
     loopi    32, 3

--- a/sw/acc/crypto/tests/mldsa/gadgets/seccompress_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/seccompress_testgen.py
@@ -23,12 +23,30 @@ NSHARES = 2
 DELTA = 44
 
 
-def arith_share_modq(vals, nshares):
+PINNED_SHARE0 = {
+    8285185: 5779889,  # least rounding slack; only correct with the +1 bias
+    8330000: 8350000,  # share 0 > x, so V' reaches 88 and both csubs run
+}
+
+
+def edge_coeffs(gamma2):
+    """Every bucket boundary: low part 0, +gamma2 and -gamma2+1."""
+    alpha = 2 * gamma2
+    vals = {0, 1, Q - 1, Q - 2}
+    for k in range(Q // alpha + 1):
+        vals.update(v for v in (k * alpha, k * alpha + gamma2,
+                                k * alpha + gamma2 + 1) if v < Q)
+    return sorted(vals)
+
+
+def arith_share_modq(vals, nshares, pinned=None):
     shares = [[0] * N_LANES for _ in range(nshares)]
     for lane in range(N_LANES):
         acc = vals[lane]
         for s in range(nshares - 1):
             r = random.randrange(Q)
+            if pinned is not None:
+                r = pinned.get(vals[lane], r)
             shares[s][lane] = r
             acc = (acc - r) % Q
         shares[nshares - 1][lane] = acc % Q
@@ -62,8 +80,11 @@ def gen_seccompress_test(
         random.seed(seed)
 
     x_vals = [random.randrange(Q) for _ in range(N_LANES)]
-    x_vals[:4] = [Q - 1, Q - 2, 0, 1]            # pin corner cases
-    share_vals = arith_share_modq(x_vals, NSHARES)
+    fixed = edge_coeffs(ML_DSA_44.gamma_2)
+    fixed += [v for v in PINNED_SHARE0 if v not in fixed]
+    assert len(fixed) <= N_LANES
+    x_vals[:len(fixed)] = fixed
+    share_vals = arith_share_modq(x_vals, NSHARES, PINNED_SHARE0)
 
     alpha = 2 * ML_DSA_44.gamma_2
     w1 = [high_bits(x, alpha, Q) for x in x_vals]

--- a/sw/acc/crypto/tests/mldsa/gadgets/secdecompose_testgen.py
+++ b/sw/acc/crypto/tests/mldsa/gadgets/secdecompose_testgen.py
@@ -24,13 +24,30 @@ NSHARES = 2
 SPECIAL_L2 = [Q - 1, Q - 2, 8285185, 8285184, 8330000]
 SPECIAL_L35 = [Q - 1, Q - 2, 8118529, 8118528, 8249473]
 
+PINNED_SHARE0_L2 = {
+    8285185: 5779889,  # least SecCompress rounding slack; needs the +1 bias
+    8330000: 8350000,  # share 0 > w, so V' reaches 88 and both csubs run
+}
 
-def arith_share(vals):
+
+def edge_coeffs(gamma2):
+    """Every bucket boundary: w0 = 0, +gamma2 and -gamma2+1."""
+    alpha = 2 * gamma2
+    vals = {0, 1, Q - 1, Q - 2}
+    for k in range(Q // alpha + 1):
+        vals.update(v for v in (k * alpha, k * alpha + gamma2,
+                                k * alpha + gamma2 + 1) if v < Q)
+    return sorted(vals)
+
+
+def arith_share(vals, pinned=None):
     shares = [[0] * N_COEFS for _ in range(NSHARES)]
     for lane in range(N_COEFS):
         acc = vals[lane]
         for s in range(NSHARES - 1):
             r = random.randrange(Q)
+            if pinned is not None:
+                r = pinned.get(vals[lane], r)
             shares[s][lane] = r
             acc = (acc - r) % Q
         shares[NSHARES - 1][lane] = acc % Q
@@ -53,16 +70,19 @@ def pack_canonical(vals):
     return bytes(buf)
 
 
-def decompose_poly(mldsa, special):
+def decompose_poly(mldsa, special, pinned=None):
     alpha = 2 * mldsa.gamma_2
     w_vals = [random.randrange(Q) for _ in range(N_COEFS)]
-    w_vals[:len(special)] = special
+    fixed = special + [v for v in edge_coeffs(mldsa.gamma_2) if v not in special]
+    fixed += [v for v in (pinned or {}) if v not in fixed]
+    assert len(fixed) <= N_COEFS
+    w_vals[:len(fixed)] = fixed
     w1_ref, w0_ref = [], []
     for v in w_vals:
         r1, r0 = decompose(v, alpha, Q)
         w1_ref.append(r1)
         w0_ref.append(r0)
-    return arith_share(w_vals), w1_ref, w0_ref
+    return arith_share(w_vals, pinned), w1_ref, w0_ref
 
 
 def gen_secdecompose_test(
@@ -71,7 +91,7 @@ def gen_secdecompose_test(
     if seed is not None:
         random.seed(seed)
 
-    sh2, w1_2, w0_2 = decompose_poly(ML_DSA_44, SPECIAL_L2)
+    sh2, w1_2, w0_2 = decompose_poly(ML_DSA_44, SPECIAL_L2, PINNED_SHARE0_L2)
     sh35, w1_35, w0_35 = decompose_poly(ML_DSA_65, SPECIAL_L35)
     gamma2_35 = ML_DSA_65.gamma_2
 


### PR DESCRIPTION
seccompress applies its truncating Barrett multiply to each arithmetic share, so two truncations need correcting, but the bias was sized for one. For w = q - gamma2, whose quotient sits closest in Z_q to a rounding boundary, a rare share splitting produced a wrong w1.

Use 2^(ell-1) + 1 as the bias which has been verified through exhaustive testing.

Extend the seccompress and secdecompose vectors to cover more edge cases and include cases with fixed sharing.