### PR TITLE
[ci] Prioritize nightly FPGA and Vivado jobs

### DIFF
--- a/.github/workflows/bitstream.yml
+++ b/.github/workflows/bitstream.yml
@@ -14,6 +14,10 @@ on:
       vivado_version:
         default: "2024.1"
         type: string
+      nightly:
+        default: false
+        type: boolean
+        description: Run on the prioritized nightly runner group.
 
 jobs:
   check-cache:
@@ -67,7 +71,7 @@ jobs:
   bitstream:
     name: Build bitstream
     runs-on:
-      group: pavona-vivado
+      group: pavona-vivado${{ inputs.nightly && '-nightly' || '' }}
     needs: check-cache
     if: needs.check-cache.outputs.bitstreamStrategy != 'cached'
     timeout-minutes: 240

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ name: CI
 on:
   pull_request:
   workflow_call:
+    inputs:
+      nightly:
+        default: false
+        type: boolean
+        description: Run on the prioritized nightly runner group.
 
 permissions:
   contents: read
@@ -321,6 +326,7 @@ jobs:
     with:
       top_name: egret
       design_suffix: cw310_hyperdebug
+      nightly: ${{ inputs.nightly || false }}
 
   chip_egret_cw340:
     name: Egret for CW340
@@ -330,6 +336,7 @@ jobs:
     with:
       top_name: egret
       design_suffix: cw340
+      nightly: ${{ inputs.nightly || false }}
 
   chip_egret_cw340_pqc:
     name: Egret for CW340 (PQC)
@@ -339,6 +346,7 @@ jobs:
     with:
       top_name: egret
       design_suffix: cw340_pqc
+      nightly: ${{ inputs.nightly || false }}
 
   # CW310 FPGA jobs
   execute_tests_cw310:

--- a/.github/workflows/egret-cw310-nightly.yml
+++ b/.github/workflows/egret-cw310-nightly.yml
@@ -24,6 +24,7 @@ jobs:
       tag_filters: cw310_test_rom
       timeout_filters: 'long,eternal'
       timeout: 300
+      nightly: true
 
   execute_long_rom_fpga_tests_cw310:
     name: CW310 ROM Long Tests
@@ -38,6 +39,7 @@ jobs:
       tag_filters: "cw310_rom_with_fake_keys,cw310_rom_with_real_keys,-manuf"
       timeout_filters: 'long,eternal'
       timeout: 300
+      nightly: true
 
   execute_long_rom_ext_fpga_tests_cw310:
     name: CW310 ROM_EXT Long Tests
@@ -52,6 +54,7 @@ jobs:
       tag_filters: cw310_rom_ext
       timeout_filters: 'long,eternal'
       timeout: 300
+      nightly: true
 
   execute_long_sival_fpga_tests_cw310:
     name: CW310 SiVal Long Tests
@@ -66,6 +69,7 @@ jobs:
       tag_filters: "cw310_sival,-manuf"
       timeout_filters: 'long,eternal'
       timeout: 300
+      nightly: true
 
   execute_long_sival_rom_ext_fpga_tests_cw310:
     name: CW310 SiVal ROM_EXT Long Tests
@@ -80,6 +84,7 @@ jobs:
       tag_filters: cw310_sival_rom_ext
       timeout_filters: 'long,eternal'
       timeout: 300
+      nightly: true
 
   execute_long_manuf_fpga_tests_cw310:
     name: CW310 Manufacturing Long Tests
@@ -94,6 +99,7 @@ jobs:
       tag_filters: "manuf,-cw340"
       timeout_filters: 'long,eternal'
       timeout: 300
+      nightly: true
 
   verify_fpga_jobs:
     name: Verify FPGA jobs

--- a/.github/workflows/egret-cw340-nightly.yml
+++ b/.github/workflows/egret-cw340-nightly.yml
@@ -25,6 +25,7 @@ jobs:
       tag_filters: cw340_test_rom
       timeout_filters: 'long,eternal'
       timeout: 300
+      nightly: true
 
   execute_long_rom_fpga_tests_cw340:
     name: CW340 ROM Long Tests
@@ -39,6 +40,7 @@ jobs:
       tag_filters: "cw340_rom_with_fake_keys,cw340_rom_with_real_keys,-manuf"
       timeout_filters: 'long,eternal'
       timeout: 300
+      nightly: true
 
   execute_long_rom_ext_fpga_tests_cw340:
     name: CW340 ROM_EXT Long Tests
@@ -53,6 +55,7 @@ jobs:
       tag_filters: cw340_rom_ext
       timeout_filters: 'long,eternal'
       timeout: 300
+      nightly: true
 
   execute_long_sival_fpga_tests_cw340:
     name: CW340 SiVal Long Tests
@@ -67,6 +70,7 @@ jobs:
       tag_filters: "cw340_sival,-manuf"
       timeout_filters: 'long,eternal'
       timeout: 300
+      nightly: true
 
   execute_long_sival_rom_ext_fpga_tests_cw340:
     name: CW340 SiVal ROM_EXT Long Tests
@@ -81,6 +85,7 @@ jobs:
       tag_filters: cw340_sival_rom_ext
       timeout_filters: 'long,eternal'
       timeout: 300
+      nightly: true
 
   execute_long_manuf_fpga_tests_cw340:
     name: CW340 Manufacturing Long Tests
@@ -95,6 +100,7 @@ jobs:
       tag_filters: "manuf,-cw310"
       timeout_filters: 'long,eternal'
       timeout: 300
+      nightly: true
 
   execute_long_pqc_fpga_tests_cw340:
     name: CW340 PQCEn=1 Long Tests
@@ -109,6 +115,7 @@ jobs:
       tag_filters: cw340_pqc_test_rom
       timeout_filters: 'long,eternal'
       timeout: 300
+      nightly: true
       extra_bazel_flags: --define=acc_has_pqc=true
 
   verify_fpga_jobs:

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -57,12 +57,16 @@ on:
         default: ""
         type: string
         description: Additional flags to pass to the Bazel test invocation.
+      nightly:
+        default: false
+        type: boolean
+        description: Run on the prioritized nightly runner group.
 
 jobs:
   fpga:
     name: ${{ inputs.name }}
     runs-on:
-      group: pavona-${{ inputs.board }}
+      group: pavona-${{ inputs.board }}${{ inputs.nightly && '-nightly' || '' }}
     timeout-minutes: ${{ inputs.timeout }}
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,6 +25,8 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/ci.yml
     secrets: inherit
+    with:
+      nightly: true
 
   # Hyper310 nightly FPGA jobs
   execute_nightly_tests_egret_cw310:


### PR DESCRIPTION
The nightly targets the same runner groups as pull request jobs, so its FPGA tests queue behind the whole backlog waiting for a board, and its bitstream builds queue for Vivado behind every pull request build ahead of them.

Instead, switch to *-nightly runner groups that get prioritized.