### PR TITLE
[verilator] Extend shutdown request mechanism to Dragonfly

### DIFF
--- a/hw/top_dragonfly/dv/verilator/chip_sim_tb.sv
+++ b/hw/top_dragonfly/dv/verilator/chip_sim_tb.sv
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -149,13 +150,15 @@ module chip_sim_tb (
     `SIM_SRAM_IF.start_addr = `VERILATOR_TEST_STATUS_ADDR;
     u_sw_test_status_if.sw_test_status_addr = `SIM_SRAM_IF.start_addr;
   end
-
+  // Print the test status on completion once, using the sw_test_status_printed
+  // variable to ensure we don't double-print the results.
+  bit sw_test_status_printed;
   always @(posedge clk_i) begin
-    if (u_sw_test_status_if.sw_test_done) begin
+    if (u_sw_test_status_if.sw_test_done && !sw_test_status_printed) begin
       $display("Verilator sim termination requested");
       $display("Your simulation wrote to 0x%h", u_sw_test_status_if.sw_test_status_addr);
       dv_test_status_pkg::dv_test_status(u_sw_test_status_if.sw_test_passed);
-      $finish;
+      sw_test_status_printed = 1'b1;
     end
   end
 


### PR DESCRIPTION
This PR extends the Verilator shutdown request mechanism added in https://github.com/pavona/pavona/commit/7d0dc6d16df04932dea59b1c01f439acd105ae13 to the Dragonfly top, fixing spurious Verilator failures in CI for Dragonfly.

This shutdown request mechanism was previously introduced to prevent spurious test failures from early UART closures, but was only added for Egret at the time. 

Prior to the introduciton of this mechanism, Egret Verilator tests would sometimes fail due to the chip simulation testbench calling `$finish` before `opentitantool console` could drain the UART buffer, triggering a test failure even after success was visibly reported over UART. 

Dragonfly Verilator tests have now been seen to exhibit this behavior, see https://github.com/pavona/pavona/actions/runs/32922858657/job/98041851478 or https://github.com/pavona/pavona/actions/runs/32924759929/job/98047183306?pr=352.

To fix this in Egret, a 'virtual' `REQUEST_EXIT` pin was added to the GPIO DPI to trigger a graceful shutdown of the verilated testbench, with the host then waiting a fixed timeout for the child subprocess to exit before killing it as before. The handshake goes as follows:

* OTTF running in Verilator emits a `PASS!` over the Verilator UART DPI interface
* opentitantool picks up on this `PASS` as usual, registers the test result, and drops the Verilator context struct
* This in turn triggers a call to `Verilator::shutdown()`, which now
    * Raises the virtual REQUEST_EXIT pin via the file descriptor shared with the GPIO DPI
    * Calls shutdown_with_timeout on the Verilator subprocess struct, Subprocess
* The Verilated EG binary sees `REQUEST_EXIT` raised and calls `$finish` from within `gpiodpi.sv`
* The Subprocess struct in `shutdown_with_timeout()` waits for the Verilated EG process to terminate
        If a timeout expires, then `shutdown_with_timeout()` kills the child process as previous

This handshake ensures that opentitantool is no longer listening on the UART DPI file descriptor by the time Verilator calls `$finish`.

The addition here to `hw/top_dragonfly/dv/verilator/chip_sim_tb.sv` mirrors the fix to the Egret Verilator top, causing Dragonfly Verilator simluations to now rely on the request exit mechanism to trigger a `$finish`. See https://github.com/pavona/pavona/commit/7d0dc6d16df04932dea59b1c01f439acd105ae13 for full context regarding the shutdown mechanism.