### PR TITLE
[dif,otp] Migrate `otp_ctrl` DIFs to DT

### DIFF
--- a/hw/ip_templates/otp_ctrl/data/dif_otp_ctrl.c.tpl.not_yet
+++ b/hw/ip_templates/otp_ctrl/data/dif_otp_ctrl.c.tpl.not_yet
@@ -163,7 +163,7 @@ dif_result_t dif_otp_ctrl_check_trigger_is_locked(const dif_otp_ctrl_t *otp,
   return kDifOk;
 }
 
-static bool sw_read_lock_reg_offset(dif_otp_ctrl_partition_t partition,
+static bool sw_read_lock_reg_offset(otp_partition_t partition,
                                     ptrdiff_t *reg_offset,
                                     bitfield_bit32_index_t *index) {
   switch (partition) {
@@ -173,7 +173,7 @@ static bool sw_read_lock_reg_offset(dif_otp_ctrl_partition_t partition,
   part_name_define = part_name.as_c_define()
   index_line = f"*index = OTP_CTRL_{part_name_define}_READ_LOCK_{part_name_define}_READ_LOCK_BIT;"
 %>\
-    case kDifOtpCtrlPartition${part_name.as_camel_case()}:
+    case kOtpPartition${part_name.as_camel_case()}:
       *reg_offset = OTP_CTRL_${part_name_define}_READ_LOCK_REG_OFFSET;
   % if len(index_line) > 80 - 6:
       *index =
@@ -190,7 +190,7 @@ static bool sw_read_lock_reg_offset(dif_otp_ctrl_partition_t partition,
 }
 
 dif_result_t dif_otp_ctrl_lock_reading(const dif_otp_ctrl_t *otp,
-                                       dif_otp_ctrl_partition_t partition) {
+                                       otp_partition_t partition) {
   if (otp == NULL) {
     return kDifBadArg;
   }
@@ -208,7 +208,7 @@ dif_result_t dif_otp_ctrl_lock_reading(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_reading_is_locked(const dif_otp_ctrl_t *otp,
-                                            dif_otp_ctrl_partition_t partition,
+                                            otp_partition_t partition,
                                             bool *is_locked) {
   if (otp == NULL || is_locked == NULL) {
     return kDifBadArg;
@@ -372,7 +372,7 @@ static const partition_info_t kPartitions[] = {
   is_lifecycle = part["variant"] == "LifeCycle"
   is_software = part["variant"] == "Unbuffered"
 %>\
-    [kDifOtpCtrlPartition${part_name_camel}] = {
+    [kOtpPartition${part_name_camel}] = {
         .start_addr = OTP_CTRL_PARAM_${part_name_define}_OFFSET,
         .len = OTP_CTRL_PARAM_${part_name_define}_SIZE,
         .align_mask = ${"0x7" if part in secret_parts else "0x3"},
@@ -383,7 +383,7 @@ static const partition_info_t kPartitions[] = {
 };
 // clang-format on
 
-dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
+dif_result_t dif_otp_ctrl_relative_address(otp_partition_t partition,
                                            uint32_t abs_address,
                                            uint32_t *relative_address) {
   *relative_address = 0;
@@ -410,7 +410,7 @@ dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
 }
 
 dif_result_t dif_otp_ctrl_dai_read_start(const dif_otp_ctrl_t *otp,
-                                         dif_otp_ctrl_partition_t partition,
+                                         otp_partition_t partition,
                                          uint32_t address) {
   if (otp == NULL || partition >= ARRAYSIZE(kPartitions)) {
     return kDifBadArg;
@@ -462,7 +462,7 @@ dif_result_t dif_otp_ctrl_dai_read64_end(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_dai_program32(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint32_t value) {
   if (otp == NULL || partition >= ARRAYSIZE(kPartitions)) {
     return kDifBadArg;
@@ -506,7 +506,7 @@ dif_result_t dif_otp_ctrl_dai_program32(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_dai_program64(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint64_t value) {
   if (otp == NULL || partition >= ARRAYSIZE(kPartitions)) {
     return kDifBadArg;
@@ -547,7 +547,7 @@ dif_result_t dif_otp_ctrl_dai_program64(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
-                                     dif_otp_ctrl_partition_t partition,
+                                     otp_partition_t partition,
                                      uint64_t digest) {
   if (otp == NULL || partition >= ARRAYSIZE(kPartitions)) {
     return kDifBadArg;
@@ -591,7 +591,7 @@ dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
   return kDifOk;
 }
 
-static bool get_digest_regs(dif_otp_ctrl_partition_t partition, ptrdiff_t *reg0,
+static bool get_digest_regs(otp_partition_t partition, ptrdiff_t *reg0,
                             ptrdiff_t *reg1) {
   switch (partition) {
 % for part in digest_parts:
@@ -599,7 +599,7 @@ static bool get_digest_regs(dif_otp_ctrl_partition_t partition, ptrdiff_t *reg0,
   part_name = Name.from_snake_case(part["name"])
   part_name_define = part_name.as_c_define()
 %>\
-    case kDifOtpCtrlPartition${part_name.as_camel_case()}:
+    case kOtpPartition${part_name.as_camel_case()}:
       *reg0 = OTP_CTRL_${part_name_define}_DIGEST_0_REG_OFFSET;
       *reg1 = OTP_CTRL_${part_name_define}_DIGEST_1_REG_OFFSET;
       break;
@@ -612,7 +612,7 @@ static bool get_digest_regs(dif_otp_ctrl_partition_t partition, ptrdiff_t *reg0,
 }
 
 dif_result_t dif_otp_ctrl_is_digest_computed(const dif_otp_ctrl_t *otp,
-                                             dif_otp_ctrl_partition_t partition,
+                                             otp_partition_t partition,
                                              bool *is_computed) {
   if (otp == NULL || is_computed == NULL) {
     return kDifBadArg;
@@ -633,7 +633,7 @@ dif_result_t dif_otp_ctrl_is_digest_computed(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_get_digest(const dif_otp_ctrl_t *otp,
-                                     dif_otp_ctrl_partition_t partition,
+                                     otp_partition_t partition,
                                      uint64_t *digest) {
   if (otp == NULL || digest == NULL) {
     return kDifBadArg;
@@ -657,7 +657,7 @@ dif_result_t dif_otp_ctrl_get_digest(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_read_blocking(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint32_t *buf,
                                         size_t len) {
   if (otp == NULL || partition >= ARRAYSIZE(kPartitions) || buf == NULL) {

--- a/hw/ip_templates/otp_ctrl/data/dif_otp_ctrl.h.tpl.not_yet
+++ b/hw/ip_templates/otp_ctrl/data/dif_otp_ctrl.h.tpl.not_yet
@@ -51,9 +51,9 @@ typedef enum dif_otp_ctrl_partition {
 ${long_desc}
   %endif
    */
-  kDifOtpCtrlPartition${part_name_camel},
+  kOtpPartition${part_name_camel},
 % endfor
-} dif_otp_ctrl_partition_t;
+} otp_partition_t;
 
 /**
  * Runtime configuration for OTP.
@@ -379,7 +379,7 @@ dif_result_t dif_otp_ctrl_check_trigger_is_locked(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_lock_reading(const dif_otp_ctrl_t *otp,
-                                       dif_otp_ctrl_partition_t partition);
+                                       otp_partition_t partition);
 
 /**
  * Checks whether reads to a SW partition are locked out.
@@ -394,7 +394,7 @@ dif_result_t dif_otp_ctrl_lock_reading(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_reading_is_locked(const dif_otp_ctrl_t *otp,
-                                            dif_otp_ctrl_partition_t partition,
+                                            otp_partition_t partition,
                                             bool *is_locked);
 
 /**
@@ -420,7 +420,7 @@ dif_result_t dif_otp_ctrl_get_status(const dif_otp_ctrl_t *otp,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
+dif_result_t dif_otp_ctrl_relative_address(otp_partition_t partition,
                                            uint32_t abs_address,
                                            uint32_t *relative_address);
 
@@ -442,7 +442,7 @@ dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_dai_read_start(const dif_otp_ctrl_t *otp,
-                                         dif_otp_ctrl_partition_t partition,
+                                         otp_partition_t partition,
                                          uint32_t address);
 
 /**
@@ -496,7 +496,7 @@ dif_result_t dif_otp_ctrl_dai_read64_end(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_dai_program32(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint32_t value);
 
 /**
@@ -517,7 +517,7 @@ dif_result_t dif_otp_ctrl_dai_program32(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_dai_program64(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint64_t value);
 
 /**
@@ -540,7 +540,7 @@ dif_result_t dif_otp_ctrl_dai_program64(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
-                                     dif_otp_ctrl_partition_t partition,
+                                     otp_partition_t partition,
                                      uint64_t digest);
 
 /**
@@ -558,7 +558,7 @@ dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_is_digest_computed(const dif_otp_ctrl_t *otp,
-                                             dif_otp_ctrl_partition_t partition,
+                                             otp_partition_t partition,
                                              bool *is_computed);
 
 /**
@@ -578,7 +578,7 @@ dif_result_t dif_otp_ctrl_is_digest_computed(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_get_digest(const dif_otp_ctrl_t *otp,
-                                     dif_otp_ctrl_partition_t partition,
+                                     otp_partition_t partition,
                                      uint64_t *digest);
 
 /**
@@ -602,7 +602,7 @@ dif_result_t dif_otp_ctrl_get_digest(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_read_blocking(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint32_t *buf,
                                         size_t len);
 

--- a/hw/ip_templates/otp_ctrl/data/dif_otp_ctrl_unittest.cc.tpl.not_yet
+++ b/hw/ip_templates/otp_ctrl/data/dif_otp_ctrl_unittest.cc.tpl.not_yet
@@ -193,7 +193,7 @@ TEST_F(ReadLockTest, IsLocked) {
       {{OTP_CTRL_${part_name_define}_READ_LOCK_${part_name_define}_READ_LOCK_BIT,
         true}});
   EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartition${part_name_camel}, &flag));
+      &otp_, kOtpPartition${part_name_camel}, &flag));
   EXPECT_FALSE(flag);
 
   EXPECT_READ32(
@@ -201,7 +201,7 @@ TEST_F(ReadLockTest, IsLocked) {
       {{OTP_CTRL_${part_name_define}_READ_LOCK_${part_name_define}_READ_LOCK_BIT,
         false}});
   EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartition${part_name_camel}, &flag));
+      &otp_, kOtpPartition${part_name_camel}, &flag));
   EXPECT_TRUE(flag);
   % if not loop.last:
 
@@ -221,7 +221,7 @@ TEST_F(ReadLockTest, Lock) {
       {{OTP_CTRL_${part_name_define}_READ_LOCK_${part_name_define}_READ_LOCK_BIT,
         false}});
   EXPECT_DIF_OK(dif_otp_ctrl_lock_reading(
-      &otp_, kDifOtpCtrlPartition${part_name_camel}));
+      &otp_, kOtpPartition${part_name_camel}));
   % if not loop.last:
 
   %endif
@@ -235,9 +235,9 @@ TEST_F(ReadLockTest, NotLockablePartitions) {
   part_name_camel = Name.to_camel_case(part["name"])
 %>\
   EXPECT_DIF_BADARG(
-      dif_otp_ctrl_lock_reading(&otp_, kDifOtpCtrlPartition${part_name_camel}));
+      dif_otp_ctrl_lock_reading(&otp_, kOtpPartition${part_name_camel}));
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartition${part_name_camel}, &flag));
+      &otp_, kOtpPartition${part_name_camel}, &flag));
   % if not loop.last:
 
   %endif
@@ -250,15 +250,15 @@ TEST_F(ReadLockTest, NullArgs) {
 % for part in read_locked_csr_parts:
 <%
   part_name_camel = Name.to_camel_case(part["name"])
-  lock_reading_line = f"dif_otp_ctrl_lock_reading(nullptr, kDifOtpCtrlPartition{part_name_camel}));"
+  lock_reading_line = f"dif_otp_ctrl_lock_reading(nullptr, kOtpPartition{part_name_camel}));"
 %>\
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      nullptr, kDifOtpCtrlPartition${part_name_camel}, &flag));
+      nullptr, kOtpPartition${part_name_camel}, &flag));
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartition${part_name_camel}, nullptr));
+      &otp_, kOtpPartition${part_name_camel}, nullptr));
   % if len(lock_reading_line) > 80 - 6:
   EXPECT_DIF_BADARG(dif_otp_ctrl_lock_reading(
-      nullptr, kDifOtpCtrlPartition${part_name_camel}));
+      nullptr, kOtpPartition${part_name_camel}));
   % else:
   EXPECT_DIF_BADARG(
       ${lock_reading_line}
@@ -323,7 +323,7 @@ TEST_F(StatusTest, NullArgs) {
 
 struct RelativeAddressParams {
   std::string name;
-  dif_otp_ctrl_partition_t partition;
+  otp_partition_t partition;
   uint32_t abs_address;
   dif_result_t expected_result;
   uint32_t expected_relative_address;
@@ -353,14 +353,14 @@ INSTANTIATE_TEST_SUITE_P(
 %>\
         RelativeAddressParams{
             "${part_name_camel}Okay",
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
             OTP_CTRL_PARAM_${part_name_define}_OFFSET + ${step},
             kDifOk,
             ${step},
         },
         RelativeAddressParams{
             "${part_name_camel}Unaligned",
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
             OTP_CTRL_PARAM_${part_name_define}_OFFSET + 1,
             kDifUnaligned,
             0,
@@ -371,7 +371,7 @@ INSTANTIATE_TEST_SUITE_P(
   % if not loop.first:
         RelativeAddressParams{
             "${part_name_camel}OutOfRangeBeforeStart",
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
             OTP_CTRL_PARAM_${part_name_define}_OFFSET - ${step},
             kDifOutOfRange,
             0,
@@ -379,7 +379,7 @@ INSTANTIATE_TEST_SUITE_P(
   % endif
         RelativeAddressParams{
             "${part_name_camel}OutOfRangePastEnd",
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
   % if len(f"OTP_CTRL_PARAM_{part_name_define}_OFFSET + OTP_CTRL_PARAM_{part_name_define}_SIZE,") <= 80 - 12:
             OTP_CTRL_PARAM_${part_name_define}_OFFSET + OTP_CTRL_PARAM_${part_name_define}_SIZE,
   % else:
@@ -402,7 +402,7 @@ TEST_F(DaiReadTest, Read32) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_RD_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionHwCfg0,
                                             /*address=*/0x20));
 
   EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET, 0x12345678);
@@ -425,7 +425,7 @@ TEST_F(DaiReadTest, Read64) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_RD_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartition${part_name_camel},
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartition${part_name_camel},
                                             /*address=*/0x8));
 
   EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET, 0x12345678);
@@ -440,23 +440,23 @@ TEST_F(DaiReadTest, Read64) {
 }
 
 TEST_F(DaiReadTest, Unaligned) {
-  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionHwCfg0,
                                         /*address=*/0b01),
             kDifUnaligned);
-  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionSecret2,
+  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionSecret2,
                                         /*address=*/0b100),
             kDifUnaligned);
 }
 
 TEST_F(DaiReadTest, OutOfRange) {
-  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionHwCfg0,
                                         /*address=*/0x100),
             kDifOutOfRange);
 }
 
 TEST_F(DaiReadTest, NullArgs) {
   EXPECT_DIF_BADARG(dif_otp_ctrl_dai_read_start(nullptr,
-                                                kDifOtpCtrlPartitionHwCfg0,
+                                                kOtpPartitionHwCfg0,
                                                 /*address=*/0x0));
 
   uint32_t val32;
@@ -477,7 +477,7 @@ TEST_F(DaiProgramTest, Program32) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_program32(&otp_, kOtpPartitionHwCfg0,
                                            /*address=*/0x20,
                                            /*value=*/0x12345678));
 }
@@ -490,30 +490,30 @@ TEST_F(DaiProgramTest, Program64) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_program64(&otp_, kDifOtpCtrlPartitionSecret2,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_program64(&otp_, kOtpPartitionSecret2,
                                            /*address=*/0x8,
                                            /*value=*/0x1234567890abcdef));
 }
 
 TEST_F(DaiProgramTest, BadPartition) {
-  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionSecret1,
+  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kOtpPartitionSecret1,
                                        /*address=*/0x0, /*value=*/42),
             kDifError);
-  EXPECT_EQ(dif_otp_ctrl_dai_program64(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_EQ(dif_otp_ctrl_dai_program64(&otp_, kOtpPartitionHwCfg0,
                                        /*address=*/0x0, /*value=*/42),
             kDifError);
 
   // LC is never writeable.
-  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionLifeCycle,
+  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kOtpPartitionLifeCycle,
                                        /*address=*/0x0, /*value=*/42),
             kDifError);
 }
 
 TEST_F(DaiProgramTest, Unaligned) {
-  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kOtpPartitionHwCfg0,
                                        /*address=*/0b01, /*value=*/42),
             kDifUnaligned);
-  EXPECT_EQ(dif_otp_ctrl_dai_program64(&otp_, kDifOtpCtrlPartitionSecret2,
+  EXPECT_EQ(dif_otp_ctrl_dai_program64(&otp_, kOtpPartitionSecret2,
                                        /*address=*/0b100, /*value=*/42),
             kDifUnaligned);
 }
@@ -521,24 +521,24 @@ TEST_F(DaiProgramTest, Unaligned) {
 TEST_F(DaiProgramTest, OutOfRange) {
   // Check that we can't write a digest directly.
   EXPECT_EQ(dif_otp_ctrl_dai_program32(
-                &otp_, kDifOtpCtrlPartitionCreatorSwCfg,
+                &otp_, kOtpPartitionCreatorSwCfg,
                 /*address=*/OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_OFFSET,
                 /*value=*/42),
             kDifOutOfRange);
 
   // Same digest check for 64-bit.
   EXPECT_EQ(dif_otp_ctrl_dai_program64(
-                &otp_, kDifOtpCtrlPartitionSecret2,
+                &otp_, kOtpPartitionSecret2,
                 /*address=*/OTP_CTRL_PARAM_SECRET2_DIGEST_OFFSET, /*value=*/42),
             kDifOutOfRange);
 }
 
 TEST_F(DaiProgramTest, NullArgs) {
   EXPECT_DIF_BADARG(dif_otp_ctrl_dai_program32(nullptr,
-                                               kDifOtpCtrlPartitionHwCfg0,
+                                               kOtpPartitionHwCfg0,
                                                /*address=*/0x0, /*value=*/42));
   EXPECT_DIF_BADARG(dif_otp_ctrl_dai_program64(nullptr,
-                                               kDifOtpCtrlPartitionSecret0,
+                                               kOtpPartitionSecret0,
                                                /*address=*/0x0, /*value=*/42));
 }
 
@@ -551,7 +551,7 @@ TEST_F(DaiDigestTest, DigestSw) {
   part_name_define = part_name.as_c_define()
   part_name_camel = part_name.as_camel_case()
   dai_digest_line = ("EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, "
-                     + f"kDifOtpCtrlPartition{part_name_camel},")
+                     + f"kOtpPartition{part_name_camel},")
 %>\
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
                  OTP_CTRL_PARAM_${part_name.as_c_define()}_DIGEST_OFFSET);
@@ -561,14 +561,14 @@ TEST_F(DaiDigestTest, DigestSw) {
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
 
   % if len(dai_digest_line) > 80 - 2:
-<% dai_digest_line = (f"kDifOtpCtrlPartition{part_name_camel},") %>\
+<% dai_digest_line = (f"kOtpPartition{part_name_camel},") %>\
     % if len(dai_digest_line) > 80 - 40:
   EXPECT_DIF_OK(
-      dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartition${part_name_camel},
+      dif_otp_ctrl_dai_digest(&otp_, kOtpPartition${part_name_camel},
                               /*digest=*/0xabcdef0000abcdef));
     % else:
   EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_,
-                                        kDifOtpCtrlPartition${part_name_camel},
+                                        kOtpPartition${part_name_camel},
                                         /*digest=*/0xabcdef0000abcdef));
     % endif
   % else:
@@ -588,14 +588,14 @@ TEST_F(DaiDigestTest, DigestHw) {
   part_name_define = part_name.as_c_define()
   part_name_camel = part_name.as_camel_case()
   dai_digest_line = ("EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, "
-                     + f"kDifOtpCtrlPartition{part_name_camel},")
+                     + f"kOtpPartition{part_name_camel},")
 %>\
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
                  OTP_CTRL_PARAM_${part_name_define}_OFFSET);
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_DIGEST_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartition${part_name_camel},
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kOtpPartition${part_name_camel},
                                         /*digest=*/0));
   % if not loop.last:
 
@@ -604,22 +604,22 @@ TEST_F(DaiDigestTest, DigestHw) {
 }
 
 TEST_F(DaiDigestTest, BadPartition) {
-  EXPECT_EQ(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionLifeCycle,
+  EXPECT_EQ(dif_otp_ctrl_dai_digest(&otp_, kOtpPartitionLifeCycle,
                                     /*digest=*/0),
             kDifError);
 }
 
 TEST_F(DaiDigestTest, BadDigest) {
-  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(&otp_, kOtpPartitionHwCfg0,
                                             /*digest=*/0xabcdef0000abcdef));
   EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(&otp_,
-                                            kDifOtpCtrlPartitionCreatorSwCfg,
+                                            kOtpPartitionCreatorSwCfg,
                                             /*digest=*/0));
 }
 
 TEST_F(DaiDigestTest, NullArgs) {
   EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(nullptr,
-                                            kDifOtpCtrlPartitionCreatorSwCfg,
+                                            kOtpPartitionCreatorSwCfg,
                                             /*digest=*/0xabcdef0000abcdef));
 }
 
@@ -628,17 +628,17 @@ class IsDigestComputed : public OtpTest {};
 TEST_F(IsDigestComputed, NullArgs) {
   bool is_computed;
   EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
-      nullptr, kDifOtpCtrlPartitionSecret2, &is_computed));
+      nullptr, kOtpPartitionSecret2, &is_computed));
   EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
-      &otp_, kDifOtpCtrlPartitionSecret2, nullptr));
+      &otp_, kOtpPartitionSecret2, nullptr));
   EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
-      nullptr, kDifOtpCtrlPartitionSecret2, nullptr));
+      nullptr, kOtpPartitionSecret2, nullptr));
 }
 
 TEST_F(IsDigestComputed, BadPartition) {
   bool is_computed;
   EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
-      &otp_, kDifOtpCtrlPartitionLifeCycle, &is_computed));
+      &otp_, kOtpPartitionLifeCycle, &is_computed));
 }
 
 TEST_F(IsDigestComputed, Success) {
@@ -647,18 +647,18 @@ TEST_F(IsDigestComputed, Success) {
   EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_1_REG_OFFSET, 0x98abcdef);
   EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_0_REG_OFFSET, 0xabcdef01);
   EXPECT_DIF_OK(dif_otp_ctrl_is_digest_computed(
-      &otp_, kDifOtpCtrlPartitionSecret2, &is_computed));
+      &otp_, kOtpPartitionSecret2, &is_computed));
   EXPECT_TRUE(is_computed);
 
   EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_1_REG_OFFSET, 0);
   EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_0_REG_OFFSET, 0);
   EXPECT_DIF_OK(dif_otp_ctrl_is_digest_computed(
-      &otp_, kDifOtpCtrlPartitionSecret2, &is_computed));
+      &otp_, kOtpPartitionSecret2, &is_computed));
   EXPECT_FALSE(is_computed);
 }
 
 struct DigestParams {
-  dif_otp_ctrl_partition_t partition;
+  otp_partition_t partition;
   bool has_digest;
   ptrdiff_t reg0, reg1;
 };
@@ -717,14 +717,14 @@ INSTANTIATE_TEST_SUITE_P(
 %>\
   % if part in digest_parts:
         DigestParams{
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
             true,
             OTP_CTRL_${part_name_define}_DIGEST_0_REG_OFFSET,
             OTP_CTRL_${part_name_define}_DIGEST_1_REG_OFFSET,
         }${"" if loop.last else ","}
   % else:
         DigestParams{
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
             false,
             0,
             0,
@@ -747,30 +747,30 @@ TEST_F(BlockingIoTest, Read) {
 
   std::vector<uint32_t> buf(kWords);
   EXPECT_DIF_OK(dif_otp_ctrl_read_blocking(
-      &otp_, kDifOtpCtrlPartitionOwnerSwCfg, 0x10, buf.data(), buf.size()));
+      &otp_, kOtpPartitionOwnerSwCfg, 0x10, buf.data(), buf.size()));
   EXPECT_THAT(buf, ElementsAre(1, 2, 3, 4));
 }
 
 TEST_F(BlockingIoTest, BadPartition) {
   std::vector<uint32_t> buf(kWords);
-  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kDifOtpCtrlPartitionHwCfg0, 0x10,
+  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionHwCfg0, 0x10,
                                        buf.data(), buf.size()),
             kDifError);
 }
 
 TEST_F(BlockingIoTest, Unaligned) {
   std::vector<uint32_t> buf(kWords);
-  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kDifOtpCtrlPartitionOwnerSwCfg,
+  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionOwnerSwCfg,
                                        0x11, buf.data(), buf.size()),
             kDifUnaligned);
 }
 
 TEST_F(BlockingIoTest, OutOfRange) {
   std::vector<uint32_t> buf(0x2f0);
-  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kDifOtpCtrlPartitionOwnerSwCfg,
+  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionOwnerSwCfg,
                                        0x300, buf.data(), buf.size()),
             kDifOutOfRange);
-  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kDifOtpCtrlPartitionOwnerSwCfg,
+  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionOwnerSwCfg,
                                        0x10, buf.data(), 0x330),
             kDifOutOfRange);
 }
@@ -778,9 +778,9 @@ TEST_F(BlockingIoTest, OutOfRange) {
 TEST_F(BlockingIoTest, NullArgs) {
   std::vector<uint32_t> buf(kWords);
   EXPECT_DIF_BADARG(dif_otp_ctrl_read_blocking(
-      nullptr, kDifOtpCtrlPartitionOwnerSwCfg, 0x10, buf.data(), buf.size()));
+      nullptr, kOtpPartitionOwnerSwCfg, 0x10, buf.data(), buf.size()));
   EXPECT_DIF_BADARG(dif_otp_ctrl_read_blocking(
-      &otp_, kDifOtpCtrlPartitionOwnerSwCfg, 0x10, nullptr, buf.size()));
+      &otp_, kOtpPartitionOwnerSwCfg, 0x10, nullptr, buf.size()));
 }
 
 }  // namespace

--- a/hw/ip_templates/otp_ctrl/util/dt.py
+++ b/hw/ip_templates/otp_ctrl/util/dt.py
@@ -33,15 +33,15 @@ HEADER_EXT_TEMPLATE = """
  * @return OTP partition information.
  */
 %(otp_partition_info_struct_name)s
-dt_otp_ctrl_sw_readable_partition(dt_otp_ctrl_t dt, %(otp_partition_ids_enum_name)s partition);
+dt_otp_ctrl_partition(dt_otp_ctrl_t dt, %(otp_partition_ids_enum_name)s partition);
 """
 
 SOURCE_EXT_TEMPLATE = """
 
 %(otp_partition_info_struct_name)s
-dt_otp_ctrl_sw_readable_partition(dt_otp_ctrl_t dt, %(otp_partition_ids_enum_name)s partition) {
+dt_otp_ctrl_partition(dt_otp_ctrl_t dt, %(otp_partition_ids_enum_name)s partition) {
   %(otp_partition_info_struct_name)s invalid_part = %(invalid_partition)s;
-  return TRY_GET_DT(dt, invalid_part)->sw_readable_partitions.info[partition];
+  return TRY_GET_DT(dt, invalid_part)->partitions.info[partition];
 }
 
 """
@@ -52,7 +52,16 @@ class OtpCtrlExt(Extension):
 
     OTP_PARTITION_INFO_STRUCT_START_ADDR_FIELD_NAME = Name(["start", "addr"])
     OTP_PARTITION_INFO_STRUCT_SIZE_FIELD_NAME = Name(["size"])
+    OTP_PARTITION_INFO_STRUCT_SECRET_FIELD_NAME = Name(["secret"])
+    OTP_PARTITION_INFO_STRUCT_SW_READABLE_FIELD_NAME = Name(["sw", "readable"])
+    OTP_PARTITION_INFO_STRUCT_SW_DIGEST_FIELD_NAME = Name(["sw", "digest"])
+    OTP_PARTITION_INFO_STRUCT_HW_DIGEST_FIELD_NAME = Name(["hw", "digest"])
     OTP_PARTITION_INFO_STRUCT_DIGEST_ADDR_FIELD_NAME = Name(["digest", "reg", "offset"])
+    OTP_PARTITION_INFO_STRUCT_READ_LOCKABLE_FIELD_NAME = Name(["read", "lockable"])
+    OTP_PARTITION_INFO_STRUCT_LOCK_ADDR_FIELD_NAME = Name(["lock", "reg", "offset"])
+    OTP_PARTITION_INFO_STRUCT_READ_LOCK_BIT_FIELD_NAME = Name(["read", "lock", "bit"])
+    OTP_PARTITION_INFO_STRUCT_LIFECYCLE_FIELD_NAME = Name(["is", "lifecycle"])
+    OTP_PARTITION_INFO_STRUCT_ZEROIZABLE_FIELD_NAME = Name(["zeroizable"])
     OTP_PARTITION_INFO_STRUCT_ALIGN_MASK_FIELD_NAME = Name(["align", "mask"])
     OTP_PARTITION_INFO_STRUCT_NAME = Name.from_snake_case("dt_otp_partition_info")
 
@@ -63,7 +72,7 @@ class OtpCtrlExt(Extension):
         self._otp_partition_ids_prefix = Name(["Otp", "Partition"])
         self._ipconfig = OtpCtrlIpConfig(ip_helper.ipconfig, self._otp_partition_ids_prefix)
         self._otp_partition_ids = CEnum(top_name = None, name = self._otp_partition_ids_prefix)
-        for partition in self._ipconfig.sw_readable_partitions():
+        for partition in self._ipconfig.partitions():
             self._otp_partition_ids.add_constant(partition["name"])
         self._otp_partition_ids.add_count_constant()
 
@@ -77,13 +86,53 @@ class OtpCtrlExt(Extension):
         self._otp_partition_info_struct.add_field(
             name = self.OTP_PARTITION_INFO_STRUCT_SIZE_FIELD_NAME,
             field_type = ScalarType("size_t"),
-            docstring = "Size (in bytes) of the partition, excluding the digest field",
+            docstring = "Size of the partition (bytes), excluding the digest / zeroization fields.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_SW_READABLE_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Set to true iff the partition is readable by software.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_SW_DIGEST_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Set to true iff the partition has a software digest.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_HW_DIGEST_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Set to true iff the partition has a hardware digest.",
         )
         self._otp_partition_info_struct.add_field(
             name = self.OTP_PARTITION_INFO_STRUCT_DIGEST_ADDR_FIELD_NAME,
             field_type = ScalarType("uint32_t"),
             docstring = "The OTP digest CSR (where the digest is buffered) offset for " +
             "this partition.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_READ_LOCKABLE_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Whether the partition can be locked for reading by software.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_LOCK_ADDR_FIELD_NAME,
+            field_type = ScalarType("uint32_t"),
+            docstring = "The OTP lock CSR offset for this partition.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_READ_LOCK_BIT_FIELD_NAME,
+            field_type = ScalarType("uint32_t"),
+            docstring = "The bit-offset of the read lock in the OTP lock CSR for this partition.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_ZEROIZABLE_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Whether this partition is zeroizable."
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_LIFECYCLE_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Whether this partition stores the chip life cycle state."
         )
         self._otp_partition_info_struct.add_field(
             name = self.OTP_PARTITION_INFO_STRUCT_ALIGN_MASK_FIELD_NAME,
@@ -94,7 +143,15 @@ class OtpCtrlExt(Extension):
         self._invalid_partition_info = {
             self.OTP_PARTITION_INFO_STRUCT_START_ADDR_FIELD_NAME: "0xdeadbeef",
             self.OTP_PARTITION_INFO_STRUCT_SIZE_FIELD_NAME: "0x0",
+            self.OTP_PARTITION_INFO_STRUCT_SW_READABLE_FIELD_NAME: "0",
+            self.OTP_PARTITION_INFO_STRUCT_SW_DIGEST_FIELD_NAME: "0",
+            self.OTP_PARTITION_INFO_STRUCT_HW_DIGEST_FIELD_NAME: "0",
             self.OTP_PARTITION_INFO_STRUCT_DIGEST_ADDR_FIELD_NAME: "0xdeadbeef",
+            self.OTP_PARTITION_INFO_STRUCT_READ_LOCKABLE_FIELD_NAME: "0",
+            self.OTP_PARTITION_INFO_STRUCT_LOCK_ADDR_FIELD_NAME: "0xdeadbeef",
+            self.OTP_PARTITION_INFO_STRUCT_READ_LOCK_BIT_FIELD_NAME: "0xdeadbeef",
+            self.OTP_PARTITION_INFO_STRUCT_ZEROIZABLE_FIELD_NAME: "0",
+            self.OTP_PARTITION_INFO_STRUCT_LIFECYCLE_FIELD_NAME: "0",
             self.OTP_PARTITION_INFO_STRUCT_ALIGN_MASK_FIELD_NAME: "0x0",
         }
 
@@ -104,9 +161,9 @@ class OtpCtrlExt(Extension):
             return OtpCtrlExt(ip_helper)
 
     def extend_dt_ip(self) -> tuple[Name, StructType]:
-        partition_count = len(self._ipconfig.sw_readable_partitions())
+        partition_count = len(self._ipconfig.partitions())
         st = StructType()
-        # Add field to list measurable clocks.
+        # Add field to count OTP partitions.
         st.add_field(
             name = self.OTP_PARTITION_INFO_FIELD_NAME,
             field_type = ArrayMapType(
@@ -114,26 +171,52 @@ class OtpCtrlExt(Extension):
                 index_type = ScalarType("size_t"),
                 length = str(partition_count),
             ),
-            docstring = "List of SW readable OTP partitions",
+            docstring = "List of OTP partitions",
         )
-        return Name(["sw_readable_partitions"]), st
+        return Name(["partitions"]), st
 
     def fill_dt_ip(self, m) -> Dict:
         otp_partitions = {}
-        for partition in self._ipconfig.sw_readable_partitions():
+        for partition in self._ipconfig.partitions():
             part_prefix = "OTP_CTRL_" + partition["name"].as_c_define() + "_"
             part_param_prefix = "OTP_CTRL_PARAM_" + partition["name"].as_c_define() + "_"
 
+            partition_size_expr = part_param_prefix + "SIZE"
+            if partition["sw_digest"] or partition["hw_digest"]:
+                partition_size_expr += " - " + part_param_prefix + "DIGEST_SIZE"
+            if partition["zeroizable"]:
+                partition_size_expr += " - " + part_param_prefix + "ZER_SIZE"
+            has_digest_csr = partition["sw_digest"] or partition["hw_digest"]
+            has_lock_csr = partition["read_lock"] == "CSR"
+            partition_name = partition["name"].as_c_define()
+            read_lock_bit = part_prefix + "READ_LOCK_" + partition_name + "_READ_LOCK_BIT"
             for (id, value, _) in self._otp_partition_ids.constants:
                 if id == partition["id"]:
                     otp_partitions[id.as_c_enum()] = {
+                        self.OTP_PARTITION_INFO_STRUCT_SW_READABLE_FIELD_NAME:
+                            1 if partition["sw_readable"] else 0,
+                        self.OTP_PARTITION_INFO_STRUCT_SW_DIGEST_FIELD_NAME:
+                            1 if partition["sw_digest"] else 0,
+                        self.OTP_PARTITION_INFO_STRUCT_HW_DIGEST_FIELD_NAME:
+                            1 if partition["hw_digest"] else 0,
                         self.OTP_PARTITION_INFO_STRUCT_START_ADDR_FIELD_NAME:
                             part_param_prefix + "OFFSET",
                         self.OTP_PARTITION_INFO_STRUCT_SIZE_FIELD_NAME:
-                            part_param_prefix + "SIZE - " + part_param_prefix + "DIGEST_SIZE",
+                            partition_size_expr,
                         self.OTP_PARTITION_INFO_STRUCT_DIGEST_ADDR_FIELD_NAME:
-                            part_prefix + "DIGEST_0_REG_OFFSET",
-                        self.OTP_PARTITION_INFO_STRUCT_ALIGN_MASK_FIELD_NAME: "0x3",
+                            part_prefix + "DIGEST_0_REG_OFFSET" if has_digest_csr else "0xdeadbeef",
+                        self.OTP_PARTITION_INFO_STRUCT_READ_LOCKABLE_FIELD_NAME:
+                            1 if has_lock_csr else 0,
+                        self.OTP_PARTITION_INFO_STRUCT_LOCK_ADDR_FIELD_NAME:
+                            part_prefix + "READ_LOCK_REG_OFFSET" if has_lock_csr else "0xdeadbeef",
+                        self.OTP_PARTITION_INFO_STRUCT_READ_LOCK_BIT_FIELD_NAME:
+                            read_lock_bit if has_lock_csr else "0xdeadbeef",
+                        self.OTP_PARTITION_INFO_STRUCT_ZEROIZABLE_FIELD_NAME:
+                            1 if partition["zeroizable"] else 0,
+                        self.OTP_PARTITION_INFO_STRUCT_LIFECYCLE_FIELD_NAME:
+                            1 if partition["variant"] == "LifeCycle" else 0,
+                        self.OTP_PARTITION_INFO_STRUCT_ALIGN_MASK_FIELD_NAME:
+                            "0x7" if partition["secret"] else "0x3",
                     }
 
         return {

--- a/hw/ip_templates/otp_ctrl/util/ipconfig.py
+++ b/hw/ip_templates/otp_ctrl/util/ipconfig.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 """
-This contains a class to access the clkmgr's configuration from its ipconfig
+This contains a class to access the otp_ctrl's configuration from its ipconfig
 files.
 """
 from typing import List, Dict
@@ -20,31 +20,33 @@ class OtpCtrlIpConfig:
         self._param_values = ipconfig["param_values"]
         self._id_prefix = id_prefix
 
-    def sw_readable_partitions(self) -> List[Dict]:
+    def sw_readable(self, partition) -> bool:
         """
-        Return the list of OTP partitions whose fields are readable after being locked,
-        i.e. those that have a digest (SW or HW), that are not secret and that can not
-        be read locked (or only through SW).
-        Each partition is described by its name and its identifier through the following
-        fields:
-        - `name` is the OTP partition name, e.g. `CREATOR_SW_CFG`
-        - `id` is the OTP partition identifier, e.g. `kOtpCtrlCreatorSwCfg`
+        Returns true iff a partition should be marked as software-readable.
         """
-        readable_partitions = []
-        for partition in self._param_values["otp_mmap"]["partitions"]:
-            if partition.get("read_lock") not in ["CSR", "None"]:
-                continue
-            if partition.get("secret"):
-                continue
-            if not partition.get("sw_digest") and not partition.get("hw_digest"):
-                continue
+        if partition.get("read_lock") not in ["CSR", "None"]:
+            return False
+        if partition.get("secret"):
+            return False
+        if not partition.get("sw_digest") and not partition.get("hw_digest"):
+            return False
+        return True
 
-            readable_partitions.append(partition)
-
+    def partitions(self) -> List[Dict]:
+        """
+        Return the list of all OTP partitions.
+        """
         return [
             {
                 "name": Name.from_snake_case(partition["name"]),
                 "id": self._id_prefix + Name.from_snake_case(partition["name"]),
+                "variant": partition["variant"],
+                "secret": partition["secret"],
+                "sw_readable": self.sw_readable(partition),
+                "sw_digest": partition["sw_digest"],
+                "hw_digest": partition["hw_digest"],
+                "read_lock": partition["read_lock"],
+                "zeroizable": partition["zeroizable"],
             }
-            for partition in readable_partitions
+            for partition in self._param_values["otp_mmap"]["partitions"]
         ]

--- a/hw/top_dragonfly/ip_autogen/otp_ctrl/data/dif_otp_ctrl.c.tpl.not_yet
+++ b/hw/top_dragonfly/ip_autogen/otp_ctrl/data/dif_otp_ctrl.c.tpl.not_yet
@@ -163,7 +163,7 @@ dif_result_t dif_otp_ctrl_check_trigger_is_locked(const dif_otp_ctrl_t *otp,
   return kDifOk;
 }
 
-static bool sw_read_lock_reg_offset(dif_otp_ctrl_partition_t partition,
+static bool sw_read_lock_reg_offset(otp_partition_t partition,
                                     ptrdiff_t *reg_offset,
                                     bitfield_bit32_index_t *index) {
   switch (partition) {
@@ -173,7 +173,7 @@ static bool sw_read_lock_reg_offset(dif_otp_ctrl_partition_t partition,
   part_name_define = part_name.as_c_define()
   index_line = f"*index = OTP_CTRL_{part_name_define}_READ_LOCK_{part_name_define}_READ_LOCK_BIT;"
 %>\
-    case kDifOtpCtrlPartition${part_name.as_camel_case()}:
+    case kOtpPartition${part_name.as_camel_case()}:
       *reg_offset = OTP_CTRL_${part_name_define}_READ_LOCK_REG_OFFSET;
   % if len(index_line) > 80 - 6:
       *index =
@@ -190,7 +190,7 @@ static bool sw_read_lock_reg_offset(dif_otp_ctrl_partition_t partition,
 }
 
 dif_result_t dif_otp_ctrl_lock_reading(const dif_otp_ctrl_t *otp,
-                                       dif_otp_ctrl_partition_t partition) {
+                                       otp_partition_t partition) {
   if (otp == NULL) {
     return kDifBadArg;
   }
@@ -208,7 +208,7 @@ dif_result_t dif_otp_ctrl_lock_reading(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_reading_is_locked(const dif_otp_ctrl_t *otp,
-                                            dif_otp_ctrl_partition_t partition,
+                                            otp_partition_t partition,
                                             bool *is_locked) {
   if (otp == NULL || is_locked == NULL) {
     return kDifBadArg;
@@ -372,7 +372,7 @@ static const partition_info_t kPartitions[] = {
   is_lifecycle = part["variant"] == "LifeCycle"
   is_software = part["variant"] == "Unbuffered"
 %>\
-    [kDifOtpCtrlPartition${part_name_camel}] = {
+    [kOtpPartition${part_name_camel}] = {
         .start_addr = OTP_CTRL_PARAM_${part_name_define}_OFFSET,
         .len = OTP_CTRL_PARAM_${part_name_define}_SIZE,
         .align_mask = ${"0x7" if part in secret_parts else "0x3"},
@@ -383,7 +383,7 @@ static const partition_info_t kPartitions[] = {
 };
 // clang-format on
 
-dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
+dif_result_t dif_otp_ctrl_relative_address(otp_partition_t partition,
                                            uint32_t abs_address,
                                            uint32_t *relative_address) {
   *relative_address = 0;
@@ -410,7 +410,7 @@ dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
 }
 
 dif_result_t dif_otp_ctrl_dai_read_start(const dif_otp_ctrl_t *otp,
-                                         dif_otp_ctrl_partition_t partition,
+                                         otp_partition_t partition,
                                          uint32_t address) {
   if (otp == NULL || partition >= ARRAYSIZE(kPartitions)) {
     return kDifBadArg;
@@ -462,7 +462,7 @@ dif_result_t dif_otp_ctrl_dai_read64_end(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_dai_program32(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint32_t value) {
   if (otp == NULL || partition >= ARRAYSIZE(kPartitions)) {
     return kDifBadArg;
@@ -506,7 +506,7 @@ dif_result_t dif_otp_ctrl_dai_program32(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_dai_program64(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint64_t value) {
   if (otp == NULL || partition >= ARRAYSIZE(kPartitions)) {
     return kDifBadArg;
@@ -547,7 +547,7 @@ dif_result_t dif_otp_ctrl_dai_program64(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
-                                     dif_otp_ctrl_partition_t partition,
+                                     otp_partition_t partition,
                                      uint64_t digest) {
   if (otp == NULL || partition >= ARRAYSIZE(kPartitions)) {
     return kDifBadArg;
@@ -591,7 +591,7 @@ dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
   return kDifOk;
 }
 
-static bool get_digest_regs(dif_otp_ctrl_partition_t partition, ptrdiff_t *reg0,
+static bool get_digest_regs(otp_partition_t partition, ptrdiff_t *reg0,
                             ptrdiff_t *reg1) {
   switch (partition) {
 % for part in digest_parts:
@@ -599,7 +599,7 @@ static bool get_digest_regs(dif_otp_ctrl_partition_t partition, ptrdiff_t *reg0,
   part_name = Name.from_snake_case(part["name"])
   part_name_define = part_name.as_c_define()
 %>\
-    case kDifOtpCtrlPartition${part_name.as_camel_case()}:
+    case kOtpPartition${part_name.as_camel_case()}:
       *reg0 = OTP_CTRL_${part_name_define}_DIGEST_0_REG_OFFSET;
       *reg1 = OTP_CTRL_${part_name_define}_DIGEST_1_REG_OFFSET;
       break;
@@ -612,7 +612,7 @@ static bool get_digest_regs(dif_otp_ctrl_partition_t partition, ptrdiff_t *reg0,
 }
 
 dif_result_t dif_otp_ctrl_is_digest_computed(const dif_otp_ctrl_t *otp,
-                                             dif_otp_ctrl_partition_t partition,
+                                             otp_partition_t partition,
                                              bool *is_computed) {
   if (otp == NULL || is_computed == NULL) {
     return kDifBadArg;
@@ -633,7 +633,7 @@ dif_result_t dif_otp_ctrl_is_digest_computed(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_get_digest(const dif_otp_ctrl_t *otp,
-                                     dif_otp_ctrl_partition_t partition,
+                                     otp_partition_t partition,
                                      uint64_t *digest) {
   if (otp == NULL || digest == NULL) {
     return kDifBadArg;
@@ -657,7 +657,7 @@ dif_result_t dif_otp_ctrl_get_digest(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_read_blocking(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint32_t *buf,
                                         size_t len) {
   if (otp == NULL || partition >= ARRAYSIZE(kPartitions) || buf == NULL) {

--- a/hw/top_dragonfly/ip_autogen/otp_ctrl/data/dif_otp_ctrl.h.tpl.not_yet
+++ b/hw/top_dragonfly/ip_autogen/otp_ctrl/data/dif_otp_ctrl.h.tpl.not_yet
@@ -51,9 +51,9 @@ typedef enum dif_otp_ctrl_partition {
 ${long_desc}
   %endif
    */
-  kDifOtpCtrlPartition${part_name_camel},
+  kOtpPartition${part_name_camel},
 % endfor
-} dif_otp_ctrl_partition_t;
+} otp_partition_t;
 
 /**
  * Runtime configuration for OTP.
@@ -379,7 +379,7 @@ dif_result_t dif_otp_ctrl_check_trigger_is_locked(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_lock_reading(const dif_otp_ctrl_t *otp,
-                                       dif_otp_ctrl_partition_t partition);
+                                       otp_partition_t partition);
 
 /**
  * Checks whether reads to a SW partition are locked out.
@@ -394,7 +394,7 @@ dif_result_t dif_otp_ctrl_lock_reading(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_reading_is_locked(const dif_otp_ctrl_t *otp,
-                                            dif_otp_ctrl_partition_t partition,
+                                            otp_partition_t partition,
                                             bool *is_locked);
 
 /**
@@ -420,7 +420,7 @@ dif_result_t dif_otp_ctrl_get_status(const dif_otp_ctrl_t *otp,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
+dif_result_t dif_otp_ctrl_relative_address(otp_partition_t partition,
                                            uint32_t abs_address,
                                            uint32_t *relative_address);
 
@@ -442,7 +442,7 @@ dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_dai_read_start(const dif_otp_ctrl_t *otp,
-                                         dif_otp_ctrl_partition_t partition,
+                                         otp_partition_t partition,
                                          uint32_t address);
 
 /**
@@ -496,7 +496,7 @@ dif_result_t dif_otp_ctrl_dai_read64_end(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_dai_program32(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint32_t value);
 
 /**
@@ -517,7 +517,7 @@ dif_result_t dif_otp_ctrl_dai_program32(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_dai_program64(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint64_t value);
 
 /**
@@ -540,7 +540,7 @@ dif_result_t dif_otp_ctrl_dai_program64(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
-                                     dif_otp_ctrl_partition_t partition,
+                                     otp_partition_t partition,
                                      uint64_t digest);
 
 /**
@@ -558,7 +558,7 @@ dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_is_digest_computed(const dif_otp_ctrl_t *otp,
-                                             dif_otp_ctrl_partition_t partition,
+                                             otp_partition_t partition,
                                              bool *is_computed);
 
 /**
@@ -578,7 +578,7 @@ dif_result_t dif_otp_ctrl_is_digest_computed(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_get_digest(const dif_otp_ctrl_t *otp,
-                                     dif_otp_ctrl_partition_t partition,
+                                     otp_partition_t partition,
                                      uint64_t *digest);
 
 /**
@@ -602,7 +602,7 @@ dif_result_t dif_otp_ctrl_get_digest(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_read_blocking(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint32_t *buf,
                                         size_t len);
 

--- a/hw/top_dragonfly/ip_autogen/otp_ctrl/data/dif_otp_ctrl_unittest.cc.tpl.not_yet
+++ b/hw/top_dragonfly/ip_autogen/otp_ctrl/data/dif_otp_ctrl_unittest.cc.tpl.not_yet
@@ -193,7 +193,7 @@ TEST_F(ReadLockTest, IsLocked) {
       {{OTP_CTRL_${part_name_define}_READ_LOCK_${part_name_define}_READ_LOCK_BIT,
         true}});
   EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartition${part_name_camel}, &flag));
+      &otp_, kOtpPartition${part_name_camel}, &flag));
   EXPECT_FALSE(flag);
 
   EXPECT_READ32(
@@ -201,7 +201,7 @@ TEST_F(ReadLockTest, IsLocked) {
       {{OTP_CTRL_${part_name_define}_READ_LOCK_${part_name_define}_READ_LOCK_BIT,
         false}});
   EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartition${part_name_camel}, &flag));
+      &otp_, kOtpPartition${part_name_camel}, &flag));
   EXPECT_TRUE(flag);
   % if not loop.last:
 
@@ -221,7 +221,7 @@ TEST_F(ReadLockTest, Lock) {
       {{OTP_CTRL_${part_name_define}_READ_LOCK_${part_name_define}_READ_LOCK_BIT,
         false}});
   EXPECT_DIF_OK(dif_otp_ctrl_lock_reading(
-      &otp_, kDifOtpCtrlPartition${part_name_camel}));
+      &otp_, kOtpPartition${part_name_camel}));
   % if not loop.last:
 
   %endif
@@ -235,9 +235,9 @@ TEST_F(ReadLockTest, NotLockablePartitions) {
   part_name_camel = Name.to_camel_case(part["name"])
 %>\
   EXPECT_DIF_BADARG(
-      dif_otp_ctrl_lock_reading(&otp_, kDifOtpCtrlPartition${part_name_camel}));
+      dif_otp_ctrl_lock_reading(&otp_, kOtpPartition${part_name_camel}));
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartition${part_name_camel}, &flag));
+      &otp_, kOtpPartition${part_name_camel}, &flag));
   % if not loop.last:
 
   %endif
@@ -250,15 +250,15 @@ TEST_F(ReadLockTest, NullArgs) {
 % for part in read_locked_csr_parts:
 <%
   part_name_camel = Name.to_camel_case(part["name"])
-  lock_reading_line = f"dif_otp_ctrl_lock_reading(nullptr, kDifOtpCtrlPartition{part_name_camel}));"
+  lock_reading_line = f"dif_otp_ctrl_lock_reading(nullptr, kOtpPartition{part_name_camel}));"
 %>\
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      nullptr, kDifOtpCtrlPartition${part_name_camel}, &flag));
+      nullptr, kOtpPartition${part_name_camel}, &flag));
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartition${part_name_camel}, nullptr));
+      &otp_, kOtpPartition${part_name_camel}, nullptr));
   % if len(lock_reading_line) > 80 - 6:
   EXPECT_DIF_BADARG(dif_otp_ctrl_lock_reading(
-      nullptr, kDifOtpCtrlPartition${part_name_camel}));
+      nullptr, kOtpPartition${part_name_camel}));
   % else:
   EXPECT_DIF_BADARG(
       ${lock_reading_line}
@@ -323,7 +323,7 @@ TEST_F(StatusTest, NullArgs) {
 
 struct RelativeAddressParams {
   std::string name;
-  dif_otp_ctrl_partition_t partition;
+  otp_partition_t partition;
   uint32_t abs_address;
   dif_result_t expected_result;
   uint32_t expected_relative_address;
@@ -353,14 +353,14 @@ INSTANTIATE_TEST_SUITE_P(
 %>\
         RelativeAddressParams{
             "${part_name_camel}Okay",
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
             OTP_CTRL_PARAM_${part_name_define}_OFFSET + ${step},
             kDifOk,
             ${step},
         },
         RelativeAddressParams{
             "${part_name_camel}Unaligned",
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
             OTP_CTRL_PARAM_${part_name_define}_OFFSET + 1,
             kDifUnaligned,
             0,
@@ -371,7 +371,7 @@ INSTANTIATE_TEST_SUITE_P(
   % if not loop.first:
         RelativeAddressParams{
             "${part_name_camel}OutOfRangeBeforeStart",
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
             OTP_CTRL_PARAM_${part_name_define}_OFFSET - ${step},
             kDifOutOfRange,
             0,
@@ -379,7 +379,7 @@ INSTANTIATE_TEST_SUITE_P(
   % endif
         RelativeAddressParams{
             "${part_name_camel}OutOfRangePastEnd",
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
   % if len(f"OTP_CTRL_PARAM_{part_name_define}_OFFSET + OTP_CTRL_PARAM_{part_name_define}_SIZE,") <= 80 - 12:
             OTP_CTRL_PARAM_${part_name_define}_OFFSET + OTP_CTRL_PARAM_${part_name_define}_SIZE,
   % else:
@@ -402,7 +402,7 @@ TEST_F(DaiReadTest, Read32) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_RD_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionHwCfg0,
                                             /*address=*/0x20));
 
   EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET, 0x12345678);
@@ -425,7 +425,7 @@ TEST_F(DaiReadTest, Read64) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_RD_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartition${part_name_camel},
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartition${part_name_camel},
                                             /*address=*/0x8));
 
   EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET, 0x12345678);
@@ -440,23 +440,23 @@ TEST_F(DaiReadTest, Read64) {
 }
 
 TEST_F(DaiReadTest, Unaligned) {
-  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionHwCfg0,
                                         /*address=*/0b01),
             kDifUnaligned);
-  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionSecret2,
+  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionSecret2,
                                         /*address=*/0b100),
             kDifUnaligned);
 }
 
 TEST_F(DaiReadTest, OutOfRange) {
-  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionHwCfg0,
                                         /*address=*/0x100),
             kDifOutOfRange);
 }
 
 TEST_F(DaiReadTest, NullArgs) {
   EXPECT_DIF_BADARG(dif_otp_ctrl_dai_read_start(nullptr,
-                                                kDifOtpCtrlPartitionHwCfg0,
+                                                kOtpPartitionHwCfg0,
                                                 /*address=*/0x0));
 
   uint32_t val32;
@@ -477,7 +477,7 @@ TEST_F(DaiProgramTest, Program32) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_program32(&otp_, kOtpPartitionHwCfg0,
                                            /*address=*/0x20,
                                            /*value=*/0x12345678));
 }
@@ -490,30 +490,30 @@ TEST_F(DaiProgramTest, Program64) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_program64(&otp_, kDifOtpCtrlPartitionSecret2,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_program64(&otp_, kOtpPartitionSecret2,
                                            /*address=*/0x8,
                                            /*value=*/0x1234567890abcdef));
 }
 
 TEST_F(DaiProgramTest, BadPartition) {
-  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionSecret1,
+  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kOtpPartitionSecret1,
                                        /*address=*/0x0, /*value=*/42),
             kDifError);
-  EXPECT_EQ(dif_otp_ctrl_dai_program64(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_EQ(dif_otp_ctrl_dai_program64(&otp_, kOtpPartitionHwCfg0,
                                        /*address=*/0x0, /*value=*/42),
             kDifError);
 
   // LC is never writeable.
-  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionLifeCycle,
+  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kOtpPartitionLifeCycle,
                                        /*address=*/0x0, /*value=*/42),
             kDifError);
 }
 
 TEST_F(DaiProgramTest, Unaligned) {
-  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kOtpPartitionHwCfg0,
                                        /*address=*/0b01, /*value=*/42),
             kDifUnaligned);
-  EXPECT_EQ(dif_otp_ctrl_dai_program64(&otp_, kDifOtpCtrlPartitionSecret2,
+  EXPECT_EQ(dif_otp_ctrl_dai_program64(&otp_, kOtpPartitionSecret2,
                                        /*address=*/0b100, /*value=*/42),
             kDifUnaligned);
 }
@@ -521,24 +521,24 @@ TEST_F(DaiProgramTest, Unaligned) {
 TEST_F(DaiProgramTest, OutOfRange) {
   // Check that we can't write a digest directly.
   EXPECT_EQ(dif_otp_ctrl_dai_program32(
-                &otp_, kDifOtpCtrlPartitionCreatorSwCfg,
+                &otp_, kOtpPartitionCreatorSwCfg,
                 /*address=*/OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_OFFSET,
                 /*value=*/42),
             kDifOutOfRange);
 
   // Same digest check for 64-bit.
   EXPECT_EQ(dif_otp_ctrl_dai_program64(
-                &otp_, kDifOtpCtrlPartitionSecret2,
+                &otp_, kOtpPartitionSecret2,
                 /*address=*/OTP_CTRL_PARAM_SECRET2_DIGEST_OFFSET, /*value=*/42),
             kDifOutOfRange);
 }
 
 TEST_F(DaiProgramTest, NullArgs) {
   EXPECT_DIF_BADARG(dif_otp_ctrl_dai_program32(nullptr,
-                                               kDifOtpCtrlPartitionHwCfg0,
+                                               kOtpPartitionHwCfg0,
                                                /*address=*/0x0, /*value=*/42));
   EXPECT_DIF_BADARG(dif_otp_ctrl_dai_program64(nullptr,
-                                               kDifOtpCtrlPartitionSecret0,
+                                               kOtpPartitionSecret0,
                                                /*address=*/0x0, /*value=*/42));
 }
 
@@ -551,7 +551,7 @@ TEST_F(DaiDigestTest, DigestSw) {
   part_name_define = part_name.as_c_define()
   part_name_camel = part_name.as_camel_case()
   dai_digest_line = ("EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, "
-                     + f"kDifOtpCtrlPartition{part_name_camel},")
+                     + f"kOtpPartition{part_name_camel},")
 %>\
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
                  OTP_CTRL_PARAM_${part_name.as_c_define()}_DIGEST_OFFSET);
@@ -561,14 +561,14 @@ TEST_F(DaiDigestTest, DigestSw) {
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
 
   % if len(dai_digest_line) > 80 - 2:
-<% dai_digest_line = (f"kDifOtpCtrlPartition{part_name_camel},") %>\
+<% dai_digest_line = (f"kOtpPartition{part_name_camel},") %>\
     % if len(dai_digest_line) > 80 - 40:
   EXPECT_DIF_OK(
-      dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartition${part_name_camel},
+      dif_otp_ctrl_dai_digest(&otp_, kOtpPartition${part_name_camel},
                               /*digest=*/0xabcdef0000abcdef));
     % else:
   EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_,
-                                        kDifOtpCtrlPartition${part_name_camel},
+                                        kOtpPartition${part_name_camel},
                                         /*digest=*/0xabcdef0000abcdef));
     % endif
   % else:
@@ -588,14 +588,14 @@ TEST_F(DaiDigestTest, DigestHw) {
   part_name_define = part_name.as_c_define()
   part_name_camel = part_name.as_camel_case()
   dai_digest_line = ("EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, "
-                     + f"kDifOtpCtrlPartition{part_name_camel},")
+                     + f"kOtpPartition{part_name_camel},")
 %>\
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
                  OTP_CTRL_PARAM_${part_name_define}_OFFSET);
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_DIGEST_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartition${part_name_camel},
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kOtpPartition${part_name_camel},
                                         /*digest=*/0));
   % if not loop.last:
 
@@ -604,22 +604,22 @@ TEST_F(DaiDigestTest, DigestHw) {
 }
 
 TEST_F(DaiDigestTest, BadPartition) {
-  EXPECT_EQ(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionLifeCycle,
+  EXPECT_EQ(dif_otp_ctrl_dai_digest(&otp_, kOtpPartitionLifeCycle,
                                     /*digest=*/0),
             kDifError);
 }
 
 TEST_F(DaiDigestTest, BadDigest) {
-  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(&otp_, kOtpPartitionHwCfg0,
                                             /*digest=*/0xabcdef0000abcdef));
   EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(&otp_,
-                                            kDifOtpCtrlPartitionCreatorSwCfg,
+                                            kOtpPartitionCreatorSwCfg,
                                             /*digest=*/0));
 }
 
 TEST_F(DaiDigestTest, NullArgs) {
   EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(nullptr,
-                                            kDifOtpCtrlPartitionCreatorSwCfg,
+                                            kOtpPartitionCreatorSwCfg,
                                             /*digest=*/0xabcdef0000abcdef));
 }
 
@@ -628,17 +628,17 @@ class IsDigestComputed : public OtpTest {};
 TEST_F(IsDigestComputed, NullArgs) {
   bool is_computed;
   EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
-      nullptr, kDifOtpCtrlPartitionSecret2, &is_computed));
+      nullptr, kOtpPartitionSecret2, &is_computed));
   EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
-      &otp_, kDifOtpCtrlPartitionSecret2, nullptr));
+      &otp_, kOtpPartitionSecret2, nullptr));
   EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
-      nullptr, kDifOtpCtrlPartitionSecret2, nullptr));
+      nullptr, kOtpPartitionSecret2, nullptr));
 }
 
 TEST_F(IsDigestComputed, BadPartition) {
   bool is_computed;
   EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
-      &otp_, kDifOtpCtrlPartitionLifeCycle, &is_computed));
+      &otp_, kOtpPartitionLifeCycle, &is_computed));
 }
 
 TEST_F(IsDigestComputed, Success) {
@@ -647,18 +647,18 @@ TEST_F(IsDigestComputed, Success) {
   EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_1_REG_OFFSET, 0x98abcdef);
   EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_0_REG_OFFSET, 0xabcdef01);
   EXPECT_DIF_OK(dif_otp_ctrl_is_digest_computed(
-      &otp_, kDifOtpCtrlPartitionSecret2, &is_computed));
+      &otp_, kOtpPartitionSecret2, &is_computed));
   EXPECT_TRUE(is_computed);
 
   EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_1_REG_OFFSET, 0);
   EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_0_REG_OFFSET, 0);
   EXPECT_DIF_OK(dif_otp_ctrl_is_digest_computed(
-      &otp_, kDifOtpCtrlPartitionSecret2, &is_computed));
+      &otp_, kOtpPartitionSecret2, &is_computed));
   EXPECT_FALSE(is_computed);
 }
 
 struct DigestParams {
-  dif_otp_ctrl_partition_t partition;
+  otp_partition_t partition;
   bool has_digest;
   ptrdiff_t reg0, reg1;
 };
@@ -717,14 +717,14 @@ INSTANTIATE_TEST_SUITE_P(
 %>\
   % if part in digest_parts:
         DigestParams{
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
             true,
             OTP_CTRL_${part_name_define}_DIGEST_0_REG_OFFSET,
             OTP_CTRL_${part_name_define}_DIGEST_1_REG_OFFSET,
         }${"" if loop.last else ","}
   % else:
         DigestParams{
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
             false,
             0,
             0,
@@ -747,30 +747,30 @@ TEST_F(BlockingIoTest, Read) {
 
   std::vector<uint32_t> buf(kWords);
   EXPECT_DIF_OK(dif_otp_ctrl_read_blocking(
-      &otp_, kDifOtpCtrlPartitionOwnerSwCfg, 0x10, buf.data(), buf.size()));
+      &otp_, kOtpPartitionOwnerSwCfg, 0x10, buf.data(), buf.size()));
   EXPECT_THAT(buf, ElementsAre(1, 2, 3, 4));
 }
 
 TEST_F(BlockingIoTest, BadPartition) {
   std::vector<uint32_t> buf(kWords);
-  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kDifOtpCtrlPartitionHwCfg0, 0x10,
+  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionHwCfg0, 0x10,
                                        buf.data(), buf.size()),
             kDifError);
 }
 
 TEST_F(BlockingIoTest, Unaligned) {
   std::vector<uint32_t> buf(kWords);
-  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kDifOtpCtrlPartitionOwnerSwCfg,
+  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionOwnerSwCfg,
                                        0x11, buf.data(), buf.size()),
             kDifUnaligned);
 }
 
 TEST_F(BlockingIoTest, OutOfRange) {
   std::vector<uint32_t> buf(0x2f0);
-  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kDifOtpCtrlPartitionOwnerSwCfg,
+  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionOwnerSwCfg,
                                        0x300, buf.data(), buf.size()),
             kDifOutOfRange);
-  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kDifOtpCtrlPartitionOwnerSwCfg,
+  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionOwnerSwCfg,
                                        0x10, buf.data(), 0x330),
             kDifOutOfRange);
 }
@@ -778,9 +778,9 @@ TEST_F(BlockingIoTest, OutOfRange) {
 TEST_F(BlockingIoTest, NullArgs) {
   std::vector<uint32_t> buf(kWords);
   EXPECT_DIF_BADARG(dif_otp_ctrl_read_blocking(
-      nullptr, kDifOtpCtrlPartitionOwnerSwCfg, 0x10, buf.data(), buf.size()));
+      nullptr, kOtpPartitionOwnerSwCfg, 0x10, buf.data(), buf.size()));
   EXPECT_DIF_BADARG(dif_otp_ctrl_read_blocking(
-      &otp_, kDifOtpCtrlPartitionOwnerSwCfg, 0x10, nullptr, buf.size()));
+      &otp_, kOtpPartitionOwnerSwCfg, 0x10, nullptr, buf.size()));
 }
 
 }  // namespace

--- a/hw/top_dragonfly/ip_autogen/otp_ctrl/util/dt.py
+++ b/hw/top_dragonfly/ip_autogen/otp_ctrl/util/dt.py
@@ -33,15 +33,15 @@ HEADER_EXT_TEMPLATE = """
  * @return OTP partition information.
  */
 %(otp_partition_info_struct_name)s
-dt_otp_ctrl_sw_readable_partition(dt_otp_ctrl_t dt, %(otp_partition_ids_enum_name)s partition);
+dt_otp_ctrl_partition(dt_otp_ctrl_t dt, %(otp_partition_ids_enum_name)s partition);
 """
 
 SOURCE_EXT_TEMPLATE = """
 
 %(otp_partition_info_struct_name)s
-dt_otp_ctrl_sw_readable_partition(dt_otp_ctrl_t dt, %(otp_partition_ids_enum_name)s partition) {
+dt_otp_ctrl_partition(dt_otp_ctrl_t dt, %(otp_partition_ids_enum_name)s partition) {
   %(otp_partition_info_struct_name)s invalid_part = %(invalid_partition)s;
-  return TRY_GET_DT(dt, invalid_part)->sw_readable_partitions.info[partition];
+  return TRY_GET_DT(dt, invalid_part)->partitions.info[partition];
 }
 
 """
@@ -52,7 +52,16 @@ class OtpCtrlExt(Extension):
 
     OTP_PARTITION_INFO_STRUCT_START_ADDR_FIELD_NAME = Name(["start", "addr"])
     OTP_PARTITION_INFO_STRUCT_SIZE_FIELD_NAME = Name(["size"])
+    OTP_PARTITION_INFO_STRUCT_SECRET_FIELD_NAME = Name(["secret"])
+    OTP_PARTITION_INFO_STRUCT_SW_READABLE_FIELD_NAME = Name(["sw", "readable"])
+    OTP_PARTITION_INFO_STRUCT_SW_DIGEST_FIELD_NAME = Name(["sw", "digest"])
+    OTP_PARTITION_INFO_STRUCT_HW_DIGEST_FIELD_NAME = Name(["hw", "digest"])
     OTP_PARTITION_INFO_STRUCT_DIGEST_ADDR_FIELD_NAME = Name(["digest", "reg", "offset"])
+    OTP_PARTITION_INFO_STRUCT_READ_LOCKABLE_FIELD_NAME = Name(["read", "lockable"])
+    OTP_PARTITION_INFO_STRUCT_LOCK_ADDR_FIELD_NAME = Name(["lock", "reg", "offset"])
+    OTP_PARTITION_INFO_STRUCT_READ_LOCK_BIT_FIELD_NAME = Name(["read", "lock", "bit"])
+    OTP_PARTITION_INFO_STRUCT_LIFECYCLE_FIELD_NAME = Name(["is", "lifecycle"])
+    OTP_PARTITION_INFO_STRUCT_ZEROIZABLE_FIELD_NAME = Name(["zeroizable"])
     OTP_PARTITION_INFO_STRUCT_ALIGN_MASK_FIELD_NAME = Name(["align", "mask"])
     OTP_PARTITION_INFO_STRUCT_NAME = Name.from_snake_case("dt_otp_partition_info")
 
@@ -63,7 +72,7 @@ class OtpCtrlExt(Extension):
         self._otp_partition_ids_prefix = Name(["Otp", "Partition"])
         self._ipconfig = OtpCtrlIpConfig(ip_helper.ipconfig, self._otp_partition_ids_prefix)
         self._otp_partition_ids = CEnum(top_name = None, name = self._otp_partition_ids_prefix)
-        for partition in self._ipconfig.sw_readable_partitions():
+        for partition in self._ipconfig.partitions():
             self._otp_partition_ids.add_constant(partition["name"])
         self._otp_partition_ids.add_count_constant()
 
@@ -77,13 +86,53 @@ class OtpCtrlExt(Extension):
         self._otp_partition_info_struct.add_field(
             name = self.OTP_PARTITION_INFO_STRUCT_SIZE_FIELD_NAME,
             field_type = ScalarType("size_t"),
-            docstring = "Size (in bytes) of the partition, excluding the digest field",
+            docstring = "Size of the partition (bytes), excluding the digest / zeroization fields.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_SW_READABLE_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Set to true iff the partition is readable by software.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_SW_DIGEST_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Set to true iff the partition has a software digest.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_HW_DIGEST_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Set to true iff the partition has a hardware digest.",
         )
         self._otp_partition_info_struct.add_field(
             name = self.OTP_PARTITION_INFO_STRUCT_DIGEST_ADDR_FIELD_NAME,
             field_type = ScalarType("uint32_t"),
             docstring = "The OTP digest CSR (where the digest is buffered) offset for " +
             "this partition.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_READ_LOCKABLE_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Whether the partition can be locked for reading by software.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_LOCK_ADDR_FIELD_NAME,
+            field_type = ScalarType("uint32_t"),
+            docstring = "The OTP lock CSR offset for this partition.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_READ_LOCK_BIT_FIELD_NAME,
+            field_type = ScalarType("uint32_t"),
+            docstring = "The bit-offset of the read lock in the OTP lock CSR for this partition.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_ZEROIZABLE_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Whether this partition is zeroizable."
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_LIFECYCLE_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Whether this partition stores the chip life cycle state."
         )
         self._otp_partition_info_struct.add_field(
             name = self.OTP_PARTITION_INFO_STRUCT_ALIGN_MASK_FIELD_NAME,
@@ -94,7 +143,15 @@ class OtpCtrlExt(Extension):
         self._invalid_partition_info = {
             self.OTP_PARTITION_INFO_STRUCT_START_ADDR_FIELD_NAME: "0xdeadbeef",
             self.OTP_PARTITION_INFO_STRUCT_SIZE_FIELD_NAME: "0x0",
+            self.OTP_PARTITION_INFO_STRUCT_SW_READABLE_FIELD_NAME: "0",
+            self.OTP_PARTITION_INFO_STRUCT_SW_DIGEST_FIELD_NAME: "0",
+            self.OTP_PARTITION_INFO_STRUCT_HW_DIGEST_FIELD_NAME: "0",
             self.OTP_PARTITION_INFO_STRUCT_DIGEST_ADDR_FIELD_NAME: "0xdeadbeef",
+            self.OTP_PARTITION_INFO_STRUCT_READ_LOCKABLE_FIELD_NAME: "0",
+            self.OTP_PARTITION_INFO_STRUCT_LOCK_ADDR_FIELD_NAME: "0xdeadbeef",
+            self.OTP_PARTITION_INFO_STRUCT_READ_LOCK_BIT_FIELD_NAME: "0xdeadbeef",
+            self.OTP_PARTITION_INFO_STRUCT_ZEROIZABLE_FIELD_NAME: "0",
+            self.OTP_PARTITION_INFO_STRUCT_LIFECYCLE_FIELD_NAME: "0",
             self.OTP_PARTITION_INFO_STRUCT_ALIGN_MASK_FIELD_NAME: "0x0",
         }
 
@@ -104,9 +161,9 @@ class OtpCtrlExt(Extension):
             return OtpCtrlExt(ip_helper)
 
     def extend_dt_ip(self) -> tuple[Name, StructType]:
-        partition_count = len(self._ipconfig.sw_readable_partitions())
+        partition_count = len(self._ipconfig.partitions())
         st = StructType()
-        # Add field to list measurable clocks.
+        # Add field to count OTP partitions.
         st.add_field(
             name = self.OTP_PARTITION_INFO_FIELD_NAME,
             field_type = ArrayMapType(
@@ -114,26 +171,52 @@ class OtpCtrlExt(Extension):
                 index_type = ScalarType("size_t"),
                 length = str(partition_count),
             ),
-            docstring = "List of SW readable OTP partitions",
+            docstring = "List of OTP partitions",
         )
-        return Name(["sw_readable_partitions"]), st
+        return Name(["partitions"]), st
 
     def fill_dt_ip(self, m) -> Dict:
         otp_partitions = {}
-        for partition in self._ipconfig.sw_readable_partitions():
+        for partition in self._ipconfig.partitions():
             part_prefix = "OTP_CTRL_" + partition["name"].as_c_define() + "_"
             part_param_prefix = "OTP_CTRL_PARAM_" + partition["name"].as_c_define() + "_"
 
+            partition_size_expr = part_param_prefix + "SIZE"
+            if partition["sw_digest"] or partition["hw_digest"]:
+                partition_size_expr += " - " + part_param_prefix + "DIGEST_SIZE"
+            if partition["zeroizable"]:
+                partition_size_expr += " - " + part_param_prefix + "ZER_SIZE"
+            has_digest_csr = partition["sw_digest"] or partition["hw_digest"]
+            has_lock_csr = partition["read_lock"] == "CSR"
+            partition_name = partition["name"].as_c_define()
+            read_lock_bit = part_prefix + "READ_LOCK_" + partition_name + "_READ_LOCK_BIT"
             for (id, value, _) in self._otp_partition_ids.constants:
                 if id == partition["id"]:
                     otp_partitions[id.as_c_enum()] = {
+                        self.OTP_PARTITION_INFO_STRUCT_SW_READABLE_FIELD_NAME:
+                            1 if partition["sw_readable"] else 0,
+                        self.OTP_PARTITION_INFO_STRUCT_SW_DIGEST_FIELD_NAME:
+                            1 if partition["sw_digest"] else 0,
+                        self.OTP_PARTITION_INFO_STRUCT_HW_DIGEST_FIELD_NAME:
+                            1 if partition["hw_digest"] else 0,
                         self.OTP_PARTITION_INFO_STRUCT_START_ADDR_FIELD_NAME:
                             part_param_prefix + "OFFSET",
                         self.OTP_PARTITION_INFO_STRUCT_SIZE_FIELD_NAME:
-                            part_param_prefix + "SIZE - " + part_param_prefix + "DIGEST_SIZE",
+                            partition_size_expr,
                         self.OTP_PARTITION_INFO_STRUCT_DIGEST_ADDR_FIELD_NAME:
-                            part_prefix + "DIGEST_0_REG_OFFSET",
-                        self.OTP_PARTITION_INFO_STRUCT_ALIGN_MASK_FIELD_NAME: "0x3",
+                            part_prefix + "DIGEST_0_REG_OFFSET" if has_digest_csr else "0xdeadbeef",
+                        self.OTP_PARTITION_INFO_STRUCT_READ_LOCKABLE_FIELD_NAME:
+                            1 if has_lock_csr else 0,
+                        self.OTP_PARTITION_INFO_STRUCT_LOCK_ADDR_FIELD_NAME:
+                            part_prefix + "READ_LOCK_REG_OFFSET" if has_lock_csr else "0xdeadbeef",
+                        self.OTP_PARTITION_INFO_STRUCT_READ_LOCK_BIT_FIELD_NAME:
+                            read_lock_bit if has_lock_csr else "0xdeadbeef",
+                        self.OTP_PARTITION_INFO_STRUCT_ZEROIZABLE_FIELD_NAME:
+                            1 if partition["zeroizable"] else 0,
+                        self.OTP_PARTITION_INFO_STRUCT_LIFECYCLE_FIELD_NAME:
+                            1 if partition["variant"] == "LifeCycle" else 0,
+                        self.OTP_PARTITION_INFO_STRUCT_ALIGN_MASK_FIELD_NAME:
+                            "0x7" if partition["secret"] else "0x3",
                     }
 
         return {

--- a/hw/top_dragonfly/ip_autogen/otp_ctrl/util/ipconfig.py
+++ b/hw/top_dragonfly/ip_autogen/otp_ctrl/util/ipconfig.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 """
-This contains a class to access the clkmgr's configuration from its ipconfig
+This contains a class to access the otp_ctrl's configuration from its ipconfig
 files.
 """
 from typing import List, Dict
@@ -20,31 +20,33 @@ class OtpCtrlIpConfig:
         self._param_values = ipconfig["param_values"]
         self._id_prefix = id_prefix
 
-    def sw_readable_partitions(self) -> List[Dict]:
+    def sw_readable(self, partition) -> bool:
         """
-        Return the list of OTP partitions whose fields are readable after being locked,
-        i.e. those that have a digest (SW or HW), that are not secret and that can not
-        be read locked (or only through SW).
-        Each partition is described by its name and its identifier through the following
-        fields:
-        - `name` is the OTP partition name, e.g. `CREATOR_SW_CFG`
-        - `id` is the OTP partition identifier, e.g. `kOtpCtrlCreatorSwCfg`
+        Returns true iff a partition should be marked as software-readable.
         """
-        readable_partitions = []
-        for partition in self._param_values["otp_mmap"]["partitions"]:
-            if partition.get("read_lock") not in ["CSR", "None"]:
-                continue
-            if partition.get("secret"):
-                continue
-            if not partition.get("sw_digest") and not partition.get("hw_digest"):
-                continue
+        if partition.get("read_lock") not in ["CSR", "None"]:
+            return False
+        if partition.get("secret"):
+            return False
+        if not partition.get("sw_digest") and not partition.get("hw_digest"):
+            return False
+        return True
 
-            readable_partitions.append(partition)
-
+    def partitions(self) -> List[Dict]:
+        """
+        Return the list of all OTP partitions.
+        """
         return [
             {
                 "name": Name.from_snake_case(partition["name"]),
                 "id": self._id_prefix + Name.from_snake_case(partition["name"]),
+                "variant": partition["variant"],
+                "secret": partition["secret"],
+                "sw_readable": self.sw_readable(partition),
+                "sw_digest": partition["sw_digest"],
+                "hw_digest": partition["hw_digest"],
+                "read_lock": partition["read_lock"],
+                "zeroizable": partition["zeroizable"],
             }
-            for partition in readable_partitions
+            for partition in self._param_values["otp_mmap"]["partitions"]
         ]

--- a/hw/top_egret/ip_autogen/otp_ctrl/data/dif_otp_ctrl.c.tpl.not_yet
+++ b/hw/top_egret/ip_autogen/otp_ctrl/data/dif_otp_ctrl.c.tpl.not_yet
@@ -163,7 +163,7 @@ dif_result_t dif_otp_ctrl_check_trigger_is_locked(const dif_otp_ctrl_t *otp,
   return kDifOk;
 }
 
-static bool sw_read_lock_reg_offset(dif_otp_ctrl_partition_t partition,
+static bool sw_read_lock_reg_offset(otp_partition_t partition,
                                     ptrdiff_t *reg_offset,
                                     bitfield_bit32_index_t *index) {
   switch (partition) {
@@ -173,7 +173,7 @@ static bool sw_read_lock_reg_offset(dif_otp_ctrl_partition_t partition,
   part_name_define = part_name.as_c_define()
   index_line = f"*index = OTP_CTRL_{part_name_define}_READ_LOCK_{part_name_define}_READ_LOCK_BIT;"
 %>\
-    case kDifOtpCtrlPartition${part_name.as_camel_case()}:
+    case kOtpPartition${part_name.as_camel_case()}:
       *reg_offset = OTP_CTRL_${part_name_define}_READ_LOCK_REG_OFFSET;
   % if len(index_line) > 80 - 6:
       *index =
@@ -190,7 +190,7 @@ static bool sw_read_lock_reg_offset(dif_otp_ctrl_partition_t partition,
 }
 
 dif_result_t dif_otp_ctrl_lock_reading(const dif_otp_ctrl_t *otp,
-                                       dif_otp_ctrl_partition_t partition) {
+                                       otp_partition_t partition) {
   if (otp == NULL) {
     return kDifBadArg;
   }
@@ -208,7 +208,7 @@ dif_result_t dif_otp_ctrl_lock_reading(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_reading_is_locked(const dif_otp_ctrl_t *otp,
-                                            dif_otp_ctrl_partition_t partition,
+                                            otp_partition_t partition,
                                             bool *is_locked) {
   if (otp == NULL || is_locked == NULL) {
     return kDifBadArg;
@@ -372,7 +372,7 @@ static const partition_info_t kPartitions[] = {
   is_lifecycle = part["variant"] == "LifeCycle"
   is_software = part["variant"] == "Unbuffered"
 %>\
-    [kDifOtpCtrlPartition${part_name_camel}] = {
+    [kOtpPartition${part_name_camel}] = {
         .start_addr = OTP_CTRL_PARAM_${part_name_define}_OFFSET,
         .len = OTP_CTRL_PARAM_${part_name_define}_SIZE,
         .align_mask = ${"0x7" if part in secret_parts else "0x3"},
@@ -383,7 +383,7 @@ static const partition_info_t kPartitions[] = {
 };
 // clang-format on
 
-dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
+dif_result_t dif_otp_ctrl_relative_address(otp_partition_t partition,
                                            uint32_t abs_address,
                                            uint32_t *relative_address) {
   *relative_address = 0;
@@ -410,7 +410,7 @@ dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
 }
 
 dif_result_t dif_otp_ctrl_dai_read_start(const dif_otp_ctrl_t *otp,
-                                         dif_otp_ctrl_partition_t partition,
+                                         otp_partition_t partition,
                                          uint32_t address) {
   if (otp == NULL || partition >= ARRAYSIZE(kPartitions)) {
     return kDifBadArg;
@@ -462,7 +462,7 @@ dif_result_t dif_otp_ctrl_dai_read64_end(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_dai_program32(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint32_t value) {
   if (otp == NULL || partition >= ARRAYSIZE(kPartitions)) {
     return kDifBadArg;
@@ -506,7 +506,7 @@ dif_result_t dif_otp_ctrl_dai_program32(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_dai_program64(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint64_t value) {
   if (otp == NULL || partition >= ARRAYSIZE(kPartitions)) {
     return kDifBadArg;
@@ -547,7 +547,7 @@ dif_result_t dif_otp_ctrl_dai_program64(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
-                                     dif_otp_ctrl_partition_t partition,
+                                     otp_partition_t partition,
                                      uint64_t digest) {
   if (otp == NULL || partition >= ARRAYSIZE(kPartitions)) {
     return kDifBadArg;
@@ -591,7 +591,7 @@ dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
   return kDifOk;
 }
 
-static bool get_digest_regs(dif_otp_ctrl_partition_t partition, ptrdiff_t *reg0,
+static bool get_digest_regs(otp_partition_t partition, ptrdiff_t *reg0,
                             ptrdiff_t *reg1) {
   switch (partition) {
 % for part in digest_parts:
@@ -599,7 +599,7 @@ static bool get_digest_regs(dif_otp_ctrl_partition_t partition, ptrdiff_t *reg0,
   part_name = Name.from_snake_case(part["name"])
   part_name_define = part_name.as_c_define()
 %>\
-    case kDifOtpCtrlPartition${part_name.as_camel_case()}:
+    case kOtpPartition${part_name.as_camel_case()}:
       *reg0 = OTP_CTRL_${part_name_define}_DIGEST_0_REG_OFFSET;
       *reg1 = OTP_CTRL_${part_name_define}_DIGEST_1_REG_OFFSET;
       break;
@@ -612,7 +612,7 @@ static bool get_digest_regs(dif_otp_ctrl_partition_t partition, ptrdiff_t *reg0,
 }
 
 dif_result_t dif_otp_ctrl_is_digest_computed(const dif_otp_ctrl_t *otp,
-                                             dif_otp_ctrl_partition_t partition,
+                                             otp_partition_t partition,
                                              bool *is_computed) {
   if (otp == NULL || is_computed == NULL) {
     return kDifBadArg;
@@ -633,7 +633,7 @@ dif_result_t dif_otp_ctrl_is_digest_computed(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_get_digest(const dif_otp_ctrl_t *otp,
-                                     dif_otp_ctrl_partition_t partition,
+                                     otp_partition_t partition,
                                      uint64_t *digest) {
   if (otp == NULL || digest == NULL) {
     return kDifBadArg;
@@ -657,7 +657,7 @@ dif_result_t dif_otp_ctrl_get_digest(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_read_blocking(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint32_t *buf,
                                         size_t len) {
   if (otp == NULL || partition >= ARRAYSIZE(kPartitions) || buf == NULL) {

--- a/hw/top_egret/ip_autogen/otp_ctrl/data/dif_otp_ctrl.h.tpl.not_yet
+++ b/hw/top_egret/ip_autogen/otp_ctrl/data/dif_otp_ctrl.h.tpl.not_yet
@@ -51,9 +51,9 @@ typedef enum dif_otp_ctrl_partition {
 ${long_desc}
   %endif
    */
-  kDifOtpCtrlPartition${part_name_camel},
+  kOtpPartition${part_name_camel},
 % endfor
-} dif_otp_ctrl_partition_t;
+} otp_partition_t;
 
 /**
  * Runtime configuration for OTP.
@@ -379,7 +379,7 @@ dif_result_t dif_otp_ctrl_check_trigger_is_locked(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_lock_reading(const dif_otp_ctrl_t *otp,
-                                       dif_otp_ctrl_partition_t partition);
+                                       otp_partition_t partition);
 
 /**
  * Checks whether reads to a SW partition are locked out.
@@ -394,7 +394,7 @@ dif_result_t dif_otp_ctrl_lock_reading(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_reading_is_locked(const dif_otp_ctrl_t *otp,
-                                            dif_otp_ctrl_partition_t partition,
+                                            otp_partition_t partition,
                                             bool *is_locked);
 
 /**
@@ -420,7 +420,7 @@ dif_result_t dif_otp_ctrl_get_status(const dif_otp_ctrl_t *otp,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
+dif_result_t dif_otp_ctrl_relative_address(otp_partition_t partition,
                                            uint32_t abs_address,
                                            uint32_t *relative_address);
 
@@ -442,7 +442,7 @@ dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_dai_read_start(const dif_otp_ctrl_t *otp,
-                                         dif_otp_ctrl_partition_t partition,
+                                         otp_partition_t partition,
                                          uint32_t address);
 
 /**
@@ -496,7 +496,7 @@ dif_result_t dif_otp_ctrl_dai_read64_end(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_dai_program32(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint32_t value);
 
 /**
@@ -517,7 +517,7 @@ dif_result_t dif_otp_ctrl_dai_program32(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_dai_program64(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint64_t value);
 
 /**
@@ -540,7 +540,7 @@ dif_result_t dif_otp_ctrl_dai_program64(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
-                                     dif_otp_ctrl_partition_t partition,
+                                     otp_partition_t partition,
                                      uint64_t digest);
 
 /**
@@ -558,7 +558,7 @@ dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_is_digest_computed(const dif_otp_ctrl_t *otp,
-                                             dif_otp_ctrl_partition_t partition,
+                                             otp_partition_t partition,
                                              bool *is_computed);
 
 /**
@@ -578,7 +578,7 @@ dif_result_t dif_otp_ctrl_is_digest_computed(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_get_digest(const dif_otp_ctrl_t *otp,
-                                     dif_otp_ctrl_partition_t partition,
+                                     otp_partition_t partition,
                                      uint64_t *digest);
 
 /**
@@ -602,7 +602,7 @@ dif_result_t dif_otp_ctrl_get_digest(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_read_blocking(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint32_t *buf,
                                         size_t len);
 

--- a/hw/top_egret/ip_autogen/otp_ctrl/data/dif_otp_ctrl_unittest.cc.tpl.not_yet
+++ b/hw/top_egret/ip_autogen/otp_ctrl/data/dif_otp_ctrl_unittest.cc.tpl.not_yet
@@ -193,7 +193,7 @@ TEST_F(ReadLockTest, IsLocked) {
       {{OTP_CTRL_${part_name_define}_READ_LOCK_${part_name_define}_READ_LOCK_BIT,
         true}});
   EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartition${part_name_camel}, &flag));
+      &otp_, kOtpPartition${part_name_camel}, &flag));
   EXPECT_FALSE(flag);
 
   EXPECT_READ32(
@@ -201,7 +201,7 @@ TEST_F(ReadLockTest, IsLocked) {
       {{OTP_CTRL_${part_name_define}_READ_LOCK_${part_name_define}_READ_LOCK_BIT,
         false}});
   EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartition${part_name_camel}, &flag));
+      &otp_, kOtpPartition${part_name_camel}, &flag));
   EXPECT_TRUE(flag);
   % if not loop.last:
 
@@ -221,7 +221,7 @@ TEST_F(ReadLockTest, Lock) {
       {{OTP_CTRL_${part_name_define}_READ_LOCK_${part_name_define}_READ_LOCK_BIT,
         false}});
   EXPECT_DIF_OK(dif_otp_ctrl_lock_reading(
-      &otp_, kDifOtpCtrlPartition${part_name_camel}));
+      &otp_, kOtpPartition${part_name_camel}));
   % if not loop.last:
 
   %endif
@@ -235,9 +235,9 @@ TEST_F(ReadLockTest, NotLockablePartitions) {
   part_name_camel = Name.to_camel_case(part["name"])
 %>\
   EXPECT_DIF_BADARG(
-      dif_otp_ctrl_lock_reading(&otp_, kDifOtpCtrlPartition${part_name_camel}));
+      dif_otp_ctrl_lock_reading(&otp_, kOtpPartition${part_name_camel}));
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartition${part_name_camel}, &flag));
+      &otp_, kOtpPartition${part_name_camel}, &flag));
   % if not loop.last:
 
   %endif
@@ -250,15 +250,15 @@ TEST_F(ReadLockTest, NullArgs) {
 % for part in read_locked_csr_parts:
 <%
   part_name_camel = Name.to_camel_case(part["name"])
-  lock_reading_line = f"dif_otp_ctrl_lock_reading(nullptr, kDifOtpCtrlPartition{part_name_camel}));"
+  lock_reading_line = f"dif_otp_ctrl_lock_reading(nullptr, kOtpPartition{part_name_camel}));"
 %>\
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      nullptr, kDifOtpCtrlPartition${part_name_camel}, &flag));
+      nullptr, kOtpPartition${part_name_camel}, &flag));
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartition${part_name_camel}, nullptr));
+      &otp_, kOtpPartition${part_name_camel}, nullptr));
   % if len(lock_reading_line) > 80 - 6:
   EXPECT_DIF_BADARG(dif_otp_ctrl_lock_reading(
-      nullptr, kDifOtpCtrlPartition${part_name_camel}));
+      nullptr, kOtpPartition${part_name_camel}));
   % else:
   EXPECT_DIF_BADARG(
       ${lock_reading_line}
@@ -323,7 +323,7 @@ TEST_F(StatusTest, NullArgs) {
 
 struct RelativeAddressParams {
   std::string name;
-  dif_otp_ctrl_partition_t partition;
+  otp_partition_t partition;
   uint32_t abs_address;
   dif_result_t expected_result;
   uint32_t expected_relative_address;
@@ -353,14 +353,14 @@ INSTANTIATE_TEST_SUITE_P(
 %>\
         RelativeAddressParams{
             "${part_name_camel}Okay",
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
             OTP_CTRL_PARAM_${part_name_define}_OFFSET + ${step},
             kDifOk,
             ${step},
         },
         RelativeAddressParams{
             "${part_name_camel}Unaligned",
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
             OTP_CTRL_PARAM_${part_name_define}_OFFSET + 1,
             kDifUnaligned,
             0,
@@ -371,7 +371,7 @@ INSTANTIATE_TEST_SUITE_P(
   % if not loop.first:
         RelativeAddressParams{
             "${part_name_camel}OutOfRangeBeforeStart",
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
             OTP_CTRL_PARAM_${part_name_define}_OFFSET - ${step},
             kDifOutOfRange,
             0,
@@ -379,7 +379,7 @@ INSTANTIATE_TEST_SUITE_P(
   % endif
         RelativeAddressParams{
             "${part_name_camel}OutOfRangePastEnd",
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
   % if len(f"OTP_CTRL_PARAM_{part_name_define}_OFFSET + OTP_CTRL_PARAM_{part_name_define}_SIZE,") <= 80 - 12:
             OTP_CTRL_PARAM_${part_name_define}_OFFSET + OTP_CTRL_PARAM_${part_name_define}_SIZE,
   % else:
@@ -402,7 +402,7 @@ TEST_F(DaiReadTest, Read32) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_RD_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionHwCfg0,
                                             /*address=*/0x20));
 
   EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET, 0x12345678);
@@ -425,7 +425,7 @@ TEST_F(DaiReadTest, Read64) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_RD_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartition${part_name_camel},
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartition${part_name_camel},
                                             /*address=*/0x8));
 
   EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET, 0x12345678);
@@ -440,23 +440,23 @@ TEST_F(DaiReadTest, Read64) {
 }
 
 TEST_F(DaiReadTest, Unaligned) {
-  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionHwCfg0,
                                         /*address=*/0b01),
             kDifUnaligned);
-  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionSecret2,
+  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionSecret2,
                                         /*address=*/0b100),
             kDifUnaligned);
 }
 
 TEST_F(DaiReadTest, OutOfRange) {
-  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionHwCfg0,
                                         /*address=*/0x100),
             kDifOutOfRange);
 }
 
 TEST_F(DaiReadTest, NullArgs) {
   EXPECT_DIF_BADARG(dif_otp_ctrl_dai_read_start(nullptr,
-                                                kDifOtpCtrlPartitionHwCfg0,
+                                                kOtpPartitionHwCfg0,
                                                 /*address=*/0x0));
 
   uint32_t val32;
@@ -477,7 +477,7 @@ TEST_F(DaiProgramTest, Program32) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_program32(&otp_, kOtpPartitionHwCfg0,
                                            /*address=*/0x20,
                                            /*value=*/0x12345678));
 }
@@ -490,30 +490,30 @@ TEST_F(DaiProgramTest, Program64) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_program64(&otp_, kDifOtpCtrlPartitionSecret2,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_program64(&otp_, kOtpPartitionSecret2,
                                            /*address=*/0x8,
                                            /*value=*/0x1234567890abcdef));
 }
 
 TEST_F(DaiProgramTest, BadPartition) {
-  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionSecret1,
+  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kOtpPartitionSecret1,
                                        /*address=*/0x0, /*value=*/42),
             kDifError);
-  EXPECT_EQ(dif_otp_ctrl_dai_program64(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_EQ(dif_otp_ctrl_dai_program64(&otp_, kOtpPartitionHwCfg0,
                                        /*address=*/0x0, /*value=*/42),
             kDifError);
 
   // LC is never writeable.
-  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionLifeCycle,
+  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kOtpPartitionLifeCycle,
                                        /*address=*/0x0, /*value=*/42),
             kDifError);
 }
 
 TEST_F(DaiProgramTest, Unaligned) {
-  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kOtpPartitionHwCfg0,
                                        /*address=*/0b01, /*value=*/42),
             kDifUnaligned);
-  EXPECT_EQ(dif_otp_ctrl_dai_program64(&otp_, kDifOtpCtrlPartitionSecret2,
+  EXPECT_EQ(dif_otp_ctrl_dai_program64(&otp_, kOtpPartitionSecret2,
                                        /*address=*/0b100, /*value=*/42),
             kDifUnaligned);
 }
@@ -521,24 +521,24 @@ TEST_F(DaiProgramTest, Unaligned) {
 TEST_F(DaiProgramTest, OutOfRange) {
   // Check that we can't write a digest directly.
   EXPECT_EQ(dif_otp_ctrl_dai_program32(
-                &otp_, kDifOtpCtrlPartitionCreatorSwCfg,
+                &otp_, kOtpPartitionCreatorSwCfg,
                 /*address=*/OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_OFFSET,
                 /*value=*/42),
             kDifOutOfRange);
 
   // Same digest check for 64-bit.
   EXPECT_EQ(dif_otp_ctrl_dai_program64(
-                &otp_, kDifOtpCtrlPartitionSecret2,
+                &otp_, kOtpPartitionSecret2,
                 /*address=*/OTP_CTRL_PARAM_SECRET2_DIGEST_OFFSET, /*value=*/42),
             kDifOutOfRange);
 }
 
 TEST_F(DaiProgramTest, NullArgs) {
   EXPECT_DIF_BADARG(dif_otp_ctrl_dai_program32(nullptr,
-                                               kDifOtpCtrlPartitionHwCfg0,
+                                               kOtpPartitionHwCfg0,
                                                /*address=*/0x0, /*value=*/42));
   EXPECT_DIF_BADARG(dif_otp_ctrl_dai_program64(nullptr,
-                                               kDifOtpCtrlPartitionSecret0,
+                                               kOtpPartitionSecret0,
                                                /*address=*/0x0, /*value=*/42));
 }
 
@@ -551,7 +551,7 @@ TEST_F(DaiDigestTest, DigestSw) {
   part_name_define = part_name.as_c_define()
   part_name_camel = part_name.as_camel_case()
   dai_digest_line = ("EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, "
-                     + f"kDifOtpCtrlPartition{part_name_camel},")
+                     + f"kOtpPartition{part_name_camel},")
 %>\
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
                  OTP_CTRL_PARAM_${part_name.as_c_define()}_DIGEST_OFFSET);
@@ -561,14 +561,14 @@ TEST_F(DaiDigestTest, DigestSw) {
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
 
   % if len(dai_digest_line) > 80 - 2:
-<% dai_digest_line = (f"kDifOtpCtrlPartition{part_name_camel},") %>\
+<% dai_digest_line = (f"kOtpPartition{part_name_camel},") %>\
     % if len(dai_digest_line) > 80 - 40:
   EXPECT_DIF_OK(
-      dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartition${part_name_camel},
+      dif_otp_ctrl_dai_digest(&otp_, kOtpPartition${part_name_camel},
                               /*digest=*/0xabcdef0000abcdef));
     % else:
   EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_,
-                                        kDifOtpCtrlPartition${part_name_camel},
+                                        kOtpPartition${part_name_camel},
                                         /*digest=*/0xabcdef0000abcdef));
     % endif
   % else:
@@ -588,14 +588,14 @@ TEST_F(DaiDigestTest, DigestHw) {
   part_name_define = part_name.as_c_define()
   part_name_camel = part_name.as_camel_case()
   dai_digest_line = ("EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, "
-                     + f"kDifOtpCtrlPartition{part_name_camel},")
+                     + f"kOtpPartition{part_name_camel},")
 %>\
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
                  OTP_CTRL_PARAM_${part_name_define}_OFFSET);
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_DIGEST_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartition${part_name_camel},
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kOtpPartition${part_name_camel},
                                         /*digest=*/0));
   % if not loop.last:
 
@@ -604,22 +604,22 @@ TEST_F(DaiDigestTest, DigestHw) {
 }
 
 TEST_F(DaiDigestTest, BadPartition) {
-  EXPECT_EQ(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionLifeCycle,
+  EXPECT_EQ(dif_otp_ctrl_dai_digest(&otp_, kOtpPartitionLifeCycle,
                                     /*digest=*/0),
             kDifError);
 }
 
 TEST_F(DaiDigestTest, BadDigest) {
-  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(&otp_, kOtpPartitionHwCfg0,
                                             /*digest=*/0xabcdef0000abcdef));
   EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(&otp_,
-                                            kDifOtpCtrlPartitionCreatorSwCfg,
+                                            kOtpPartitionCreatorSwCfg,
                                             /*digest=*/0));
 }
 
 TEST_F(DaiDigestTest, NullArgs) {
   EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(nullptr,
-                                            kDifOtpCtrlPartitionCreatorSwCfg,
+                                            kOtpPartitionCreatorSwCfg,
                                             /*digest=*/0xabcdef0000abcdef));
 }
 
@@ -628,17 +628,17 @@ class IsDigestComputed : public OtpTest {};
 TEST_F(IsDigestComputed, NullArgs) {
   bool is_computed;
   EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
-      nullptr, kDifOtpCtrlPartitionSecret2, &is_computed));
+      nullptr, kOtpPartitionSecret2, &is_computed));
   EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
-      &otp_, kDifOtpCtrlPartitionSecret2, nullptr));
+      &otp_, kOtpPartitionSecret2, nullptr));
   EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
-      nullptr, kDifOtpCtrlPartitionSecret2, nullptr));
+      nullptr, kOtpPartitionSecret2, nullptr));
 }
 
 TEST_F(IsDigestComputed, BadPartition) {
   bool is_computed;
   EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
-      &otp_, kDifOtpCtrlPartitionLifeCycle, &is_computed));
+      &otp_, kOtpPartitionLifeCycle, &is_computed));
 }
 
 TEST_F(IsDigestComputed, Success) {
@@ -647,18 +647,18 @@ TEST_F(IsDigestComputed, Success) {
   EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_1_REG_OFFSET, 0x98abcdef);
   EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_0_REG_OFFSET, 0xabcdef01);
   EXPECT_DIF_OK(dif_otp_ctrl_is_digest_computed(
-      &otp_, kDifOtpCtrlPartitionSecret2, &is_computed));
+      &otp_, kOtpPartitionSecret2, &is_computed));
   EXPECT_TRUE(is_computed);
 
   EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_1_REG_OFFSET, 0);
   EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_0_REG_OFFSET, 0);
   EXPECT_DIF_OK(dif_otp_ctrl_is_digest_computed(
-      &otp_, kDifOtpCtrlPartitionSecret2, &is_computed));
+      &otp_, kOtpPartitionSecret2, &is_computed));
   EXPECT_FALSE(is_computed);
 }
 
 struct DigestParams {
-  dif_otp_ctrl_partition_t partition;
+  otp_partition_t partition;
   bool has_digest;
   ptrdiff_t reg0, reg1;
 };
@@ -717,14 +717,14 @@ INSTANTIATE_TEST_SUITE_P(
 %>\
   % if part in digest_parts:
         DigestParams{
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
             true,
             OTP_CTRL_${part_name_define}_DIGEST_0_REG_OFFSET,
             OTP_CTRL_${part_name_define}_DIGEST_1_REG_OFFSET,
         }${"" if loop.last else ","}
   % else:
         DigestParams{
-            kDifOtpCtrlPartition${part_name_camel},
+            kOtpPartition${part_name_camel},
             false,
             0,
             0,
@@ -747,30 +747,30 @@ TEST_F(BlockingIoTest, Read) {
 
   std::vector<uint32_t> buf(kWords);
   EXPECT_DIF_OK(dif_otp_ctrl_read_blocking(
-      &otp_, kDifOtpCtrlPartitionOwnerSwCfg, 0x10, buf.data(), buf.size()));
+      &otp_, kOtpPartitionOwnerSwCfg, 0x10, buf.data(), buf.size()));
   EXPECT_THAT(buf, ElementsAre(1, 2, 3, 4));
 }
 
 TEST_F(BlockingIoTest, BadPartition) {
   std::vector<uint32_t> buf(kWords);
-  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kDifOtpCtrlPartitionHwCfg0, 0x10,
+  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionHwCfg0, 0x10,
                                        buf.data(), buf.size()),
             kDifError);
 }
 
 TEST_F(BlockingIoTest, Unaligned) {
   std::vector<uint32_t> buf(kWords);
-  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kDifOtpCtrlPartitionOwnerSwCfg,
+  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionOwnerSwCfg,
                                        0x11, buf.data(), buf.size()),
             kDifUnaligned);
 }
 
 TEST_F(BlockingIoTest, OutOfRange) {
   std::vector<uint32_t> buf(0x2f0);
-  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kDifOtpCtrlPartitionOwnerSwCfg,
+  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionOwnerSwCfg,
                                        0x300, buf.data(), buf.size()),
             kDifOutOfRange);
-  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kDifOtpCtrlPartitionOwnerSwCfg,
+  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionOwnerSwCfg,
                                        0x10, buf.data(), 0x330),
             kDifOutOfRange);
 }
@@ -778,9 +778,9 @@ TEST_F(BlockingIoTest, OutOfRange) {
 TEST_F(BlockingIoTest, NullArgs) {
   std::vector<uint32_t> buf(kWords);
   EXPECT_DIF_BADARG(dif_otp_ctrl_read_blocking(
-      nullptr, kDifOtpCtrlPartitionOwnerSwCfg, 0x10, buf.data(), buf.size()));
+      nullptr, kOtpPartitionOwnerSwCfg, 0x10, buf.data(), buf.size()));
   EXPECT_DIF_BADARG(dif_otp_ctrl_read_blocking(
-      &otp_, kDifOtpCtrlPartitionOwnerSwCfg, 0x10, nullptr, buf.size()));
+      &otp_, kOtpPartitionOwnerSwCfg, 0x10, nullptr, buf.size()));
 }
 
 }  // namespace

--- a/hw/top_egret/ip_autogen/otp_ctrl/util/dt.py
+++ b/hw/top_egret/ip_autogen/otp_ctrl/util/dt.py
@@ -33,15 +33,15 @@ HEADER_EXT_TEMPLATE = """
  * @return OTP partition information.
  */
 %(otp_partition_info_struct_name)s
-dt_otp_ctrl_sw_readable_partition(dt_otp_ctrl_t dt, %(otp_partition_ids_enum_name)s partition);
+dt_otp_ctrl_partition(dt_otp_ctrl_t dt, %(otp_partition_ids_enum_name)s partition);
 """
 
 SOURCE_EXT_TEMPLATE = """
 
 %(otp_partition_info_struct_name)s
-dt_otp_ctrl_sw_readable_partition(dt_otp_ctrl_t dt, %(otp_partition_ids_enum_name)s partition) {
+dt_otp_ctrl_partition(dt_otp_ctrl_t dt, %(otp_partition_ids_enum_name)s partition) {
   %(otp_partition_info_struct_name)s invalid_part = %(invalid_partition)s;
-  return TRY_GET_DT(dt, invalid_part)->sw_readable_partitions.info[partition];
+  return TRY_GET_DT(dt, invalid_part)->partitions.info[partition];
 }
 
 """
@@ -52,7 +52,16 @@ class OtpCtrlExt(Extension):
 
     OTP_PARTITION_INFO_STRUCT_START_ADDR_FIELD_NAME = Name(["start", "addr"])
     OTP_PARTITION_INFO_STRUCT_SIZE_FIELD_NAME = Name(["size"])
+    OTP_PARTITION_INFO_STRUCT_SECRET_FIELD_NAME = Name(["secret"])
+    OTP_PARTITION_INFO_STRUCT_SW_READABLE_FIELD_NAME = Name(["sw", "readable"])
+    OTP_PARTITION_INFO_STRUCT_SW_DIGEST_FIELD_NAME = Name(["sw", "digest"])
+    OTP_PARTITION_INFO_STRUCT_HW_DIGEST_FIELD_NAME = Name(["hw", "digest"])
     OTP_PARTITION_INFO_STRUCT_DIGEST_ADDR_FIELD_NAME = Name(["digest", "reg", "offset"])
+    OTP_PARTITION_INFO_STRUCT_READ_LOCKABLE_FIELD_NAME = Name(["read", "lockable"])
+    OTP_PARTITION_INFO_STRUCT_LOCK_ADDR_FIELD_NAME = Name(["lock", "reg", "offset"])
+    OTP_PARTITION_INFO_STRUCT_READ_LOCK_BIT_FIELD_NAME = Name(["read", "lock", "bit"])
+    OTP_PARTITION_INFO_STRUCT_LIFECYCLE_FIELD_NAME = Name(["is", "lifecycle"])
+    OTP_PARTITION_INFO_STRUCT_ZEROIZABLE_FIELD_NAME = Name(["zeroizable"])
     OTP_PARTITION_INFO_STRUCT_ALIGN_MASK_FIELD_NAME = Name(["align", "mask"])
     OTP_PARTITION_INFO_STRUCT_NAME = Name.from_snake_case("dt_otp_partition_info")
 
@@ -63,7 +72,7 @@ class OtpCtrlExt(Extension):
         self._otp_partition_ids_prefix = Name(["Otp", "Partition"])
         self._ipconfig = OtpCtrlIpConfig(ip_helper.ipconfig, self._otp_partition_ids_prefix)
         self._otp_partition_ids = CEnum(top_name = None, name = self._otp_partition_ids_prefix)
-        for partition in self._ipconfig.sw_readable_partitions():
+        for partition in self._ipconfig.partitions():
             self._otp_partition_ids.add_constant(partition["name"])
         self._otp_partition_ids.add_count_constant()
 
@@ -77,13 +86,53 @@ class OtpCtrlExt(Extension):
         self._otp_partition_info_struct.add_field(
             name = self.OTP_PARTITION_INFO_STRUCT_SIZE_FIELD_NAME,
             field_type = ScalarType("size_t"),
-            docstring = "Size (in bytes) of the partition, excluding the digest field",
+            docstring = "Size of the partition (bytes), excluding the digest / zeroization fields.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_SW_READABLE_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Set to true iff the partition is readable by software.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_SW_DIGEST_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Set to true iff the partition has a software digest.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_HW_DIGEST_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Set to true iff the partition has a hardware digest.",
         )
         self._otp_partition_info_struct.add_field(
             name = self.OTP_PARTITION_INFO_STRUCT_DIGEST_ADDR_FIELD_NAME,
             field_type = ScalarType("uint32_t"),
             docstring = "The OTP digest CSR (where the digest is buffered) offset for " +
             "this partition.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_READ_LOCKABLE_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Whether the partition can be locked for reading by software.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_LOCK_ADDR_FIELD_NAME,
+            field_type = ScalarType("uint32_t"),
+            docstring = "The OTP lock CSR offset for this partition.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_READ_LOCK_BIT_FIELD_NAME,
+            field_type = ScalarType("uint32_t"),
+            docstring = "The bit-offset of the read lock in the OTP lock CSR for this partition.",
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_ZEROIZABLE_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Whether this partition is zeroizable."
+        )
+        self._otp_partition_info_struct.add_field(
+            name = self.OTP_PARTITION_INFO_STRUCT_LIFECYCLE_FIELD_NAME,
+            field_type = ScalarType("uint8_t"),
+            docstring = "Whether this partition stores the chip life cycle state."
         )
         self._otp_partition_info_struct.add_field(
             name = self.OTP_PARTITION_INFO_STRUCT_ALIGN_MASK_FIELD_NAME,
@@ -94,7 +143,15 @@ class OtpCtrlExt(Extension):
         self._invalid_partition_info = {
             self.OTP_PARTITION_INFO_STRUCT_START_ADDR_FIELD_NAME: "0xdeadbeef",
             self.OTP_PARTITION_INFO_STRUCT_SIZE_FIELD_NAME: "0x0",
+            self.OTP_PARTITION_INFO_STRUCT_SW_READABLE_FIELD_NAME: "0",
+            self.OTP_PARTITION_INFO_STRUCT_SW_DIGEST_FIELD_NAME: "0",
+            self.OTP_PARTITION_INFO_STRUCT_HW_DIGEST_FIELD_NAME: "0",
             self.OTP_PARTITION_INFO_STRUCT_DIGEST_ADDR_FIELD_NAME: "0xdeadbeef",
+            self.OTP_PARTITION_INFO_STRUCT_READ_LOCKABLE_FIELD_NAME: "0",
+            self.OTP_PARTITION_INFO_STRUCT_LOCK_ADDR_FIELD_NAME: "0xdeadbeef",
+            self.OTP_PARTITION_INFO_STRUCT_READ_LOCK_BIT_FIELD_NAME: "0xdeadbeef",
+            self.OTP_PARTITION_INFO_STRUCT_ZEROIZABLE_FIELD_NAME: "0",
+            self.OTP_PARTITION_INFO_STRUCT_LIFECYCLE_FIELD_NAME: "0",
             self.OTP_PARTITION_INFO_STRUCT_ALIGN_MASK_FIELD_NAME: "0x0",
         }
 
@@ -104,9 +161,9 @@ class OtpCtrlExt(Extension):
             return OtpCtrlExt(ip_helper)
 
     def extend_dt_ip(self) -> tuple[Name, StructType]:
-        partition_count = len(self._ipconfig.sw_readable_partitions())
+        partition_count = len(self._ipconfig.partitions())
         st = StructType()
-        # Add field to list measurable clocks.
+        # Add field to count OTP partitions.
         st.add_field(
             name = self.OTP_PARTITION_INFO_FIELD_NAME,
             field_type = ArrayMapType(
@@ -114,26 +171,52 @@ class OtpCtrlExt(Extension):
                 index_type = ScalarType("size_t"),
                 length = str(partition_count),
             ),
-            docstring = "List of SW readable OTP partitions",
+            docstring = "List of OTP partitions",
         )
-        return Name(["sw_readable_partitions"]), st
+        return Name(["partitions"]), st
 
     def fill_dt_ip(self, m) -> Dict:
         otp_partitions = {}
-        for partition in self._ipconfig.sw_readable_partitions():
+        for partition in self._ipconfig.partitions():
             part_prefix = "OTP_CTRL_" + partition["name"].as_c_define() + "_"
             part_param_prefix = "OTP_CTRL_PARAM_" + partition["name"].as_c_define() + "_"
 
+            partition_size_expr = part_param_prefix + "SIZE"
+            if partition["sw_digest"] or partition["hw_digest"]:
+                partition_size_expr += " - " + part_param_prefix + "DIGEST_SIZE"
+            if partition["zeroizable"]:
+                partition_size_expr += " - " + part_param_prefix + "ZER_SIZE"
+            has_digest_csr = partition["sw_digest"] or partition["hw_digest"]
+            has_lock_csr = partition["read_lock"] == "CSR"
+            partition_name = partition["name"].as_c_define()
+            read_lock_bit = part_prefix + "READ_LOCK_" + partition_name + "_READ_LOCK_BIT"
             for (id, value, _) in self._otp_partition_ids.constants:
                 if id == partition["id"]:
                     otp_partitions[id.as_c_enum()] = {
+                        self.OTP_PARTITION_INFO_STRUCT_SW_READABLE_FIELD_NAME:
+                            1 if partition["sw_readable"] else 0,
+                        self.OTP_PARTITION_INFO_STRUCT_SW_DIGEST_FIELD_NAME:
+                            1 if partition["sw_digest"] else 0,
+                        self.OTP_PARTITION_INFO_STRUCT_HW_DIGEST_FIELD_NAME:
+                            1 if partition["hw_digest"] else 0,
                         self.OTP_PARTITION_INFO_STRUCT_START_ADDR_FIELD_NAME:
                             part_param_prefix + "OFFSET",
                         self.OTP_PARTITION_INFO_STRUCT_SIZE_FIELD_NAME:
-                            part_param_prefix + "SIZE - " + part_param_prefix + "DIGEST_SIZE",
+                            partition_size_expr,
                         self.OTP_PARTITION_INFO_STRUCT_DIGEST_ADDR_FIELD_NAME:
-                            part_prefix + "DIGEST_0_REG_OFFSET",
-                        self.OTP_PARTITION_INFO_STRUCT_ALIGN_MASK_FIELD_NAME: "0x3",
+                            part_prefix + "DIGEST_0_REG_OFFSET" if has_digest_csr else "0xdeadbeef",
+                        self.OTP_PARTITION_INFO_STRUCT_READ_LOCKABLE_FIELD_NAME:
+                            1 if has_lock_csr else 0,
+                        self.OTP_PARTITION_INFO_STRUCT_LOCK_ADDR_FIELD_NAME:
+                            part_prefix + "READ_LOCK_REG_OFFSET" if has_lock_csr else "0xdeadbeef",
+                        self.OTP_PARTITION_INFO_STRUCT_READ_LOCK_BIT_FIELD_NAME:
+                            read_lock_bit if has_lock_csr else "0xdeadbeef",
+                        self.OTP_PARTITION_INFO_STRUCT_ZEROIZABLE_FIELD_NAME:
+                            1 if partition["zeroizable"] else 0,
+                        self.OTP_PARTITION_INFO_STRUCT_LIFECYCLE_FIELD_NAME:
+                            1 if partition["variant"] == "LifeCycle" else 0,
+                        self.OTP_PARTITION_INFO_STRUCT_ALIGN_MASK_FIELD_NAME:
+                            "0x7" if partition["secret"] else "0x3",
                     }
 
         return {

--- a/hw/top_egret/ip_autogen/otp_ctrl/util/ipconfig.py
+++ b/hw/top_egret/ip_autogen/otp_ctrl/util/ipconfig.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 """
-This contains a class to access the clkmgr's configuration from its ipconfig
+This contains a class to access the otp_ctrl's configuration from its ipconfig
 files.
 """
 from typing import List, Dict
@@ -20,31 +20,33 @@ class OtpCtrlIpConfig:
         self._param_values = ipconfig["param_values"]
         self._id_prefix = id_prefix
 
-    def sw_readable_partitions(self) -> List[Dict]:
+    def sw_readable(self, partition) -> bool:
         """
-        Return the list of OTP partitions whose fields are readable after being locked,
-        i.e. those that have a digest (SW or HW), that are not secret and that can not
-        be read locked (or only through SW).
-        Each partition is described by its name and its identifier through the following
-        fields:
-        - `name` is the OTP partition name, e.g. `CREATOR_SW_CFG`
-        - `id` is the OTP partition identifier, e.g. `kOtpCtrlCreatorSwCfg`
+        Returns true iff a partition should be marked as software-readable.
         """
-        readable_partitions = []
-        for partition in self._param_values["otp_mmap"]["partitions"]:
-            if partition.get("read_lock") not in ["CSR", "None"]:
-                continue
-            if partition.get("secret"):
-                continue
-            if not partition.get("sw_digest") and not partition.get("hw_digest"):
-                continue
+        if partition.get("read_lock") not in ["CSR", "None"]:
+            return False
+        if partition.get("secret"):
+            return False
+        if not partition.get("sw_digest") and not partition.get("hw_digest"):
+            return False
+        return True
 
-            readable_partitions.append(partition)
-
+    def partitions(self) -> List[Dict]:
+        """
+        Return the list of all OTP partitions.
+        """
         return [
             {
                 "name": Name.from_snake_case(partition["name"]),
                 "id": self._id_prefix + Name.from_snake_case(partition["name"]),
+                "variant": partition["variant"],
+                "secret": partition["secret"],
+                "sw_readable": self.sw_readable(partition),
+                "sw_digest": partition["sw_digest"],
+                "hw_digest": partition["hw_digest"],
+                "read_lock": partition["read_lock"],
+                "zeroizable": partition["zeroizable"],
             }
-            for partition in readable_partitions
+            for partition in self._param_values["otp_mmap"]["partitions"]
         ]

--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -68,9 +68,7 @@ DIFS = {
     "mbx": {
         "deps": ["//sw/device/lib/base:abs_mmio"],
     },
-    "otp_ctrl": {
-        "ut_target_compatible_with": pavona_require_top("egret"),
-    },
+    "otp_ctrl": {},
     "pattgen": {},
     "pinmux": {
         "ut_target_compatible_with": pavona_require_top("egret"),

--- a/sw/device/lib/dif/dif_otp_ctrl.c
+++ b/sw/device/lib/dif/dif_otp_ctrl.c
@@ -199,146 +199,41 @@ dif_result_t dif_otp_ctrl_check_trigger_is_locked(const dif_otp_ctrl_t *otp,
   return kDifOk;
 }
 
-static bool sw_read_lock_reg_offset(dif_otp_ctrl_partition_t partition,
-                                    ptrdiff_t *reg_offset,
-                                    bitfield_bit32_index_t *index) {
-  switch (partition) {
-    case kDifOtpCtrlPartitionVendorTest:
-      *reg_offset = OTP_CTRL_VENDOR_TEST_READ_LOCK_REG_OFFSET;
-      *index = OTP_CTRL_VENDOR_TEST_READ_LOCK_VENDOR_TEST_READ_LOCK_BIT;
-      break;
-    case kDifOtpCtrlPartitionCreatorSwCfg:
-      *reg_offset = OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_REG_OFFSET;
-      *index = OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK_BIT;
-      break;
-    case kDifOtpCtrlPartitionOwnerSwCfg:
-      *reg_offset = OTP_CTRL_OWNER_SW_CFG_READ_LOCK_REG_OFFSET;
-      *index = OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OWNER_SW_CFG_READ_LOCK_BIT;
-      break;
-#if defined(OPENTITAN_IS_EGRET)
-    case kDifOtpCtrlPartitionRotCreatorAuthCodesign:
-      *reg_offset = OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_REG_OFFSET;
-      *index =
-          OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_BIT;
-      break;
-    case kDifOtpCtrlPartitionRotCreatorAuthState:
-      *reg_offset = OTP_CTRL_ROT_CREATOR_AUTH_STATE_READ_LOCK_REG_OFFSET;
-      *index =
-          OTP_CTRL_ROT_CREATOR_AUTH_STATE_READ_LOCK_ROT_CREATOR_AUTH_STATE_READ_LOCK_BIT;
-      break;
-#elif defined(OPENTITAN_IS_DRAGONFLY)
-    case kDifOtpCtrlPartitionOwnershipSlotState:
-      *reg_offset = OTP_CTRL_OWNERSHIP_SLOT_STATE_READ_LOCK_REG_OFFSET;
-      *index =
-          OTP_CTRL_OWNERSHIP_SLOT_STATE_READ_LOCK_OWNERSHIP_SLOT_STATE_READ_LOCK_BIT;
-      break;
-    case kDifOtpCtrlPartitionRotCreatorIdentity:
-      *reg_offset = OTP_CTRL_ROT_CREATOR_IDENTITY_READ_LOCK_REG_OFFSET;
-      *index =
-          OTP_CTRL_ROT_CREATOR_IDENTITY_READ_LOCK_ROT_CREATOR_IDENTITY_READ_LOCK_BIT;
-      break;
-    case kDifOtpCtrlPartitionRotOwnerAuthSlot0:
-      *reg_offset = OTP_CTRL_ROT_OWNER_AUTH_SLOT0_READ_LOCK_REG_OFFSET;
-      *index =
-          OTP_CTRL_ROT_OWNER_AUTH_SLOT0_READ_LOCK_ROT_OWNER_AUTH_SLOT0_READ_LOCK_BIT;
-      break;
-    case kDifOtpCtrlPartitionRotOwnerAuthSlot1:
-      *reg_offset = OTP_CTRL_ROT_OWNER_AUTH_SLOT1_READ_LOCK_REG_OFFSET;
-      *index =
-          OTP_CTRL_ROT_OWNER_AUTH_SLOT1_READ_LOCK_ROT_OWNER_AUTH_SLOT1_READ_LOCK_BIT;
-      break;
-    case kDifOtpCtrlPartitionPlatIntegAuthSlot0:
-      *reg_offset = OTP_CTRL_PLAT_INTEG_AUTH_SLOT0_READ_LOCK_REG_OFFSET;
-      *index =
-          OTP_CTRL_PLAT_INTEG_AUTH_SLOT0_READ_LOCK_PLAT_INTEG_AUTH_SLOT0_READ_LOCK_BIT;
-      break;
-    case kDifOtpCtrlPartitionPlatIntegAuthSlot1:
-      *reg_offset = OTP_CTRL_PLAT_INTEG_AUTH_SLOT1_READ_LOCK_REG_OFFSET;
-      *index =
-          OTP_CTRL_PLAT_INTEG_AUTH_SLOT1_READ_LOCK_PLAT_INTEG_AUTH_SLOT1_READ_LOCK_BIT;
-      break;
-    case kDifOtpCtrlPartitionPlatOwnerAuthSlot0:
-      *reg_offset = OTP_CTRL_PLAT_OWNER_AUTH_SLOT0_READ_LOCK_REG_OFFSET;
-      *index =
-          OTP_CTRL_PLAT_OWNER_AUTH_SLOT0_READ_LOCK_PLAT_OWNER_AUTH_SLOT0_READ_LOCK_BIT;
-      break;
-    case kDifOtpCtrlPartitionPlatOwnerAuthSlot1:
-      *reg_offset = OTP_CTRL_PLAT_OWNER_AUTH_SLOT1_READ_LOCK_REG_OFFSET;
-      *index =
-          OTP_CTRL_PLAT_OWNER_AUTH_SLOT1_READ_LOCK_PLAT_OWNER_AUTH_SLOT1_READ_LOCK_BIT;
-      break;
-    case kDifOtpCtrlPartitionPlatOwnerAuthSlot2:
-      *reg_offset = OTP_CTRL_PLAT_OWNER_AUTH_SLOT2_READ_LOCK_REG_OFFSET;
-      *index =
-          OTP_CTRL_PLAT_OWNER_AUTH_SLOT2_READ_LOCK_PLAT_OWNER_AUTH_SLOT2_READ_LOCK_BIT;
-      break;
-    case kDifOtpCtrlPartitionPlatOwnerAuthSlot3:
-      *reg_offset = OTP_CTRL_PLAT_OWNER_AUTH_SLOT3_READ_LOCK_REG_OFFSET;
-      *index =
-          OTP_CTRL_PLAT_OWNER_AUTH_SLOT3_READ_LOCK_PLAT_OWNER_AUTH_SLOT3_READ_LOCK_BIT;
-      break;
-    case kDifOtpCtrlPartitionExtNvm:
-      *reg_offset = OTP_CTRL_EXT_NVM_READ_LOCK_REG_OFFSET;
-      *index = OTP_CTRL_EXT_NVM_READ_LOCK_EXT_NVM_READ_LOCK_BIT;
-      break;
-    case kDifOtpCtrlPartitionRomPatch:
-      *reg_offset = OTP_CTRL_ROM_PATCH_READ_LOCK_REG_OFFSET;
-      *index = OTP_CTRL_ROM_PATCH_READ_LOCK_ROM_PATCH_READ_LOCK_BIT;
-      break;
-    case kDifOtpCtrlPartitionSocFusesCp:
-      *reg_offset = OTP_CTRL_SOC_FUSES_CP_READ_LOCK_REG_OFFSET;
-      *index = OTP_CTRL_SOC_FUSES_CP_READ_LOCK_SOC_FUSES_CP_READ_LOCK_BIT;
-      break;
-    case kDifOtpCtrlPartitionSocFusesFt:
-      *reg_offset = OTP_CTRL_SOC_FUSES_FT_READ_LOCK_REG_OFFSET;
-      *index = OTP_CTRL_SOC_FUSES_FT_READ_LOCK_SOC_FUSES_FT_READ_LOCK_BIT;
-      break;
-    case kDifOtpCtrlPartitionScratchFuses:
-      *reg_offset = OTP_CTRL_SCRATCH_FUSES_READ_LOCK_REG_OFFSET;
-      *index = OTP_CTRL_SCRATCH_FUSES_READ_LOCK_SCRATCH_FUSES_READ_LOCK_BIT;
-      break;
-#else
-#error "dif_otp_ctrl does not support this top"
-#endif
-    default:
-      return false;
-  }
-  return true;
-}
-
 dif_result_t dif_otp_ctrl_lock_reading(const dif_otp_ctrl_t *otp,
-                                       dif_otp_ctrl_partition_t partition) {
+                                       otp_partition_t partition) {
   if (otp == NULL) {
     return kDifBadArg;
   }
 
-  ptrdiff_t offset;
-  bitfield_bit32_index_t index;
-  if (!sw_read_lock_reg_offset(partition, &offset, &index)) {
+  dt_otp_partition_info_t partition_info =
+      dt_otp_ctrl_partition(otp->dt, partition);
+  if (!partition_info.read_lockable) {
     return kDifBadArg;
   }
 
-  uint32_t reg = bitfield_bit32_write(0, index, false);
-  mmio_region_write32(otp->base_addr, offset, reg);
+  uint32_t reg = bitfield_bit32_write(0, partition_info.read_lock_bit, false);
+  mmio_region_write32(otp->base_addr, (ptrdiff_t)partition_info.lock_reg_offset,
+                      reg);
 
   return kDifOk;
 }
 
 dif_result_t dif_otp_ctrl_reading_is_locked(const dif_otp_ctrl_t *otp,
-                                            dif_otp_ctrl_partition_t partition,
+                                            otp_partition_t partition,
                                             bool *is_locked) {
   if (otp == NULL || is_locked == NULL) {
     return kDifBadArg;
   }
 
-  ptrdiff_t offset;
-  bitfield_bit32_index_t index;
-  if (!sw_read_lock_reg_offset(partition, &offset, &index)) {
+  dt_otp_partition_info_t partition_info =
+      dt_otp_ctrl_partition(otp->dt, partition);
+  if (!partition_info.read_lockable) {
     return kDifBadArg;
   }
 
-  uint32_t reg = mmio_region_read32(otp->base_addr, offset);
-  *is_locked = !bitfield_bit32_read(reg, index);
+  uint32_t reg = mmio_region_read32(otp->base_addr,
+                                    (ptrdiff_t)partition_info.lock_reg_offset);
+  *is_locked = !bitfield_bit32_read(reg, partition_info.read_lock_bit);
   return kDifOk;
 }
 
@@ -357,7 +252,7 @@ dif_result_t dif_otp_ctrl_get_status(const dif_otp_ctrl_t *otp,
   // Only read PARTITION_STATUS_0 register if PARTITION_ERROR bit is set
   if (bitfield_bit32_read(status_code_reg,
                           OTP_CTRL_STATUS_PARTITION_ERROR_BIT)) {
-    uint32_t num_part_status_regs = (kDifOtpCtrlNumberOfPartitions + 31) / 32;
+    uint32_t num_part_status_regs = (kOtpPartitionCount + 31) / 32;
     for (int status_reg_num = 0; status_reg_num < num_part_status_regs;
          ++status_reg_num) {
       uint32_t partition_status_reg = mmio_region_read32(
@@ -368,7 +263,7 @@ dif_result_t dif_otp_ctrl_get_status(const dif_otp_ctrl_t *otp,
       for (int status_idx = 0; status_idx < 32; ++status_idx) {
         uint32_t partition_number =
             (uint32_t)status_reg_num * 32 + (uint32_t)status_idx;
-        if (partition_number > kDifOtpCtrlNumberOfPartitions) {
+        if (partition_number > kOtpPartitionCount) {
           break;
         }
         // If the error is not present at all, we clear its cause and bail
@@ -394,7 +289,7 @@ dif_result_t dif_otp_ctrl_get_status(const dif_otp_ctrl_t *otp,
     }
   } else {
     // No partition errors, clear all partition error causes
-    for (int i = 0; i < kDifOtpCtrlNumberOfPartitions; ++i) {
+    for (int i = 0; i < kOtpPartitionCount; ++i) {
       status->causes[i] = kDifOtpCtrlErrorOk;
     }
   }
@@ -402,7 +297,7 @@ dif_result_t dif_otp_ctrl_get_status(const dif_otp_ctrl_t *otp,
   // Process DAI/LCI status bits from main STATUS register
   for (int i = kDifOtpCtrlStatusCodeDaiError;
        i <= kDifOtpCtrlStatusCodeLciError; ++i) {
-    uint32_t err_code_index = kDifOtpCtrlNumberOfPartitions - 1 + (uint32_t)i;
+    uint32_t err_code_index = kOtpPartitionCount - 1 + (uint32_t)i;
     dif_otp_ctrl_error_t err = kDifOtpCtrlErrorOk;
 
     if (bitfield_bit32_read(status_code_reg, (bitfield_bit32_index_t)i)) {
@@ -420,7 +315,7 @@ dif_result_t dif_otp_ctrl_get_status(const dif_otp_ctrl_t *otp,
   }
 
   // Process other status bits from main STATUS register
-  for (int i = kDifOtpCtrlStatusCodeLciError + 1; i < kDifOtpCtrlNumberOfCauses;
+  for (int i = kDifOtpCtrlStatusCodeLciError + 1; i < ARRAYSIZE(status->causes);
        ++i) {
     if (!bitfield_bit32_read(status_code_reg, (bitfield_bit32_index_t)i)) {
       continue;
@@ -433,248 +328,36 @@ dif_result_t dif_otp_ctrl_get_status(const dif_otp_ctrl_t *otp,
   return kDifOk;
 }
 
-typedef struct partition_info {
-  /**
-   * The absolute OTP address at which this partition starts.
-   */
-  uint32_t start_addr;
-  /**
-   * The length of this partition, in bytes, including the digest.
-   *
-   * If the partition has a digest, it is expected to be at address
-   * `start_addr + len - sizeof(uint64_t)`.
-   */
-  uint32_t len;
-  /**
-   * The alignment mask for this partition.
-   *
-   * A valid address for this partition must be such that
-   * `addr & align_mask == 0`.
-   */
-  uint32_t align_mask;
-
-  /**
-   * Whether this is a software-managed partition with a software-managed
-   * digest.
-   */
-  bool is_software;
-
-  /**
-   * Whether this partition has a digest field.
-   */
-  bool has_digest;
-
-  /**
-   * Whether this partition is the lifecycle partition.
-   */
-  bool is_lifecycle;
-} partition_info_t;
-
-// This is generates too many lines with different formatting variants, so
-// We opt to just disable formatting.
-// clang-format off
-static const partition_info_t kPartitions[] = {
-    [kDifOtpCtrlPartitionVendorTest] = {
-        .start_addr = OTP_CTRL_PARAM_VENDOR_TEST_OFFSET,
-        .len = OTP_CTRL_PARAM_VENDOR_TEST_SIZE,
-        .align_mask = 0x3,
-        .is_software = true,
-        .has_digest = true,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionCreatorSwCfg] = {
-        .start_addr = OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET,
-        .len = OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE,
-        .align_mask = 0x3,
-        .is_software = true,
-        .has_digest = true,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionOwnerSwCfg] = {
-        .start_addr = OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET,
-        .len = OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE,
-        .align_mask = 0x3,
-        .is_software = true,
-        .has_digest = true,
-        .is_lifecycle = false},
-#if defined(OPENTITAN_IS_EGRET)
-    [kDifOtpCtrlPartitionRotCreatorAuthCodesign] = {
-        .start_addr = OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_OFFSET,
-        .len = OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE,
-        .align_mask = 0x3,
-        .is_software = true,
-        .has_digest = true,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionRotCreatorAuthState] = {
-        .start_addr = OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_OFFSET,
-        .len = OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE,
-        .align_mask = 0x3,
-        .is_software = true,
-        .has_digest = true,
-        .is_lifecycle = false},
-#elif defined(OPENTITAN_IS_DRAGONFLY)
-    [kDifOtpCtrlPartitionOwnershipSlotState] = {
-        .start_addr = OTP_CTRL_PARAM_OWNERSHIP_SLOT_STATE_OFFSET,
-        .len = OTP_CTRL_PARAM_OWNERSHIP_SLOT_STATE_SIZE,
-        .align_mask = 0x3,
-        .is_software = true,
-        .has_digest = false,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionRotCreatorIdentity] = {
-        .start_addr = OTP_CTRL_PARAM_ROT_CREATOR_IDENTITY_OFFSET,
-        .len = OTP_CTRL_PARAM_ROT_CREATOR_IDENTITY_SIZE,
-        .align_mask = 0x3,
-        .is_software = true,
-        .has_digest = true,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionRotOwnerAuthSlot0] = {
-        .start_addr = OTP_CTRL_PARAM_ROT_OWNER_AUTH_SLOT0_OFFSET,
-        .len = OTP_CTRL_PARAM_ROT_OWNER_AUTH_SLOT0_SIZE,
-        .align_mask = 0x3,
-        .is_software = true,
-        .has_digest = true,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionRotOwnerAuthSlot1] = {
-        .start_addr = OTP_CTRL_PARAM_ROT_OWNER_AUTH_SLOT1_OFFSET,
-        .len = OTP_CTRL_PARAM_ROT_OWNER_AUTH_SLOT1_SIZE,
-        .align_mask = 0x3,
-        .is_software = true,
-        .has_digest = true,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionPlatIntegAuthSlot0] = {
-        .start_addr = OTP_CTRL_PARAM_PLAT_INTEG_AUTH_SLOT0_OFFSET,
-        .len = OTP_CTRL_PARAM_PLAT_INTEG_AUTH_SLOT0_SIZE,
-        .align_mask = 0x3,
-        .is_software = true,
-        .has_digest = true,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionPlatIntegAuthSlot1] = {
-        .start_addr = OTP_CTRL_PARAM_PLAT_INTEG_AUTH_SLOT1_OFFSET,
-        .len = OTP_CTRL_PARAM_PLAT_INTEG_AUTH_SLOT1_SIZE,
-        .align_mask = 0x3,
-        .is_software = true,
-        .has_digest = true,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionPlatOwnerAuthSlot0] = {
-        .start_addr = OTP_CTRL_PARAM_PLAT_OWNER_AUTH_SLOT0_OFFSET,
-        .len = OTP_CTRL_PARAM_PLAT_OWNER_AUTH_SLOT0_SIZE,
-        .align_mask = 0x3,
-        .is_software = true,
-        .has_digest = true,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionPlatOwnerAuthSlot1] = {
-        .start_addr = OTP_CTRL_PARAM_PLAT_OWNER_AUTH_SLOT1_OFFSET,
-        .len = OTP_CTRL_PARAM_PLAT_OWNER_AUTH_SLOT1_SIZE,
-        .align_mask = 0x3,
-        .is_software = true,
-        .has_digest = true,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionPlatOwnerAuthSlot2] = {
-        .start_addr = OTP_CTRL_PARAM_PLAT_OWNER_AUTH_SLOT2_OFFSET,
-        .len = OTP_CTRL_PARAM_PLAT_OWNER_AUTH_SLOT2_SIZE,
-        .align_mask = 0x3,
-        .is_software = true,
-        .has_digest = true,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionPlatOwnerAuthSlot3] = {
-        .start_addr = OTP_CTRL_PARAM_PLAT_OWNER_AUTH_SLOT3_OFFSET,
-        .len = OTP_CTRL_PARAM_PLAT_OWNER_AUTH_SLOT3_SIZE,
-        .align_mask = 0x3,
-        .is_software = true,
-        .has_digest = true,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionExtNvm] = {
-        .start_addr = OTP_CTRL_PARAM_EXT_NVM_OFFSET,
-        .len = OTP_CTRL_PARAM_EXT_NVM_SIZE,
-        .align_mask = 0x3,
-        .is_software = true,
-        .has_digest = false,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionRomPatch] = {
-        .start_addr = OTP_CTRL_PARAM_ROM_PATCH_OFFSET,
-        .len = OTP_CTRL_PARAM_ROM_PATCH_SIZE,
-        .align_mask = 0x3,
-        .is_software = true,
-        .has_digest = true,
-        .is_lifecycle = false},
-#else
-#error "dif_otp_ctrl does not support this top"
-#endif
-    [kDifOtpCtrlPartitionHwCfg0] = {
-        .start_addr = OTP_CTRL_PARAM_HW_CFG0_OFFSET,
-        .len = OTP_CTRL_PARAM_HW_CFG0_SIZE,
-        .align_mask = 0x3,
-        .is_software = false,
-        .has_digest = true,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionHwCfg1] = {
-        .start_addr = OTP_CTRL_PARAM_HW_CFG1_OFFSET,
-        .len = OTP_CTRL_PARAM_HW_CFG1_SIZE,
-        .align_mask = 0x3,
-        .is_software = false,
-        .has_digest = true,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionSecret0] = {
-        .start_addr = OTP_CTRL_PARAM_SECRET0_OFFSET,
-        .len = OTP_CTRL_PARAM_SECRET0_SIZE,
-        .align_mask = 0x7,
-        .is_software = false,
-        .has_digest = true,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionSecret1] = {
-        .start_addr = OTP_CTRL_PARAM_SECRET1_OFFSET,
-        .len = OTP_CTRL_PARAM_SECRET1_SIZE,
-        .align_mask = 0x7,
-        .is_software = false,
-        .has_digest = true,
-        .is_lifecycle = false},
-    [kDifOtpCtrlPartitionSecret2] = {
-        .start_addr = OTP_CTRL_PARAM_SECRET2_OFFSET,
-        .len = OTP_CTRL_PARAM_SECRET2_SIZE,
-        .align_mask = 0x7,
-        .is_software = false,
-        .has_digest = true,
-        .is_lifecycle = false},
-#if defined(OPENTITAN_IS_DRAGONFLY)
-    [kDifOtpCtrlPartitionSecret3] = {
-        .start_addr = OTP_CTRL_PARAM_SECRET3_OFFSET,
-        .len = OTP_CTRL_PARAM_SECRET3_SIZE,
-        .align_mask = 0x7,
-        .is_software = false,
-        .has_digest = true,
-        .is_lifecycle = false},
-#elif defined(OPENTITAN_IS_EGRET)
-// Egret only has 3 secret partitions.
-#else
-#error "dif_otp_ctrl does not support this top"
-#endif
-    [kDifOtpCtrlPartitionLifeCycle] = {
-        .start_addr = OTP_CTRL_PARAM_LIFE_CYCLE_OFFSET,
-        .len = OTP_CTRL_PARAM_LIFE_CYCLE_SIZE,
-        .align_mask = 0x3,
-        .is_software = false,
-        .has_digest = false,
-        .is_lifecycle = true},
-};
-// clang-format on
-
-dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
+dif_result_t dif_otp_ctrl_relative_address(const dif_otp_ctrl_t *otp,
+                                           otp_partition_t partition,
                                            uint32_t abs_address,
                                            uint32_t *relative_address) {
   *relative_address = 0;
 
-  if (partition >= ARRAYSIZE(kPartitions)) {
+  if (partition >= kOtpPartitionCount) {
     return kDifBadArg;
   }
 
-  if ((abs_address & kPartitions[partition].align_mask) != 0) {
+  dt_otp_partition_info_t partition_info =
+      dt_otp_ctrl_partition(otp->dt, partition);
+  if ((abs_address & partition_info.align_mask) != 0) {
     return kDifUnaligned;
   }
 
-  if (abs_address < kPartitions[partition].start_addr) {
+  if (abs_address < partition_info.start_addr) {
     return kDifOutOfRange;
   }
 
-  *relative_address = abs_address - kPartitions[partition].start_addr;
-  if (*relative_address >= kPartitions[partition].len) {
+  *relative_address = abs_address - partition_info.start_addr;
+  // NOTE: `partition_info.size` excludes the digest / zeroization fields.
+  size_t partition_end = partition_info.size;
+  if (partition_info.sw_digest || partition_info.hw_digest) {
+    partition_end += sizeof(uint64_t);
+  }
+  if (partition_info.zeroizable) {
+    partition_end += sizeof(uint64_t);
+  }
+  if (*relative_address >= partition_end) {
     *relative_address = 0;
     return kDifOutOfRange;
   }
@@ -683,21 +366,31 @@ dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
 }
 
 dif_result_t dif_otp_ctrl_dai_read_start(const dif_otp_ctrl_t *otp,
-                                         dif_otp_ctrl_partition_t partition,
+                                         otp_partition_t partition,
                                          uint32_t address) {
-  if (otp == NULL || partition >= ARRAYSIZE(kPartitions)) {
+  if (otp == NULL || partition >= kOtpPartitionCount) {
     return kDifBadArg;
   }
 
-  if ((address & kPartitions[partition].align_mask) != 0) {
+  dt_otp_partition_info_t partition_info =
+      dt_otp_ctrl_partition(otp->dt, partition);
+  if ((address & partition_info.align_mask) != 0) {
     return kDifUnaligned;
   }
 
-  if (address >= kPartitions[partition].len) {
+  // NOTE: `partition_info.size` excludes the digest / zeroization fields.
+  size_t partition_end = partition_info.size;
+  if (partition_info.sw_digest || partition_info.hw_digest) {
+    partition_end += sizeof(uint64_t);
+  }
+  if (partition_info.zeroizable) {
+    partition_end += sizeof(uint64_t);
+  }
+  if (address >= partition_end) {
     return kDifOutOfRange;
   }
 
-  address += kPartitions[partition].start_addr;
+  address += partition_info.start_addr;
   mmio_region_write32(otp->base_addr, OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
                       address);
 
@@ -735,35 +428,40 @@ dif_result_t dif_otp_ctrl_dai_read64_end(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_dai_program32(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint32_t value) {
-  if (otp == NULL || partition >= ARRAYSIZE(kPartitions)) {
+  if (otp == NULL || partition >= kOtpPartitionCount) {
     return kDifBadArg;
   }
+  dt_otp_partition_info_t partition_info =
+      dt_otp_ctrl_partition(otp->dt, partition);
 
   // Ensure that we are writing to a 32-bit-access partition by checking that
   // the alignment mask is 0b11.
   //
   // Note furthermore that the LC partition is *not* writeable, so we eject
   // here.
-  if (kPartitions[partition].align_mask != 0x3 ||
-      kPartitions[partition].is_lifecycle) {
+  if (partition_info.align_mask != 0x3 || partition_info.is_lifecycle) {
     return kDifError;
   }
 
-  if ((address & kPartitions[partition].align_mask) != 0) {
+  if ((address & partition_info.align_mask) != 0) {
     return kDifUnaligned;
   }
 
-  // NOTE: The bounds check is tightened here, since we disallow writing the
-  // digest directly. If the partition does not have a digest, no tightening is
-  // needed.
-  size_t digest_size = kPartitions[partition].has_digest * sizeof(uint64_t);
-  if (address >= kPartitions[partition].len - digest_size) {
+  // NOTE: `partition_info.size` excludes the digest / zeroization fields.
+  size_t partition_end = partition_info.size;
+  if (partition_info.sw_digest || partition_info.hw_digest) {
+    partition_end += sizeof(uint64_t);
+  }
+  if (partition_info.zeroizable) {
+    partition_end += sizeof(uint64_t);
+  }
+  if (address >= partition_end) {
     return kDifOutOfRange;
   }
 
-  address += kPartitions[partition].start_addr;
+  address += partition_info.start_addr;
   mmio_region_write32(otp->base_addr, OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
                       address);
 
@@ -779,30 +477,41 @@ dif_result_t dif_otp_ctrl_dai_program32(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_dai_program64(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint64_t value) {
-  if (otp == NULL || partition >= ARRAYSIZE(kPartitions)) {
+  if (otp == NULL || partition >= kOtpPartitionCount) {
     return kDifBadArg;
   }
+  dt_otp_partition_info_t partition_info =
+      dt_otp_ctrl_partition(otp->dt, partition);
 
+  // Some partitions are not accessible by software.
+  if (partition_info.is_lifecycle) {
+    return kDifError;
+  }
   // Ensure that we are writing to a 64-bit-access partition by checking that
   // the alignment mask is 0b111.
-  if (kPartitions[partition].align_mask != 0x7) {
+  if (partition_info.align_mask != 0x7) {
     return kDifError;
   }
 
-  if ((address & kPartitions[partition].align_mask) != 0) {
+  if ((address & partition_info.align_mask) != 0) {
     return kDifUnaligned;
   }
 
-  // NOTE: The bounds check is tightened here, since we disallow writing the
-  // digest directly.
-  size_t digest_size = sizeof(uint64_t);
-  if (address >= kPartitions[partition].len - digest_size) {
+  // NOTE: `partition_info.size` excludes the digest / zeroization fields.
+  size_t partition_end = partition_info.size;
+  if (partition_info.sw_digest || partition_info.hw_digest) {
+    partition_end += sizeof(uint64_t);
+  }
+  if (partition_info.zeroizable) {
+    partition_end += sizeof(uint64_t);
+  }
+  if (address >= partition_end) {
     return kDifOutOfRange;
   }
 
-  address += kPartitions[partition].start_addr;
+  address += partition_info.start_addr;
   mmio_region_write32(otp->base_addr, OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
                       address);
 
@@ -820,27 +529,30 @@ dif_result_t dif_otp_ctrl_dai_program64(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
-                                     dif_otp_ctrl_partition_t partition,
+                                     otp_partition_t partition,
                                      uint64_t digest) {
-  if (otp == NULL || partition >= ARRAYSIZE(kPartitions)) {
+  if (otp == NULL || partition >= kOtpPartitionCount) {
     return kDifBadArg;
   }
+  dt_otp_partition_info_t partition_info =
+      dt_otp_ctrl_partition(otp->dt, partition);
 
   // Not all partitions have a digest.
-  if (!kPartitions[partition].has_digest) {
-    return kDifError;
+  if (!partition_info.sw_digest && !partition_info.hw_digest) {
+    return kDifBadArg;
   }
 
   // For software partitions, the digest must be nonzero; for all other
   // partitions it must be zero.
-  bool is_sw = kPartitions[partition].is_software;
+  bool is_sw = partition_info.sw_digest;
   if (is_sw == (digest == 0)) {
     return kDifBadArg;
   }
 
-  uint32_t address = kPartitions[partition].start_addr;
+  uint32_t address = partition_info.start_addr;
   if (is_sw) {
-    address += kPartitions[partition].len - sizeof(digest);
+    // NOTE: `partition_info.size` excludes the digest / zeroization fields.
+    address += partition_info.size;
   }
   mmio_region_write32(otp->base_addr, OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
                       address);
@@ -864,126 +576,26 @@ dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
   return kDifOk;
 }
 
-static bool get_digest_regs(dif_otp_ctrl_partition_t partition, ptrdiff_t *reg0,
-                            ptrdiff_t *reg1) {
-  switch (partition) {
-    case kDifOtpCtrlPartitionVendorTest:
-      *reg0 = OTP_CTRL_VENDOR_TEST_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_VENDOR_TEST_DIGEST_1_REG_OFFSET;
-      break;
-    case kDifOtpCtrlPartitionCreatorSwCfg:
-      *reg0 = OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_CREATOR_SW_CFG_DIGEST_1_REG_OFFSET;
-      break;
-    case kDifOtpCtrlPartitionOwnerSwCfg:
-      *reg0 = OTP_CTRL_OWNER_SW_CFG_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_OWNER_SW_CFG_DIGEST_1_REG_OFFSET;
-      break;
-#if defined(OPENTITAN_IS_EGRET)
-    case kDifOtpCtrlPartitionRotCreatorAuthCodesign:
-      *reg0 = OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_DIGEST_1_REG_OFFSET;
-      break;
-    case kDifOtpCtrlPartitionRotCreatorAuthState:
-      *reg0 = OTP_CTRL_ROT_CREATOR_AUTH_STATE_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_ROT_CREATOR_AUTH_STATE_DIGEST_1_REG_OFFSET;
-      break;
-#elif defined(OPENTITAN_IS_DRAGONFLY)
-    case kDifOtpCtrlPartitionRotCreatorIdentity:
-      *reg0 = OTP_CTRL_ROT_CREATOR_IDENTITY_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_ROT_CREATOR_IDENTITY_DIGEST_1_REG_OFFSET;
-      break;
-    case kDifOtpCtrlPartitionRotOwnerAuthSlot0:
-      *reg0 = OTP_CTRL_ROT_OWNER_AUTH_SLOT0_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_ROT_OWNER_AUTH_SLOT0_DIGEST_1_REG_OFFSET;
-      break;
-    case kDifOtpCtrlPartitionRotOwnerAuthSlot1:
-      *reg0 = OTP_CTRL_ROT_OWNER_AUTH_SLOT1_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_ROT_OWNER_AUTH_SLOT1_DIGEST_1_REG_OFFSET;
-      break;
-    case kDifOtpCtrlPartitionPlatIntegAuthSlot0:
-      *reg0 = OTP_CTRL_PLAT_INTEG_AUTH_SLOT0_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_PLAT_INTEG_AUTH_SLOT0_DIGEST_1_REG_OFFSET;
-      break;
-    case kDifOtpCtrlPartitionPlatIntegAuthSlot1:
-      *reg0 = OTP_CTRL_PLAT_INTEG_AUTH_SLOT1_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_PLAT_INTEG_AUTH_SLOT1_DIGEST_1_REG_OFFSET;
-      break;
-    case kDifOtpCtrlPartitionPlatOwnerAuthSlot0:
-      *reg0 = OTP_CTRL_PLAT_OWNER_AUTH_SLOT0_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_PLAT_OWNER_AUTH_SLOT0_DIGEST_1_REG_OFFSET;
-      break;
-    case kDifOtpCtrlPartitionPlatOwnerAuthSlot1:
-      *reg0 = OTP_CTRL_PLAT_OWNER_AUTH_SLOT1_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_PLAT_OWNER_AUTH_SLOT1_DIGEST_1_REG_OFFSET;
-      break;
-    case kDifOtpCtrlPartitionPlatOwnerAuthSlot2:
-      *reg0 = OTP_CTRL_PLAT_OWNER_AUTH_SLOT2_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_PLAT_OWNER_AUTH_SLOT2_DIGEST_1_REG_OFFSET;
-      break;
-    case kDifOtpCtrlPartitionPlatOwnerAuthSlot3:
-      *reg0 = OTP_CTRL_PLAT_OWNER_AUTH_SLOT3_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_PLAT_OWNER_AUTH_SLOT3_DIGEST_1_REG_OFFSET;
-      break;
-    case kDifOtpCtrlPartitionRomPatch:
-      *reg0 = OTP_CTRL_ROM_PATCH_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_ROM_PATCH_DIGEST_1_REG_OFFSET;
-      break;
-#else
-#error "dif_otp_ctrl does not support this top"
-#endif
-    case kDifOtpCtrlPartitionHwCfg0:
-      *reg0 = OTP_CTRL_HW_CFG0_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_HW_CFG0_DIGEST_1_REG_OFFSET;
-      break;
-    case kDifOtpCtrlPartitionHwCfg1:
-      *reg0 = OTP_CTRL_HW_CFG1_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_HW_CFG1_DIGEST_1_REG_OFFSET;
-      break;
-    case kDifOtpCtrlPartitionSecret0:
-      *reg0 = OTP_CTRL_SECRET0_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_SECRET0_DIGEST_1_REG_OFFSET;
-      break;
-    case kDifOtpCtrlPartitionSecret1:
-      *reg0 = OTP_CTRL_SECRET1_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_SECRET1_DIGEST_1_REG_OFFSET;
-      break;
-    case kDifOtpCtrlPartitionSecret2:
-      *reg0 = OTP_CTRL_SECRET2_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_SECRET2_DIGEST_1_REG_OFFSET;
-      break;
-#if defined(OPENTITAN_IS_DRAGONFLY)
-    case kDifOtpCtrlPartitionSecret3:
-      *reg0 = OTP_CTRL_SECRET3_DIGEST_0_REG_OFFSET;
-      *reg1 = OTP_CTRL_SECRET3_DIGEST_1_REG_OFFSET;
-      break;
-#elif defined(OPENTITAN_IS_EGRET)
-// Egret only has 3 secret partitions.
-#else
-#error "dif_otp_ctrl does not support this top"
-#endif
-    default:
-      return false;
-  }
-
-  return true;
-}
-
 dif_result_t dif_otp_ctrl_is_digest_computed(const dif_otp_ctrl_t *otp,
-                                             dif_otp_ctrl_partition_t partition,
+                                             otp_partition_t partition,
                                              bool *is_computed) {
   if (otp == NULL || is_computed == NULL) {
     return kDifBadArg;
   }
+  dt_otp_partition_info_t partition_info =
+      dt_otp_ctrl_partition(otp->dt, partition);
 
-  ptrdiff_t reg0, reg1;
-  if (!get_digest_regs(partition, &reg0, &reg1)) {
+  // Not all partitions have a digest.
+  if (!partition_info.sw_digest && !partition_info.hw_digest) {
     return kDifBadArg;
   }
 
-  uint64_t value = mmio_region_read32(otp->base_addr, reg1);
+  uint64_t value = mmio_region_read32(
+      otp->base_addr,
+      (ptrdiff_t)(partition_info.digest_reg_offset + sizeof(uint32_t)));
   value <<= 32;
-  value |= mmio_region_read32(otp->base_addr, reg0);
+  value |= mmio_region_read32(otp->base_addr,
+                              (ptrdiff_t)partition_info.digest_reg_offset);
 
   *is_computed = value != 0;
 
@@ -991,20 +603,25 @@ dif_result_t dif_otp_ctrl_is_digest_computed(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_get_digest(const dif_otp_ctrl_t *otp,
-                                     dif_otp_ctrl_partition_t partition,
+                                     otp_partition_t partition,
                                      uint64_t *digest) {
   if (otp == NULL || digest == NULL) {
     return kDifBadArg;
   }
+  dt_otp_partition_info_t partition_info =
+      dt_otp_ctrl_partition(otp->dt, partition);
 
-  ptrdiff_t reg0, reg1;
-  if (!get_digest_regs(partition, &reg0, &reg1)) {
+  // Not all partitions have a digest.
+  if (!partition_info.sw_digest && !partition_info.hw_digest) {
     return kDifBadArg;
   }
 
-  uint64_t value = mmio_region_read32(otp->base_addr, reg1);
+  uint64_t value = mmio_region_read32(
+      otp->base_addr,
+      (ptrdiff_t)(partition_info.digest_reg_offset + sizeof(uint32_t)));
   value <<= 32;
-  value |= mmio_region_read32(otp->base_addr, reg0);
+  value |= mmio_region_read32(otp->base_addr,
+                              (ptrdiff_t)partition_info.digest_reg_offset);
 
   if (value == 0) {
     return kDifError;
@@ -1015,27 +632,29 @@ dif_result_t dif_otp_ctrl_get_digest(const dif_otp_ctrl_t *otp,
 }
 
 dif_result_t dif_otp_ctrl_read_blocking(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint32_t *buf,
                                         size_t len) {
-  if (otp == NULL || partition >= ARRAYSIZE(kPartitions) || buf == NULL) {
+  if (otp == NULL || partition >= kOtpPartitionCount || buf == NULL) {
     return kDifBadArg;
   }
+  dt_otp_partition_info_t partition_info =
+      dt_otp_ctrl_partition(otp->dt, partition);
 
-  if (!kPartitions[partition].is_software) {
+  if (!partition_info.sw_digest) {
     return kDifError;
   }
 
-  if ((address & kPartitions[partition].align_mask) != 0) {
+  if ((address & partition_info.align_mask) != 0) {
     return kDifUnaligned;
   }
 
-  if (address + len >= kPartitions[partition].len) {
+  if (address + len >= partition_info.size) {
     return kDifOutOfRange;
   }
 
-  uint32_t reg_offset = OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
-                        kPartitions[partition].start_addr + address;
+  uint32_t reg_offset =
+      OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET + partition_info.start_addr + address;
   mmio_region_memcpy_from_mmio32(otp->base_addr, reg_offset, buf,
                                  len * sizeof(uint32_t));
   return kDifOk;

--- a/sw/device/lib/dif/dif_otp_ctrl.h
+++ b/sw/device/lib/dif/dif_otp_ctrl.h
@@ -24,238 +24,6 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * A partition within OTP memory.
- */
-typedef enum dif_otp_ctrl_partition {
-  /**
-   * Vendor test partition.
-   *
-   * This is reserved for manufacturing smoke checks. The OTP wrapper
-   * control logic inside prim_otp is allowed to read/write to this
-   * region. ECC uncorrectable errors seen on the functional prim_otp
-   * interface will not lead to an alert for this partition.
-   * Instead, such errors will be reported as correctable ECC errors.
-   */
-  kDifOtpCtrlPartitionVendorTest,
-  /**
-   * Software configuration partition.
-   *
-   * This is for device-specific calibration data, e.g, clock, LDO, RNG,
-   * and configuration settings set by the ROM.
-   */
-  kDifOtpCtrlPartitionCreatorSwCfg,
-  /**
-   * Software configuration partition.
-   *
-   * This contains data that changes software behavior in the ROM, for
-   * example enabling defensive features in ROM or selecting failure
-   * modes if verification fails.
-   */
-  kDifOtpCtrlPartitionOwnerSwCfg,
-#if defined(OPENTITAN_IS_EGRET)
-  /**
-   * This OTP partition is used to store four P-256 keys and four Sphincs+ keys.
-   *
-   * The partition requires 464
-   * bytes of software visible storage. The partition is
-   * locked at manufacturing time to protect against
-   * malicious write attempts.
-   */
-  kDifOtpCtrlPartitionRotCreatorAuthCodesign,
-  /**
-   * This OTP partition is used to capture the state of each key slot.
-   *
-   * Each key can be in one of the
-   * following states: BLANK, ENABLED, DISABLED. The
-   * encoded values are such that transitions between
-   * BLANK -> ENABLED ->  DISABLED are possible without
-   * causing ECC errors (this is a mechanism similar to
-   * how we manage life cycle state transitions). The
-   * partition is left unlocked to allow STATE updates in
-   * the field. The ROM_EXT is required to lock access to
-   * the OTP Direct Access Interface to prevent DoS
-   * attacks from malicious code executing on Silicon
-   * Owner partitions. DAI write locking is available in
-   * Egret.
-   */
-  kDifOtpCtrlPartitionRotCreatorAuthState,
-#elif defined(OPENTITAN_IS_DRAGONFLY)
-  /**
-   * SW managed asset ownership states partition.
-   *
-   * Multibit enable value for the tracking the asset ownership states.
-   * Note that the states can be written multiple times in a device lifetime.
-   * The values to be written are engineered in the same way as the LC_CTRL
-   * state encoding words so that the ECC encoding remains valid even after
-   * updating the values.
-   *
-   * The constants can be found in the lc_ctrl_state_pkg.sv package.
-   *
-   * The programming order has to adhere to:
-   *
-   * OWNERSHIP_ST_RAW (factory all-zero state) ->
-   * OWNERSHIP_ST_LOCKED0 ->
-   * OWNERSHIP_ST_RELEASED0 ->
-   * ...
-   * OWNERSHIP_ST_SCRAPPED
-   *
-   * Note that if there are less than 4 slots available the higher slot states
-   * become logically equivalent to OWNERSHIP_SCRAPPED (firmware has to handle
-   * this correctly).
-   */
-  kDifOtpCtrlPartitionOwnershipSlotState,
-  /**
-   * Software managed creator partition.
-   *
-   */
-  kDifOtpCtrlPartitionRotCreatorIdentity,
-  /**
-   * Software managed owner slot 0 partition.
-   *
-   */
-  kDifOtpCtrlPartitionRotOwnerAuthSlot0,
-  /**
-   * Software managed owner slot 1 partition.
-   *
-   */
-  kDifOtpCtrlPartitionRotOwnerAuthSlot1,
-  /**
-   * Software managed platform integrator slot 0 partition.
-   *
-   */
-  kDifOtpCtrlPartitionPlatIntegAuthSlot0,
-  /**
-   * Software managed platform integrator slot 1 partition.
-   *
-   */
-  kDifOtpCtrlPartitionPlatIntegAuthSlot1,
-  /**
-   * Software managed platform owner slot 0 partition.
-   *
-   */
-  kDifOtpCtrlPartitionPlatOwnerAuthSlot0,
-  /**
-   * Software managed platform owner slot 1 partition.
-   *
-   */
-  kDifOtpCtrlPartitionPlatOwnerAuthSlot1,
-  /**
-   * Software managed platform owner slot 2 partition.
-   *
-   */
-  kDifOtpCtrlPartitionPlatOwnerAuthSlot2,
-  /**
-   * Software managed platform owner slot 3 partition.
-   *
-   */
-  kDifOtpCtrlPartitionPlatOwnerAuthSlot3,
-  /**
-   * Anti-replay protection Strike Counters partition.
-   *
-   */
-  kDifOtpCtrlPartitionExtNvm,
-  /**
-   * ROM Patch Code section.
-   *
-   * May contain multiple signed ROM2 patches.
-   */
-  kDifOtpCtrlPartitionRomPatch,
-  /**
-   * SoC Fuses CP section.
-   *
-   */
-  kDifOtpCtrlPartitionSocFusesCp,
-  /**
-   * SoC Fuses FT section.
-   *
-   */
-  kDifOtpCtrlPartitionSocFusesFt,
-  /**
-   * Scratch Fuses section.
-   *
-   */
-  kDifOtpCtrlPartitionScratchFuses,
-#else
-#error "dif_otp_ctrl does not support this top"
-#endif
-  /**
-   * Hardware configuration 0 partition.
-   *
-   * This contains a device identifier and manufacturing state.
-   */
-  kDifOtpCtrlPartitionHwCfg0,
-  /**
-   * Hardware configuration 1 partition.
-   *
-   * This contains several hardware feature switches.
-   */
-  kDifOtpCtrlPartitionHwCfg1,
-  /**
-   * Secret partition 0.
-   *
-   * This contains TEST lifecycle unlock tokens.
-   */
-  kDifOtpCtrlPartitionSecret0,
-  /**
-   * Secret partition 1.
-   *
-   * This contains SRAM and flash scrambling keys.
-   */
-  kDifOtpCtrlPartitionSecret1,
-  /**
-   * Secret partition 2.
-   *
-   * This contains RMA unlock token, creator root key, and creator seed.
-   */
-  kDifOtpCtrlPartitionSecret2,
-#if defined(OPENTITAN_IS_DRAGONFLY)
-  /**
-   * Secret partition 3.
-   *
-   * This contains the owner seed.
-   */
-  kDifOtpCtrlPartitionSecret3,
-#elif defined(OPENTITAN_IS_EGRET)
-// Egret only has 3 secret partitions.
-#else
-#error "dif_otp_ctrl does not support this top"
-#endif
-  /**
-   * Lifecycle partition.
-   *
-   * This contains lifecycle transition count and state. This partition
-   * cannot be locked since the life cycle state needs to advance to RMA
-   * in-field. Note that while this partition is not marked secret, it
-   * is not readable nor writeable via the DAI. Only the LC controller
-   * can access this partition, and even via the LC controller it is not
-   * possible to read the raw manufacturing life cycle state in encoded
-   * form, since that encoding is considered a netlist secret. The LC
-   * controller only exposes a decoded version of this state.
-   */
-  kDifOtpCtrlPartitionLifeCycle,
-
-  /**
-   * This is not a partition; rather, it represents the total number of
-   * partitions.
-   */
-  kDifOtpCtrlNumberOfPartitions,
-
-  /**
-   * The following two are not partitions; rather they represent error codes
-   * that have a corresponding entry in dif_otp_ctrl_status_t.causes.
-   */
-  kDifOtpCtrlPartitionDaiError = kDifOtpCtrlNumberOfPartitions,
-  kDifOtpCtrlPartitionLciError,
-
-  /**
-   * This is not a partition; rather, it represents the total number of entries
-   * in dif_otp_ctrl_status_t.causes.
-   */
-  kDifOtpCtrlNumberOfCauses,
-
-} dif_otp_ctrl_partition_t;
-
-/**
  * Runtime configuration for OTP.
  *
  * This struct describes runtime information for one-time configuration of the
@@ -426,9 +194,9 @@ typedef struct dif_otp_ctrl_status {
   uint32_t codes;
   /**
    * A list of root causes for each partition as well as for DAI and LCI.
-   * dif_otp_ctrl_partition_t can be used for indexing.
+   * otp_partition_t can be used for indexing.
    */
-  dif_otp_ctrl_error_t causes[kDifOtpCtrlNumberOfCauses];
+  dif_otp_ctrl_error_t causes[kOtpPartitionCount + 2];
 } dif_otp_ctrl_status_t;
 
 /**
@@ -562,7 +330,7 @@ dif_result_t dif_otp_ctrl_check_trigger_is_locked(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_lock_reading(const dif_otp_ctrl_t *otp,
-                                       dif_otp_ctrl_partition_t partition);
+                                       otp_partition_t partition);
 
 /**
  * Checks whether reads to a SW partition are locked out.
@@ -577,7 +345,7 @@ dif_result_t dif_otp_ctrl_lock_reading(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_reading_is_locked(const dif_otp_ctrl_t *otp,
-                                            dif_otp_ctrl_partition_t partition,
+                                            otp_partition_t partition,
                                             bool *is_locked);
 
 /**
@@ -603,7 +371,8 @@ dif_result_t dif_otp_ctrl_get_status(const dif_otp_ctrl_t *otp,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
+dif_result_t dif_otp_ctrl_relative_address(const dif_otp_ctrl_t *otp,
+                                           otp_partition_t partition,
                                            uint32_t abs_address,
                                            uint32_t *relative_address);
 
@@ -625,7 +394,7 @@ dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_dai_read_start(const dif_otp_ctrl_t *otp,
-                                         dif_otp_ctrl_partition_t partition,
+                                         otp_partition_t partition,
                                          uint32_t address);
 
 /**
@@ -679,7 +448,7 @@ dif_result_t dif_otp_ctrl_dai_read64_end(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_dai_program32(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint32_t value);
 
 /**
@@ -700,7 +469,7 @@ dif_result_t dif_otp_ctrl_dai_program32(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_dai_program64(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint64_t value);
 
 /**
@@ -723,7 +492,7 @@ dif_result_t dif_otp_ctrl_dai_program64(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
-                                     dif_otp_ctrl_partition_t partition,
+                                     otp_partition_t partition,
                                      uint64_t digest);
 
 /**
@@ -741,7 +510,7 @@ dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_is_digest_computed(const dif_otp_ctrl_t *otp,
-                                             dif_otp_ctrl_partition_t partition,
+                                             otp_partition_t partition,
                                              bool *is_computed);
 
 /**
@@ -761,7 +530,7 @@ dif_result_t dif_otp_ctrl_is_digest_computed(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_get_digest(const dif_otp_ctrl_t *otp,
-                                     dif_otp_ctrl_partition_t partition,
+                                     otp_partition_t partition,
                                      uint64_t *digest);
 
 /**
@@ -785,7 +554,7 @@ dif_result_t dif_otp_ctrl_get_digest(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_read_blocking(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t address, uint32_t *buf,
                                         size_t len);
 

--- a/sw/device/lib/dif/dif_otp_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_otp_ctrl_unittest.cc
@@ -8,6 +8,7 @@
 #include <ostream>
 
 #include "gtest/gtest.h"
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/mock_mmio.h"
 #include "sw/device/lib/dif/dif_test_base.h"
@@ -176,7 +177,7 @@ TEST_F(ReadLockTest, IsLocked) {
       {{OTP_CTRL_VENDOR_TEST_READ_LOCK_VENDOR_TEST_READ_LOCK_BIT,
         true}});
   EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionVendorTest, &flag));
+      &otp_, kOtpPartitionVendorTest, &flag));
   EXPECT_FALSE(flag);
 
   EXPECT_READ32(
@@ -184,7 +185,7 @@ TEST_F(ReadLockTest, IsLocked) {
       {{OTP_CTRL_VENDOR_TEST_READ_LOCK_VENDOR_TEST_READ_LOCK_BIT,
         false}});
   EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionVendorTest, &flag));
+      &otp_, kOtpPartitionVendorTest, &flag));
   EXPECT_TRUE(flag);
 
   EXPECT_READ32(
@@ -192,7 +193,7 @@ TEST_F(ReadLockTest, IsLocked) {
       {{OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK_BIT,
         true}});
   EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionCreatorSwCfg, &flag));
+      &otp_, kOtpPartitionCreatorSwCfg, &flag));
   EXPECT_FALSE(flag);
 
   EXPECT_READ32(
@@ -200,7 +201,7 @@ TEST_F(ReadLockTest, IsLocked) {
       {{OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK_BIT,
         false}});
   EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionCreatorSwCfg, &flag));
+      &otp_, kOtpPartitionCreatorSwCfg, &flag));
   EXPECT_TRUE(flag);
 
   EXPECT_READ32(
@@ -208,7 +209,7 @@ TEST_F(ReadLockTest, IsLocked) {
       {{OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OWNER_SW_CFG_READ_LOCK_BIT,
         true}});
   EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionOwnerSwCfg, &flag));
+      &otp_, kOtpPartitionOwnerSwCfg, &flag));
   EXPECT_FALSE(flag);
 
   EXPECT_READ32(
@@ -216,40 +217,40 @@ TEST_F(ReadLockTest, IsLocked) {
       {{OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OWNER_SW_CFG_READ_LOCK_BIT,
         false}});
   EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionOwnerSwCfg, &flag));
+      &otp_, kOtpPartitionOwnerSwCfg, &flag));
   EXPECT_TRUE(flag);
 
-  EXPECT_READ32(
-      OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_REG_OFFSET,
-      {{OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_BIT,
-        true}});
-  EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionRotCreatorAuthCodesign, &flag));
-  EXPECT_FALSE(flag);
+  //EXPECT_READ32(
+  //    OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_REG_OFFSET,
+  //    {{OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_BIT,
+  //      true}});
+  //EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
+  //    &otp_, kOtpPartitionRotCreatorAuthCodesign, &flag));
+  //EXPECT_FALSE(flag);
 
-  EXPECT_READ32(
-      OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_REG_OFFSET,
-      {{OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_BIT,
-        false}});
-  EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionRotCreatorAuthCodesign, &flag));
-  EXPECT_TRUE(flag);
+  //EXPECT_READ32(
+  //    OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_REG_OFFSET,
+  //    {{OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_BIT,
+  //      false}});
+  //EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
+  //    &otp_, kOtpPartitionRotCreatorAuthCodesign, &flag));
+  //EXPECT_TRUE(flag);
 
-  EXPECT_READ32(
-      OTP_CTRL_ROT_CREATOR_AUTH_STATE_READ_LOCK_REG_OFFSET,
-      {{OTP_CTRL_ROT_CREATOR_AUTH_STATE_READ_LOCK_ROT_CREATOR_AUTH_STATE_READ_LOCK_BIT,
-        true}});
-  EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionRotCreatorAuthState, &flag));
-  EXPECT_FALSE(flag);
+  //EXPECT_READ32(
+  //    OTP_CTRL_ROT_CREATOR_AUTH_STATE_READ_LOCK_REG_OFFSET,
+  //    {{OTP_CTRL_ROT_CREATOR_AUTH_STATE_READ_LOCK_ROT_CREATOR_AUTH_STATE_READ_LOCK_BIT,
+  //      true}});
+  //EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
+  //    &otp_, kOtpPartitionRotCreatorAuthState, &flag));
+  //EXPECT_FALSE(flag);
 
-  EXPECT_READ32(
-      OTP_CTRL_ROT_CREATOR_AUTH_STATE_READ_LOCK_REG_OFFSET,
-      {{OTP_CTRL_ROT_CREATOR_AUTH_STATE_READ_LOCK_ROT_CREATOR_AUTH_STATE_READ_LOCK_BIT,
-        false}});
-  EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionRotCreatorAuthState, &flag));
-  EXPECT_TRUE(flag);
+  //EXPECT_READ32(
+  //    OTP_CTRL_ROT_CREATOR_AUTH_STATE_READ_LOCK_REG_OFFSET,
+  //    {{OTP_CTRL_ROT_CREATOR_AUTH_STATE_READ_LOCK_ROT_CREATOR_AUTH_STATE_READ_LOCK_BIT,
+  //      false}});
+  //EXPECT_DIF_OK(dif_otp_ctrl_reading_is_locked(
+  //    &otp_, kOtpPartitionRotCreatorAuthState, &flag));
+  //EXPECT_TRUE(flag);
 }
 
 TEST_F(ReadLockTest, Lock) {
@@ -258,107 +259,108 @@ TEST_F(ReadLockTest, Lock) {
       {{OTP_CTRL_VENDOR_TEST_READ_LOCK_VENDOR_TEST_READ_LOCK_BIT,
         false}});
   EXPECT_DIF_OK(dif_otp_ctrl_lock_reading(
-      &otp_, kDifOtpCtrlPartitionVendorTest));
+      &otp_, kOtpPartitionVendorTest));
 
   EXPECT_WRITE32(
       OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_REG_OFFSET,
       {{OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK_BIT,
         false}});
   EXPECT_DIF_OK(dif_otp_ctrl_lock_reading(
-      &otp_, kDifOtpCtrlPartitionCreatorSwCfg));
+      &otp_, kOtpPartitionCreatorSwCfg));
 
   EXPECT_WRITE32(
       OTP_CTRL_OWNER_SW_CFG_READ_LOCK_REG_OFFSET,
       {{OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OWNER_SW_CFG_READ_LOCK_BIT,
         false}});
   EXPECT_DIF_OK(dif_otp_ctrl_lock_reading(
-      &otp_, kDifOtpCtrlPartitionOwnerSwCfg));
+      &otp_, kOtpPartitionOwnerSwCfg));
 
-  EXPECT_WRITE32(
-      OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_REG_OFFSET,
-      {{OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_BIT,
-        false}});
-  EXPECT_DIF_OK(dif_otp_ctrl_lock_reading(
-      &otp_, kDifOtpCtrlPartitionRotCreatorAuthCodesign));
+  //EXPECT_WRITE32(
+  //    OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_REG_OFFSET,
+  //    {{OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_ROT_CREATOR_AUTH_CODESIGN_READ_LOCK_BIT,
+  //      false}});
+  //EXPECT_DIF_OK(dif_otp_ctrl_lock_reading(
+  //    &otp_, kOtpPartitionRotCreatorAuthCodesign));
 
-  EXPECT_WRITE32(
-      OTP_CTRL_ROT_CREATOR_AUTH_STATE_READ_LOCK_REG_OFFSET,
-      {{OTP_CTRL_ROT_CREATOR_AUTH_STATE_READ_LOCK_ROT_CREATOR_AUTH_STATE_READ_LOCK_BIT,
-        false}});
-  EXPECT_DIF_OK(dif_otp_ctrl_lock_reading(
-      &otp_, kDifOtpCtrlPartitionRotCreatorAuthState));
+  //EXPECT_WRITE32(
+  //    OTP_CTRL_ROT_CREATOR_AUTH_STATE_READ_LOCK_REG_OFFSET,
+  //    {{OTP_CTRL_ROT_CREATOR_AUTH_STATE_READ_LOCK_ROT_CREATOR_AUTH_STATE_READ_LOCK_BIT,
+  //      false}});
+  //EXPECT_DIF_OK(dif_otp_ctrl_lock_reading(
+  //    &otp_, kOtpPartitionRotCreatorAuthState));
 }
 
 TEST_F(ReadLockTest, NotLockablePartitions) {
   bool flag;
   EXPECT_DIF_BADARG(
-      dif_otp_ctrl_lock_reading(&otp_, kDifOtpCtrlPartitionHwCfg0));
+      dif_otp_ctrl_lock_reading(&otp_, kOtpPartitionHwCfg0));
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionHwCfg0, &flag));
+      &otp_, kOtpPartitionHwCfg0, &flag));
 
   EXPECT_DIF_BADARG(
-      dif_otp_ctrl_lock_reading(&otp_, kDifOtpCtrlPartitionHwCfg1));
+      dif_otp_ctrl_lock_reading(&otp_, kOtpPartitionHwCfg1));
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionHwCfg1, &flag));
+      &otp_, kOtpPartitionHwCfg1, &flag));
 
   EXPECT_DIF_BADARG(
-      dif_otp_ctrl_lock_reading(&otp_, kDifOtpCtrlPartitionSecret0));
+      dif_otp_ctrl_lock_reading(&otp_, kOtpPartitionSecret0));
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionSecret0, &flag));
+      &otp_, kOtpPartitionSecret0, &flag));
 
   EXPECT_DIF_BADARG(
-      dif_otp_ctrl_lock_reading(&otp_, kDifOtpCtrlPartitionSecret1));
+      dif_otp_ctrl_lock_reading(&otp_, kOtpPartitionSecret1));
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionSecret1, &flag));
+      &otp_, kOtpPartitionSecret1, &flag));
 
   EXPECT_DIF_BADARG(
-      dif_otp_ctrl_lock_reading(&otp_, kDifOtpCtrlPartitionSecret2));
+      dif_otp_ctrl_lock_reading(&otp_, kOtpPartitionSecret2));
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionSecret2, &flag));
+      &otp_, kOtpPartitionSecret2, &flag));
 
   EXPECT_DIF_BADARG(
-      dif_otp_ctrl_lock_reading(&otp_, kDifOtpCtrlPartitionLifeCycle));
+      dif_otp_ctrl_lock_reading(&otp_, kOtpPartitionLifeCycle));
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionLifeCycle, &flag));
+      &otp_, kOtpPartitionLifeCycle, &flag));
 }
 // clang-format on
 
 TEST_F(ReadLockTest, NullArgs) {
   bool flag;
-  EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      nullptr, kDifOtpCtrlPartitionVendorTest, &flag));
-  EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionVendorTest, nullptr));
   EXPECT_DIF_BADARG(
-      dif_otp_ctrl_lock_reading(nullptr, kDifOtpCtrlPartitionVendorTest));
-
-  EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      nullptr, kDifOtpCtrlPartitionCreatorSwCfg, &flag));
-  EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionCreatorSwCfg, nullptr));
+      dif_otp_ctrl_reading_is_locked(nullptr, kOtpPartitionVendorTest, &flag));
   EXPECT_DIF_BADARG(
-      dif_otp_ctrl_lock_reading(nullptr, kDifOtpCtrlPartitionCreatorSwCfg));
-
-  EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      nullptr, kDifOtpCtrlPartitionOwnerSwCfg, &flag));
-  EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionOwnerSwCfg, nullptr));
+      dif_otp_ctrl_reading_is_locked(&otp_, kOtpPartitionVendorTest, nullptr));
   EXPECT_DIF_BADARG(
-      dif_otp_ctrl_lock_reading(nullptr, kDifOtpCtrlPartitionOwnerSwCfg));
+      dif_otp_ctrl_lock_reading(nullptr, kOtpPartitionVendorTest));
 
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      nullptr, kDifOtpCtrlPartitionRotCreatorAuthCodesign, &flag));
+      nullptr, kOtpPartitionCreatorSwCfg, &flag));
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionRotCreatorAuthCodesign, nullptr));
-  EXPECT_DIF_BADARG(dif_otp_ctrl_lock_reading(
-      nullptr, kDifOtpCtrlPartitionRotCreatorAuthCodesign));
+      &otp_, kOtpPartitionCreatorSwCfg, nullptr));
+  EXPECT_DIF_BADARG(
+      dif_otp_ctrl_lock_reading(nullptr, kOtpPartitionCreatorSwCfg));
 
-  EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      nullptr, kDifOtpCtrlPartitionRotCreatorAuthState, &flag));
-  EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
-      &otp_, kDifOtpCtrlPartitionRotCreatorAuthState, nullptr));
-  EXPECT_DIF_BADARG(dif_otp_ctrl_lock_reading(
-      nullptr, kDifOtpCtrlPartitionRotCreatorAuthState));
+  EXPECT_DIF_BADARG(
+      dif_otp_ctrl_reading_is_locked(nullptr, kOtpPartitionOwnerSwCfg, &flag));
+  EXPECT_DIF_BADARG(
+      dif_otp_ctrl_reading_is_locked(&otp_, kOtpPartitionOwnerSwCfg, nullptr));
+  EXPECT_DIF_BADARG(
+      dif_otp_ctrl_lock_reading(nullptr, kOtpPartitionOwnerSwCfg));
+
+  //  EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
+  //      nullptr, kOtpPartitionRotCreatorAuthCodesign, &flag));
+  //  EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
+  //      &otp_, kOtpPartitionRotCreatorAuthCodesign, nullptr));
+  //  EXPECT_DIF_BADARG(
+  //      dif_otp_ctrl_lock_reading(nullptr,
+  //      kOtpPartitionRotCreatorAuthCodesign));
+  //
+  //  EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
+  //      nullptr, kOtpPartitionRotCreatorAuthState, &flag));
+  //  EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(
+  //      &otp_, kOtpPartitionRotCreatorAuthState, nullptr));
+  //  EXPECT_DIF_BADARG(
+  //      dif_otp_ctrl_lock_reading(nullptr, kOtpPartitionRotCreatorAuthState));
 }
 
 class StatusTest : public OtpTest {};
@@ -388,10 +390,13 @@ TEST_F(StatusTest, Errors) {
                     {OTP_CTRL_PARTITION_STATUS_0_HW_CFG0_ERROR_BIT, true},
                 });
 
-  EXPECT_READ32(OTP_CTRL_ERR_CODE_5_REG_OFFSET,
-                {{OTP_CTRL_ERR_CODE_0_ERR_CODE_0_OFFSET,
-                  OTP_CTRL_ERR_CODE_0_ERR_CODE_0_VALUE_MACRO_ECC_CORR_ERROR}});
-  EXPECT_READ32(OTP_CTRL_ERR_CODE_12_REG_OFFSET,
+  EXPECT_READ32(
+      OTP_CTRL_ERR_CODE_0_REG_OFFSET + (kOtpPartitionHwCfg0 * sizeof(uint32_t)),
+      {{OTP_CTRL_ERR_CODE_0_ERR_CODE_0_OFFSET,
+        OTP_CTRL_ERR_CODE_0_ERR_CODE_0_VALUE_MACRO_ECC_CORR_ERROR}});
+  // Partition count + 1 is reserved as a life cycle error code.
+  EXPECT_READ32(OTP_CTRL_ERR_CODE_0_REG_OFFSET +
+                    ((kOtpPartitionCount + 1) * sizeof(uint32_t)),
                 {{OTP_CTRL_ERR_CODE_0_ERR_CODE_0_OFFSET,
                   OTP_CTRL_ERR_CODE_0_ERR_CODE_0_VALUE_MACRO_ERROR}});
 
@@ -399,9 +404,9 @@ TEST_F(StatusTest, Errors) {
   EXPECT_EQ(status.codes, (1 << kDifOtpCtrlStatusCodeDaiIdle) |
                               (1 << kDifOtpCtrlStatusCodePartitionError) |
                               (1 << kDifOtpCtrlStatusCodeLciError));
-  EXPECT_EQ(status.causes[kDifOtpCtrlPartitionHwCfg0],
+  EXPECT_EQ(status.causes[kOtpPartitionHwCfg0],
             kDifOtpCtrlErrorMacroRecoverableRead);
-  EXPECT_EQ(status.causes[kDifOtpCtrlPartitionLciError],
+  EXPECT_EQ(status.causes[kOtpPartitionCount + 1],
             kDifOtpCtrlErrorMacroUnspecified);
 }
 
@@ -414,7 +419,7 @@ TEST_F(StatusTest, NullArgs) {
 
 struct RelativeAddressParams {
   std::string name;
-  dif_otp_ctrl_partition_t partition;
+  otp_partition_t partition;
   uint32_t abs_address;
   dif_result_t expected_result;
   uint32_t expected_relative_address;
@@ -427,7 +432,8 @@ class RelativeAddress
 TEST_P(RelativeAddress, RelativeAddress) {
   uint32_t got_relative_address;
   dif_result_t got_result = dif_otp_ctrl_relative_address(
-      GetParam().partition, GetParam().abs_address, &got_relative_address);
+      &otp_, GetParam().partition, GetParam().abs_address,
+      &got_relative_address);
   EXPECT_EQ(got_result, GetParam().expected_result);
   EXPECT_EQ(got_relative_address, GetParam().expected_relative_address);
 }
@@ -437,49 +443,49 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Values(
         RelativeAddressParams{
             "VendorTestOkay",
-            kDifOtpCtrlPartitionVendorTest,
+            kOtpPartitionVendorTest,
             OTP_CTRL_PARAM_VENDOR_TEST_OFFSET + 4,
             kDifOk,
             4,
         },
         RelativeAddressParams{
             "VendorTestUnaligned",
-            kDifOtpCtrlPartitionVendorTest,
+            kOtpPartitionVendorTest,
             OTP_CTRL_PARAM_VENDOR_TEST_OFFSET + 1,
             kDifUnaligned,
             0,
         },
         RelativeAddressParams{
             "VendorTestOutOfRangePastEnd",
-            kDifOtpCtrlPartitionVendorTest,
+            kOtpPartitionVendorTest,
             OTP_CTRL_PARAM_VENDOR_TEST_OFFSET + OTP_CTRL_PARAM_VENDOR_TEST_SIZE,
             kDifOutOfRange,
             0,
         },
         RelativeAddressParams{
             "CreatorSwCfgOkay",
-            kDifOtpCtrlPartitionCreatorSwCfg,
+            kOtpPartitionCreatorSwCfg,
             OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET + 4,
             kDifOk,
             4,
         },
         RelativeAddressParams{
             "CreatorSwCfgUnaligned",
-            kDifOtpCtrlPartitionCreatorSwCfg,
+            kOtpPartitionCreatorSwCfg,
             OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET + 1,
             kDifUnaligned,
             0,
         },
         RelativeAddressParams{
             "CreatorSwCfgOutOfRangeBeforeStart",
-            kDifOtpCtrlPartitionCreatorSwCfg,
+            kOtpPartitionCreatorSwCfg,
             OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET - 4,
             kDifOutOfRange,
             0,
         },
         RelativeAddressParams{
             "CreatorSwCfgOutOfRangePastEnd",
-            kDifOtpCtrlPartitionCreatorSwCfg,
+            kOtpPartitionCreatorSwCfg,
             OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET +
                 OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE,
             kDifOutOfRange,
@@ -487,255 +493,255 @@ INSTANTIATE_TEST_SUITE_P(
         },
         RelativeAddressParams{
             "OwnerSwCfgOkay",
-            kDifOtpCtrlPartitionOwnerSwCfg,
+            kOtpPartitionOwnerSwCfg,
             OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET + 4,
             kDifOk,
             4,
         },
         RelativeAddressParams{
             "OwnerSwCfgUnaligned",
-            kDifOtpCtrlPartitionOwnerSwCfg,
+            kOtpPartitionOwnerSwCfg,
             OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET + 1,
             kDifUnaligned,
             0,
         },
         RelativeAddressParams{
             "OwnerSwCfgOutOfRangeBeforeStart",
-            kDifOtpCtrlPartitionOwnerSwCfg,
+            kOtpPartitionOwnerSwCfg,
             OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET - 4,
             kDifOutOfRange,
             0,
         },
         RelativeAddressParams{
             "OwnerSwCfgOutOfRangePastEnd",
-            kDifOtpCtrlPartitionOwnerSwCfg,
+            kOtpPartitionOwnerSwCfg,
             OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET +
                 OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE,
             kDifOutOfRange,
             0,
         },
-        RelativeAddressParams{
-            "RotCreatorAuthCodesignOkay",
-            kDifOtpCtrlPartitionRotCreatorAuthCodesign,
-            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_OFFSET + 4,
-            kDifOk,
-            4,
-        },
-        RelativeAddressParams{
-            "RotCreatorAuthCodesignUnaligned",
-            kDifOtpCtrlPartitionRotCreatorAuthCodesign,
-            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_OFFSET + 1,
-            kDifUnaligned,
-            0,
-        },
-        RelativeAddressParams{
-            "RotCreatorAuthCodesignOutOfRangeBeforeStart",
-            kDifOtpCtrlPartitionRotCreatorAuthCodesign,
-            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_OFFSET - 4,
-            kDifOutOfRange,
-            0,
-        },
-        RelativeAddressParams{
-            "RotCreatorAuthCodesignOutOfRangePastEnd",
-            kDifOtpCtrlPartitionRotCreatorAuthCodesign,
-            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_OFFSET +
-                OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE,
-            kDifOutOfRange,
-            0,
-        },
-        RelativeAddressParams{
-            "RotCreatorAuthStateOkay",
-            kDifOtpCtrlPartitionRotCreatorAuthState,
-            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_OFFSET + 4,
-            kDifOk,
-            4,
-        },
-        RelativeAddressParams{
-            "RotCreatorAuthStateUnaligned",
-            kDifOtpCtrlPartitionRotCreatorAuthState,
-            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_OFFSET + 1,
-            kDifUnaligned,
-            0,
-        },
-        RelativeAddressParams{
-            "RotCreatorAuthStateOutOfRangeBeforeStart",
-            kDifOtpCtrlPartitionRotCreatorAuthState,
-            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_OFFSET - 4,
-            kDifOutOfRange,
-            0,
-        },
-        RelativeAddressParams{
-            "RotCreatorAuthStateOutOfRangePastEnd",
-            kDifOtpCtrlPartitionRotCreatorAuthState,
-            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_OFFSET +
-                OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE,
-            kDifOutOfRange,
-            0,
-        },
+        // RelativeAddressParams{
+        //     "RotCreatorAuthCodesignOkay",
+        //     kOtpPartitionRotCreatorAuthCodesign,
+        //     OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_OFFSET + 4,
+        //     kDifOk,
+        //     4,
+        // },
+        // RelativeAddressParams{
+        //     "RotCreatorAuthCodesignUnaligned",
+        //     kOtpPartitionRotCreatorAuthCodesign,
+        //     OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_OFFSET + 1,
+        //     kDifUnaligned,
+        //     0,
+        // },
+        // RelativeAddressParams{
+        //     "RotCreatorAuthCodesignOutOfRangeBeforeStart",
+        //     kOtpPartitionRotCreatorAuthCodesign,
+        //     OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_OFFSET - 4,
+        //     kDifOutOfRange,
+        //     0,
+        // },
+        // RelativeAddressParams{
+        //     "RotCreatorAuthCodesignOutOfRangePastEnd",
+        //     kOtpPartitionRotCreatorAuthCodesign,
+        //     OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_OFFSET +
+        //         OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE,
+        //     kDifOutOfRange,
+        //     0,
+        // },
+        // RelativeAddressParams{
+        //     "RotCreatorAuthStateOkay",
+        //     kOtpPartitionRotCreatorAuthState,
+        //     OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_OFFSET + 4,
+        //     kDifOk,
+        //     4,
+        // },
+        // RelativeAddressParams{
+        //     "RotCreatorAuthStateUnaligned",
+        //     kOtpPartitionRotCreatorAuthState,
+        //     OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_OFFSET + 1,
+        //     kDifUnaligned,
+        //     0,
+        // },
+        // RelativeAddressParams{
+        //     "RotCreatorAuthStateOutOfRangeBeforeStart",
+        //     kOtpPartitionRotCreatorAuthState,
+        //     OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_OFFSET - 4,
+        //     kDifOutOfRange,
+        //     0,
+        // },
+        // RelativeAddressParams{
+        //     "RotCreatorAuthStateOutOfRangePastEnd",
+        //     kOtpPartitionRotCreatorAuthState,
+        //     OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_OFFSET +
+        //         OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE,
+        //     kDifOutOfRange,
+        //     0,
+        // },
         RelativeAddressParams{
             "HwCfg0Okay",
-            kDifOtpCtrlPartitionHwCfg0,
+            kOtpPartitionHwCfg0,
             OTP_CTRL_PARAM_HW_CFG0_OFFSET + 4,
             kDifOk,
             4,
         },
         RelativeAddressParams{
             "HwCfg0Unaligned",
-            kDifOtpCtrlPartitionHwCfg0,
+            kOtpPartitionHwCfg0,
             OTP_CTRL_PARAM_HW_CFG0_OFFSET + 1,
             kDifUnaligned,
             0,
         },
         RelativeAddressParams{
             "HwCfg0OutOfRangeBeforeStart",
-            kDifOtpCtrlPartitionHwCfg0,
+            kOtpPartitionHwCfg0,
             OTP_CTRL_PARAM_HW_CFG0_OFFSET - 4,
             kDifOutOfRange,
             0,
         },
         RelativeAddressParams{
             "HwCfg0OutOfRangePastEnd",
-            kDifOtpCtrlPartitionHwCfg0,
+            kOtpPartitionHwCfg0,
             OTP_CTRL_PARAM_HW_CFG0_OFFSET + OTP_CTRL_PARAM_HW_CFG0_SIZE,
             kDifOutOfRange,
             0,
         },
         RelativeAddressParams{
             "HwCfg1Okay",
-            kDifOtpCtrlPartitionHwCfg1,
+            kOtpPartitionHwCfg1,
             OTP_CTRL_PARAM_HW_CFG1_OFFSET + 4,
             kDifOk,
             4,
         },
         RelativeAddressParams{
             "HwCfg1Unaligned",
-            kDifOtpCtrlPartitionHwCfg1,
+            kOtpPartitionHwCfg1,
             OTP_CTRL_PARAM_HW_CFG1_OFFSET + 1,
             kDifUnaligned,
             0,
         },
         RelativeAddressParams{
             "HwCfg1OutOfRangeBeforeStart",
-            kDifOtpCtrlPartitionHwCfg1,
+            kOtpPartitionHwCfg1,
             OTP_CTRL_PARAM_HW_CFG1_OFFSET - 4,
             kDifOutOfRange,
             0,
         },
         RelativeAddressParams{
             "HwCfg1OutOfRangePastEnd",
-            kDifOtpCtrlPartitionHwCfg1,
+            kOtpPartitionHwCfg1,
             OTP_CTRL_PARAM_HW_CFG1_OFFSET + OTP_CTRL_PARAM_HW_CFG1_SIZE,
             kDifOutOfRange,
             0,
         },
         RelativeAddressParams{
             "Secret0Okay",
-            kDifOtpCtrlPartitionSecret0,
+            kOtpPartitionSecret0,
             OTP_CTRL_PARAM_SECRET0_OFFSET + 8,
             kDifOk,
             8,
         },
         RelativeAddressParams{
             "Secret0Unaligned",
-            kDifOtpCtrlPartitionSecret0,
+            kOtpPartitionSecret0,
             OTP_CTRL_PARAM_SECRET0_OFFSET + 1,
             kDifUnaligned,
             0,
         },
         RelativeAddressParams{
             "Secret0OutOfRangeBeforeStart",
-            kDifOtpCtrlPartitionSecret0,
+            kOtpPartitionSecret0,
             OTP_CTRL_PARAM_SECRET0_OFFSET - 8,
             kDifOutOfRange,
             0,
         },
         RelativeAddressParams{
             "Secret0OutOfRangePastEnd",
-            kDifOtpCtrlPartitionSecret0,
+            kOtpPartitionSecret0,
             OTP_CTRL_PARAM_SECRET0_OFFSET + OTP_CTRL_PARAM_SECRET0_SIZE,
             kDifOutOfRange,
             0,
         },
         RelativeAddressParams{
             "Secret1Okay",
-            kDifOtpCtrlPartitionSecret1,
+            kOtpPartitionSecret1,
             OTP_CTRL_PARAM_SECRET1_OFFSET + 8,
             kDifOk,
             8,
         },
         RelativeAddressParams{
             "Secret1Unaligned",
-            kDifOtpCtrlPartitionSecret1,
+            kOtpPartitionSecret1,
             OTP_CTRL_PARAM_SECRET1_OFFSET + 1,
             kDifUnaligned,
             0,
         },
         RelativeAddressParams{
             "Secret1OutOfRangeBeforeStart",
-            kDifOtpCtrlPartitionSecret1,
+            kOtpPartitionSecret1,
             OTP_CTRL_PARAM_SECRET1_OFFSET - 8,
             kDifOutOfRange,
             0,
         },
         RelativeAddressParams{
             "Secret1OutOfRangePastEnd",
-            kDifOtpCtrlPartitionSecret1,
+            kOtpPartitionSecret1,
             OTP_CTRL_PARAM_SECRET1_OFFSET + OTP_CTRL_PARAM_SECRET1_SIZE,
             kDifOutOfRange,
             0,
         },
         RelativeAddressParams{
             "Secret2Okay",
-            kDifOtpCtrlPartitionSecret2,
+            kOtpPartitionSecret2,
             OTP_CTRL_PARAM_SECRET2_OFFSET + 8,
             kDifOk,
             8,
         },
         RelativeAddressParams{
             "Secret2Unaligned",
-            kDifOtpCtrlPartitionSecret2,
+            kOtpPartitionSecret2,
             OTP_CTRL_PARAM_SECRET2_OFFSET + 1,
             kDifUnaligned,
             0,
         },
         RelativeAddressParams{
             "Secret2OutOfRangeBeforeStart",
-            kDifOtpCtrlPartitionSecret2,
+            kOtpPartitionSecret2,
             OTP_CTRL_PARAM_SECRET2_OFFSET - 8,
             kDifOutOfRange,
             0,
         },
         RelativeAddressParams{
             "Secret2OutOfRangePastEnd",
-            kDifOtpCtrlPartitionSecret2,
+            kOtpPartitionSecret2,
             OTP_CTRL_PARAM_SECRET2_OFFSET + OTP_CTRL_PARAM_SECRET2_SIZE,
             kDifOutOfRange,
             0,
         },
         RelativeAddressParams{
             "LifeCycleOkay",
-            kDifOtpCtrlPartitionLifeCycle,
+            kOtpPartitionLifeCycle,
             OTP_CTRL_PARAM_LIFE_CYCLE_OFFSET + 4,
             kDifOk,
             4,
         },
         RelativeAddressParams{
             "LifeCycleUnaligned",
-            kDifOtpCtrlPartitionLifeCycle,
+            kOtpPartitionLifeCycle,
             OTP_CTRL_PARAM_LIFE_CYCLE_OFFSET + 1,
             kDifUnaligned,
             0,
         },
         RelativeAddressParams{
             "LifeCycleOutOfRangeBeforeStart",
-            kDifOtpCtrlPartitionLifeCycle,
+            kOtpPartitionLifeCycle,
             OTP_CTRL_PARAM_LIFE_CYCLE_OFFSET - 4,
             kDifOutOfRange,
             0,
         },
         RelativeAddressParams{
             "LifeCycleOutOfRangePastEnd",
-            kDifOtpCtrlPartitionLifeCycle,
+            kOtpPartitionLifeCycle,
             OTP_CTRL_PARAM_LIFE_CYCLE_OFFSET + OTP_CTRL_PARAM_LIFE_CYCLE_SIZE,
             kDifOutOfRange,
             0,
@@ -748,12 +754,12 @@ class DaiReadTest : public OtpTest {};
 
 TEST_F(DaiReadTest, Read32) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
-                 OTP_CTRL_PARAM_MANUF_STATE_OFFSET);
+                 OTP_CTRL_PARAM_DEVICE_ID_OFFSET);
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_RD_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionHwCfg0,
-                                            /*address=*/0x20));
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionHwCfg0,
+                                            /*address=*/0x0));
 
   EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET, 0x12345678);
 
@@ -769,7 +775,7 @@ TEST_F(DaiReadTest, Read64) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_RD_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionSecret0,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionSecret0,
                                             /*address=*/0x8));
 
   EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET, 0x12345678);
@@ -783,7 +789,7 @@ TEST_F(DaiReadTest, Read64) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_RD_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionSecret1,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionSecret1,
                                             /*address=*/0x8));
 
   EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET, 0x12345678);
@@ -797,7 +803,7 @@ TEST_F(DaiReadTest, Read64) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_RD_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionSecret2,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionSecret2,
                                             /*address=*/0x8));
 
   EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET, 0x12345678);
@@ -808,23 +814,19 @@ TEST_F(DaiReadTest, Read64) {
 }
 
 TEST_F(DaiReadTest, Unaligned) {
-  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionHwCfg0,
-                                        /*address=*/0b01),
-            kDifUnaligned);
-  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionSecret2,
-                                        /*address=*/0b100),
+  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionHwCfg0,
+                                        /*address=*/0b10),
             kDifUnaligned);
 }
 
 TEST_F(DaiReadTest, OutOfRange) {
-  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kOtpPartitionHwCfg0,
                                         /*address=*/0x100),
             kDifOutOfRange);
 }
 
 TEST_F(DaiReadTest, NullArgs) {
-  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_read_start(nullptr,
-                                                kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_read_start(nullptr, kOtpPartitionHwCfg0,
                                                 /*address=*/0x0));
 
   uint32_t val32;
@@ -840,13 +842,13 @@ class DaiProgramTest : public OtpTest {};
 
 TEST_F(DaiProgramTest, Program32) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
-                 OTP_CTRL_PARAM_MANUF_STATE_OFFSET);
+                 OTP_CTRL_PARAM_DEVICE_ID_OFFSET);
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_WDATA_0_REG_OFFSET, 0x12345678);
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionHwCfg0,
-                                           /*address=*/0x20,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_program32(&otp_, kOtpPartitionHwCfg0,
+                                           /*address=*/0x0,
                                            /*value=*/0x12345678));
 }
 
@@ -858,30 +860,30 @@ TEST_F(DaiProgramTest, Program64) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_program64(&otp_, kDifOtpCtrlPartitionSecret2,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_program64(&otp_, kOtpPartitionSecret2,
                                            /*address=*/0x8,
                                            /*value=*/0x1234567890abcdef));
 }
 
 TEST_F(DaiProgramTest, BadPartition) {
-  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionSecret1,
+  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kOtpPartitionSecret1,
                                        /*address=*/0x0, /*value=*/42),
             kDifError);
-  EXPECT_EQ(dif_otp_ctrl_dai_program64(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_EQ(dif_otp_ctrl_dai_program64(&otp_, kOtpPartitionHwCfg0,
                                        /*address=*/0x0, /*value=*/42),
             kDifError);
 
   // LC is never writeable.
-  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionLifeCycle,
+  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kOtpPartitionLifeCycle,
                                        /*address=*/0x0, /*value=*/42),
             kDifError);
 }
 
 TEST_F(DaiProgramTest, Unaligned) {
-  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kOtpPartitionHwCfg0,
                                        /*address=*/0b01, /*value=*/42),
             kDifUnaligned);
-  EXPECT_EQ(dif_otp_ctrl_dai_program64(&otp_, kDifOtpCtrlPartitionSecret2,
+  EXPECT_EQ(dif_otp_ctrl_dai_program64(&otp_, kOtpPartitionSecret2,
                                        /*address=*/0b100, /*value=*/42),
             kDifUnaligned);
 }
@@ -889,24 +891,22 @@ TEST_F(DaiProgramTest, Unaligned) {
 TEST_F(DaiProgramTest, OutOfRange) {
   // Check that we can't write a digest directly.
   EXPECT_EQ(dif_otp_ctrl_dai_program32(
-                &otp_, kDifOtpCtrlPartitionCreatorSwCfg,
+                &otp_, kOtpPartitionCreatorSwCfg,
                 /*address=*/OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_OFFSET,
                 /*value=*/42),
             kDifOutOfRange);
 
   // Same digest check for 64-bit.
   EXPECT_EQ(dif_otp_ctrl_dai_program64(
-                &otp_, kDifOtpCtrlPartitionSecret2,
+                &otp_, kOtpPartitionSecret2,
                 /*address=*/OTP_CTRL_PARAM_SECRET2_DIGEST_OFFSET, /*value=*/42),
             kDifOutOfRange);
 }
 
 TEST_F(DaiProgramTest, NullArgs) {
-  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_program32(nullptr,
-                                               kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_program32(nullptr, kOtpPartitionHwCfg0,
                                                /*address=*/0x0, /*value=*/42));
-  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_program64(nullptr,
-                                               kDifOtpCtrlPartitionSecret0,
+  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_program64(nullptr, kOtpPartitionSecret0,
                                                /*address=*/0x0, /*value=*/42));
 }
 
@@ -920,7 +920,7 @@ TEST_F(DaiDigestTest, DigestSw) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionVendorTest,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kOtpPartitionVendorTest,
                                         /*digest=*/0xabcdef0000abcdef));
 
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
@@ -930,7 +930,7 @@ TEST_F(DaiDigestTest, DigestSw) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionCreatorSwCfg,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kOtpPartitionCreatorSwCfg,
                                         /*digest=*/0xabcdef0000abcdef));
 
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
@@ -940,30 +940,30 @@ TEST_F(DaiDigestTest, DigestSw) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionOwnerSwCfg,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kOtpPartitionOwnerSwCfg,
                                         /*digest=*/0xabcdef0000abcdef));
 
-  EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
-                 OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_DIGEST_OFFSET);
-  EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_WDATA_0_REG_OFFSET, 0x00abcdef);
-  EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_WDATA_1_REG_OFFSET, 0xabcdef00);
-  EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
-                 {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
+  // EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
+  //                OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_DIGEST_OFFSET);
+  // EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_WDATA_0_REG_OFFSET, 0x00abcdef);
+  // EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_WDATA_1_REG_OFFSET, 0xabcdef00);
+  // EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
+  //                {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
 
-  EXPECT_DIF_OK(
-      dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionRotCreatorAuthCodesign,
-                              /*digest=*/0xabcdef0000abcdef));
+  // EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_,
+  //                                       kOtpPartitionRotCreatorAuthCodesign,
+  //                                       /*digest=*/0xabcdef0000abcdef));
 
-  EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
-                 OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_DIGEST_OFFSET);
-  EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_WDATA_0_REG_OFFSET, 0x00abcdef);
-  EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_WDATA_1_REG_OFFSET, 0xabcdef00);
-  EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
-                 {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
+  // EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
+  //                OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_DIGEST_OFFSET);
+  // EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_WDATA_0_REG_OFFSET, 0x00abcdef);
+  // EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_WDATA_1_REG_OFFSET, 0xabcdef00);
+  // EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
+  //                {{OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_,
-                                        kDifOtpCtrlPartitionRotCreatorAuthState,
-                                        /*digest=*/0xabcdef0000abcdef));
+  // EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_,
+  // kOtpPartitionRotCreatorAuthState,
+  //                                       /*digest=*/0xabcdef0000abcdef));
 }
 
 TEST_F(DaiDigestTest, DigestHw) {
@@ -972,7 +972,7 @@ TEST_F(DaiDigestTest, DigestHw) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_DIGEST_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kOtpPartitionHwCfg0,
                                         /*digest=*/0));
 
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
@@ -980,7 +980,7 @@ TEST_F(DaiDigestTest, DigestHw) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_DIGEST_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionHwCfg1,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kOtpPartitionHwCfg1,
                                         /*digest=*/0));
 
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
@@ -988,7 +988,7 @@ TEST_F(DaiDigestTest, DigestHw) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_DIGEST_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionSecret0,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kOtpPartitionSecret0,
                                         /*digest=*/0));
 
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
@@ -996,7 +996,7 @@ TEST_F(DaiDigestTest, DigestHw) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_DIGEST_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionSecret1,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kOtpPartitionSecret1,
                                         /*digest=*/0));
 
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
@@ -1004,27 +1004,25 @@ TEST_F(DaiDigestTest, DigestHw) {
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
                  {{OTP_CTRL_DIRECT_ACCESS_CMD_DIGEST_BIT, true}});
 
-  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionSecret2,
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_digest(&otp_, kOtpPartitionSecret2,
                                         /*digest=*/0));
 }
 
 TEST_F(DaiDigestTest, BadPartition) {
-  EXPECT_EQ(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionLifeCycle,
+  EXPECT_EQ(dif_otp_ctrl_dai_digest(&otp_, kOtpPartitionLifeCycle,
                                     /*digest=*/0),
-            kDifError);
+            kDifBadArg);
 }
 
 TEST_F(DaiDigestTest, BadDigest) {
-  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionHwCfg0,
+  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(&otp_, kOtpPartitionHwCfg0,
                                             /*digest=*/0xabcdef0000abcdef));
-  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(&otp_,
-                                            kDifOtpCtrlPartitionCreatorSwCfg,
+  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(&otp_, kOtpPartitionCreatorSwCfg,
                                             /*digest=*/0));
 }
 
 TEST_F(DaiDigestTest, NullArgs) {
-  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(nullptr,
-                                            kDifOtpCtrlPartitionCreatorSwCfg,
+  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_digest(nullptr, kOtpPartitionCreatorSwCfg,
                                             /*digest=*/0xabcdef0000abcdef));
 }
 
@@ -1033,17 +1031,17 @@ class IsDigestComputed : public OtpTest {};
 TEST_F(IsDigestComputed, NullArgs) {
   bool is_computed;
   EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
-      nullptr, kDifOtpCtrlPartitionSecret2, &is_computed));
-  EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
-      &otp_, kDifOtpCtrlPartitionSecret2, nullptr));
-  EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
-      nullptr, kDifOtpCtrlPartitionSecret2, nullptr));
+      nullptr, kOtpPartitionSecret2, &is_computed));
+  EXPECT_DIF_BADARG(
+      dif_otp_ctrl_is_digest_computed(&otp_, kOtpPartitionSecret2, nullptr));
+  EXPECT_DIF_BADARG(
+      dif_otp_ctrl_is_digest_computed(nullptr, kOtpPartitionSecret2, nullptr));
 }
 
 TEST_F(IsDigestComputed, BadPartition) {
   bool is_computed;
   EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
-      &otp_, kDifOtpCtrlPartitionLifeCycle, &is_computed));
+      &otp_, kOtpPartitionLifeCycle, &is_computed));
 }
 
 TEST_F(IsDigestComputed, Success) {
@@ -1051,19 +1049,19 @@ TEST_F(IsDigestComputed, Success) {
 
   EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_1_REG_OFFSET, 0x98abcdef);
   EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_0_REG_OFFSET, 0xabcdef01);
-  EXPECT_DIF_OK(dif_otp_ctrl_is_digest_computed(
-      &otp_, kDifOtpCtrlPartitionSecret2, &is_computed));
+  EXPECT_DIF_OK(dif_otp_ctrl_is_digest_computed(&otp_, kOtpPartitionSecret2,
+                                                &is_computed));
   EXPECT_TRUE(is_computed);
 
   EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_1_REG_OFFSET, 0);
   EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_0_REG_OFFSET, 0);
-  EXPECT_DIF_OK(dif_otp_ctrl_is_digest_computed(
-      &otp_, kDifOtpCtrlPartitionSecret2, &is_computed));
+  EXPECT_DIF_OK(dif_otp_ctrl_is_digest_computed(&otp_, kOtpPartitionSecret2,
+                                                &is_computed));
   EXPECT_FALSE(is_computed);
 }
 
 struct DigestParams {
-  dif_otp_ctrl_partition_t partition;
+  otp_partition_t partition;
   bool has_digest;
   ptrdiff_t reg0, reg1;
 };
@@ -1115,67 +1113,67 @@ INSTANTIATE_TEST_SUITE_P(
     AllDigests, GetDigest,
     testing::Values(
         DigestParams{
-            kDifOtpCtrlPartitionVendorTest,
+            kOtpPartitionVendorTest,
             true,
             OTP_CTRL_VENDOR_TEST_DIGEST_0_REG_OFFSET,
             OTP_CTRL_VENDOR_TEST_DIGEST_1_REG_OFFSET,
         },
         DigestParams{
-            kDifOtpCtrlPartitionCreatorSwCfg,
+            kOtpPartitionCreatorSwCfg,
             true,
             OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_REG_OFFSET,
             OTP_CTRL_CREATOR_SW_CFG_DIGEST_1_REG_OFFSET,
         },
         DigestParams{
-            kDifOtpCtrlPartitionOwnerSwCfg,
+            kOtpPartitionOwnerSwCfg,
             true,
             OTP_CTRL_OWNER_SW_CFG_DIGEST_0_REG_OFFSET,
             OTP_CTRL_OWNER_SW_CFG_DIGEST_1_REG_OFFSET,
         },
+        //DigestParams{
+        //    kOtpPartitionRotCreatorAuthCodesign,
+        //    true,
+        //    OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_DIGEST_0_REG_OFFSET,
+        //    OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_DIGEST_1_REG_OFFSET,
+        //},
+        //DigestParams{
+        //    kOtpPartitionRotCreatorAuthState,
+        //    true,
+        //    OTP_CTRL_ROT_CREATOR_AUTH_STATE_DIGEST_0_REG_OFFSET,
+        //    OTP_CTRL_ROT_CREATOR_AUTH_STATE_DIGEST_1_REG_OFFSET,
+        //},
         DigestParams{
-            kDifOtpCtrlPartitionRotCreatorAuthCodesign,
-            true,
-            OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_DIGEST_0_REG_OFFSET,
-            OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_DIGEST_1_REG_OFFSET,
-        },
-        DigestParams{
-            kDifOtpCtrlPartitionRotCreatorAuthState,
-            true,
-            OTP_CTRL_ROT_CREATOR_AUTH_STATE_DIGEST_0_REG_OFFSET,
-            OTP_CTRL_ROT_CREATOR_AUTH_STATE_DIGEST_1_REG_OFFSET,
-        },
-        DigestParams{
-            kDifOtpCtrlPartitionHwCfg0,
+            kOtpPartitionHwCfg0,
             true,
             OTP_CTRL_HW_CFG0_DIGEST_0_REG_OFFSET,
             OTP_CTRL_HW_CFG0_DIGEST_1_REG_OFFSET,
         },
         DigestParams{
-            kDifOtpCtrlPartitionHwCfg1,
+            kOtpPartitionHwCfg1,
             true,
             OTP_CTRL_HW_CFG1_DIGEST_0_REG_OFFSET,
             OTP_CTRL_HW_CFG1_DIGEST_1_REG_OFFSET,
         },
         DigestParams{
-            kDifOtpCtrlPartitionSecret0,
+            kOtpPartitionSecret0,
             true,
             OTP_CTRL_SECRET0_DIGEST_0_REG_OFFSET,
             OTP_CTRL_SECRET0_DIGEST_1_REG_OFFSET,
         },
         DigestParams{
-            kDifOtpCtrlPartitionSecret1,
+            kOtpPartitionSecret1,
             true,
             OTP_CTRL_SECRET1_DIGEST_0_REG_OFFSET,
             OTP_CTRL_SECRET1_DIGEST_1_REG_OFFSET,
         },
         DigestParams{
-            kDifOtpCtrlPartitionSecret2,
+            kOtpPartitionSecret2,
             true,
             OTP_CTRL_SECRET2_DIGEST_0_REG_OFFSET,
             OTP_CTRL_SECRET2_DIGEST_1_REG_OFFSET,
         },
         DigestParams{
-            kDifOtpCtrlPartitionLifeCycle,
+            kOtpPartitionLifeCycle,
             false,
             0,
             0,
@@ -1195,41 +1193,51 @@ TEST_F(BlockingIoTest, Read) {
   }
 
   std::vector<uint32_t> buf(kWords);
-  EXPECT_DIF_OK(dif_otp_ctrl_read_blocking(
-      &otp_, kDifOtpCtrlPartitionOwnerSwCfg, 0x10, buf.data(), buf.size()));
+  EXPECT_DIF_OK(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionOwnerSwCfg, 0x10,
+                                           buf.data(), buf.size()));
   EXPECT_THAT(buf, ElementsAre(1, 2, 3, 4));
 }
 
 TEST_F(BlockingIoTest, BadPartition) {
   std::vector<uint32_t> buf(kWords);
-  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kDifOtpCtrlPartitionHwCfg0, 0x10,
+  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionHwCfg0, 0x10,
                                        buf.data(), buf.size()),
             kDifError);
 }
 
 TEST_F(BlockingIoTest, Unaligned) {
   std::vector<uint32_t> buf(kWords);
-  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kDifOtpCtrlPartitionOwnerSwCfg,
-                                       0x11, buf.data(), buf.size()),
+  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionOwnerSwCfg, 0x11,
+                                       buf.data(), buf.size()),
             kDifUnaligned);
 }
 
 TEST_F(BlockingIoTest, OutOfRange) {
-  std::vector<uint32_t> buf(0x2f0);
-  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kDifOtpCtrlPartitionOwnerSwCfg,
-                                       0x300, buf.data(), buf.size()),
+  dt_otp_partition_info_t partition_info =
+      dt_otp_ctrl_partition(kDtOtpCtrl, kOtpPartitionOwnerSwCfg);
+  size_t partition_len = partition_info.size;
+  if (partition_info.sw_digest || partition_info.hw_digest) {
+    partition_len += sizeof(uint64_t);
+  }
+  if (partition_info.zeroizable) {
+    partition_len += sizeof(uint64_t);
+  }
+  std::vector<uint32_t> buf0(0x4);
+  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionOwnerSwCfg,
+                                       partition_len, buf0.data(), buf0.size()),
             kDifOutOfRange);
-  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kDifOtpCtrlPartitionOwnerSwCfg,
-                                       0x10, buf.data(), 0x330),
+  std::vector<uint32_t> buf1(partition_len);
+  EXPECT_EQ(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionOwnerSwCfg, 0x10,
+                                       buf1.data(), buf1.size()),
             kDifOutOfRange);
 }
 
 TEST_F(BlockingIoTest, NullArgs) {
   std::vector<uint32_t> buf(kWords);
-  EXPECT_DIF_BADARG(dif_otp_ctrl_read_blocking(
-      nullptr, kDifOtpCtrlPartitionOwnerSwCfg, 0x10, buf.data(), buf.size()));
-  EXPECT_DIF_BADARG(dif_otp_ctrl_read_blocking(
-      &otp_, kDifOtpCtrlPartitionOwnerSwCfg, 0x10, nullptr, buf.size()));
+  EXPECT_DIF_BADARG(dif_otp_ctrl_read_blocking(nullptr, kOtpPartitionOwnerSwCfg,
+                                               0x10, buf.data(), buf.size()));
+  EXPECT_DIF_BADARG(dif_otp_ctrl_read_blocking(&otp_, kOtpPartitionOwnerSwCfg,
+                                               0x10, nullptr, buf.size()));
 }
 
 }  // namespace

--- a/sw/device/lib/testing/keymgr_dpe_testutils.c
+++ b/sw/device/lib/testing/keymgr_dpe_testutils.c
@@ -31,10 +31,8 @@ status_t keymgr_dpe_testutils_startup(dif_keymgr_dpe_t *keymgr_dpe,
         "Powered up for the first time, lock SECRET2 and SECRET3 partitions");
     dif_otp_ctrl_t otp;
     TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
-    TRY(otp_ctrl_testutils_lock_partition(&otp, kDifOtpCtrlPartitionSecret2,
-                                          0));
-    TRY(otp_ctrl_testutils_lock_partition(&otp, kDifOtpCtrlPartitionSecret3,
-                                          0));
+    TRY(otp_ctrl_testutils_lock_partition(&otp, kOtpPartitionSecret2, 0));
+    TRY(otp_ctrl_testutils_lock_partition(&otp, kOtpPartitionSecret3, 0));
 
     // Reboot device.
     rstmgr_testutils_reason_clear();

--- a/sw/device/lib/testing/keymgr_testutils.c
+++ b/sw/device/lib/testing/keymgr_testutils.c
@@ -91,17 +91,17 @@ static status_t check_lock_otp_partition(void) {
   TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
 
   bool is_computed;
-  TRY(dif_otp_ctrl_is_digest_computed(&otp, kDifOtpCtrlPartitionSecret2,
+  TRY(dif_otp_ctrl_is_digest_computed(&otp, kOtpPartitionSecret2,
                                       &is_computed));
   if (is_computed) {
     uint64_t digest;
-    TRY(dif_otp_ctrl_get_digest(&otp, kDifOtpCtrlPartitionSecret2, &digest));
+    TRY(dif_otp_ctrl_get_digest(&otp, kOtpPartitionSecret2, &digest));
     LOG_INFO("OTP partition locked. Digest: %x-%x", ((uint32_t *)&digest)[0],
              ((uint32_t *)&digest)[1]);
     return OK_STATUS();
   }
 
-  TRY(otp_ctrl_testutils_lock_partition(&otp, kDifOtpCtrlPartitionSecret2, 0));
+  TRY(otp_ctrl_testutils_lock_partition(&otp, kOtpPartitionSecret2, 0));
   return OK_STATUS();
 }
 
@@ -206,7 +206,7 @@ status_t keymgr_testutils_init_nvm_then_reset(void) {
         mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
 
     bool secret2_computed = false;
-    TRY(dif_otp_ctrl_is_digest_computed(&otp_ctrl, kDifOtpCtrlPartitionSecret2,
+    TRY(dif_otp_ctrl_is_digest_computed(&otp_ctrl, kOtpPartitionSecret2,
                                         &secret2_computed));
 
     // Only initialise the creator secret if `SECRET2` digest has not been

--- a/sw/device/lib/testing/otp_ctrl_testutils.c
+++ b/sw/device/lib/testing/otp_ctrl_testutils.c
@@ -38,7 +38,7 @@ status_t otp_ctrl_testutils_dai_access_error_check(
     if (!bitfield_bit32_read(status.codes, kDifOtpCtrlStatusCodeDaiError)) {
       LOG_ERROR("Expected a DAI error for access to 0x%x", address);
     }
-    // causes[kOtpPartitionCount] is resrved for the DAI error.
+    // causes[kOtpPartitionCount] is reserved for the DAI error.
     if (status.causes[kOtpPartitionCount] != kDifOtpCtrlErrorLockedAccess) {
       LOG_ERROR("Expected access locked error for access to 0x%x", address);
     }
@@ -46,7 +46,7 @@ status_t otp_ctrl_testutils_dai_access_error_check(
     if (bitfield_bit32_read(status.codes, kDifOtpCtrlStatusCodeDaiError)) {
       LOG_ERROR("No DAI error expected for access to 0x%x", address);
     }
-    // causes[kOtpPartitionCount] is resrved for the DAI error.
+    // causes[kOtpPartitionCount] is reserved for the DAI error.
     if (status.causes[kOtpPartitionCount] != kDifOtpCtrlErrorOk) {
       LOG_ERROR("No DAI error code expected for access to 0x%x", address);
     }

--- a/sw/device/lib/testing/otp_ctrl_testutils.c
+++ b/sw/device/lib/testing/otp_ctrl_testutils.c
@@ -38,15 +38,16 @@ status_t otp_ctrl_testutils_dai_access_error_check(
     if (!bitfield_bit32_read(status.codes, kDifOtpCtrlStatusCodeDaiError)) {
       LOG_ERROR("Expected a DAI error for access to 0x%x", address);
     }
-    if (status.causes[kDifOtpCtrlPartitionDaiError] !=
-        kDifOtpCtrlErrorLockedAccess) {
+    // causes[kOtpPartitionCount] is resrved for the DAI error.
+    if (status.causes[kOtpPartitionCount] != kDifOtpCtrlErrorLockedAccess) {
       LOG_ERROR("Expected access locked error for access to 0x%x", address);
     }
   } else {
     if (bitfield_bit32_read(status.codes, kDifOtpCtrlStatusCodeDaiError)) {
       LOG_ERROR("No DAI error expected for access to 0x%x", address);
     }
-    if (status.causes[kDifOtpCtrlPartitionDaiError] != kDifOtpCtrlErrorOk) {
+    // causes[kOtpPartitionCount] is resrved for the DAI error.
+    if (status.causes[kOtpPartitionCount] != kDifOtpCtrlErrorOk) {
       LOG_ERROR("No DAI error code expected for access to 0x%x", address);
     }
   }
@@ -61,14 +62,14 @@ status_t otp_ctrl_testutils_wait_for_dai(const dif_otp_ctrl_t *otp_ctrl) {
 }
 
 status_t otp_ctrl_testutils_lock_partition(const dif_otp_ctrl_t *otp,
-                                           dif_otp_ctrl_partition_t partition,
+                                           otp_partition_t partition,
                                            uint64_t digest) {
   TRY(dif_otp_ctrl_dai_digest(otp, partition, digest));
   return otp_ctrl_testutils_wait_for_dai(otp);
 }
 
 status_t otp_ctrl_testutils_dai_read32(const dif_otp_ctrl_t *otp,
-                                       dif_otp_ctrl_partition_t partition,
+                                       otp_partition_t partition,
                                        uint32_t address, uint32_t *result) {
   TRY(otp_ctrl_testutils_wait_for_dai(otp));
   TRY(otp_ctrl_testutils_dai_read_pre_hook(otp));
@@ -80,7 +81,7 @@ status_t otp_ctrl_testutils_dai_read32(const dif_otp_ctrl_t *otp,
 }
 
 status_t otp_ctrl_testutils_dai_read32_array(const dif_otp_ctrl_t *otp,
-                                             dif_otp_ctrl_partition_t partition,
+                                             otp_partition_t partition,
                                              uint32_t start_address,
                                              uint32_t *buffer, size_t len) {
   uint32_t stop_address = start_address + (len * sizeof(uint32_t));
@@ -97,7 +98,7 @@ status_t otp_ctrl_testutils_dai_read32_array(const dif_otp_ctrl_t *otp,
 }
 
 status_t otp_ctrl_testutils_dai_read64(const dif_otp_ctrl_t *otp,
-                                       dif_otp_ctrl_partition_t partition,
+                                       otp_partition_t partition,
                                        uint32_t address, uint64_t *result) {
   TRY(otp_ctrl_testutils_wait_for_dai(otp));
   TRY(otp_ctrl_testutils_dai_read_pre_hook(otp));
@@ -109,7 +110,7 @@ status_t otp_ctrl_testutils_dai_read64(const dif_otp_ctrl_t *otp,
 }
 
 status_t otp_ctrl_testutils_dai_read64_array(const dif_otp_ctrl_t *otp,
-                                             dif_otp_ctrl_partition_t partition,
+                                             otp_partition_t partition,
                                              uint32_t start_address,
                                              uint64_t *buffer, size_t len) {
   uint32_t stop_address = start_address + (len * sizeof(uint64_t));
@@ -147,7 +148,7 @@ static status_t otp_ctrl_dai_write_error_check(const dif_otp_ctrl_t *otp) {
 }
 
 status_t otp_ctrl_testutils_dai_write32(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t start_address,
                                         const uint32_t *buffer, size_t len) {
   // Software partitions don't have scrambling or ECC enabled, so it is possible
@@ -155,11 +156,11 @@ status_t otp_ctrl_testutils_dai_write32(const dif_otp_ctrl_t *otp,
   // performing the write.
   bool check_before_write = (
 #ifdef OPENTITAN_IS_EGRET
-      partition == kDifOtpCtrlPartitionRotCreatorAuthCodesign ||
-      partition == kDifOtpCtrlPartitionRotCreatorAuthState ||
+      partition == kOtpPartitionRotCreatorAuthCodesign ||
+      partition == kOtpPartitionRotCreatorAuthState ||
 #endif  // OPENTITAN_IS_EGRET
-      partition == kDifOtpCtrlPartitionCreatorSwCfg ||
-      partition == kDifOtpCtrlPartitionOwnerSwCfg);
+      partition == kOtpPartitionCreatorSwCfg ||
+      partition == kOtpPartitionOwnerSwCfg);
   uint32_t stop_address = start_address + (len * sizeof(uint32_t));
   for (uint32_t addr = start_address, i = 0; addr < stop_address;
        addr += sizeof(uint32_t), ++i) {
@@ -194,7 +195,7 @@ status_t otp_ctrl_testutils_dai_write32(const dif_otp_ctrl_t *otp,
 }
 
 status_t otp_ctrl_testutils_dai_write64(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t start_address,
                                         const uint64_t *buffer, size_t len) {
   uint32_t stop_address = start_address + (len * sizeof(uint64_t));

--- a/sw/device/lib/testing/otp_ctrl_testutils.h
+++ b/sw/device/lib/testing/otp_ctrl_testutils.h
@@ -118,10 +118,10 @@ status_t otp_ctrl_testutils_dai_read64_array(const dif_otp_ctrl_t *otp,
  * Writes `len` number of 32bit words from buffer into otp `partition` starting
  * at `start_address` using the DAI interface.
  *
- * For software partitions (`kDifOtpCtrlPartitionCreatorSwCfg`,
- * `kDifOtpCtrlPartitionOwnerSwCfg`,
- * `kDifOtpCtrlPartitionRotCreatorAuthCodesign`, or
- * `kDifOtpCtrlPartitionRotCreatorAuthState`), the function will attempt to read
+ * For software partitions (`kOtpPartitionCreatorSwCfg`,
+ * `kOtpPartitionOwnerSwCfg`,
+ * `kOtpPartitionRotCreatorAuthCodesign`, or
+ * `kOtpPartitionRotCreatorAuthState`), the function will attempt to read
  * the target OTP offsets and skip the write if the existing value matches the
  * expected one. This is possible due to the fact that software partitions are
  * not scrambled nor ECC protected.

--- a/sw/device/lib/testing/otp_ctrl_testutils.h
+++ b/sw/device/lib/testing/otp_ctrl_testutils.h
@@ -47,7 +47,7 @@ status_t otp_ctrl_testutils_wait_for_dai(const dif_otp_ctrl_t *otp_ctrl);
  */
 OT_WARN_UNUSED_RESULT
 status_t otp_ctrl_testutils_lock_partition(const dif_otp_ctrl_t *otp,
-                                           dif_otp_ctrl_partition_t partition,
+                                           otp_partition_t partition,
                                            uint64_t digest);
 
 /**
@@ -62,7 +62,7 @@ status_t otp_ctrl_testutils_lock_partition(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 status_t otp_ctrl_testutils_dai_read32(const dif_otp_ctrl_t *otp,
-                                       dif_otp_ctrl_partition_t partition,
+                                       otp_partition_t partition,
                                        uint32_t address, uint32_t *result);
 
 /**
@@ -78,7 +78,7 @@ status_t otp_ctrl_testutils_dai_read32(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 status_t otp_ctrl_testutils_dai_read32_array(const dif_otp_ctrl_t *otp,
-                                             dif_otp_ctrl_partition_t partition,
+                                             otp_partition_t partition,
                                              uint32_t start_address,
                                              uint32_t *buffer, size_t len);
 
@@ -94,7 +94,7 @@ status_t otp_ctrl_testutils_dai_read32_array(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 status_t otp_ctrl_testutils_dai_read64(const dif_otp_ctrl_t *otp,
-                                       dif_otp_ctrl_partition_t partition,
+                                       otp_partition_t partition,
                                        uint32_t address, uint64_t *result);
 
 /**
@@ -110,7 +110,7 @@ status_t otp_ctrl_testutils_dai_read64(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 status_t otp_ctrl_testutils_dai_read64_array(const dif_otp_ctrl_t *otp,
-                                             dif_otp_ctrl_partition_t partition,
+                                             otp_partition_t partition,
                                              uint32_t start_address,
                                              uint64_t *buffer, size_t len);
 
@@ -137,7 +137,7 @@ status_t otp_ctrl_testutils_dai_read64_array(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 status_t otp_ctrl_testutils_dai_write32(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t start_address,
                                         const uint32_t *buffer, size_t len);
 
@@ -156,7 +156,7 @@ status_t otp_ctrl_testutils_dai_write32(const dif_otp_ctrl_t *otp,
  */
 OT_WARN_UNUSED_RESULT
 status_t otp_ctrl_testutils_dai_write64(const dif_otp_ctrl_t *otp,
-                                        dif_otp_ctrl_partition_t partition,
+                                        otp_partition_t partition,
                                         uint32_t start_address,
                                         const uint64_t *buffer, size_t len);
 

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -119,18 +119,17 @@ static void init_flash(void) {
 
 static void check_lock_otp_partition(const dif_otp_ctrl_t *otp) {
   bool is_computed;
-  CHECK_DIF_OK(dif_otp_ctrl_is_digest_computed(otp, kDifOtpCtrlPartitionSecret2,
-                                               &is_computed));
+  CHECK_DIF_OK(
+      dif_otp_ctrl_is_digest_computed(otp, kOtpPartitionSecret2, &is_computed));
   if (is_computed) {
     uint64_t digest;
-    CHECK_DIF_OK(
-        dif_otp_ctrl_get_digest(otp, kDifOtpCtrlPartitionSecret2, &digest));
+    CHECK_DIF_OK(dif_otp_ctrl_get_digest(otp, kOtpPartitionSecret2, &digest));
     LOG_INFO("OTP partition locked. Digest: %x-%x", ((uint32_t *)&digest)[0],
              ((uint32_t *)&digest)[1]);
     return;
   }
   CHECK_STATUS_OK(
-      otp_ctrl_testutils_lock_partition(otp, kDifOtpCtrlPartitionSecret2, 0));
+      otp_ctrl_testutils_lock_partition(otp, kOtpPartitionSecret2, 0));
 }
 
 /** Key manager configuration steps performed in ROM. */

--- a/sw/device/silicon_creator/lib/drivers/otp.c
+++ b/sw/device/silicon_creator/lib/drivers/otp.c
@@ -48,7 +48,7 @@ void otp_read(uint32_t address, uint32_t *data, size_t num_words) {
 dt_otp_partition_info_t otp_readable_partition_info(otp_partition_t partition) {
   HARDENED_CHECK_LT(partition, kOtpPartitionCount);
   dt_otp_partition_info_t partition_info =
-      dt_otp_ctrl_sw_readable_partition(kDtOtpCtrl, partition);
+      dt_otp_ctrl_partition(kDtOtpCtrl, partition);
   HARDENED_CHECK_GT(partition_info.size, 0);
 
   return partition_info;

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -262,8 +262,7 @@ static status_t peripheral_handles_init(void) {
   TRY(dif_gpio_init(mmio_region_from_addr(TOP_EGRET_GPIO_BASE_ADDR), &gpio));
   TRY(dif_lc_ctrl_init(mmio_region_from_addr(TOP_EGRET_LC_CTRL_REGS_BASE_ADDR),
                        &lc_ctrl));
-  TRY(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
   TRY(dif_pinmux_init(mmio_region_from_addr(TOP_EGRET_PINMUX_AON_BASE_ADDR),
                       &pinmux));
   TRY(dif_rstmgr_init(mmio_region_from_addr(TOP_EGRET_RSTMGR_AON_BASE_ADDR),
@@ -351,10 +350,10 @@ static status_t measure_otp_partition(otp_partition_t partition,
     // until the final stages of personalization.
     if (partition == kOtpPartitionOwnerSwCfg) {
       manuf_individualize_device_partition_expected_read(
-          kDifOtpCtrlPartitionOwnerSwCfg, (uint8_t *)otp_state);
+          &otp_ctrl, kOtpPartitionOwnerSwCfg, (uint8_t *)otp_state);
     } else if (partition == kOtpPartitionCreatorSwCfg) {
       manuf_individualize_device_partition_expected_read(
-          kDifOtpCtrlPartitionCreatorSwCfg, (uint8_t *)otp_state);
+          &otp_ctrl, kOtpPartitionCreatorSwCfg, (uint8_t *)otp_state);
     }
   }
 
@@ -708,7 +707,7 @@ static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
   // Read complete device ID and push into perso blob. The host will need the
   // device ID to reconstruct the WAS.
   uint32_t device_id[kHwCfgDeviceIdSizeIn32BitWords] = {0};
-  TRY(otp_ctrl_testutils_dai_read32_array(&otp_ctrl, kDifOtpCtrlPartitionHwCfg0,
+  TRY(otp_ctrl_testutils_dai_read32_array(&otp_ctrl, kOtpPartitionHwCfg0,
                                           kHwCfgDeviceIdOffset, device_id,
                                           ARRAYSIZE(device_id)));
   perso_tlv_object_header_t device_id_header = 0;

--- a/sw/device/silicon_creator/manuf/lib/individualize.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize.c
@@ -66,7 +66,7 @@ static status_t hw_cfg1_enable_knobs_set(const dif_otp_ctrl_t *otp_ctrl) {
   val = bitfield_field32_write(val, kDisRvDmLateDebug,
                                kHwCfg1Settings.dis_rv_dm_late_debug);
 
-  TRY(otp_ctrl_testutils_dai_write32(otp_ctrl, kDifOtpCtrlPartitionHwCfg1,
+  TRY(otp_ctrl_testutils_dai_write32(otp_ctrl, kOtpPartitionHwCfg1,
                                      kHwCfgEnSramIfetchOffset, &val,
                                      /*len=*/1));
   return OK_STATUS();
@@ -79,7 +79,7 @@ status_t manuf_individualize_device_hw_cfg(
   bool is_locked;
 
   // Provision HW_CFG0 if it is not locked.
-  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionHwCfg0,
+  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kOtpPartitionHwCfg0,
                                       &is_locked));
   if (!is_locked) {
     // Configure flash info page permissions in case we started from a cold
@@ -145,27 +145,27 @@ status_t manuf_individualize_device_hw_cfg(
         (ast_cfg_version << 8);
 
     // Write the complete device ID to OTP.
-    TRY(otp_ctrl_testutils_dai_write32(otp_ctrl, kDifOtpCtrlPartitionHwCfg0,
+    TRY(otp_ctrl_testutils_dai_write32(otp_ctrl, kOtpPartitionHwCfg0,
                                        kHwCfgDeviceIdOffset, device_id,
                                        kHwCfgDeviceIdSizeIn32BitWords));
 
     // Configure ManufState as all 0s. It is unused.
     uint32_t manuf_state[kHwCfgManufStateSizeIn32BitWords] = {0};
-    TRY(otp_ctrl_testutils_dai_write32(otp_ctrl, kDifOtpCtrlPartitionHwCfg0,
+    TRY(otp_ctrl_testutils_dai_write32(otp_ctrl, kOtpPartitionHwCfg0,
                                        kHwCfgManufStateOffset, manuf_state,
                                        kHwCfgManufStateSizeIn32BitWords));
-    TRY(otp_ctrl_testutils_lock_partition(otp_ctrl, kDifOtpCtrlPartitionHwCfg0,
+    TRY(otp_ctrl_testutils_lock_partition(otp_ctrl, kOtpPartitionHwCfg0,
                                           /*digest=*/0));
   }
 
   // Provision HW_CFG1 if it is not locked.
-  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionHwCfg1,
+  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kOtpPartitionHwCfg1,
                                       &is_locked));
   if (!is_locked) {
     // Configure byte-sized hardware enable knobs.
     TRY(hw_cfg1_enable_knobs_set(otp_ctrl));
 
-    TRY(otp_ctrl_testutils_lock_partition(otp_ctrl, kDifOtpCtrlPartitionHwCfg1,
+    TRY(otp_ctrl_testutils_lock_partition(otp_ctrl, kOtpPartitionHwCfg1,
                                           /*digest=*/0));
   }
   return OK_STATUS();
@@ -176,13 +176,13 @@ status_t manuf_individualize_device_hw_cfg_check(
   // TODO: Add DeviceId by comparing OTP flash value against the value reported
   // by lc_ctrl. Consider erasing the data from the flash info pages.
   bool is_locked0, is_locked1;
-  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionHwCfg0,
+  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kOtpPartitionHwCfg0,
                                       &is_locked0));
-  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionHwCfg1,
+  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kOtpPartitionHwCfg1,
                                       &is_locked1));
   uint64_t digest0, digest1;
-  TRY(dif_otp_ctrl_get_digest(otp_ctrl, kDifOtpCtrlPartitionHwCfg0, &digest0));
-  TRY(dif_otp_ctrl_get_digest(otp_ctrl, kDifOtpCtrlPartitionHwCfg1, &digest1));
+  TRY(dif_otp_ctrl_get_digest(otp_ctrl, kOtpPartitionHwCfg0, &digest0));
+  TRY(dif_otp_ctrl_get_digest(otp_ctrl, kOtpPartitionHwCfg1, &digest1));
 
   return is_locked0 && is_locked1 ? OK_STATUS() : INTERNAL();
 }
@@ -191,22 +191,22 @@ status_t manuf_individualize_device_secret0(
     const dif_lc_ctrl_t *lc_ctrl, const dif_otp_ctrl_t *otp_ctrl,
     const manuf_cp_provisioning_data_t *provisioning_data) {
   bool is_locked;
-  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionSecret0,
+  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kOtpPartitionSecret0,
                                       &is_locked));
   if (is_locked) {
     return OK_STATUS();
   }
 
-  TRY(otp_ctrl_testutils_dai_write64(otp_ctrl, kDifOtpCtrlPartitionSecret0,
+  TRY(otp_ctrl_testutils_dai_write64(otp_ctrl, kOtpPartitionSecret0,
                                      kSecret0TestUnlockTokenOffset,
                                      provisioning_data->test_unlock_token_hash,
                                      kSecret0TestUnlockTokenSizeIn64BitWords));
-  TRY(otp_ctrl_testutils_dai_write64(otp_ctrl, kDifOtpCtrlPartitionSecret0,
+  TRY(otp_ctrl_testutils_dai_write64(otp_ctrl, kOtpPartitionSecret0,
                                      kSecret0TestExitTokenOffset,
                                      provisioning_data->test_exit_token_hash,
                                      kSecret0TestExitTokenSizeIn64BitWords));
 
-  TRY(otp_ctrl_testutils_lock_partition(otp_ctrl, kDifOtpCtrlPartitionSecret0,
+  TRY(otp_ctrl_testutils_lock_partition(otp_ctrl, kOtpPartitionSecret0,
                                         /*digest=*/0));
 
   return OK_STATUS();
@@ -215,7 +215,7 @@ status_t manuf_individualize_device_secret0(
 status_t manuf_individualize_device_secret0_check(
     const dif_otp_ctrl_t *otp_ctrl) {
   bool is_locked;
-  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionSecret0,
+  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kOtpPartitionSecret0,
                                       &is_locked));
   return is_locked ? OK_STATUS() : INTERNAL();
 }

--- a/sw/device/silicon_creator/manuf/lib/individualize_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_functest.c
@@ -105,7 +105,7 @@ bool test_main(void) {
     // Check the value of the DeviceId in the HW_CFG0 partition.
     uint32_t device_id[kHwCfgDeviceIdSizeIn32BitWords];
     CHECK_STATUS_OK(otp_ctrl_testutils_dai_read32_array(
-        &otp_ctrl, kDifOtpCtrlPartitionHwCfg0, 0, device_id,
+        &otp_ctrl, kOtpPartitionHwCfg0, 0, device_id,
         kHwCfgDeviceIdSizeIn32BitWords));
     LOG_INFO("CP Device ID in OTP: %08x%08x%08x%08x", device_id[3],
              device_id[2], device_id[2], device_id[0]);

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h"
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
@@ -46,8 +47,8 @@ static uint32_t
  */
 OT_WARN_UNUSED_RESULT
 static status_t otp_img_write(const dif_otp_ctrl_t *otp,
-                              dif_otp_ctrl_partition_t partition,
-                              const otp_kv_t *kv, size_t len) {
+                              otp_partition_t partition, const otp_kv_t *kv,
+                              size_t len) {
   for (size_t i = 0; i < len; ++i) {
     // We purposely skip the provisioning of the flash data region default
     // configuration as it must be enabled only after the OTP SECRET1
@@ -89,7 +90,7 @@ static status_t otp_img_write(const dif_otp_ctrl_t *otp,
     }
     // clang-format on
     uint32_t offset;
-    TRY(dif_otp_ctrl_relative_address(partition, kv[i].offset, &offset));
+    TRY(dif_otp_ctrl_relative_address(otp, partition, kv[i].offset, &offset));
     switch (kv[i].type) {
       case kOptValTypeUint32Buff:
         TRY(otp_ctrl_testutils_dai_write32(otp, partition, offset,
@@ -118,11 +119,13 @@ static status_t otp_img_write(const dif_otp_ctrl_t *otp,
  * @return OK_STATUS if the expected OTP values are successfully written to the
  * `buffer`.
  */
-static status_t otp_img_expected_value_read(dif_otp_ctrl_partition_t partition,
+static status_t otp_img_expected_value_read(const dif_otp_ctrl_t *otp,
+                                            otp_partition_t partition,
                                             uint32_t field_offset,
                                             uint8_t *buffer) {
   uint32_t relative_addr;
-  TRY(dif_otp_ctrl_relative_address(partition, field_offset, &relative_addr));
+  TRY(dif_otp_ctrl_relative_address(otp, partition, field_offset,
+                                    &relative_addr));
   switch (field_offset) {
     case OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_OFFSET:
       memcpy(buffer + relative_addr, &kOwnerSwCfgRomBootstrapDisValue,
@@ -159,7 +162,7 @@ static status_t otp_img_expected_value_read(dif_otp_ctrl_partition_t partition,
  */
 OT_WARN_UNUSED_RESULT
 static status_t lock_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
-                                   dif_otp_ctrl_partition_t partition) {
+                                   otp_partition_t partition) {
   // Compute SHA256 of the OTP partition.
   uint32_t digest[kSha256DigestWords];
   otcrypto_word32_buf_t otp_partition_digest = {
@@ -221,11 +224,11 @@ static status_t manuf_individualize_device_ast_cfg(
     if (addr < kValidAstCfgOtpAddrLow || addr >= kInvalidAstCfgOtpAddrHigh) {
       return OUT_OF_RANGE();
     }
-    TRY(dif_otp_ctrl_relative_address(kDifOtpCtrlPartitionCreatorSwCfg, addr,
+    TRY(dif_otp_ctrl_relative_address(otp_ctrl, kOtpPartitionCreatorSwCfg, addr,
                                       &relative_addr));
-    TRY(otp_ctrl_testutils_dai_write32(
-        otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg, relative_addr, &data,
-        /*len=*/1));
+    TRY(otp_ctrl_testutils_dai_write32(otp_ctrl, kOtpPartitionCreatorSwCfg,
+                                       relative_addr, &data,
+                                       /*len=*/1));
     flash_info_page_buf[ast_cfg_offset + i] =
         UINT32_MAX;  // Erase AST config data after use.
   }
@@ -247,8 +250,8 @@ static status_t manuf_individualize_device_ast_cfg(
 
 status_t manuf_individualize_device_creator_sw_cfg(
     const dif_otp_ctrl_t *otp_ctrl, dif_flash_ctrl_state_t *flash_state) {
-  TRY(otp_img_write(otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg,
-                    kOtpKvCreatorSwCfg, kOtpKvCreatorSwCfgSize));
+  TRY(otp_img_write(otp_ctrl, kOtpPartitionCreatorSwCfg, kOtpKvCreatorSwCfg,
+                    kOtpKvCreatorSwCfgSize));
   TRY(manuf_individualize_device_ast_cfg(otp_ctrl, flash_state));
   return OK_STATUS();
 }
@@ -257,33 +260,34 @@ status_t manuf_individualize_device_field_cfg(const dif_otp_ctrl_t *otp_ctrl,
                                               uint32_t field_offset) {
   uint32_t relative_addr;
   const uint32_t *field_value_addr;
-  dif_otp_ctrl_partition_t partition;
+  otp_partition_t partition;
   switch (field_offset) {
     case OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_OFFSET:
       field_value_addr = &kOwnerSwCfgRomBootstrapDisValue;
-      partition = kDifOtpCtrlPartitionOwnerSwCfg;
+      partition = kOtpPartitionOwnerSwCfg;
       break;
     case OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG_OFFSET:
       field_value_addr = &kCreatorSwCfgFlashInfoBootDataCfgValue;
-      partition = kDifOtpCtrlPartitionCreatorSwCfg;
+      partition = kOtpPartitionCreatorSwCfg;
       break;
     case OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG_OFFSET:
       field_value_addr = &kCreatorSwCfgFlashDataDefaultCfgValue;
-      partition = kDifOtpCtrlPartitionCreatorSwCfg;
+      partition = kOtpPartitionCreatorSwCfg;
       break;
     case OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET:
       field_value_addr = &kCreatorSwCfgImmutableRomExtEnValue;
-      partition = kDifOtpCtrlPartitionCreatorSwCfg;
+      partition = kOtpPartitionCreatorSwCfg;
       break;
     case OTP_CTRL_PARAM_CREATOR_SW_CFG_MANUF_STATE_OFFSET:
       field_value_addr = &kCreatorSwCfgManufStateValue;
-      partition = kDifOtpCtrlPartitionCreatorSwCfg;
+      partition = kOtpPartitionCreatorSwCfg;
       break;
     default:
       return INTERNAL();
   }
 
-  TRY(dif_otp_ctrl_relative_address(partition, field_offset, &relative_addr));
+  TRY(dif_otp_ctrl_relative_address(otp_ctrl, partition, field_offset,
+                                    &relative_addr));
   TRY(otp_ctrl_testutils_dai_write32(otp_ctrl, partition, relative_addr,
                                      field_value_addr, /*len=*/1));
 
@@ -294,11 +298,11 @@ status_t manuf_individualize_device_flash_data_default_cfg_check(
     const dif_otp_ctrl_t *otp_ctrl) {
   uint32_t offset;
   TRY(dif_otp_ctrl_relative_address(
-      kDifOtpCtrlPartitionCreatorSwCfg,
+      otp_ctrl, kOtpPartitionCreatorSwCfg,
       OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG_OFFSET, &offset));
   uint32_t val = 0;
-  TRY(otp_ctrl_testutils_dai_read32(otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg,
-                                    offset, &val));
+  TRY(otp_ctrl_testutils_dai_read32(otp_ctrl, kOtpPartitionCreatorSwCfg, offset,
+                                    &val));
   bool is_provisioned = (val == kCreatorSwCfgFlashDataDefaultCfgValue);
   return is_provisioned ? OK_STATUS() : INTERNAL();
 }
@@ -307,54 +311,56 @@ status_t manuf_individualize_device_flash_info_boot_data_cfg_check(
     const dif_otp_ctrl_t *otp_ctrl) {
   uint32_t offset;
   TRY(dif_otp_ctrl_relative_address(
-      kDifOtpCtrlPartitionCreatorSwCfg,
+      otp_ctrl, kOtpPartitionCreatorSwCfg,
       OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG_OFFSET, &offset));
   uint32_t val = 0;
-  TRY(otp_ctrl_testutils_dai_read32(otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg,
-                                    offset, &val));
+  TRY(otp_ctrl_testutils_dai_read32(otp_ctrl, kOtpPartitionCreatorSwCfg, offset,
+                                    &val));
   bool is_provisioned = (val == kCreatorSwCfgFlashInfoBootDataCfgValue);
   return is_provisioned ? OK_STATUS() : INTERNAL();
 }
 
 status_t manuf_individualize_device_creator_sw_cfg_lock(
     const dif_otp_ctrl_t *otp_ctrl) {
-  TRY(lock_otp_partition(otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg));
+  TRY(lock_otp_partition(otp_ctrl, kOtpPartitionCreatorSwCfg));
   return OK_STATUS();
 }
 
 status_t manuf_individualize_device_creator_sw_cfg_check(
     const dif_otp_ctrl_t *otp_ctrl) {
   bool is_locked;
-  TRY(dif_otp_ctrl_is_digest_computed(
-      otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg, &is_locked));
+  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kOtpPartitionCreatorSwCfg,
+                                      &is_locked));
   return is_locked ? OK_STATUS() : INTERNAL();
 }
 
 status_t manuf_individualize_device_owner_sw_cfg(
     const dif_otp_ctrl_t *otp_ctrl) {
-  TRY(otp_img_write(otp_ctrl, kDifOtpCtrlPartitionOwnerSwCfg, kOtpKvOwnerSwCfg,
+  TRY(otp_img_write(otp_ctrl, kOtpPartitionOwnerSwCfg, kOtpKvOwnerSwCfg,
                     kOtpKvOwnerSwCfgSize));
   return OK_STATUS();
 }
 
 status_t manuf_individualize_device_partition_expected_read(
-    dif_otp_ctrl_partition_t partition, uint8_t *buffer) {
+    const dif_otp_ctrl_t *otp_ctrl, otp_partition_t partition,
+    uint8_t *buffer) {
   switch (partition) {
-    case kDifOtpCtrlPartitionOwnerSwCfg:
+    case kOtpPartitionOwnerSwCfg:
       TRY(otp_img_expected_value_read(
-          partition, OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_OFFSET,
-          buffer));
+          otp_ctrl, partition,
+          OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_OFFSET, buffer));
       break;
-    case kDifOtpCtrlPartitionCreatorSwCfg:
+    case kOtpPartitionCreatorSwCfg:
       TRY(otp_img_expected_value_read(
-          partition,
+          otp_ctrl, partition,
           OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG_OFFSET,
           buffer));
       TRY(otp_img_expected_value_read(
-          partition, OTP_CTRL_PARAM_CREATOR_SW_CFG_MANUF_STATE_OFFSET, buffer));
-      TRY(otp_img_expected_value_read(
-          partition, OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET,
+          otp_ctrl, partition, OTP_CTRL_PARAM_CREATOR_SW_CFG_MANUF_STATE_OFFSET,
           buffer));
+      TRY(otp_img_expected_value_read(
+          otp_ctrl, partition,
+          OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET, buffer));
       break;
     default:
       return INTERNAL();
@@ -365,32 +371,32 @@ status_t manuf_individualize_device_partition_expected_read(
 
 status_t manuf_individualize_device_owner_sw_cfg_lock(
     const dif_otp_ctrl_t *otp_ctrl) {
-  TRY(lock_otp_partition(otp_ctrl, kDifOtpCtrlPartitionOwnerSwCfg));
+  TRY(lock_otp_partition(otp_ctrl, kOtpPartitionOwnerSwCfg));
   return OK_STATUS();
 }
 
 status_t manuf_individualize_device_owner_sw_cfg_check(
     const dif_otp_ctrl_t *otp_ctrl) {
   bool is_locked;
-  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionOwnerSwCfg,
+  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kOtpPartitionOwnerSwCfg,
                                       &is_locked));
   return is_locked ? OK_STATUS() : INTERNAL();
 }
 
 status_t manuf_individualize_device_rot_creator_auth_codesign(
     const dif_otp_ctrl_t *otp_ctrl) {
-  TRY(otp_img_write(otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthCodesign,
+  TRY(otp_img_write(otp_ctrl, kOtpPartitionRotCreatorAuthCodesign,
                     kOtpKvRotCreatorAuthCodesign,
                     kOtpKvRotCreatorAuthCodesignSize));
-  TRY(lock_otp_partition(otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthCodesign));
+  TRY(lock_otp_partition(otp_ctrl, kOtpPartitionRotCreatorAuthCodesign));
   return OK_STATUS();
 }
 
 status_t manuf_individualize_device_rot_creator_auth_state(
     const dif_otp_ctrl_t *otp_ctrl) {
-  TRY(otp_img_write(otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthState,
+  TRY(otp_img_write(otp_ctrl, kOtpPartitionRotCreatorAuthState,
                     kOtpKvRotCreatorAuthState, kOtpKvRotCreatorAuthStateSize));
-  TRY(lock_otp_partition(otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthState));
+  TRY(lock_otp_partition(otp_ctrl, kOtpPartitionRotCreatorAuthState));
   return OK_STATUS();
 }
 
@@ -398,7 +404,7 @@ status_t manuf_individualize_device_rot_creator_auth_codesign_check(
     const dif_otp_ctrl_t *otp_ctrl) {
   bool is_locked;
   TRY(dif_otp_ctrl_is_digest_computed(
-      otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthCodesign, &is_locked));
+      otp_ctrl, kOtpPartitionRotCreatorAuthCodesign, &is_locked));
   return is_locked ? OK_STATUS() : INTERNAL();
 }
 
@@ -406,6 +412,6 @@ status_t manuf_individualize_device_rot_creator_auth_state_check(
     const dif_otp_ctrl_t *otp_ctrl) {
   bool is_locked;
   TRY(dif_otp_ctrl_is_digest_computed(
-      otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthState, &is_locked));
+      otp_ctrl, kOtpPartitionRotCreatorAuthState, &is_locked));
   return is_locked ? OK_STATUS() : INTERNAL();
 }

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h
@@ -180,7 +180,7 @@ status_t manuf_individualize_device_owner_sw_cfg_check(
  * to the `buffer`.
  */
 status_t manuf_individualize_device_partition_expected_read(
-    dif_otp_ctrl_partition_t partition, uint8_t *buffer);
+    const dif_otp_ctrl_t *otp_ctrl, otp_partition_t partition, uint8_t *buffer);
 
 /**
  * Configures and locks the ROT_CREATOR_AUTH_CODESIGN OTP partition.

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg_functest.c
@@ -91,17 +91,17 @@ static status_t init_flash_info_page0(bool write_ast_data) {
 /**
  * Check the AST configuration data was programmed correctly.
  */
-static status_t check_otp_ast_cfg(void) {
+static status_t check_otp_ast_cfg(const dif_otp_ctrl_t *otp) {
   // Check OTP fields were programmed correctly.
   uint32_t data;
   uint32_t relative_addr;
   for (size_t i = 0; i < kFlashInfoAstCalibrationDataSizeIn32BitWords; ++i) {
     TRY(dif_otp_ctrl_relative_address(
-        kDifOtpCtrlPartitionCreatorSwCfg,
+        otp, kOtpPartitionCreatorSwCfg,
         OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_CFG_OFFSET + i * sizeof(uint32_t),
         &relative_addr));
-    TRY(otp_ctrl_testutils_dai_read32(
-        &otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg, relative_addr, &data));
+    TRY(otp_ctrl_testutils_dai_read32(&otp_ctrl, kOtpPartitionCreatorSwCfg,
+                                      relative_addr, &data));
     TRY_CHECK(data == i);
   }
 
@@ -121,7 +121,7 @@ static status_t check_otp_ast_cfg(void) {
 /**
  * Check the *SW_CFG partition digests.
  */
-static status_t check_otp_sw_cfg_digest(dif_otp_ctrl_partition_t partition) {
+static status_t check_otp_sw_cfg_digest(otp_partition_t partition) {
   uint64_t expected_digest, actual_digest = 0;
 
   // Get actual_digest.
@@ -133,26 +133,26 @@ static status_t check_otp_sw_cfg_digest(dif_otp_ctrl_partition_t partition) {
       (const unsigned char *)TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR +
       OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET;
   switch (partition) {
-    case kDifOtpCtrlPartitionCreatorSwCfg:
+    case kOtpPartitionCreatorSwCfg:
       hmac_sha256_update(kOtpSwCfgWindowBase +
                              OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_INIT_EN_OFFSET,
                          OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE -
                              OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_SIZE -
                              OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_CFG_SIZE);
       break;
-    case kDifOtpCtrlPartitionOwnerSwCfg:
+    case kOtpPartitionOwnerSwCfg:
       hmac_sha256_update(
           kOtpSwCfgWindowBase + OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET,
           OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE -
               OTP_CTRL_PARAM_OWNER_SW_CFG_DIGEST_SIZE);
       break;
-    case kDifOtpCtrlPartitionRotCreatorAuthCodesign:
+    case kOtpPartitionRotCreatorAuthCodesign:
       hmac_sha256_update(
           kOtpSwCfgWindowBase + OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_OFFSET,
           OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE -
               OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_DIGEST_SIZE);
       break;
-    case kDifOtpCtrlPartitionRotCreatorAuthState:
+    case kOtpPartitionRotCreatorAuthState:
       hmac_sha256_update(
           kOtpSwCfgWindowBase + OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_OFFSET,
           OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE -
@@ -252,17 +252,16 @@ bool test_main(void) {
       status_ok(
           manuf_individualize_device_rot_creator_auth_state_check(&otp_ctrl))) {
     // Check OTP AST and digest contents.
-    CHECK_STATUS_OK(check_otp_ast_cfg());
+    CHECK_STATUS_OK(check_otp_ast_cfg(&otp_ctrl));
     LOG_INFO("Checking CreatorSwCfg digest ...");
-    CHECK_STATUS_OK(check_otp_sw_cfg_digest(kDifOtpCtrlPartitionCreatorSwCfg));
+    CHECK_STATUS_OK(check_otp_sw_cfg_digest(kOtpPartitionCreatorSwCfg));
     LOG_INFO("Checking OwnerSwCfg digest ...");
-    CHECK_STATUS_OK(check_otp_sw_cfg_digest(kDifOtpCtrlPartitionOwnerSwCfg));
+    CHECK_STATUS_OK(check_otp_sw_cfg_digest(kOtpPartitionOwnerSwCfg));
     LOG_INFO("Checking RotCreatorAuthCodesign digest ...");
     CHECK_STATUS_OK(
-        check_otp_sw_cfg_digest(kDifOtpCtrlPartitionRotCreatorAuthCodesign));
+        check_otp_sw_cfg_digest(kOtpPartitionRotCreatorAuthCodesign));
     LOG_INFO("Checking RotCreatorAuthState digest ...");
-    CHECK_STATUS_OK(
-        check_otp_sw_cfg_digest(kDifOtpCtrlPartitionRotCreatorAuthState));
+    CHECK_STATUS_OK(check_otp_sw_cfg_digest(kOtpPartitionRotCreatorAuthState));
     return true;
   }
 

--- a/sw/device/silicon_creator/manuf/lib/personalize.c
+++ b/sw/device/silicon_creator/manuf/lib/personalize.c
@@ -174,16 +174,16 @@ static status_t otp_partition_secret2_configure(
 
   // Provision RMA unlock token and RootKey shares into OTP.
   TRY(otp_ctrl_testutils_dai_write64(
-      otp_ctrl, kDifOtpCtrlPartitionSecret2, kRmaUnlockTokenOffset,
+      otp_ctrl, kOtpPartitionSecret2, kRmaUnlockTokenOffset,
       rma_unlock_token_hash->hash, kRmaUnlockTokenSizeIn64BitWords));
-  TRY(otp_ctrl_testutils_dai_write64(otp_ctrl, kDifOtpCtrlPartitionSecret2,
+  TRY(otp_ctrl_testutils_dai_write64(otp_ctrl, kOtpPartitionSecret2,
                                      kRootKeyOffsetShare0, share0,
                                      kRootKeyShareSizeIn64BitWords));
-  TRY(otp_ctrl_testutils_dai_write64(otp_ctrl, kDifOtpCtrlPartitionSecret2,
+  TRY(otp_ctrl_testutils_dai_write64(otp_ctrl, kOtpPartitionSecret2,
                                      kRootKeyOffsetShare1, share1,
                                      kRootKeyShareSizeIn64BitWords));
 
-  TRY(otp_ctrl_testutils_lock_partition(otp_ctrl, kDifOtpCtrlPartitionSecret2,
+  TRY(otp_ctrl_testutils_lock_partition(otp_ctrl, kOtpPartitionSecret2,
                                         /*digest=*/0));
 
   return OK_STATUS();
@@ -198,7 +198,7 @@ status_t manuf_personalize_device_secrets(
 
   // Skip provisioning of SECRET1 OTP partition if already done.
   bool is_locked;
-  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionSecret2,
+  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kOtpPartitionSecret2,
                                       &is_locked));
   if (is_locked) {
     return OK_STATUS();
@@ -211,7 +211,7 @@ status_t manuf_personalize_device_secrets(
   // Note: for SECRET1 partition to be provisioned, the HW_CFG1 partition
   // must have been provisioned, and the CSRNG SW interface should have been
   // enabled, so no need to check again here.
-  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionSecret1,
+  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kOtpPartitionSecret1,
                                       &is_locked));
   if (!is_locked) {
     return INTERNAL();
@@ -266,15 +266,15 @@ static status_t otp_secret_write(const dif_otp_ctrl_t *otp_ctrl,
     return INTERNAL();
   }
 
-  TRY(otp_ctrl_testutils_dai_write64(otp_ctrl, kDifOtpCtrlPartitionSecret1,
-                                     offset, data, len));
+  TRY(otp_ctrl_testutils_dai_write64(otp_ctrl, kOtpPartitionSecret1, offset,
+                                     data, len));
   return OK_STATUS();
 }
 
 status_t manuf_personalize_device_secrets_check(
     const dif_otp_ctrl_t *otp_ctrl) {
   bool is_locked;
-  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionSecret2,
+  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kOtpPartitionSecret2,
                                       &is_locked));
   return is_locked ? OK_STATUS() : INTERNAL();
 }
@@ -283,21 +283,21 @@ status_t manuf_personalize_device_secret1(const dif_lc_ctrl_t *lc_ctrl,
                                           const dif_otp_ctrl_t *otp_ctrl) {
   // Skip provisioning of SECRET1 OTP partition if already done.
   bool is_locked;
-  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionSecret1,
+  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kOtpPartitionSecret1,
                                       &is_locked));
   if (is_locked) {
     return OK_STATUS();
   }
 
   // Check that the HW_CFG0 OTP partition has been locked (and is activated).
-  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionHwCfg0,
+  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kOtpPartitionHwCfg0,
                                       &is_locked));
   if (!is_locked) {
     return INTERNAL();
   }
 
   // Check that the HW_CFG1 OTP partition has been locked (and is activated).
-  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionHwCfg1,
+  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kOtpPartitionHwCfg1,
                                       &is_locked));
   if (!is_locked) {
     return INTERNAL();
@@ -306,7 +306,7 @@ status_t manuf_personalize_device_secret1(const dif_lc_ctrl_t *lc_ctrl,
   // Check that the CSRNG SW application interface is enabled in the HW_CFG1
   // partition, as we cannot provision SECRET1 without access to the CSRNG.
   uint32_t otp_hw_cfg1_settings;
-  TRY(otp_ctrl_testutils_dai_read32(otp_ctrl, kDifOtpCtrlPartitionHwCfg1,
+  TRY(otp_ctrl_testutils_dai_read32(otp_ctrl, kOtpPartitionHwCfg1,
                                     kHwCfgEnSramIfetchOffset,
                                     &otp_hw_cfg1_settings));
   uint32_t csrng_sw_app_read =
@@ -333,7 +333,7 @@ status_t manuf_personalize_device_secret1(const dif_lc_ctrl_t *lc_ctrl,
                        kSecret1SramDataKeySeed64Bitwords));
 
   TRY(entropy_csrng_uninstantiate());
-  TRY(otp_ctrl_testutils_lock_partition(otp_ctrl, kDifOtpCtrlPartitionSecret1,
+  TRY(otp_ctrl_testutils_lock_partition(otp_ctrl, kOtpPartitionSecret1,
                                         /*digest=*/0));
 
   return OK_STATUS();
@@ -342,7 +342,7 @@ status_t manuf_personalize_device_secret1(const dif_lc_ctrl_t *lc_ctrl,
 status_t manuf_personalize_device_secret1_check(
     const dif_otp_ctrl_t *otp_ctrl) {
   bool is_locked;
-  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionSecret1,
+  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kOtpPartitionSecret1,
                                       &is_locked));
   return is_locked ? OK_STATUS() : INTERNAL();
 }

--- a/sw/device/silicon_creator/manuf/lib/personalize_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/personalize_functest.c
@@ -41,8 +41,7 @@ static status_t peripheral_handles_init(void) {
       mmio_region_from_addr(TOP_EGRET_FLASH_CTRL_CORE_BASE_ADDR)));
   TRY(dif_lc_ctrl_init(mmio_region_from_addr(TOP_EGRET_LC_CTRL_REGS_BASE_ADDR),
                        &lc_ctrl));
-  TRY(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
   TRY(dif_rstmgr_init(mmio_region_from_addr(TOP_EGRET_RSTMGR_AON_BASE_ADDR),
                       &rstmgr));
   return OK_STATUS();

--- a/sw/device/silicon_creator/manuf/lib/util.c
+++ b/sw/device/silicon_creator/manuf/lib/util.c
@@ -69,7 +69,7 @@ status_t manuf_util_hash_lc_transition_token(const uint32_t *raw_token,
 }
 
 status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
-                                       dif_otp_ctrl_partition_t partition,
+                                       otp_partition_t partition,
                                        otcrypto_word32_buf_t output) {
   if (otp_ctrl == NULL || output.len != kSha256DigestWords) {
     return INVALID_ARGUMENT();
@@ -80,13 +80,13 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
   };
 
   switch (partition) {
-    case kDifOtpCtrlPartitionVendorTest: {
+    case kOtpPartitionVendorTest: {
       uint32_t
           vendor_test_32bit_array[(OTP_CTRL_PARAM_VENDOR_TEST_SIZE -
                                    OTP_CTRL_PARAM_VENDOR_TEST_DIGEST_SIZE) /
                                   sizeof(uint32_t)];
       TRY(otp_ctrl_testutils_dai_read32_array(
-          otp_ctrl, kDifOtpCtrlPartitionVendorTest, 0, vendor_test_32bit_array,
+          otp_ctrl, kOtpPartitionVendorTest, 0, vendor_test_32bit_array,
           (OTP_CTRL_PARAM_VENDOR_TEST_SIZE -
            OTP_CTRL_PARAM_VENDOR_TEST_DIGEST_SIZE) /
               sizeof(uint32_t)));
@@ -97,7 +97,7 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
       };
       TRY(otcrypto_sha2_256(input, &digest));
     } break;
-    case kDifOtpCtrlPartitionCreatorSwCfg: {
+    case kOtpPartitionCreatorSwCfg: {
       // Note: we purposely exclude the AST configuration data field of this
       // partition from the digest calculation because this could be different
       // per chip and we do not want to it to be part of the foundation for the
@@ -119,7 +119,7 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
       };
       TRY(otcrypto_sha2_256(input, &digest));
     } break;
-    case kDifOtpCtrlPartitionOwnerSwCfg: {
+    case kOtpPartitionOwnerSwCfg: {
       otcrypto_const_byte_buf_t input = {
           .data = (unsigned char *)(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR +
                                     OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
@@ -129,13 +129,13 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
       };
       TRY(otcrypto_sha2_256(input, &digest));
     } break;
-    case kDifOtpCtrlPartitionRotCreatorAuthCodesign: {
+    case kOtpPartitionRotCreatorAuthCodesign: {
       uint32_t rot_creator_auth_codesign_32bit_array
           [(OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE -
             OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_DIGEST_SIZE) /
            sizeof(uint32_t)];
       TRY(otp_ctrl_testutils_dai_read32_array(
-          otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthCodesign, 0,
+          otp_ctrl, kOtpPartitionRotCreatorAuthCodesign, 0,
           rot_creator_auth_codesign_32bit_array,
           (OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE -
            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_DIGEST_SIZE) /
@@ -147,13 +147,13 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
       };
       TRY(otcrypto_sha2_256(input, &digest));
     } break;
-    case kDifOtpCtrlPartitionRotCreatorAuthState: {
+    case kOtpPartitionRotCreatorAuthState: {
       uint32_t rot_creator_auth_state_32bit_array
           [(OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE -
             OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_DIGEST_SIZE) /
            sizeof(uint32_t)];
       TRY(otp_ctrl_testutils_dai_read32_array(
-          otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthState, 0,
+          otp_ctrl, kOtpPartitionRotCreatorAuthState, 0,
           rot_creator_auth_state_32bit_array,
           (OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE -
            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_DIGEST_SIZE) /

--- a/sw/device/silicon_creator/manuf/lib/util.h
+++ b/sw/device/silicon_creator/manuf/lib/util.h
@@ -51,7 +51,7 @@ status_t manuf_util_hash_lc_transition_token(const uint32_t *raw_token,
  */
 OT_WARN_UNUSED_RESULT
 status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
-                                       dif_otp_ctrl_partition_t partition,
+                                       otp_partition_t partition,
                                        otcrypto_word32_buf_t hash);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_UTIL_H_

--- a/sw/device/silicon_creator/manuf/tests/sram_exec_test.c
+++ b/sw/device/silicon_creator/manuf/tests/sram_exec_test.c
@@ -52,9 +52,8 @@ static status_t peripheral_handles_init(void) {
 
 static status_t otp_ctrl_read_hw_cfg0_device_id(uint32_t *device_id) {
   for (size_t i = kDeviceIdOffset; i < kDeviceIdSizeIn32BitWords; ++i) {
-    TRY(otp_ctrl_testutils_dai_read32(&otp, kDifOtpCtrlPartitionHwCfg0,
-                                      kDeviceIdOffset + (i * 4),
-                                      &device_id[i]));
+    TRY(otp_ctrl_testutils_dai_read32(
+        &otp, kOtpPartitionHwCfg0, kDeviceIdOffset + (i * 4), &device_id[i]));
     LOG_INFO("Device ID (%d) = %08x", i, device_id[i]);
   }
   return OK_STATUS();
@@ -69,8 +68,7 @@ static status_t otp_ctrl_read_hw_cfg0_device_id(uint32_t *device_id) {
 static status_t check_device_id_is_unprovisioned(void) {
   // Check HW_CFG0 is unlocked.
   bool is_locked;
-  TRY(dif_otp_ctrl_is_digest_computed(&otp, kDifOtpCtrlPartitionHwCfg0,
-                                      &is_locked));
+  TRY(dif_otp_ctrl_is_digest_computed(&otp, kOtpPartitionHwCfg0, &is_locked));
   CHECK(!is_locked);
 
   // Check Device ID is all zeros.
@@ -88,8 +86,7 @@ static status_t check_device_id_is_unprovisioned(void) {
 static status_t check_device_id_is_provisioned(void) {
   // Check HW_CFG0 is still unlocked.
   bool is_locked;
-  TRY(dif_otp_ctrl_is_digest_computed(&otp, kDifOtpCtrlPartitionHwCfg0,
-                                      &is_locked));
+  TRY(dif_otp_ctrl_is_digest_computed(&otp, kOtpPartitionHwCfg0, &is_locked));
   CHECK(!is_locked);
 
   // Check Device ID matches what is expected.
@@ -105,9 +102,8 @@ static status_t check_device_id_is_provisioned(void) {
 static status_t provisioning_device_id_start(void) {
   LOG_INFO("Provisioning Device ID in OTP.");
   check_device_id_is_unprovisioned();
-  TRY(otp_ctrl_testutils_dai_write32(&otp, kDifOtpCtrlPartitionHwCfg0,
-                                     kDeviceIdOffset, kTestDeviceId,
-                                     kDeviceIdSizeIn32BitWords));
+  TRY(otp_ctrl_testutils_dai_write32(&otp, kOtpPartitionHwCfg0, kDeviceIdOffset,
+                                     kTestDeviceId, kDeviceIdSizeIn32BitWords));
   return OK_STATUS();
 }
 

--- a/sw/device/silicon_creator/rom/e2e/chip_specific_startup/chip_specific_startup.c
+++ b/sw/device/silicon_creator/rom/e2e/chip_specific_startup/chip_specific_startup.c
@@ -117,10 +117,10 @@ status_t test_chip_specific_startup(ujson_t *uj) {
 
   // We need to know the OTP configs for AST init and jitter in order to
   // correctly determine the pass/fail conditions.
-  TRY(dif_otp_ctrl_read_blocking(&otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg,
+  TRY(dif_otp_ctrl_read_blocking(&otp_ctrl, kOtpPartitionCreatorSwCfg,
                                  kAstInitEnOffset,
                                  &cs.otp.creator_sw_cfg_ast_init_en, 1));
-  TRY(dif_otp_ctrl_read_blocking(&otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg,
+  TRY(dif_otp_ctrl_read_blocking(&otp_ctrl, kOtpPartitionCreatorSwCfg,
                                  kJitterEnOffset,
                                  &cs.otp.creator_sw_cfg_jitter_en, 1));
 

--- a/sw/device/silicon_creator/rom/e2e/keymgr/rom_e2e_keymgr_init_test.c
+++ b/sw/device/silicon_creator/rom/e2e/keymgr/rom_e2e_keymgr_init_test.c
@@ -34,10 +34,10 @@ static uint32_t otp_state[kHmacDigestNumWords + 4] = {0};
 
 static void print_otp_sw_cfg_digests(void) {
   uint64_t creator_digest, owner_digest = 0;
-  CHECK_DIF_OK(dif_otp_ctrl_get_digest(
-      &otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg, &creator_digest));
-  CHECK_DIF_OK(dif_otp_ctrl_get_digest(
-      &otp_ctrl, kDifOtpCtrlPartitionOwnerSwCfg, &owner_digest));
+  CHECK_DIF_OK(dif_otp_ctrl_get_digest(&otp_ctrl, kOtpPartitionCreatorSwCfg,
+                                       &creator_digest));
+  CHECK_DIF_OK(dif_otp_ctrl_get_digest(&otp_ctrl, kOtpPartitionOwnerSwCfg,
+                                       &owner_digest));
   LOG_INFO("CreatorSwCfg Digest: 0x%08x%08x", (uint32_t)(creator_digest >> 32),
            (uint32_t)creator_digest);
   LOG_INFO("OwnerSwCfg Digest:   0x%08x%08x", (uint32_t)(owner_digest >> 32),
@@ -56,12 +56,12 @@ bool test_main(void) {
   if (UNWRAP(rstmgr_testutils_is_reset_info(&rstmgr, kDifRstmgrResetInfoPor))) {
     LOG_INFO("Power on reset. Locking OTP *SwCfg partitions ...");
     const uint64_t kFakeOtpDigest = 0xaaaabbbbccccdddd;
-    CHECK_STATUS_OK(otp_ctrl_testutils_lock_partition(
-        &otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg,
-        /*digest=*/kFakeOtpDigest));
-    CHECK_STATUS_OK(otp_ctrl_testutils_lock_partition(
-        &otp_ctrl, kDifOtpCtrlPartitionOwnerSwCfg,
-        /*digest=*/kFakeOtpDigest));
+    CHECK_STATUS_OK(
+        otp_ctrl_testutils_lock_partition(&otp_ctrl, kOtpPartitionCreatorSwCfg,
+                                          /*digest=*/kFakeOtpDigest));
+    CHECK_STATUS_OK(
+        otp_ctrl_testutils_lock_partition(&otp_ctrl, kOtpPartitionOwnerSwCfg,
+                                          /*digest=*/kFakeOtpDigest));
     rstmgr_testutils_reason_clear();
     LOG_INFO("Issuing a software reset ...");
     CHECK_DIF_OK(dif_rstmgr_software_device_reset(&rstmgr));
@@ -85,12 +85,12 @@ bool test_main(void) {
     //   - the digest of the CreatorSwCfg partition,
     //   - the digest of the OwnerSwCfg partition,
     //   - the SHA256 integrity hash of the first stage boot keys.
-    CHECK_DIF_OK(dif_otp_ctrl_get_digest(
-        &otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg, (uint64_t *)otp_state));
-    CHECK_DIF_OK(dif_otp_ctrl_get_digest(
-        &otp_ctrl, kDifOtpCtrlPartitionOwnerSwCfg, (uint64_t *)&otp_state[2]));
+    CHECK_DIF_OK(dif_otp_ctrl_get_digest(&otp_ctrl, kOtpPartitionCreatorSwCfg,
+                                         (uint64_t *)otp_state));
+    CHECK_DIF_OK(dif_otp_ctrl_get_digest(&otp_ctrl, kOtpPartitionOwnerSwCfg,
+                                         (uint64_t *)&otp_state[2]));
     CHECK_STATUS_OK(otp_ctrl_testutils_dai_read32_array(
-        &otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthCodesign,
+        &otp_ctrl, kOtpPartitionRotCreatorAuthCodesign,
         OTP_CTRL_PARAM_ROTCREATORAUTHCODESIGNBLOCKSHA2_256HASHOFFSET -
             OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_OFFSET,
         &otp_state[4], /*num_words=*/kHmacDigestNumWords));

--- a/sw/device/silicon_creator/rom_ext/e2e/lockdown/otp_creator_lockdown.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/lockdown/otp_creator_lockdown.c
@@ -16,15 +16,15 @@ dif_otp_ctrl_t otp;
 status_t test_otp_creator_lockdown(void) {
   uint32_t value;
   LOG_INFO("OTP OwnerSwCfg:");
-  TRY(dif_otp_ctrl_read_blocking(&otp, kDifOtpCtrlPartitionOwnerSwCfg, 0,
-                                 &value, sizeof(value)));
+  TRY(dif_otp_ctrl_read_blocking(&otp, kOtpPartitionOwnerSwCfg, 0, &value,
+                                 sizeof(value)));
   LOG_INFO("OTP OwnerSwCfg word 0 = %x", value);
 
   // If the creator partition has been locked down, this read should cause a
   // fault.
   LOG_INFO("OTP CreatorSwCfg:");
-  TRY(dif_otp_ctrl_read_blocking(&otp, kDifOtpCtrlPartitionCreatorSwCfg, 0,
-                                 &value, sizeof(value)));
+  TRY(dif_otp_ctrl_read_blocking(&otp, kOtpPartitionCreatorSwCfg, 0, &value,
+                                 sizeof(value)));
   LOG_INFO("OTP CreatorSwCfg word 0 = %x", value);
 
   return OK_STATUS();

--- a/sw/device/tests/flash_ctrl_rma_test.c
+++ b/sw/device/tests/flash_ctrl_rma_test.c
@@ -128,7 +128,7 @@ bool test_main(void) {
       // After update info partition in flash,
       // lock secret2 partition in otp.
       CHECK_STATUS_OK(otp_ctrl_testutils_lock_partition(
-          &otp_ctrl, kDifOtpCtrlPartitionSecret2, 0));
+          &otp_ctrl, kOtpPartitionSecret2, 0));
       break;
     case kTestPhase1:
       LOG_INFO("testphase1");

--- a/sw/device/tests/lc_ctrl_otp_hw_cfg0_test.c
+++ b/sw/device/tests/lc_ctrl_otp_hw_cfg0_test.c
@@ -26,8 +26,8 @@ static const uint8_t kNumDeviceId = 8;
  * Read and return 32-bit OTP data via the DAI interface.
  */
 static void otp_ctrl_dai_read_32(const dif_otp_ctrl_t *otp,
-                                 dif_otp_ctrl_partition_t partition,
-                                 uint32_t address, uint32_t *buf) {
+                                 otp_partition_t partition, uint32_t address,
+                                 uint32_t *buf) {
   CHECK_DIF_OK(dif_otp_ctrl_dai_read_start(otp, partition, address));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(otp));
   CHECK_DIF_OK(dif_otp_ctrl_dai_read32_end(otp, buf));
@@ -58,8 +58,7 @@ bool test_main(void) {
   // plan to backdoor inject.
   uint32_t otp_device_id;
   for (uint32_t i = 0; i < kNumDeviceId; i++) {
-    otp_ctrl_dai_read_32(&otp, kDifOtpCtrlPartitionHwCfg0, i * 4,
-                         &otp_device_id);
+    otp_ctrl_dai_read_32(&otp, kOtpPartitionHwCfg0, i * 4, &otp_device_id);
 
     CHECK(otp_device_id == lc_device_id.data[i],
           "Device_ID_%d mismatch bewtween otp_ctrl: %08x and lc_ctrl: %08x", i,

--- a/sw/device/tests/otp_ctrl_descrambling_test.c
+++ b/sw/device/tests/otp_ctrl_descrambling_test.c
@@ -15,25 +15,25 @@
 OTTF_DEFINE_TEST_CONFIG();
 
 typedef struct partition_data {
-  dif_otp_ctrl_partition_t partition;
+  otp_partition_t partition;
   size_t size;
 } partition_data_t;
 
 static const partition_data_t kPartitions[] = {
     {
-        .partition = kDifOtpCtrlPartitionSecret0,
+        .partition = kOtpPartitionSecret0,
         .size =
             (OTP_CTRL_PARAM_SECRET0_SIZE - OTP_CTRL_PARAM_SECRET0_DIGEST_SIZE) /
             sizeof(uint64_t),
     },
     {
-        .partition = kDifOtpCtrlPartitionSecret1,
+        .partition = kOtpPartitionSecret1,
         .size =
             (OTP_CTRL_PARAM_SECRET1_SIZE - OTP_CTRL_PARAM_SECRET1_DIGEST_SIZE) /
             sizeof(uint64_t),
     },
     {
-        .partition = kDifOtpCtrlPartitionSecret2,
+        .partition = kOtpPartitionSecret2,
         .size =
             (OTP_CTRL_PARAM_SECRET2_SIZE - OTP_CTRL_PARAM_SECRET2_DIGEST_SIZE) /
             sizeof(uint64_t),

--- a/sw/device/tests/otp_ctrl_mem_access_test.c
+++ b/sw/device/tests/otp_ctrl_mem_access_test.c
@@ -36,33 +36,9 @@ static const uint32_t kTestData[] = {
 OTTF_DEFINE_TEST_CONFIG();
 
 typedef struct partition_data {
-  dif_otp_ctrl_partition_t partition;
+  otp_partition_t partition;
   size_t size;
 } partition_data_t;
-
-static const partition_data_t kPartitions[] = {
-    {
-        .partition = kDifOtpCtrlPartitionVendorTest,
-        .size = OTP_CTRL_PARAM_VENDOR_TEST_SIZE / sizeof(uint32_t),
-    },
-    {
-        .partition = kDifOtpCtrlPartitionCreatorSwCfg,
-        .size = OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE / sizeof(uint32_t),
-    },
-    {
-        .partition = kDifOtpCtrlPartitionOwnerSwCfg,
-        .size = OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE / sizeof(uint32_t),
-    },
-    {
-        .partition = kDifOtpCtrlPartitionRotCreatorAuthCodesign,
-        .size =
-            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE / sizeof(uint32_t),
-    },
-    {
-        .partition = kDifOtpCtrlPartitionRotCreatorAuthState,
-        .size = OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE / sizeof(uint32_t),
-    },
-};
 
 static void peripheral_handles_init(void) {
   CHECK_DIF_OK(dif_otp_ctrl_init(
@@ -77,16 +53,16 @@ static void otp_ctrl_dai_write_test(bool expect_eq) {
     CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
 
     uint32_t address = 0x10 + i * sizeof(uint32_t);
-    CHECK_DIF_OK(
-        dif_otp_ctrl_dai_program32(&otp, kDifOtpCtrlPartitionVendorTest,
-                                   address, kTestData[i]),
-        "Failed to program word kTestData[%d] = 0x%08x.", i, kTestData[i]);
+    CHECK_DIF_OK(dif_otp_ctrl_dai_program32(&otp, kOtpPartitionVendorTest,
+                                            address, kTestData[i]),
+                 "Failed to program word kTestData[%d] = 0x%08x.", i,
+                 kTestData[i]);
   }
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
 
   uint32_t readout[ARRAYSIZE(kTestData)] = {0};
   CHECK_STATUS_OK(otp_ctrl_testutils_dai_read32_array(
-      &otp, kDifOtpCtrlPartitionVendorTest, 0x10, readout, ARRAYSIZE(readout)));
+      &otp, kOtpPartitionVendorTest, 0x10, readout, ARRAYSIZE(readout)));
 
   if (expect_eq) {
     CHECK_ARRAYS_EQ(readout, kTestData, ARRAYSIZE(kTestData));
@@ -107,12 +83,21 @@ static void dai_disable(void) {
 static void otp_ctrl_dai_disable_test(uint32_t last_dai_value) {
   dai_disable();
   LOG_INFO("Checking that the DAI is disabled.");
-  for (uint32_t i = 0; i < ARRAYSIZE(kPartitions); ++i) {
-    const partition_data_t *partition = &kPartitions[i];
-    LOG_INFO("Checking partition %d.", partition->partition);
-    uint32_t readout[partition->size];
+  for (uint32_t i = 0; i < kOtpPartitionCount; ++i) {
+    otp_partition_t partition = (otp_partition_t)i;
+    dt_otp_partition_info_t partition_info =
+        dt_otp_ctrl_partition(kDtOtpCtrl, partition);
+    size_t partition_len = partition_info.size;
+    if (partition_info.sw_digest || partition_info.hw_digest) {
+      partition_len += sizeof(uint64_t);
+    }
+    if (partition_info.zeroizable) {
+      partition_len += sizeof(uint64_t);
+    }
+    LOG_INFO("Checking partition %d.", partition);
+    uint32_t readout[partition_len];
     CHECK_STATUS_OK(otp_ctrl_testutils_dai_read32_array(
-        &otp, partition->partition, 0, readout, ARRAYSIZE(readout)));
+        &otp, partition, 0, readout, ARRAYSIZE(readout)));
 
     // The current DAI locking mechanism just locks the register inteface, so
     // all transactions should result in a DAI idle status.
@@ -125,8 +110,8 @@ static void otp_ctrl_dai_disable_test(uint32_t last_dai_value) {
     // returning any read values.
     for (uint32_t j = 0; j < ARRAYSIZE(readout); ++j) {
       CHECK(readout[j] == last_dai_value,
-            "Partition %d, word %d: expected 0x%08x, got 0x%08x.",
-            partition->partition, j, last_dai_value, readout[j]);
+            "Partition %d, word %d: expected 0x%08x, got 0x%08x.", partition, j,
+            last_dai_value, readout[j]);
     }
   }
 }

--- a/sw/device/tests/otp_ctrl_smoketest.c
+++ b/sw/device/tests/otp_ctrl_smoketest.c
@@ -47,15 +47,15 @@ bool test_main(void) {
     memcpy(&word, &kTestData[i], sizeof(word));
 
     CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
-    CHECK_DIF_OK(dif_otp_ctrl_dai_program32(
-                     &otp, kDifOtpCtrlPartitionVendorTest, 0x10 + i, word),
+    CHECK_DIF_OK(dif_otp_ctrl_dai_program32(&otp, kOtpPartitionVendorTest,
+                                            0x10 + i, word),
                  "Failed to program word kTestData[%d] = 0x%08x.", i, word);
   }
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
 
   uint32_t readout[ARRAYSIZE(kTestData) / sizeof(uint32_t)] = {0};
-  CHECK_DIF_OK(dif_otp_ctrl_read_blocking(&otp, kDifOtpCtrlPartitionVendorTest,
-                                          0x10, readout, ARRAYSIZE(kTestData)),
+  CHECK_DIF_OK(dif_otp_ctrl_read_blocking(&otp, kOtpPartitionVendorTest, 0x10,
+                                          readout, ARRAYSIZE(kTestData)),
                "Failed to perform OTP blocking readout.");
 
   CHECK(memcmp(kTestData, readout, ARRAYSIZE(kTestData)) == 0);

--- a/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
@@ -411,22 +411,21 @@ static status_t init_ref_otp_data(void) {
   if (!otp_ref_init) {
     // Read VENDOR_TEST partition.
     TRY(otp_ctrl_testutils_dai_read32_array(
-        &otp, kDifOtpCtrlPartitionVendorTest, 0, otp_data_read_ref_vendor_test,
+        &otp, kOtpPartitionVendorTest, 0, otp_data_read_ref_vendor_test,
         (OTP_CTRL_PARAM_VENDOR_TEST_SIZE -
          OTP_CTRL_PARAM_VENDOR_TEST_DIGEST_SIZE) /
             sizeof(uint32_t)));
 
     // Read CREATOR_SW_CFG partition.
     TRY(otp_ctrl_testutils_dai_read32_array(
-        &otp, kDifOtpCtrlPartitionCreatorSwCfg, 0,
-        otp_data_read_ref_creator_sw_cfg,
+        &otp, kOtpPartitionCreatorSwCfg, 0, otp_data_read_ref_creator_sw_cfg,
         (OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE -
          OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_SIZE) /
             sizeof(uint32_t)));
 
     // READ OWNER_SW_CFG partition.
     TRY(otp_ctrl_testutils_dai_read32_array(
-        &otp, kDifOtpCtrlPartitionOwnerSwCfg, 0, otp_data_read_ref_owner_sw_cfg,
+        &otp, kOtpPartitionOwnerSwCfg, 0, otp_data_read_ref_owner_sw_cfg,
         (OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE -
          OTP_CTRL_PARAM_OWNER_SW_CFG_DIGEST_SIZE) /
             sizeof(uint32_t)));
@@ -460,18 +459,17 @@ static status_t read_otp_partitions(ujson_t *uj) {
   pentest_set_trigger_high();
   asm volatile(NOP10);
   TRY(otp_ctrl_testutils_dai_read32_array(
-      &otp, kDifOtpCtrlPartitionVendorTest, 0, otp_data_read_res_vendor_test,
+      &otp, kOtpPartitionVendorTest, 0, otp_data_read_res_vendor_test,
       (OTP_CTRL_PARAM_VENDOR_TEST_SIZE -
        OTP_CTRL_PARAM_VENDOR_TEST_DIGEST_SIZE) /
           sizeof(uint32_t)));
   TRY(otp_ctrl_testutils_dai_read32_array(
-      &otp, kDifOtpCtrlPartitionCreatorSwCfg, 0,
-      otp_data_read_res_creator_sw_cfg,
+      &otp, kOtpPartitionCreatorSwCfg, 0, otp_data_read_res_creator_sw_cfg,
       (OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE -
        OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_SIZE) /
           sizeof(uint32_t)));
   TRY(otp_ctrl_testutils_dai_read32_array(
-      &otp, kDifOtpCtrlPartitionOwnerSwCfg, 0, otp_data_read_res_owner_sw_cfg,
+      &otp, kOtpPartitionOwnerSwCfg, 0, otp_data_read_res_owner_sw_cfg,
       (OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE -
        OTP_CTRL_PARAM_OWNER_SW_CFG_DIGEST_SIZE) /
           sizeof(uint32_t)));
@@ -4879,9 +4877,9 @@ status_t handle_ibex_fi_otp_data_read(ujson_t *uj) __attribute__((optnone)) {
 
 status_t handle_ibex_fi_otp_read_lock(ujson_t *uj) __attribute__((optnone)) {
   TRY(init_ref_otp_data());
-  TRY(dif_otp_ctrl_lock_reading(&otp, kDifOtpCtrlPartitionVendorTest));
-  TRY(dif_otp_ctrl_lock_reading(&otp, kDifOtpCtrlPartitionCreatorSwCfg));
-  TRY(dif_otp_ctrl_lock_reading(&otp, kDifOtpCtrlPartitionOwnerSwCfg));
+  TRY(dif_otp_ctrl_lock_reading(&otp, kOtpPartitionVendorTest));
+  TRY(dif_otp_ctrl_lock_reading(&otp, kOtpPartitionCreatorSwCfg));
+  TRY(dif_otp_ctrl_lock_reading(&otp, kOtpPartitionOwnerSwCfg));
 
   TRY(read_otp_partitions(uj));
 
@@ -4904,8 +4902,8 @@ status_t handle_ibex_fi_otp_write_lock(ujson_t *uj) __attribute__((optnone)) {
   pentest_set_trigger_high();
   asm volatile(NOP10);
   TRY(otp_ctrl_testutils_dai_write64(
-      &otp, kDifOtpCtrlPartitionSecret0, kSecret0TestUnlockTokenOffset,
-      faulty_token, kSecret0TestUnlockTokenSizeIn64BitWords));
+      &otp, kOtpPartitionSecret0, kSecret0TestUnlockTokenOffset, faulty_token,
+      kSecret0TestUnlockTokenSizeIn64BitWords));
   asm volatile(NOP10);
   pentest_set_trigger_low();
 

--- a/sw/device/tests/penetrationtests/firmware/fi/otp_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otp_fi.c
@@ -69,32 +69,32 @@ void init_otp_mem_dump_buffers(void) {
 
 status_t otp_vendor_test_dump(uint32_t *buffer) {
   // Read VENDOR_TEST partition
-  TRY(otp_ctrl_testutils_dai_read32_array(&otp, kDifOtpCtrlPartitionVendorTest,
-                                          0, buffer, kOtpFiVendorTestSize));
+  TRY(otp_ctrl_testutils_dai_read32_array(&otp, kOtpPartitionVendorTest, 0,
+                                          buffer, kOtpFiVendorTestSize));
 
   return OK_STATUS();
 }
 
 status_t otp_owner_sw_cfg_dump(uint32_t *buffer) {
   // Read OWNER_SW_CFG partition
-  TRY(otp_ctrl_testutils_dai_read32_array(&otp, kDifOtpCtrlPartitionOwnerSwCfg,
-                                          0, buffer, kOtpFiOwnerSwCfgSize));
+  TRY(otp_ctrl_testutils_dai_read32_array(&otp, kOtpPartitionOwnerSwCfg, 0,
+                                          buffer, kOtpFiOwnerSwCfgSize));
 
   return OK_STATUS();
 }
 
 status_t otp_hw_cfg_dump(uint32_t *buffer) {
   // Read HW_CFG partition
-  TRY(otp_ctrl_testutils_dai_read32_array(&otp, kDifOtpCtrlPartitionHwCfg0, 0,
-                                          buffer, kOtpFiHwCfg0Size));
+  TRY(otp_ctrl_testutils_dai_read32_array(&otp, kOtpPartitionHwCfg0, 0, buffer,
+                                          kOtpFiHwCfg0Size));
 
   return OK_STATUS();
 }
 
 status_t otp_life_cycle_dump(uint32_t *buffer) {
   // Read LIFE_CYCLE partition
-  TRY(otp_ctrl_testutils_dai_read32_array(&otp, kDifOtpCtrlPartitionLifeCycle,
-                                          0, buffer, kOtpFiLifeCycleSize));
+  TRY(otp_ctrl_testutils_dai_read32_array(&otp, kOtpPartitionLifeCycle, 0,
+                                          buffer, kOtpFiLifeCycleSize));
 
   return OK_STATUS();
 }
@@ -149,8 +149,9 @@ status_t handle_otp_fi_hw_cfg(ujson_t *uj) {
     }
   }
   uj_output.otp_status_codes = status.codes;
+  // Number of causes = Partition count + 2.
   memcpy(uj_output.otp_error_causes, (uint8_t *)status.causes,
-         kDifOtpCtrlNumberOfCauses);
+         kOtpPartitionCount + 2);
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
   memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
@@ -238,8 +239,9 @@ status_t handle_otp_fi_life_cycle(ujson_t *uj) {
     }
   }
   uj_output.otp_status_codes = status.codes;
+  // Number of causes = Partition count + 2.
   memcpy(uj_output.otp_error_causes, (uint8_t *)status.causes,
-         kDifOtpCtrlNumberOfCauses);
+         kOtpPartitionCount + 2);
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
   memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
@@ -299,8 +301,9 @@ status_t handle_otp_fi_owner_sw_cfg(ujson_t *uj) {
     }
   }
   uj_output.otp_status_codes = status.codes;
+  // Number of causes = Partition count + 2.
   memcpy(uj_output.otp_error_causes, (uint8_t *)status.causes,
-         kDifOtpCtrlNumberOfCauses);
+         kOtpPartitionCount + 2);
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
   memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
@@ -360,8 +363,9 @@ status_t handle_otp_fi_vendor_test(ujson_t *uj) {
     }
   }
   uj_output.otp_status_codes = status.codes;
+  // Number of causes = Partition count + 2.
   memcpy(uj_output.otp_error_causes, (uint8_t *)status.causes,
-         kDifOtpCtrlNumberOfCauses);
+         kOtpPartitionCount + 2);
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   uj_output.loc_alerts = reg_loc_alerts.loc_alerts;
   memcpy(uj_output.ast_alerts, sensor_alerts.alerts,

--- a/sw/device/tests/sim_dv/all_escalation_resets_test.c
+++ b/sw/device/tests/sim_dv/all_escalation_resets_test.c
@@ -1141,7 +1141,7 @@ static void execute_test(const dif_aon_timer_t *aon_timer) {
   if (kExpectedAlertNumber == dt_otp_ctrl_alert_to_alert_id(
                                   kOtpCtrlDt, kDtOtpCtrlAlertFatalMacroError)) {
     CHECK_DIF_OK(
-        dif_otp_ctrl_dai_read_start(&otp_ctrl, kDifOtpCtrlPartitionHwCfg0, 0));
+        dif_otp_ctrl_dai_read_start(&otp_ctrl, kOtpPartitionHwCfg0, 0));
     LOG_INFO("OTP_CTRL error inject done");
   }
 

--- a/sw/device/tests/sim_dv/csrng_fuse_en_sw_app_read.c
+++ b/sw/device/tests/sim_dv/csrng_fuse_en_sw_app_read.c
@@ -75,7 +75,7 @@ static void check_csrng_fuse_enabled(bool expected) {
 
   uint32_t value;
   // Read the current value of the partition.
-  CHECK_DIF_OK(dif_otp_ctrl_dai_read_start(&otp, kDifOtpCtrlPartitionHwCfg1,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_read_start(&otp, kOtpPartitionHwCfg1,
                                            kOtpIfetchHwRelativeOffset));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
   CHECK_DIF_OK(dif_otp_ctrl_dai_read32_end(&otp, &value));

--- a/sw/device/tests/sim_dv/csrng_lc_hw_debug_en_test.c
+++ b/sw/device/tests/sim_dv/csrng_lc_hw_debug_en_test.c
@@ -168,18 +168,16 @@ static void lock_otp_secret0_partition(void) {
   uint64_t opt_token_h;
   exit_token_cshake_hash(&otp_token_l, &opt_token_h);
 
-  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp_ctrl,
-                                          kDifOtpCtrlPartitionSecret0,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp_ctrl, kOtpPartitionSecret0,
                                           /*address=*/0x10,
                                           /*value=*/otp_token_l));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp_ctrl));
-  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp_ctrl,
-                                          kDifOtpCtrlPartitionSecret0,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp_ctrl, kOtpPartitionSecret0,
                                           /*address=*/0x18,
                                           /*value=*/opt_token_h));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp_ctrl));
 
-  CHECK_DIF_OK(dif_otp_ctrl_dai_digest(&otp_ctrl, kDifOtpCtrlPartitionSecret0,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_digest(&otp_ctrl, kOtpPartitionSecret0,
                                        /*digest=*/0));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp_ctrl));
 }

--- a/sw/device/tests/sim_dv/flash_ctrl_lc_rw_en_test.c
+++ b/sw/device/tests/sim_dv/flash_ctrl_lc_rw_en_test.c
@@ -231,7 +231,7 @@ static void keymgr_advance_state(dif_keymgr_t *keymgr,
 // creator secrets are provisioned and the DUT will not allow further writes to
 // the creator secrets.
 static void dut_provision_creator_secrets(void) {
-  CHECK_DIF_OK(dif_otp_ctrl_dai_digest(&otp, kDifOtpCtrlPartitionSecret2, 0));
+  CHECK_DIF_OK(dif_otp_ctrl_dai_digest(&otp, kOtpPartitionSecret2, 0));
   dif_otp_ctrl_status_t otp_status;
   do {
     CHECK_DIF_OK(dif_otp_ctrl_get_status(&otp, &otp_status));

--- a/sw/device/tests/sim_dv/inject_scramble_seed.c
+++ b/sw/device/tests/sim_dv/inject_scramble_seed.c
@@ -95,8 +95,8 @@ bool test_main(void) {
       &flash_ctrl, mmio_region_from_addr(TOP_EGRET_FLASH_CTRL_CORE_BASE_ADDR)));
 
   bool secret1_locked = false;
-  CHECK_DIF_OK(dif_otp_ctrl_is_digest_computed(
-      &otp_ctrl, kDifOtpCtrlPartitionSecret1, &secret1_locked));
+  CHECK_DIF_OK(dif_otp_ctrl_is_digest_computed(&otp_ctrl, kOtpPartitionSecret1,
+                                               &secret1_locked));
 
   if (!secret1_locked) {
     LOG_INFO("Powered up for the first time, program and lock otp");
@@ -123,8 +123,7 @@ bool test_main(void) {
       uint64_t val =
           (uint64_t)rand_testutils_gen32() << 32 | rand_testutils_gen32();
 
-      CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp_ctrl,
-                                              kDifOtpCtrlPartitionSecret1,
+      CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp_ctrl, kOtpPartitionSecret1,
                                               kFlashAddrKeyOffset + i, val));
       CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp_ctrl));
     };
@@ -134,8 +133,7 @@ bool test_main(void) {
       uint64_t val =
           (uint64_t)rand_testutils_gen32() << 32 | rand_testutils_gen32();
 
-      CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp_ctrl,
-                                              kDifOtpCtrlPartitionSecret1,
+      CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp_ctrl, kOtpPartitionSecret1,
                                               kFlashDataKeyOffset + i, val));
       CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp_ctrl));
     };
@@ -145,14 +143,14 @@ bool test_main(void) {
       uint64_t val =
           (uint64_t)rand_testutils_gen32() << 32 | rand_testutils_gen32();
 
-      CHECK_DIF_OK(dif_otp_ctrl_dai_program64(
-          &otp_ctrl, kDifOtpCtrlPartitionSecret1, kSramDataKeyOffset + i, val));
+      CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp_ctrl, kOtpPartitionSecret1,
+                                              kSramDataKeyOffset + i, val));
       CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp_ctrl));
     };
 
     // Lock the secret1 partition.
-    CHECK_STATUS_OK(otp_ctrl_testutils_lock_partition(
-        &otp_ctrl, kDifOtpCtrlPartitionSecret1, 0));
+    CHECK_STATUS_OK(
+        otp_ctrl_testutils_lock_partition(&otp_ctrl, kOtpPartitionSecret1, 0));
 
     // Inform rom to setup scramble next round.
     uint32_t otp_val = 0;
@@ -160,7 +158,7 @@ bool test_main(void) {
         otp_val, FLASH_CTRL_DEFAULT_REGION_SCRAMBLE_EN_FIELD,
         kMultiBitBool4True);
     CHECK_DIF_OK(dif_otp_ctrl_dai_program32(
-        &otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg,
+        &otp_ctrl, kOtpPartitionCreatorSwCfg,
         (OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG_OFFSET -
          OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET),
         otp_val));

--- a/sw/device/tests/sim_dv/lc_walkthrough_test.c
+++ b/sw/device/tests/sim_dv/lc_walkthrough_test.c
@@ -83,24 +83,24 @@ static void lock_otp_secret0_partition(void) {
     }
   }
 
-  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kDifOtpCtrlPartitionSecret0,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kOtpPartitionSecret0,
                                           /*address=*/0x0,
                                           /*value=*/otp_unlock_token_0));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
-  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kDifOtpCtrlPartitionSecret0,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kOtpPartitionSecret0,
                                           /*address=*/0x8,
                                           /*value=*/otp_unlock_token_1));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
-  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kDifOtpCtrlPartitionSecret0,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kOtpPartitionSecret0,
                                           /*address=*/0x10,
                                           /*value=*/otp_exit_token_0));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
-  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kDifOtpCtrlPartitionSecret0,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kOtpPartitionSecret0,
                                           /*address=*/0x18,
                                           /*value=*/otp_exit_token_1));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
 
-  CHECK_DIF_OK(dif_otp_ctrl_dai_digest(&otp, kDifOtpCtrlPartitionSecret0,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_digest(&otp, kOtpPartitionSecret0,
                                        /*digest=*/0));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
 }
@@ -117,16 +117,16 @@ static void lock_otp_secret2_partition(void) {
                          << ((i - LC_TOKEN_SIZE / 2) * 8);
     }
   }
-  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kDifOtpCtrlPartitionSecret2,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kOtpPartitionSecret2,
                                           /*address=*/0x0,
                                           /*value=*/otp_rma_token_0));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
-  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kDifOtpCtrlPartitionSecret2,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kOtpPartitionSecret2,
                                           /*address=*/0x8,
                                           /*value=*/otp_rma_token_1));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
 
-  CHECK_DIF_OK(dif_otp_ctrl_dai_digest(&otp, kDifOtpCtrlPartitionSecret2,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_digest(&otp, kOtpPartitionSecret2,
                                        /*digest=*/0));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
 }
@@ -166,8 +166,8 @@ bool test_main(void) {
   if (curr_state == kDifLcCtrlStateTestUnlocked0) {
     CHECK_STATUS_OK(lc_ctrl_testutils_check_transition_count(&lc, 1));
     bool secret0_locked;
-    CHECK_DIF_OK(dif_otp_ctrl_is_digest_computed(
-        &otp, kDifOtpCtrlPartitionSecret0, &secret0_locked));
+    CHECK_DIF_OK(dif_otp_ctrl_is_digest_computed(&otp, kOtpPartitionSecret0,
+                                                 &secret0_locked));
 
     if (!secret0_locked) {
       LOG_INFO("In TestUnlocked0 state. Write and lock OTP secret0 partition.");
@@ -213,8 +213,8 @@ bool test_main(void) {
     }
   } else if (curr_state == kDestState) {
     bool secret2_locked;
-    CHECK_DIF_OK(dif_otp_ctrl_is_digest_computed(
-        &otp, kDifOtpCtrlPartitionSecret2, &secret2_locked));
+    CHECK_DIF_OK(dif_otp_ctrl_is_digest_computed(&otp, kOtpPartitionSecret2,
+                                                 &secret2_locked));
 
     if (!secret2_locked) {
       LOG_INFO(

--- a/sw/device/tests/sim_dv/lc_walkthrough_testunlocks_test.c
+++ b/sw/device/tests/sim_dv/lc_walkthrough_testunlocks_test.c
@@ -63,24 +63,24 @@ static void lock_otp_secret0_partition(void) {
     }
   }
 
-  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kDifOtpCtrlPartitionSecret0,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kOtpPartitionSecret0,
                                           /*address=*/0x0,
                                           /*value=*/otp_unlock_token_0));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
-  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kDifOtpCtrlPartitionSecret0,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kOtpPartitionSecret0,
                                           /*address=*/0x8,
                                           /*value=*/otp_unlock_token_1));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
-  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kDifOtpCtrlPartitionSecret0,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kOtpPartitionSecret0,
                                           /*address=*/0x10,
                                           /*value=*/otp_exit_token_0));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
-  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kDifOtpCtrlPartitionSecret0,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_program64(&otp, kOtpPartitionSecret0,
                                           /*address=*/0x18,
                                           /*value=*/otp_exit_token_1));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
 
-  CHECK_DIF_OK(dif_otp_ctrl_dai_digest(&otp, kDifOtpCtrlPartitionSecret0,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_digest(&otp, kOtpPartitionSecret0,
                                        /*digest=*/0));
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
 }
@@ -163,8 +163,8 @@ bool test_main(void) {
   CHECK_STATUS_OK(lc_ctrl_testutils_check_transition_count(&lc, kExpCnt));
 
   bool secret0_locked;
-  CHECK_DIF_OK(dif_otp_ctrl_is_digest_computed(
-      &otp, kDifOtpCtrlPartitionSecret0, &secret0_locked));
+  CHECK_DIF_OK(dif_otp_ctrl_is_digest_computed(&otp, kOtpPartitionSecret0,
+                                               &secret0_locked));
   if (!secret0_locked) {
     // Write LC tokens to OTP secret0 partition.
     lock_otp_secret0_partition();

--- a/sw/device/tests/sim_dv/otp_ctrl_lc_signals_test.c
+++ b/sw/device/tests/sim_dv/otp_ctrl_lc_signals_test.c
@@ -100,7 +100,7 @@ static void otp_write_test(uint32_t address, const uint8_t *buffer,
     uint64_t word;
     memcpy(&word, &buffer[i], sizeof(word));
     CHECK_DIF_OK(
-        dif_otp_ctrl_dai_program64(&otp, kDifOtpCtrlPartitionSecret2, i, word));
+        dif_otp_ctrl_dai_program64(&otp, kOtpPartitionSecret2, i, word));
     CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
     CHECK(address <= INT32_MAX, "address must fit into int32_t");
     CHECK_STATUS_OK(otp_ctrl_testutils_dai_access_error_check(
@@ -122,8 +122,7 @@ static void otp_read_test(uint32_t address, const uint8_t *buffer,
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
   for (uint32_t i = address; i < address + size; i += sizeof(uint64_t)) {
     uint64_t got, exp;
-    CHECK_DIF_OK(
-        dif_otp_ctrl_dai_read_start(&otp, kDifOtpCtrlPartitionSecret2, i));
+    CHECK_DIF_OK(dif_otp_ctrl_dai_read_start(&otp, kOtpPartitionSecret2, i));
     CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
     CHECK(address <= INT32_MAX, "address must fit into int32_t");
     CHECK_STATUS_OK(otp_ctrl_testutils_dai_access_error_check(
@@ -318,8 +317,8 @@ bool test_main(void) {
         reset_chip();
 
       } else if (rst_info == kDifRstmgrResetInfoSw) {
-        CHECK_DIF_OK(dif_otp_ctrl_is_digest_computed(
-            &otp, kDifOtpCtrlPartitionSecret2, &is_computed));
+        CHECK_DIF_OK(dif_otp_ctrl_is_digest_computed(&otp, kOtpPartitionSecret2,
+                                                     &is_computed));
 
         if (!is_computed) {
           LOG_INFO("Second access test iteration...");
@@ -329,8 +328,8 @@ bool test_main(void) {
           // SECRET2 has not been locked yet.
           keymgr_check_root_key_is_invalid();
           // Lock the SECRET2 partition.
-          CHECK_STATUS_OK(otp_ctrl_testutils_lock_partition(
-              &otp, kDifOtpCtrlPartitionSecret2, 0));
+          CHECK_STATUS_OK(
+              otp_ctrl_testutils_lock_partition(&otp, kOtpPartitionSecret2, 0));
           reset_chip();
         } else {
           LOG_INFO("Third access test iteration...");

--- a/sw/device/tests/sim_dv/sram_ctrl_execution_main_test.c
+++ b/sw/device/tests/sim_dv/sram_ctrl_execution_main_test.c
@@ -69,7 +69,7 @@ static bool otp_ifetch_enabled(void) {
   };
   CHECK_DIF_OK(dif_otp_ctrl_configure(&otp, config));
 
-  CHECK_DIF_OK(dif_otp_ctrl_dai_read_start(&otp, kDifOtpCtrlPartitionHwCfg1,
+  CHECK_DIF_OK(dif_otp_ctrl_dai_read_start(&otp, kOtpPartitionHwCfg1,
                                            kOtpIfetchHwRelativeOffset));
 
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));


### PR DESCRIPTION
The OTP DIFs had relied on a significant amount of now-outdated metadata that was hard-coded. This included:

- Partition IDs that only matched Egret were hard-coded, preventing the DAI APIs
  from working on Dragonfly.
- The digest offset was assumed to be always the last field, which is no longer always true after zeroization was introduced, as the zeroization field comes after the digest in zeroizable partitions. This caused digest-locking partitions with a software digest to fail, because the DIF wrote the digest to the zeroization field instead.

This commit makes the DIFs utilize DT for partition information, which was updated in the OTP DtGen script to include the necessary layout and operation-compatibility information for the DIFs, as well as metadata for non-sofware-readable partitions, which can still be written using the DAI (e.g. during provisioning in TEST_UNLOCK). This allowed removing the hard coded layout data structures in the OTP DIFs and making the DIFs compatible with a multi-top architecture.

The unit tests were slightly updated to addresss some Egret-specific behavior. Some checks the tests perform on Egret-specific partitions were temporarily commented out. These can be reintroduced later pending the planned OTP MMAP zipper merge, which will unify the partition names for secure boot keys.