### PR TITLE
[topgen,bazel] Run topgen with Bazel

### DIFF
--- a/hw/ip/BUILD
+++ b/hw/ip/BUILD
@@ -1,4 +1,5 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -92,5 +93,39 @@ filegroup(
         "//hw/ip/tlul:doc_files",
         "//hw/ip/uart:doc_files",
         "//hw/ip/usbdev:doc_files",
+    ],
+)
+
+filegroup(
+    name = "block_descriptions",
+    srcs = [
+        "//hw/ip/acc/data:acc.hjson",
+        "//hw/ip/adc_ctrl/data:adc_ctrl.hjson",
+        "//hw/ip/aes/data:aes.hjson",
+        "//hw/ip/aon_timer/data:aon_timer.hjson",
+        "//hw/ip/csrng/data:csrng.hjson",
+        "//hw/ip/dma/data:dma.hjson",
+        "//hw/ip/edn/data:edn.hjson",
+        "//hw/ip/entropy_src/data:entropy_src.hjson",
+        "//hw/ip/flash_macro_wrapper/data:flash_macro_wrapper.hjson",
+        "//hw/ip/hmac/data:hmac.hjson",
+        "//hw/ip/i2c/data:i2c.hjson",
+        "//hw/ip/keymgr/data:keymgr.hjson",
+        "//hw/ip/keymgr_dpe/data:keymgr_dpe.hjson",
+        "//hw/ip/kmac/data:kmac.hjson",
+        "//hw/ip/lc_ctrl/data:lc_ctrl.hjson",
+        "//hw/ip/mbx/data:mbx.hjson",
+        "//hw/ip/otp_macro/data:otp_macro.hjson",
+        "//hw/ip/pattgen/data:pattgen.hjson",
+        "//hw/ip/rom_ctrl/data:rom_ctrl.hjson",
+        "//hw/ip/rv_dm/data:rv_dm.hjson",
+        "//hw/ip/rv_timer/data:rv_timer.hjson",
+        "//hw/ip/soc_dbg_ctrl/data:soc_dbg_ctrl.hjson",
+        "//hw/ip/spi_device/data:spi_device.hjson",
+        "//hw/ip/spi_host/data:spi_host.hjson",
+        "//hw/ip/sram_ctrl/data:sram_ctrl.hjson",
+        "//hw/ip/sysrst_ctrl/data:sysrst_ctrl.hjson",
+        "//hw/ip/uart/data:uart.hjson",
+        "//hw/ip/usbdev/data:usbdev.hjson",
     ],
 )

--- a/hw/ip_templates/BUILD
+++ b/hw/ip_templates/BUILD
@@ -1,8 +1,14 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
 package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)
 
 filegroup(
     name = "doc_files",

--- a/hw/top_dragonfly/data/BUILD
+++ b/hw/top_dragonfly/data/BUILD
@@ -5,6 +5,8 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("//rules:autogen.bzl", "pavona_completecfg")
+
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),
@@ -18,4 +20,16 @@ filegroup(
 filegroup(
     name = "top_xbar_hjsons",
     srcs = glob(["xbar*.hjson"]),
+)
+
+pavona_completecfg(
+    "completecfg",
+    data = [
+        ":top_xbar_hjsons",
+        "//hw/top_dragonfly/data/otp:otp_ctrl_mmap.hjson",
+        "//hw/top_dragonfly/data/racl:all_files",
+        "//hw/top_dragonfly/ip:block_descriptions",
+    ],
+    seed = ":top_dragonfly_seed.testing.hjson",
+    top = ":top_dragonfly.hjson",
 )

--- a/hw/top_dragonfly/data/BUILD
+++ b/hw/top_dragonfly/data/BUILD
@@ -6,6 +6,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//rules:autogen.bzl", "pavona_completecfg")
+load("//rules:files.bzl", "copy_files")
 
 filegroup(
     name = "all_files",
@@ -32,4 +33,11 @@ pavona_completecfg(
     ],
     seed = ":top_dragonfly_seed.testing.hjson",
     top = ":top_dragonfly.hjson",
+)
+
+copy_files(
+    name = "gen_completecfg",
+    srcs = [":completecfg"],
+    dest = "hw/top_dragonfly/data/autogen",
+    tags = ["manual"],
 )

--- a/hw/top_dragonfly/data/racl/BUILD
+++ b/hw/top_dragonfly/data/racl/BUILD
@@ -1,4 +1,3 @@
-# Copyright lowRISC contributors (OpenTitan project).
 # Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
@@ -8,14 +7,4 @@ package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),
-)
-
-filegroup(
-    name = "doc_files",
-    srcs = glob(["**/*_testplan.hjson"]),
-)
-
-filegroup(
-    name = "top_xbar_hjsons",
-    srcs = glob(["xbar*.hjson"]),
 )

--- a/hw/top_dragonfly/ip/BUILD
+++ b/hw/top_dragonfly/ip/BUILD
@@ -1,4 +1,5 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -32,5 +33,13 @@ filegroup(
     srcs = [
         "//hw/top_dragonfly/ip/ast:doc_files",
         "//hw/top_dragonfly/ip/soc_proxy:doc_files",
+    ],
+)
+
+filegroup(
+    name = "block_descriptions",
+    srcs = [
+        "//hw/top_dragonfly/ip/ast/data:ast.hjson",
+        "//hw/top_dragonfly/ip/soc_proxy/data:soc_proxy.hjson",
     ],
 )

--- a/hw/top_egret/data/BUILD
+++ b/hw/top_egret/data/BUILD
@@ -1,4 +1,5 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -12,4 +13,9 @@ filegroup(
 filegroup(
     name = "doc_files",
     srcs = glob(["**/*_testplan.hjson"]),
+)
+
+filegroup(
+    name = "top_xbar_hjsons",
+    srcs = glob(["xbar*.hjson"]),
 )

--- a/hw/top_egret/data/BUILD
+++ b/hw/top_egret/data/BUILD
@@ -6,6 +6,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//rules:autogen.bzl", "pavona_completecfg")
+load("//rules:files.bzl", "copy_files")
 
 filegroup(
     name = "all_files",
@@ -31,4 +32,11 @@ pavona_completecfg(
     ],
     seed = ":top_egret_seed.testing.hjson",
     top = ":top_egret.hjson",
+)
+
+copy_files(
+    name = "gen_completecfg",
+    srcs = [":completecfg"],
+    dest = "hw/top_egret/data/autogen",
+    tags = ["manual"],
 )

--- a/hw/top_egret/data/BUILD
+++ b/hw/top_egret/data/BUILD
@@ -5,6 +5,8 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("//rules:autogen.bzl", "pavona_completecfg")
+
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),
@@ -18,4 +20,15 @@ filegroup(
 filegroup(
     name = "top_xbar_hjsons",
     srcs = glob(["xbar*.hjson"]),
+)
+
+pavona_completecfg(
+    "completecfg",
+    data = [
+        ":top_xbar_hjsons",
+        "//hw/top_egret/data/otp:otp_ctrl_mmap.hjson",
+        "//hw/top_egret/ip:block_descriptions",
+    ],
+    seed = ":top_egret_seed.testing.hjson",
+    top = ":top_egret.hjson",
 )

--- a/hw/top_egret/ip/BUILD
+++ b/hw/top_egret/ip/BUILD
@@ -1,4 +1,5 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -32,5 +33,13 @@ filegroup(
         "//hw/top_egret/ip/ast:doc_files",
         "//hw/top_egret/ip/sensor_ctrl:doc_files",
         "//hw/top_egret/ip/xbar:doc_files",
+    ],
+)
+
+filegroup(
+    name = "block_descriptions",
+    srcs = [
+        "//hw/top_egret/ip/ast/data:ast.hjson",
+        "//hw/top_egret/ip/sensor_ctrl/data:sensor_ctrl.hjson",
     ],
 )

--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -13,12 +13,79 @@ load(
     "pavona_select_ip_attr",
 )
 
-"""Autogeneration rules for OpenTitan.
+"""Autogeneration rules for Pavona.
 
 The rules in this file are for autogenerating various file resources
-used by the OpenTitan build, such as register definition files generated
+used by the Pavona build, such as register definition files generated
 from hjson register descriptions.
 """
+
+def _pavona_completecfg_impl(ctx):
+    # get paths to output files (complete cfg and secrets file)
+    topname = ctx.file.topcfg.basename.removesuffix(".hjson")
+    seed_mode = ctx.file.seedcfg.basename.split(".")[1]  # top_<topname>.<seed_mode>.hjson
+    completecfg = ctx.actions.declare_file("autogen/" + topname + ".gen.hjson")
+    secrets = ctx.actions.declare_file("autogen/" + topname + ".secrets." + seed_mode + ".gen.hjson")
+
+    # run topgen with given inputs
+    arguments = [
+        "-t",
+        ctx.file.topcfg.path,
+        "-s",
+        ctx.file.seedcfg.path,
+        "-o",
+        "/".join(completecfg.path.split("/")[:-3]),  # top directory in sandbox
+    ]
+    ctx.actions.run(
+        outputs = [completecfg, secrets],
+        inputs = [ctx.file.topcfg, ctx.file.seedcfg] + ctx.files.data,
+        arguments = arguments,
+        executable = ctx.executable._topgen,
+    )
+
+    return [
+        DefaultInfo(files = depset([completecfg, secrets])),
+    ]
+
+pavona_completecfg_rule = rule(
+    implementation = _pavona_completecfg_impl,
+    doc = "Generate complete top config and secrets file with topgen",
+    attrs = {
+        # TODO: add more arguments to pass into topgen; for now, assuming default paths
+        "topcfg": attr.label(allow_single_file = True, doc = "Top configuration Hjson"),
+        "seedcfg": attr.label(allow_single_file = True, doc = "Seed configuration Hjson"),
+        "data": attr.label_list(allow_files = True, doc = "Other top-specific sources needed"),
+        "_topgen": attr.label(
+            default = "//util:topgen.py",
+            executable = True,
+            allow_single_file = True,
+            cfg = "exec",
+        ),
+    },
+)
+
+def pavona_completecfg(name, top, seed, data = [], **kwargs):
+    """
+    Macro around `pavona_completecfg_rule` which uses top config and seed config
+    to generate complete top information with topgen.
+
+    Data should include top-reggen IPs, the RACL config, the OTP memory map, and
+    all xbar configuration hjsons.
+    """
+    needed_for_topgen = [
+        # always required whenever running topgen
+        "//util/topgen:topgen",
+        "//hw/ip:block_descriptions",
+        "//hw/ip_templates:all_files",
+    ]
+
+    pavona_completecfg_rule(
+        name = name,
+        topcfg = top,
+        seedcfg = seed,
+        data = data + needed_for_topgen,
+        **kwargs
+    )
 
 def _pavona_ip_c_header_impl(ctx):
     header = ctx.actions.declare_file("{}_regs.h".format(ctx.attr.ip))

--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -56,9 +56,8 @@ pavona_completecfg_rule = rule(
         "seedcfg": attr.label(allow_single_file = True, doc = "Seed configuration Hjson"),
         "data": attr.label_list(allow_files = True, doc = "Other top-specific sources needed"),
         "_topgen": attr.label(
-            default = "//util:topgen.py",
+            default = "//util:toptool",
             executable = True,
-            allow_single_file = True,
             cfg = "exec",
         ),
     },
@@ -72,18 +71,11 @@ def pavona_completecfg(name, top, seed, data = [], **kwargs):
     Data should include top-reggen IPs, the RACL config, the OTP memory map, and
     all xbar configuration hjsons.
     """
-    needed_for_topgen = [
-        # always required whenever running topgen
-        "//util/topgen:topgen",
-        "//hw/ip:block_descriptions",
-        "//hw/ip_templates:all_files",
-    ]
-
     pavona_completecfg_rule(
         name = name,
         topcfg = top,
         seedcfg = seed,
-        data = data + needed_for_topgen,
+        data = data,
         **kwargs
     )
 

--- a/rules/files.bzl
+++ b/rules/files.bzl
@@ -66,13 +66,16 @@ def _copy_files(ctx):
         if _matches_filter(file.basename, ctx.attr.filter):
             files.append(file)
 
+    if not ctx.attr.dest and not ctx.attr.relative_to:
+        fail("either `dest` or `relative_to` must be set")
+
     out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
     substitutions = {
         # This is maybe a bit naughty: we rely on the fact that the `package`
         # portion of the `relative_to` label looks just like the dirname
         # of the file and the package is relative to the root of the
         # workspace in which the rule resides.
-        "__DEST__": ctx.attr.relative_to.label.package,
+        "__DEST__": ctx.attr.dest or ctx.attr.relative_to.label.package,
         "__FILES__": " ".join([f.path for f in files]),
         "__WORKSPACE__": ctx.attr.workspace_env,
     }
@@ -97,9 +100,11 @@ copy_files = rule(
             doc = "Targets producing file outputs",
         ),
         "relative_to": attr.label(
-            mandatory = True,
             allow_single_file = True,
             doc = "Label of a file in the same subdir that the files should be copied to.",
+        ),
+        "dest": attr.string(
+            doc = "Workspace-relative destination directory, for use when it holds no label to point `relative_to` at.",
         ),
         "filter": attr.string_list(
             default = [],

--- a/util/BUILD
+++ b/util/BUILD
@@ -81,6 +81,24 @@ py_binary(
 )
 
 py_binary(
+    name = "toptool",
+    srcs = ["topgen.py"],
+    data = [
+        "//hw/ip:block_descriptions",
+        "//hw/ip_templates:all_files",
+    ],
+    imports = ["."],
+    main = "topgen.py",
+    deps = [
+        "//util/design/lib:otp_mem_map",
+        "//util/ipgen",
+        "//util/reggen",
+        "//util/tlgen",
+        "//util/topgen",
+    ],
+)
+
+py_binary(
     name = "autogen_dif",
     srcs = ["autogen_dif.py"],
     data = [

--- a/util/reggen/BUILD
+++ b/util/reggen/BUILD
@@ -9,6 +9,21 @@ load("@ot_python_deps//:requirements.bzl", "requirement")
 package(default_visibility = ["//visibility:public"])
 
 py_library(
+    name = "reggen",
+    srcs = glob(["**/*.py"]),
+    imports = [".."],
+    deps = [
+        requirement("hjson"),
+        requirement("semantic_version"),
+        requirement("mako"),
+        requirement("pyyaml"),
+        requirement("mistletoe"),
+        requirement("peakrdl_systemrdl"),
+        requirement("tabulate"),
+    ],
+)
+
+py_library(
     name = "lib",
     srcs = [
         "__init__.py",

--- a/util/topgen/README.md
+++ b/util/topgen/README.md
@@ -128,6 +128,12 @@ $ cd ${REPO_TOP}
 $ make -C hw top
 ```
 
+Another means of generating the complete config with topgen is by invoking it through Bazel.
+Each top can make use of its `gen_completecfg` target in order to regenerate it:
+```console
+$ ./bazelisk.sh run //hw/top_dragonfly/data:gen_completecfg
+```
+
 It is possible to restrict what the tool should generate.
 
 <!-- BEGIN CMDGEN util/selfdoc.py quote:util/topgen.py --help -->


### PR DESCRIPTION
Related issue: https://github.com/pavona/pavona/issues/343.

Currently, topgen is most commonly run with a Makefile (`hw/Makefile`) which batch generates all hardware-side collateral for every top with one command. There are two structural changes that might improve building tops without invoking topgen directly:
1) Splitting the build targets up by top and output file group
2) Using Bazel rather than Make, as this conforms to the rest of the repo's build system and allows use of Bazel's more consistent Python environment

There is another draft PR, https://github.com/pavona/pavona/pull/369, that similarly replaces Makefiles with Bazel targets.

This PR:
* exposes more files to Bazel because topgen requires access to all IP block descriptions and IP templates
* creates a custom Bazel rule for building complete top configurations using topgen
* creates a rule for copying autogenerated files back into the repo (as topgen's outputs are all checked-in to the repo)

Because this PR only covers generating the complete config itself, it does not yet obsolete `hw/Makefile` (which generates additional files).