### PR TITLE
[test] Mark the failing CW340 SiVal ROM_EXT long tests broken

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -113,10 +113,14 @@ pavona_test(
 pavona_test(
     name = "mod_exp_ibex_functest_wycheproof",
     srcs = ["mod_exp_ibex_functest.c"],
+    broken = fpga_params(tags = ["broken"]),
     exec_env = dicts.add(
         EGRET_TEST_ENVS,
         {
             "//hw/top_egret:fpga_cw310_test_rom": None,
+            # Broken: ".rodata overlaps .non_volatile_counter_3".
+            "//hw/top_egret:fpga_cw310_sival_rom_ext": "broken",
+            "//hw/top_egret:fpga_cw340_sival_rom_ext": "broken",
         },
     ),
     fpga = fpga_params(
@@ -314,11 +318,15 @@ pavona_test(
 pavona_test(
     name = "sigverify_dynamic_functest_wycheproof",
     srcs = ["sigverify_dynamic_functest.c"],
+    broken = fpga_params(tags = ["broken"]),
     exec_env = dicts.add(
         EGRET_TEST_ENVS,
         {
             # Test set is too large as ROM_EXT
             "//hw/top_egret:fpga_cw310_test_rom": None,
+            # Broken: ".rodata overlaps .non_volatile_counter_3".
+            "//hw/top_egret:fpga_cw310_sival_rom_ext": "broken",
+            "//hw/top_egret:fpga_cw340_sival_rom_ext": "broken",
         },
     ),
     fpga = fpga_params(

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5991,7 +5991,11 @@ pavona_test(
     ),
     fpga = fpga_params(
         timeout = "long",
-        tags = ["slow_test"],
+        # Broken: "SFDP header contains incorrect signature: 0xffffffff".
+        tags = [
+            "broken",
+            "slow_test",
+        ],
         test_cmd = """
             --bootstrap="{firmware}"
             "{firmware:elf}"

--- a/sw/device/tests/penetrationtests/BUILD
+++ b/sw/device/tests/penetrationtests/BUILD
@@ -284,7 +284,8 @@ pentest_cryptolib_fi_sym(
 
 pentest_cryptolib_fi_sym(
     name = "fi_sym_cryptolib_python_test",
-    tags = [],
+    # Broken: "JSONDecodeError: Expecting value: line 1 column 1 (char 0)".
+    tags = ["broken"],
     test_args = "",
     test_harness = "//sw/host/penetrationtests/python/fi:fi_sym_cryptolib_python_test",
     test_vectors = [],
@@ -356,7 +357,8 @@ pentest_cryptolib_sca_sym(
 
 pentest_cryptolib_sca_sym(
     name = "sca_sym_cryptolib_python_test",
-    tags = [],
+    # Broken: "JSONDecodeError: Expecting value: line 1 column 1 (char 0)".
+    tags = ["broken"],
     test_args = "",
     test_harness = "//sw/host/penetrationtests/python/sca:sca_sym_cryptolib_python_test",
     test_vectors = [],


### PR DESCRIPTION
The nightly CI job "CW340 SiVal ROM_EXT Long Tests" has been failing for months due to multiple tests being broken. This commit marks the failing tests as broken, to turn the CI green again. The broken tests should be fixed in a follow-up.

See, e.g., https://github.com/pavona/pavona/actions/runs/32439924015/job/97126775554. 
I've tested that the other 31 tests in "CW340 SiVal ROM_EXT Long Tests" pass fine.