### PR TITLE
[bazel,ci] Use Python 3.12 in CI and for Bazel tools

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -25,7 +25,7 @@ inputs:
     default: ${{ github.workspace }}
   python-version:
     description: Python version to install and use
-    default: '3.10'
+    default: '3.12'
   vivado-version:
     description: Vivado version to configure, if any.
     default: ''

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -285,20 +285,20 @@ python.toolchain(
     # See <https://github.com/bazelbuild/rules_python/pull/713>.
     ignore_root_user_error = True,
     is_default = True,
-    python_version = "3.10",
+    python_version = "3.12",
 )
 use_repo(python, "pythons_hub")
 
 register_toolchains("@pythons_hub//:all")
 
 # We occasionally access the toolchain repositories directly to use interpreters.
-use_repo(python, python3 = "python_3_10", python3_host = "python_3_10_host")
+use_repo(python, python3 = "python_3_12", python3_host = "python_3_12_host")
 
 # Pip dependencies:
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
     hub_name = "ot_python_deps",
-    python_version = "3.10",
+    python_version = "3.12",
     requirements_lock = "//:python-requirements.txt",
 )
 use_repo(pip, "ot_python_deps")

--- a/ci/scripts/lib/BUILD
+++ b/ci/scripts/lib/BUILD
@@ -12,4 +12,5 @@ py_test(
         "bazel_query.py",
         "bazel_query_test.py",
     ],
+    imports = ["."],
 )

--- a/hw/ip/acc/dv/accsim/sim/BUILD
+++ b/hw/ip/acc/dv/accsim/sim/BUILD
@@ -10,17 +10,20 @@ package(default_visibility = ["//visibility:public"])
 py_library(
     name = "constants",
     srcs = ["constants.py"],
+    imports = [".."],
 )
 
 py_library(
     name = "kmac",
     srcs = ["kmac.py"],
+    imports = [".."],
     deps = [requirement("pycryptodome")],
 )
 
 py_library(
     name = "csr",
     srcs = ["csr.py"],
+    imports = [".."],
     deps = [
         ":flags",
         ":wsr",
@@ -30,6 +33,7 @@ py_library(
 py_library(
     name = "decode",
     srcs = ["decode.py"],
+    imports = [".."],
     deps = [
         ":constants",
         ":insn",
@@ -41,6 +45,7 @@ py_library(
 py_library(
     name = "dmem",
     srcs = ["dmem.py"],
+    imports = [".."],
     deps = [
         ":trace",
         "//hw/ip/acc/util/shared:mem_layout",
@@ -50,11 +55,13 @@ py_library(
 py_library(
     name = "edn_client",
     srcs = ["edn_client.py"],
+    imports = [".."],
 )
 
 py_library(
     name = "ext_regs",
     srcs = ["ext_regs.py"],
+    imports = [".."],
     deps = [
         ":edn_client",
         ":trace",
@@ -68,6 +75,7 @@ py_library(
 py_library(
     name = "flags",
     srcs = ["flags.py"],
+    imports = [".."],
     deps = [
         ":trace",
     ],
@@ -76,6 +84,7 @@ py_library(
 py_library(
     name = "gpr",
     srcs = ["gpr.py"],
+    imports = [".."],
     deps = [
         ":constants",
         ":reg",
@@ -85,6 +94,7 @@ py_library(
 py_library(
     name = "insn",
     srcs = ["insn.py"],
+    imports = [".."],
     deps = [
         ":constants",
         ":flags",
@@ -96,6 +106,7 @@ py_library(
 py_library(
     name = "isa",
     srcs = ["isa.py"],
+    imports = [".."],
     deps = [
         ":state",
         "//hw/ip/acc/util/shared:insn_yaml",
@@ -105,6 +116,7 @@ py_library(
 py_library(
     name = "load_elf",
     srcs = ["load_elf.py"],
+    imports = [".."],
     deps = [
         ":decode",
         ":sim",
@@ -115,6 +127,7 @@ py_library(
 py_library(
     name = "loop",
     srcs = ["loop.py"],
+    imports = [".."],
     deps = [
         ":constants",
         ":trace",
@@ -124,6 +137,7 @@ py_library(
 py_library(
     name = "reg",
     srcs = ["reg.py"],
+    imports = [".."],
     deps = [
         ":trace",
     ],
@@ -132,6 +146,7 @@ py_library(
 py_library(
     name = "sim",
     srcs = ["sim.py"],
+    imports = [".."],
     deps = [
         ":constants",
         ":decode",
@@ -145,6 +160,7 @@ py_library(
 py_library(
     name = "standalonesim",
     srcs = ["standalonesim.py"],
+    imports = [".."],
     deps = [
         ":sim",
     ],
@@ -153,6 +169,7 @@ py_library(
 py_library(
     name = "state",
     srcs = ["state.py"],
+    imports = [".."],
     deps = [
         ":constants",
         ":csr",
@@ -173,6 +190,7 @@ py_library(
 py_library(
     name = "stats",
     srcs = ["stats.py"],
+    imports = [".."],
     deps = [
         ":insn",
         ":isa",
@@ -185,11 +203,13 @@ py_library(
 py_library(
     name = "trace",
     srcs = ["trace.py"],
+    imports = [".."],
 )
 
 py_library(
     name = "wsr",
     srcs = ["wsr.py"],
+    imports = [".."],
     deps = [
         ":ext_regs",
         ":kmac",

--- a/hw/ip/rom_ctrl/util/BUILD
+++ b/hw/ip/rom_ctrl/util/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 py_library(
     name = "mem",
     srcs = ["mem.py"],
+    imports = ["."],
     deps = [
         "//util/design:secded_gen",
         requirement("pyelftools"),
@@ -19,6 +20,7 @@ py_library(
 py_binary(
     name = "gen_vivado_mem_image",
     srcs = ["gen_vivado_mem_image.py"],
+    imports = ["."],
     deps = [":mem"],
 )
 
@@ -31,6 +33,7 @@ py_test(
 py_binary(
     name = "scramble_image",
     srcs = ["scramble_image.py"],
+    imports = ["."],
     deps = [
         ":mem",
         "//util/design:prince",

--- a/rules/scripts/BUILD
+++ b/rules/scripts/BUILD
@@ -30,6 +30,7 @@ py_test(
     srcs = [
         "bitstreams_workspace_test.py",
     ],
+    imports = ["."],
     deps = [
         ":bitstreams_workspace",
     ],

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 py_library(
     name = "cryptotest_util",
     srcs = ["cryptotest_util.py"],
+    imports = ["."],
     visibility = ["//visibility:private"],
 )
 
@@ -19,6 +20,7 @@ py_test(
         "cryptotest_util.py",
         "cryptotest_util_test.py",
     ],
+    imports = ["."],
     visibility = ["//visibility:private"],
 )
 

--- a/util/design/lib/BUILD
+++ b/util/design/lib/BUILD
@@ -18,6 +18,7 @@ py_library(
 py_test(
     name = "common_test",
     srcs = ["common_test.py"],
+    imports = ["."],
     deps = [":common"],
 )
 

--- a/util/fpga/BUILD
+++ b/util/fpga/BUILD
@@ -28,5 +28,6 @@ py_test(
         "bitstream_bisect.py",
         "bitstream_bisect_test.py",
     ],
+    imports = ["."],
     deps = [":bitstream_bisect_support"],
 )


### PR DESCRIPTION
Python 3.10 reaches end of life in October 2026, so pin the Bazel toolchain and the CI environment to Python 3.12 instead.

This surfaced a number of BUILD targets with undeclared import paths. From Python 3.11 on, rules_python sets PYTHONSAFEPATH, so a script's own directory is no longer on sys.path.

I've also considered going straight to Python 3.14, but after discussing with @fragglet, it seems less risky to upgrade to 3.12 first. Python 3.12 is shipped as the default Python on Ubuntu 24.04 which at this point is much more widely used than Ubuntu 26.04. Note that for now we keep support for Python 3.10 (as indicated by the `pyproject.toml`).