### PR TITLE
[topgen,ipgen] Minor fixes for ipconfig generation

### DIFF
--- a/hw/top_egret/ip_autogen/flash_ctrl/data/top_egret_flash_ctrl.ipconfig.hjson
+++ b/hw/top_egret/ip_autogen/flash_ctrl/data/top_egret_flash_ctrl.ipconfig.hjson
@@ -16,11 +16,11 @@
     ]
     pages_per_bank: 256
     program_resolution: 8
-    words_per_page: 256
-    integrity_width: 4
     size: 1048576
+    words_per_page: 256
     topname: egret
     uniquified_modules: {}
+    integrity_width: 4
     module_instance_name: flash_ctrl
   }
 }

--- a/hw/top_scafi_deprecated/ip_autogen/flash_ctrl/data/top_scafi_deprecated_flash_ctrl.ipconfig.hjson
+++ b/hw/top_scafi_deprecated/ip_autogen/flash_ctrl/data/top_scafi_deprecated_flash_ctrl.ipconfig.hjson
@@ -16,11 +16,11 @@
     ]
     pages_per_bank: 16
     program_resolution: 8
-    words_per_page: 256
-    integrity_width: 4
     size: 65536
+    words_per_page: 256
     topname: scafi_deprecated
     uniquified_modules: {}
+    integrity_width: 4
     module_instance_name: flash_ctrl
   }
 }

--- a/util/design/gen-otp-mmap.py
+++ b/util/design/gen-otp-mmap.py
@@ -110,10 +110,9 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter)
 
     # Generator options for compile time random netlist constants
-    parser.add_argument('--seed',
-                        type=int,
-                        metavar='<seed>',
-                        help='Custom seed for RNG to compute default values.')
+    parser.add_argument('--gen-keys',
+                        action='store_true',
+                        help='Recompute random constants with topgen seed')
 
     parser.add_argument('--topname',
                         required=True,
@@ -126,7 +125,7 @@ def main():
     check_in_repo_top()
 
     otp_mmap = OtpMemMap.from_mmap_path(
-        MMAP_DEFINITION_FILE.replace('egret', args.topname), args.seed)
+        MMAP_DEFINITION_FILE.replace('egret', args.topname), args.gen_keys)
     partitions = otp_mmap.config["partitions"]
     output_path = (Path("hw") / f"top_{args.topname}" / "ip_autogen" /
                    "otp_ctrl")

--- a/util/gen_top_ipconfigs.py
+++ b/util/gen_top_ipconfigs.py
@@ -142,7 +142,7 @@ def main():
         inst_name = f"top_{completecfg['name']}_{module_name}"
         ip_config = IpConfig(template.params, inst_name, params)
 
-        outfile = args.outdir / (ip_config.instance_name + ".hjson")
+        outfile = args.outdir / (ip_config.instance_name + ".ipconfig.hjson")
         ip_config.to_file(outfile, HEADER.format(args.completecfg.relative_to(REPO_TOP),
                                                  args.outdir.relative_to(REPO_TOP)))
 

--- a/util/topgen/params.py
+++ b/util/topgen/params.py
@@ -278,8 +278,10 @@ def get_flash_ctrl_params(top: ConfigT) -> ParamsT:
             "In _get_flash_ctrl_params for design with no flash_ctrl")
 
     ipgen_params = get_ipgen_params(flash_mems[0])
-    ipgen_params.update(vars(flash_mems[0]["memory"]["mem"]["config"]))
+    mem_cfg = flash_mems[0]["memory"]["mem"]["config"]
+    ipgen_params.update(vars(mem_cfg) or mem_cfg)  # mem_cfg either EFlash obj or dict
     ipgen_params.pop('base_addrs', None)
+    ipgen_params.pop('type', None)
     return ipgen_params
 
 


### PR DESCRIPTION
@rtorok-zr recently found a bug while adding a new partition to an OTP memory map where OTP-related collateral was not getting regenerated properly.

Bugs fixed:
* Output path for generated IP configuration files was not quite the same path as the input to ipgen --> fixed filepath
* Errors when getting OTP parameters during topgen (where the OTP information has already been cast as an object) and ipgen (where OTP information is taken straight from the complete top configuration) --> allowed for either type to be used
* Minor typo fix in `util/design/gen-otp-mmap.py` of wrongly-named input argument --> arg renamed

The `util/design/gen-otp-mmap.py` script is old enough that it may be possible to deprecate it, as ipgen generation of otp_ctrl should properly generate all the same output files; happy to remove the file in this PR if feedback says it's warranted.