### PR TITLE
[ci] Build the Verilator model single-threaded again

### DIFF
--- a/ci/scripts/run-verilator-tests.sh
+++ b/ci/scripts/run-verilator-tests.sh
@@ -46,5 +46,6 @@ fi
     --local_resources=cpu=8 \
     --test_tag_filters=verilator,-broken \
     --test_output=errors \
+    --//hw:verilator_options=--threads,1 \
     --//hw:make_options=-j,8 \
     "${TESTS[@]}"


### PR DESCRIPTION
Restore the --threads,1 override that 403042e8db dropped. The Egret and Dragonfly Verilator jobs currently time out in about a quarter of runs.


@pqcfox, do you remember why this was changed in 403042e8db? The commit message doesn't state a reason. Is it worthwhile to try to restore it and see if it stabilizes CI?