### PR TITLE
[otp,dif] Initialize DT in OTP DIFs in tests

### DIFF
--- a/sw/device/lib/testing/keymgr_testutils.c
+++ b/sw/device/lib/testing/keymgr_testutils.c
@@ -202,8 +202,7 @@ status_t keymgr_testutils_init_nvm_then_reset(void) {
 
     TRY(dif_flash_ctrl_init_state(
         &flash, mmio_region_from_addr(TOP_EGRET_FLASH_CTRL_CORE_BASE_ADDR)));
-    TRY(dif_otp_ctrl_init(
-        mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+    TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
 
     bool secret2_computed = false;
     TRY(dif_otp_ctrl_is_digest_computed(&otp_ctrl, kOtpPartitionSecret2,

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/macros.h"
@@ -277,8 +278,7 @@ bool test_main(void) {
   info = rstmgr_testutils_reason_get();
 
   dif_otp_ctrl_t otp;
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
 
   if (info & kDifRstmgrResetInfoPor) {
     LOG_INFO("Powered up for the first time, program flash");

--- a/sw/device/silicon_creator/manuf/base/sram_cp_provision.c
+++ b/sw/device/silicon_creator/manuf/base/sram_cp_provision.c
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
@@ -63,8 +64,7 @@ static status_t peripheral_handles_init(void) {
   TRY(dif_gpio_init(mmio_region_from_addr(TOP_EGRET_GPIO_BASE_ADDR), &gpio));
   TRY(dif_lc_ctrl_init(mmio_region_from_addr(TOP_EGRET_LC_CTRL_REGS_BASE_ADDR),
                        &lc_ctrl));
-  TRY(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
   TRY(dif_pinmux_init(mmio_region_from_addr(TOP_EGRET_PINMUX_AON_BASE_ADDR),
                       &pinmux));
   return OK_STATUS();

--- a/sw/device/silicon_creator/manuf/base/sram_cp_provision_functest.c
+++ b/sw/device/silicon_creator/manuf/base/sram_cp_provision_functest.c
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
@@ -56,8 +57,7 @@ static status_t peripheral_handles_init(void) {
   TRY(dif_gpio_init(mmio_region_from_addr(TOP_EGRET_GPIO_BASE_ADDR), &gpio));
   TRY(dif_lc_ctrl_init(mmio_region_from_addr(TOP_EGRET_LC_CTRL_REGS_BASE_ADDR),
                        &lc_ctrl));
-  TRY(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
   TRY(dif_pinmux_init(mmio_region_from_addr(TOP_EGRET_PINMUX_AON_BASE_ADDR),
                       &pinmux));
   return OK_STATUS();

--- a/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
@@ -67,8 +68,7 @@ static status_t peripheral_handles_init(void) {
       &flash_ctrl_state,
       mmio_region_from_addr(TOP_EGRET_FLASH_CTRL_CORE_BASE_ADDR)));
   TRY(dif_gpio_init(mmio_region_from_addr(TOP_EGRET_GPIO_BASE_ADDR), &gpio));
-  TRY(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
   TRY(dif_pinmux_init(mmio_region_from_addr(TOP_EGRET_PINMUX_AON_BASE_ADDR),
                       &pinmux));
   return OK_STATUS();

--- a/sw/device/silicon_creator/manuf/lib/individualize_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
 #include "sw/device/lib/dif/dif_lc_ctrl.h"
@@ -57,8 +58,7 @@ static status_t peripheral_handles_init(void) {
       mmio_region_from_addr(TOP_EGRET_FLASH_CTRL_CORE_BASE_ADDR)));
   TRY(dif_lc_ctrl_init(mmio_region_from_addr(TOP_EGRET_LC_CTRL_REGS_BASE_ADDR),
                        &lc_ctrl));
-  TRY(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
   TRY(dif_rstmgr_init(mmio_region_from_addr(TOP_EGRET_RSTMGR_AON_BASE_ADDR),
                       &rstmgr));
   return OK_STATUS();

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
@@ -47,8 +48,7 @@ static status_t peripheral_handles_init(void) {
   TRY(dif_flash_ctrl_init_state(
       &flash_ctrl_state,
       mmio_region_from_addr(TOP_EGRET_FLASH_CTRL_CORE_BASE_ADDR)));
-  TRY(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
   TRY(dif_rstmgr_init(mmio_region_from_addr(TOP_EGRET_RSTMGR_AON_BASE_ADDR),
                       &rstmgr));
   return OK_STATUS();

--- a/sw/device/silicon_creator/manuf/tests/sram_device_info_flash_wr_functest.c
+++ b/sw/device/silicon_creator/manuf/tests/sram_device_info_flash_wr_functest.c
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
 #include "sw/device/lib/dif/dif_lc_ctrl.h"
@@ -39,8 +40,7 @@ static status_t peripheral_handles_init(void) {
       mmio_region_from_addr(TOP_EGRET_FLASH_CTRL_CORE_BASE_ADDR)));
   TRY(dif_lc_ctrl_init(mmio_region_from_addr(TOP_EGRET_LC_CTRL_REGS_BASE_ADDR),
                        &lc_ctrl));
-  TRY(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
   TRY(dif_pinmux_init(mmio_region_from_addr(TOP_EGRET_PINMUX_AON_BASE_ADDR),
                       &pinmux));
   return OK_STATUS();

--- a/sw/device/silicon_creator/manuf/tests/sram_exec_test.c
+++ b/sw/device/silicon_creator/manuf/tests/sram_exec_test.c
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
 #include "sw/device/lib/dif/dif_uart.h"
@@ -45,8 +46,7 @@ static const uint32_t kTestDeviceId[kDeviceIdSizeIn32BitWords] = {
 static status_t peripheral_handles_init(void) {
   TRY(dif_pinmux_init(mmio_region_from_addr(TOP_EGRET_PINMUX_AON_BASE_ADDR),
                       &pinmux));
-  TRY(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
   return OK_STATUS();
 }
 

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/flash_ecc_error_test.c
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/flash_ecc_error_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/arch/boot_stage.h"
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/macros.h"
@@ -194,8 +195,7 @@ static const corruption_word_t kWords2Corrupt[] = {
 static void init_peripherals(void) {
   CHECK_DIF_OK(dif_flash_ctrl_init_state(
       &flash_ctrl, mmio_region_from_addr(TOP_EGRET_FLASH_CTRL_CORE_BASE_ADDR)));
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
   CHECK_DIF_OK(dif_rstmgr_init(
       mmio_region_from_addr(TOP_EGRET_RSTMGR_AON_BASE_ADDR), &rstmgr));
 }

--- a/sw/device/silicon_creator/rom/e2e/chip_specific_startup/chip_specific_startup.c
+++ b/sw/device/silicon_creator/rom/e2e/chip_specific_startup/chip_specific_startup.c
@@ -6,6 +6,7 @@
 
 #include <stdbool.h>
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/csr.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_base.h"
@@ -85,8 +86,7 @@ status_t test_chip_specific_startup(ujson_t *uj) {
   TRY(dif_sram_ctrl_init(
       mmio_region_from_addr(TOP_EGRET_SRAM_CTRL_MAIN_REGS_BASE_ADDR),
       &sram_ctrl));
-  TRY(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
   TRY(dif_lc_ctrl_init(mmio_region_from_addr(TOP_EGRET_LC_CTRL_REGS_BASE_ADDR),
                        &lc));
   TRY(dif_clkmgr_init(mmio_region_from_addr(TOP_EGRET_CLKMGR_AON_BASE_ADDR),

--- a/sw/device/silicon_creator/rom/e2e/keymgr/rom_e2e_keymgr_init_test.c
+++ b/sw/device/silicon_creator/rom/e2e/keymgr/rom_e2e_keymgr_init_test.c
@@ -4,6 +4,7 @@
 
 #include <stdbool.h>
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_keymgr.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
@@ -47,8 +48,7 @@ static void print_otp_sw_cfg_digests(void) {
 bool test_main(void) {
   CHECK_DIF_OK(dif_keymgr_init(
       mmio_region_from_addr(TOP_EGRET_KEYMGR_BASE_ADDR), &keymgr));
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
   CHECK_DIF_OK(dif_rstmgr_init(
       mmio_region_from_addr(TOP_EGRET_RSTMGR_AON_BASE_ADDR), &rstmgr));
 

--- a/sw/device/silicon_creator/rom_ext/e2e/lockdown/otp_creator_lockdown.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/lockdown/otp_creator_lockdown.c
@@ -2,12 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
-
-#include "hw/top_egret/sw/autogen/top_egret.h"
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -31,8 +30,7 @@ status_t test_otp_creator_lockdown(void) {
 }
 
 bool test_main(void) {
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
 
   // Since the ePMP locks down the OTP register space, we cannot call
   // dif_otp_ctrl_configure here.

--- a/sw/device/silicon_creator/rom_ext/e2e/lockdown/otp_dai_lockdown.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/lockdown/otp_dai_lockdown.c
@@ -2,20 +2,18 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
-
-#include "hw/top_egret/sw/autogen/top_egret.h"
 
 OTTF_DEFINE_TEST_CONFIG();
 
 dif_otp_ctrl_t otp;
 
 bool test_main(void) {
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
 
   dif_otp_ctrl_config_t config = {
       .check_timeout = 100000,

--- a/sw/device/tests/chip_power_sleep_load_test.c
+++ b/sw/device/tests/chip_power_sleep_load_test.c
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/arch/boot_stage.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_adc_ctrl.h"
@@ -136,8 +137,7 @@ bool test_main(void) {
       dif_pwm_init(mmio_region_from_addr(TOP_EGRET_PWM_AON_BASE_ADDR), &pwm));
   CHECK_DIF_OK(dif_pinmux_init(
       mmio_region_from_addr(TOP_EGRET_PINMUX_AON_BASE_ADDR), &pinmux));
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
   CHECK_DIF_OK(
       dif_gpio_init(mmio_region_from_addr(TOP_EGRET_GPIO_BASE_ADDR), &gpio));
   CHECK_DIF_OK(dif_adc_ctrl_init(

--- a/sw/device/tests/flash_ctrl_rma_test.c
+++ b/sw/device/tests/flash_ctrl_rma_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
@@ -106,8 +107,7 @@ bool test_main(void) {
   pinmux_testutils_init(&pinmux);
   CHECK_DIF_OK(dif_flash_ctrl_init_state(
       &flash, mmio_region_from_addr(TOP_EGRET_FLASH_CTRL_CORE_BASE_ADDR)));
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
 
   ottf_console_init();
 

--- a/sw/device/tests/otp_ctrl_descrambling_test.c
+++ b/sw/device/tests/otp_ctrl_descrambling_test.c
@@ -4,13 +4,13 @@
 
 #include <stdbool.h>
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
 #include "sw/device/lib/testing/otp_ctrl_testutils.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "hw/top/otp_ctrl_regs.h"
-#include "hw/top_egret/sw/autogen/top_egret.h"
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -60,8 +60,7 @@ size_t compare_dword(const uint64_t *actual_arr, uint32_t part_idx,
 bool test_main(void) {
   dif_otp_ctrl_t otp_ctrl;
 
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
 
   // Number of 64-bit words that differ from the expected value; used to
   // determine overall test pass or failure.

--- a/sw/device/tests/otp_ctrl_mem_access_test.c
+++ b/sw/device/tests/otp_ctrl_mem_access_test.c
@@ -5,6 +5,7 @@
 #include <assert.h>
 #include <stdbool.h>
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
@@ -41,8 +42,7 @@ typedef struct partition_data {
 } partition_data_t;
 
 static void peripheral_handles_init(void) {
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
   CHECK_DIF_OK(dif_rstmgr_init(
       mmio_region_from_addr(TOP_EGRET_RSTMGR_AON_BASE_ADDR), &rstmgr));
 }

--- a/sw/device/tests/otp_ctrl_rot_auth_config_test.c
+++ b/sw/device/tests/otp_ctrl_rot_auth_config_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
 #include "sw/device/lib/testing/otp_ctrl_testutils.h"
@@ -10,14 +11,11 @@
 #include "sw/device/silicon_creator/manuf/lib/individualize.h"
 #include "sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h"
 
-#include "hw/top_egret/sw/autogen/top_egret.h"
-
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   dif_otp_ctrl_t otp_ctrl;
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
   CHECK_STATUS_OK(
       manuf_individualize_device_rot_creator_auth_codesign(&otp_ctrl));
   CHECK_STATUS_OK(manuf_individualize_device_rot_creator_auth_state(&otp_ctrl));

--- a/sw/device/tests/penetrationtests/firmware/fi/alert_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/alert_fi.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/tests/penetrationtests/firmware/fi/alert_fi.h"
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/status.h"
@@ -155,8 +156,7 @@ static status_t init_peripherals(void) {
   base_addr = mmio_region_from_addr(TOP_EGRET_ACC_BASE_ADDR);
   TRY(dif_acc_init(base_addr, &acc));
 
-  base_addr = mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR);
-  TRY(dif_otp_ctrl_init(base_addr, &otp_ctrl));
+  TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
 
   base_addr = mmio_region_from_addr(TOP_EGRET_PATTGEN_BASE_ADDR);
   TRY(dif_pattgen_init(base_addr, &pattgen));

--- a/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/tests/penetrationtests/firmware/fi/ibex_fi.h"
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/arch/boot_stage.h"
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/csr.h"
@@ -4837,8 +4838,7 @@ status_t handle_ibex_fi_init(ujson_t *uj) {
   TRY(flash_ctrl_testutils_wait_for_init(&flash));
 
   // Init OTP.
-  TRY(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
 
   // Initialize flash for the flash test and write reference values into page.
   flash_init = false;

--- a/sw/device/tests/penetrationtests/firmware/fi/otp_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otp_fi.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/tests/penetrationtests/firmware/fi/otp_fi.h"
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
@@ -16,7 +17,6 @@
 #include "sw/device/tests/penetrationtests/json/otp_fi_commands.h"
 
 #include "hw/top/otp_ctrl_regs.h"  // Generated.
-#include "hw/top_egret/sw/autogen/top_egret.h"
 
 static dif_otp_ctrl_t otp;
 
@@ -175,8 +175,7 @@ status_t handle_otp_fi_init(ujson_t *uj) {
                    kPentestPeripheralAes | kPentestPeripheralHmac |
                    kPentestPeripheralKmac | kPentestPeripheralAcc);
 
-  TRY(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
 
   init_otp_mem_dump_buffers();
 

--- a/sw/device/tests/sim_dv/csrng_fuse_en_sw_app_read.c
+++ b/sw/device/tests/sim_dv/csrng_fuse_en_sw_app_read.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_base.h"
@@ -62,8 +63,7 @@ static void test_fuse_disable(const dif_csrng_t *csrng) {
  */
 static void check_csrng_fuse_enabled(bool expected) {
   dif_otp_ctrl_t otp;
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
 
   dif_otp_ctrl_config_t config = {
       .check_timeout = 100000,

--- a/sw/device/tests/sim_dv/csrng_lc_hw_debug_en_test.c
+++ b/sw/device/tests/sim_dv/csrng_lc_hw_debug_en_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_csrng.h"
@@ -109,8 +110,7 @@ static void peripherals_init(void) {
       mmio_region_from_addr(TOP_EGRET_LC_CTRL_REGS_BASE_ADDR), &lc_ctrl));
   CHECK_DIF_OK(dif_entropy_src_init(
       mmio_region_from_addr(TOP_EGRET_ENTROPY_SRC_BASE_ADDR), &entropy_src));
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
   CHECK_DIF_OK(dif_rstmgr_init(
       mmio_region_from_addr(TOP_EGRET_RSTMGR_AON_BASE_ADDR), &rstmgr));
 

--- a/sw/device/tests/sim_dv/flash_ctrl_lc_rw_en_test.c
+++ b/sw/device/tests/sim_dv/flash_ctrl_lc_rw_en_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
@@ -166,8 +167,7 @@ static const partition_check_cfg_t kTest[] = {
 static void init_peripheral_handles(void) {
   CHECK_DIF_OK(dif_keymgr_init(
       mmio_region_from_addr(TOP_EGRET_KEYMGR_BASE_ADDR), &keymgr));
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
   CHECK_DIF_OK(
       dif_kmac_init(mmio_region_from_addr(TOP_EGRET_KMAC_BASE_ADDR), &kmac));
   CHECK_DIF_OK(dif_lc_ctrl_init(

--- a/sw/device/tests/sim_dv/flash_rma_unlocked_test.c
+++ b/sw/device/tests/sim_dv/flash_rma_unlocked_test.c
@@ -5,6 +5,7 @@
 // Note that since rma process takes more than 100ms in dvsim,
 // the test runs 1.6h (110ms in simtime).
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
@@ -288,8 +289,7 @@ bool rom_test_main(void) {
       mmio_region_from_addr(TOP_EGRET_LC_CTRL_REGS_BASE_ADDR), &lc));
 
   dif_otp_ctrl_t otp;
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
 
   dif_otp_ctrl_config_t otp_config = {
       .check_timeout = 100000,

--- a/sw/device/tests/sim_dv/inject_scramble_seed.c
+++ b/sw/device/tests/sim_dv/inject_scramble_seed.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/mmio.h"
@@ -88,8 +89,7 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_rstmgr_init(
       mmio_region_from_addr(TOP_EGRET_RSTMGR_AON_BASE_ADDR), &rstmgr));
 
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp_ctrl));
 
   CHECK_DIF_OK(dif_flash_ctrl_init_state(
       &flash_ctrl, mmio_region_from_addr(TOP_EGRET_FLASH_CTRL_CORE_BASE_ADDR)));

--- a/sw/device/tests/sim_dv/otp_ctrl_lc_signals_test.c
+++ b/sw/device/tests/sim_dv/otp_ctrl_lc_signals_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_keymgr.h"
@@ -69,8 +70,7 @@ static void init_peripherals(void) {
   CHECK_DIF_OK(dif_lc_ctrl_init(
       mmio_region_from_addr(TOP_EGRET_LC_CTRL_REGS_BASE_ADDR), &lc));
   // OTP
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
   CHECK_DIF_OK(dif_otp_ctrl_configure(&otp, config));
   // Rstmgr
   CHECK_DIF_OK(dif_rstmgr_init(

--- a/sw/device/tests/sim_dv/otp_ctrl_vendor_test_csr_access_test.c
+++ b/sw/device/tests/sim_dv/otp_ctrl_vendor_test_csr_access_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_lc_ctrl.h"
@@ -28,8 +29,7 @@ static void init_peripherals(void) {
   CHECK_DIF_OK(dif_lc_ctrl_init(
       mmio_region_from_addr(TOP_EGRET_LC_CTRL_REGS_BASE_ADDR), &lc));
   // OTP
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
   CHECK_DIF_OK(dif_otp_ctrl_configure(&otp, config));
 }
 

--- a/sw/device/tests/sim_dv/otp_ctrl_vendor_test_ecc_error_test.c
+++ b/sw/device/tests/sim_dv/otp_ctrl_vendor_test_ecc_error_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
@@ -10,8 +11,6 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 #include "sw/device/silicon_creator/lib/base/chip.h"
-
-#include "hw/top_egret/sw/autogen/top_egret.h"
 
 // This is the address that has an ecc error injected.
 static volatile const uint32_t kTestAddress = 0;
@@ -27,8 +26,7 @@ static void init_peripherals(void) {
       .consistency_period_mask = 0x3ffffff,
   };
   // OTP
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
   CHECK_DIF_OK(dif_otp_ctrl_configure(&otp, config));
 }
 

--- a/sw/device/tests/sim_dv/sram_ctrl_execution_main_test.c
+++ b/sw/device/tests/sim_dv/sram_ctrl_execution_main_test.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/multibits.h"
@@ -59,8 +60,7 @@ void execute_code_in_sram(void) { asm volatile("jalr zero, 0(ra)"); }
 
 static bool otp_ifetch_enabled(void) {
   dif_otp_ctrl_t otp;
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EGRET_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
 
   dif_otp_ctrl_config_t config = {
       .check_timeout = 100000,


### PR DESCRIPTION
#392 updated the OTP DIFs to use DT to avoid hard-coding the partition metadata. This caused a problem for some tests that used the older `dif_otp_ctrl_init` API to initialized their DIF object, which left the `dt` field uninitialized, leading to unexpected behavior of the DIF.

This commit fixes this issue by always initializing the DIF using the newer `_from_dt` API.

Issue #407 recommends removing the older `dif_<hwip>_init` APIs in favor of the newer `dif_<hwip>_init_from_dt` for all HWIP blocks, preventing the caller from ever ending up with a partially uninitialized DIF object.