### PR TITLE
[test] Mark flaky FPGA e2e tests broken

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/chip_specific_startup/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/chip_specific_startup/BUILD
@@ -28,7 +28,8 @@ package(default_visibility = ["//visibility:public"])
         },
         fpga = fpga_params(
             otp = "//sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_entry:otp_img_e2e_bootstrap_entry_{}".format(lc_state),
-            tags = maybe_skip_in_ci(lc_state_val),
+            # Broken: fails intermittently on CW310.
+            tags = maybe_skip_in_ci(lc_state_val) + ["broken"],
             test_cmd = """
                 --bootstrap="{firmware}"
                 --otp-unprogrammed

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -173,6 +173,8 @@ ownership_transfer_test(
     name = "bad_activate_test",
     fpga = fpga_params(
         changes_otp = True,
+        # Broken: fails repeatedly on CW340.
+        tags = ["broken"],
         test_cmd = """
             --clear-bitstream
             --bootstrap={firmware}
@@ -734,6 +736,8 @@ ownership_transfer_test(
         },
         changes_otp = True,
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_keys",
+        # Broken: fails repeatedly on CW340.
+        tags = ["broken"],
         test_cmd = """
             --clear-bitstream
             --bootstrap={firmware}

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -177,6 +177,8 @@ genrule(
             rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual",
             rom_ext_offset = _POSITIONS[rxslot]["rom_ext_offset"],
             slot = position["slot"],
+            # Broken: fails repeatedly on CW340.
+            tags = ["broken"],
             test_cmd = """
                 --exec="transport init"
                 --exec="fpga load-bitstream {bitstream}"
@@ -291,6 +293,8 @@ pavona_test(
             ":boot_test_slot_a": "payload",
         },
         changes_otp = True,
+        # Broken: fails repeatedly on CW340.
+        tags = ["broken"],
         test_cmd = """
             --exec="transport init"
             --exec="fpga load-bitstream {bitstream}"

--- a/sw/device/silicon_creator/rom_ext/e2e/secver/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/secver/BUILD
@@ -119,6 +119,8 @@ pavona_test(
         changes_otp = True,
         exit_success = "BFV:{}".format(hex_digits(CONST.BFV.BOOT_POLICY.ROLLBACK)),
         rom_ext = ":rom_ext_0",
+        # Broken: fails repeatedly on CW340.
+        tags = ["broken"],
         test_cmd = """
             # First, assemble the additional images we'll need for this test.
             --exec="image assemble -s 131072 --mirror=false -o fw1.bin {rom_ext1}@0 {boot_test_b}@0x10000"


### PR DESCRIPTION
These tests are the largest single source of spurious CI failures over the past week.
I suggest we open an issue to investigate those separately. 


Failure counts per target over that week:

   9  rescue_rom_ext_slot_a_update_slot_b
   5  e2e_chip_specific_startup_rma
   4  rescue_rom_ext_slot_b_update_slot_a
   4  secver_write_test
   4  rescue_rate_test
   3  rescue_rom_ext_slot_a_update_slot_a
   3  bad_activate_test
   2  rescue_rom_ext_slot_b_update_slot_b
   2  transfer_pq_to_pq_test
   
CI already runs the FPGA tests with --flaky_test_attempts=3, so each of
these failures is a test that failed three times in a row.