### PR TITLE
[acc,mlkem] Fix off-by-one in the poly_rej_samp accept bound

### DIFF
--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -487,9 +487,9 @@ refreshios:
 .globl poly_rej_samp
 .type poly_rej_samp, @function
 poly_rej_samp:
-	/* Load 19*Q into w1. */
+	/* Load 19*Q - 1 into w1. */
 	addi      t0, x0, 1
-	la        t1, modulus_times_19
+	la        t1, modulus_times_19_minus_1
 	bn.lid    t0++, 0(t1)
 	bn.shv.8s w1, w1 >> 16
 

--- a/sw/acc/crypto/mlkem/mlkem_consts.s
+++ b/sw/acc/crypto/mlkem/mlkem_consts.s
@@ -72,16 +72,17 @@ modulus_over_2_m2_16:
   .word 0x0af70af7
   .word 0x0af70af7
 
-.globl modulus_times_19
-modulus_times_19:
-  .word 0xf713f713
-  .word 0xf713f713
-  .word 0xf713f713
-  .word 0xf713f713
-  .word 0xf713f713
-  .word 0xf713f713
-  .word 0xf713f713
-  .word 0xf713f713
+/* 19 * Q - 1. */
+.globl modulus_times_19_minus_1
+modulus_times_19_minus_1:
+  .word 0xf712f712
+  .word 0xf712f712
+  .word 0xf712f712
+  .word 0xf712f712
+  .word 0xf712f712
+  .word 0xf712f712
+  .word 0xf712f712
+  .word 0xf712f712
 
 .globl mont
 mont:

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_rej_samp_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_rej_samp_testgen.py
@@ -12,7 +12,7 @@ from shared.testgen import write_test_data, write_test_exp, write_test_dexp
 KYBER_Q = 3329
 N = 256  # number of output coefficients
 # Largest multiple of q below 2**16; a batch is rejected if any of its 16
-# candidates exceeds LIMIT.
+# candidates is >= LIMIT.
 LIMIT = 19 * KYBER_Q
 
 
@@ -31,9 +31,9 @@ def gen_poly_rej_samp_test(
         word = [random.getrandbits(16) for _ in range(16)]
         for c in word:
             rand_in += int.to_bytes(c, byteorder="little", length=2)
-        # The gadget accepts the whole word only if every candidate <= 19*q,
+        # The gadget accepts the whole word only if every candidate < 19*q,
         # then reduces each accepted candidate mod q.
-        if all(c <= LIMIT for c in word):
+        if all(c < LIMIT for c in word):
             coeffs += [c % KYBER_Q for c in word]
 
     r_bytes = bytes()


### PR DESCRIPTION
poly_rej_samp draws the uniform polynomial used by refreshmodq and secb2amodq to refresh masking, so the bug below does not change any ML-KEM output; it only makes the refresh mask slightly non-uniform.

The sign of 19*Q - x is only negative for x > 19*Q, so a draw of exactly 19*Q was accepted giving 0 mod q a slightly higher probability than all other values.
Instead use 19*Q-1 so the outputs are uniform mod q.