### PR TITLE
[ci] Raise the FPGA test job timeouts

### DIFF
--- a/.github/workflows/bitstream.yml
+++ b/.github/workflows/bitstream.yml
@@ -20,7 +20,7 @@ jobs:
     name: Check for cached bitstream
     runs-on:
       group: pavona-basic
-    timeout-minutes: 20
+    timeout-minutes: 30
     outputs:
       bitstreamStrategy: ${{ steps.strategy.outputs.bitstreamStrategy }}
     steps:

--- a/.github/workflows/egret-cw310-pr.yml
+++ b/.github/workflows/egret-cw310-pr.yml
@@ -36,7 +36,7 @@ jobs:
       board: cw310
       interface: hyper310
       tag_filters: "cw310_rom_with_fake_keys,cw310_rom_with_real_keys,-manuf"
-      timeout: 90
+      timeout: 150
 
   execute_rom_ext_fpga_tests_cw310:
     name: CW310 ROM_EXT Tests

--- a/.github/workflows/egret-cw340-pr.yml
+++ b/.github/workflows/egret-cw340-pr.yml
@@ -49,7 +49,7 @@ jobs:
       board: cw340
       interface: cw340
       tag_filters: cw340_rom_ext
-      timeout: 120
+      timeout: 180
 
   execute_sival_fpga_tests_cw340:
     name: CW340 SiVal Tests
@@ -76,7 +76,7 @@ jobs:
       board: cw340
       interface: cw340
       tag_filters: cw340_sival_rom_ext
-      timeout: 120
+      timeout: 180
 
   execute_manuf_fpga_tests_cw340:
     name: CW340 Manufacturing Tests

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -35,7 +35,7 @@ on:
         type: string
         description: Bazel timeout filters for the tests
       timeout:
-        default: 60
+        default: 120
         type: number
         description: Timeout for the job in minutes
       vivado_version:


### PR DESCRIPTION
Six jobs in the nightly were killed at their cap in the last month with no test failures.

Timeout observed in yesterday's nightly: https://github.com/pavona/pavona/actions/runs/32801259584/job/97686308001
We may want to investigate separately why runtime seems to vary a lot for same job over multiple runs.