### PR TITLE
[acc,iflow] Track every WDR a non-constant index could reference 

### DIFF
--- a/hw/ip/acc/util/shared/information_flow.py
+++ b/hw/ip/acc/util/shared/information_flow.py
@@ -20,6 +20,9 @@ FLAG_NAMES = ['c', 'm', 'l', 'z']
 # Deliberately invalid CSR address used by unimp.
 UNIMP_CSR_ADDR = 3072
 
+# Number of wide data registers.
+NUM_WDRS = 32
+
 # Registers that can be involved in information flow without being an operand
 SPECIAL_REG_NAMES = ['mod', 'acc', 'acch', 'kmac_core', 'rnd', 'urnd']
 
@@ -694,6 +697,22 @@ class InsnInformationFlowNode:
     def is_read_only(self, op_vals: Dict[str, int]) -> bool:
         return False
 
+    def is_may_write(self, op_vals: Dict[str, int],
+                     constant_regs: Dict[str, int], coarse_dmem: bool) -> bool:
+        '''True if this sink may be written rather than certainly written.
+
+        A may-write sink depends on itself as well as on the rule's sources,
+        since the write need not have covered it. Only an indirect WDR
+        reference with a non-constant index and a coarse DMEM node qualify.
+        '''
+        return False
+
+    def extra_sources(self, op_vals: Dict[str, int],
+                      constant_regs: Dict[str, int],
+                      coarse_dmem: bool) -> List[InformationFlowNode]:
+        '''Nodes the flow depends on besides the ones evaluate() names.'''
+        return []
+
     def evaluate(self, op_vals: Dict[str, int], constant_regs: Dict[str, int],
                  coarse_dmem: bool) -> List[InformationFlowNode]:
         '''Determines information flow graph for the instruction.
@@ -827,6 +846,12 @@ class InsnDmemOperandNode(InsnInformationFlowNode):
             DmemInformationFlowNode(addr + offset, addr + offset + self.width)
         ]
 
+    def is_may_write(self, op_vals: Dict[str, int],
+                     constant_regs: Dict[str, int],
+                     coarse_dmem: bool) -> bool:
+        # The coarse "dmem" node covers far more than the access.
+        return coarse_dmem
+
 
 def _eval_indirect_wdr(gpr: str,
                        constant_regs: Dict[str, int]) -> InformationFlowNode:
@@ -877,11 +902,23 @@ class InsnIndirectWDRNode(InsnInformationFlowNode):
         gpr = self._get_gpr_name(op_vals)
         if coarse_dmem and gpr not in constant_regs:
             # The index is not statically known (e.g. a loop-carried WDR index
-            # in a variable-count loop). Fall back to a single conservative node
-            # standing in for the referenced WDR; the exact WDR is irrelevant to
-            # instruction counting.
-            return [InformationFlowNode('wref-{}'.format(gpr))]
+            # in a variable-count loop), so any WDR may be the one referenced.
+            return [InformationFlowNode('w{}'.format(i)) for i in range(NUM_WDRS)]
         return [_eval_indirect_wdr(gpr, constant_regs)]
+
+    def is_may_write(self, op_vals: Dict[str, int],
+                     constant_regs: Dict[str, int],
+                     coarse_dmem: bool) -> bool:
+        return coarse_dmem and self._get_gpr_name(op_vals) not in constant_regs
+
+    def extra_sources(self, op_vals: Dict[str, int],
+                      constant_regs: Dict[str, int],
+                      coarse_dmem: bool) -> List[InformationFlowNode]:
+        # The index selects which WDR, so it feeds whatever comes out.
+        gpr = self._get_gpr_name(op_vals)
+        if coarse_dmem and gpr not in constant_regs:
+            return [InformationFlowNode(gpr)]
+        return []
 
 
 class InsnGroupFlagNode(InsnInformationFlowNode):
@@ -1150,6 +1187,10 @@ class InsnInformationFlowRule:
         self.flows_to = flows_to
         self.flows_from = flows_from
         self.test = test
+        # Only these node types can be may-writes or name extra sources.
+        partial = (InsnDmemOperandNode, InsnIndirectWDRNode)
+        self.has_partial_refs = any(
+            isinstance(n, partial) for n in list(flows_to) + list(flows_from))
 
     def required_constants(self, op_vals: Dict[str, int],
                            coarse_dmem: bool) -> Set[str]:
@@ -1174,18 +1215,25 @@ class InsnInformationFlowRule:
             for node in insn_node.evaluate(op_vals, constant_regs,
                                            coarse_dmem):
                 sources.add(node)
+        if self.has_partial_refs:
+            # An unresolved reference also depends on whatever selects it.
+            for insn_node in self.flows_from:
+                sources.update(
+                    insn_node.extra_sources(op_vals, constant_regs, coarse_dmem))
+            for insn_node in self.flows_to:
+                sources.update(
+                    insn_node.extra_sources(op_vals, constant_regs, coarse_dmem))
         flow = {}
         for insn_node in self.flows_to:
+            may_write = self.has_partial_refs and insn_node.is_may_write(
+                op_vals, constant_regs, coarse_dmem)
             for node in insn_node.evaluate(op_vals, constant_regs,
                                            coarse_dmem):
                 if not insn_node.is_read_only(op_vals):
                     assert node not in flow
                     flow[node] = sources.copy()
-            if coarse_dmem and isinstance(insn_node, InsnDmemOperandNode):
-                # if we are doing coarse dmem tracking, then the single "dmem"
-                # node should not get overwritten by writes; it should always
-                # inherit its own previous value as well.
-                flow[node].add(node)
+                    if may_write:
+                        flow[node].add(node)
         return InformationFlowGraph(flow)
 
     @staticmethod

--- a/hw/ip/acc/util/shared/information_flow_test.py
+++ b/hw/ip/acc/util/shared/information_flow_test.py
@@ -5,8 +5,10 @@
 
 import unittest
 
-from shared.information_flow import (DmemInformationFlowNode,
-                                     InformationFlowGraph, InformationFlowNode)
+from shared.information_flow import (NUM_WDRS, DmemInformationFlowNode,
+                                     InformationFlowGraph,
+                                     InformationFlowNode, InsnInformationFlow)
+from shared.insn_yaml import load_insns_yaml
 
 
 class TestInformationFlowGraphSimplify(unittest.TestCase):
@@ -74,6 +76,74 @@ class TestInformationFlowGraphSimplify(unittest.TestCase):
                     InformationFlowNode("x4")
                 }
             })
+
+
+class TestIndirectWDRReference(unittest.TestCase):
+
+    # bn.lid x5, 0(x10): the destination WDR is the one x5 names.
+    LID_OPS = {'grd': 5, 'grs1': 10, 'offset': 0, 'grs1_inc': 0, 'grd_inc': 0}
+    # bn.sid x5, 0(x10): the source WDR is the one x5 names.
+    SID_OPS = {'grs1': 10, 'grs2': 5, 'offset': 0, 'grs1_inc': 0, 'grs2_inc': 0}
+
+    @staticmethod
+    def _iflow(mnemonic: str) -> InsnInformationFlow:
+        return load_insns_yaml().mnemonic_to_insn[mnemonic].iflow
+
+    def test_constant_index(self) -> None:
+        flow = self._iflow('bn.lid').evaluate(self.LID_OPS, {'x5': 3}, True)
+
+        # x5 is known, so only w3 is written, and fully.
+        self.assertEqual(flow.flow, {
+            InformationFlowNode('w3'): {InformationFlowNode('dmem')}
+        })
+
+    def test_unknown_index_as_sink(self) -> None:
+        flow = self._iflow('bn.lid').evaluate(self.LID_OPS, {}, True)
+
+        # Every WDR is a may-write sink, and x5 selects which one.
+        self.assertEqual(flow.flow, {
+            InformationFlowNode('w{}'.format(i)): {
+                InformationFlowNode('dmem'),
+                InformationFlowNode('w{}'.format(i)),
+                InformationFlowNode('x5'),
+            }
+            for i in range(NUM_WDRS)
+        })
+
+    def test_unknown_index_as_source(self) -> None:
+        flow = self._iflow('bn.sid').evaluate(self.SID_OPS, {}, True)
+
+        # Any WDR may be the one stored, so all of them flow to dmem.
+        sources = {InformationFlowNode('w{}'.format(i)) for i in range(NUM_WDRS)}
+        sources |= {InformationFlowNode('dmem'), InformationFlowNode('x5')}
+        self.assertEqual(flow.flow, {InformationFlowNode('dmem'): sources})
+
+    def test_coarse_dmem_sink_keeps_own_value(self) -> None:
+        flow = self._iflow('bn.sid').evaluate(self.SID_OPS, {'x5': 3}, True)
+
+        # The coarse dmem node stands for all of memory, so it is a may-write.
+        self.assertEqual(flow.flow, {
+            InformationFlowNode('dmem'): {InformationFlowNode('dmem'),
+                                          InformationFlowNode('w3')}
+        })
+
+    def test_tracked_dmem_sink_is_overwritten(self) -> None:
+        constants = {'x5': 3, 'x10': 0x100}
+        flow = self._iflow('bn.sid').evaluate(self.SID_OPS, constants, False)
+
+        # A tracked range is covered by the store, so it is not a may-write.
+        self.assertEqual(flow.flow, {
+            DmemInformationFlowNode(0x100, 0x120): {InformationFlowNode('w3')}
+        })
+
+    def test_tracked_dmem_needs_a_constant_index(self) -> None:
+        iflow = self._iflow('bn.lid')
+
+        # Tracking dmem precisely needs both the address and the WDR index.
+        self.assertEqual(iflow.required_constants(self.LID_OPS, False),
+                         {'x5', 'x10'})
+        with self.assertRaises(RuntimeError):
+            iflow.evaluate(self.LID_OPS, {}, False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
An indirect WDR reference whose index register is not a known constant
was represented by a single synthetic "wref-<gpr>" node, which is not
the register the instruction touches. The real register was never
marked a sink and kept its stale dependencies, so a secret loaded by
bn.lid or stored by bn.sid never reached the graph and a const-time
check could pass while missing the flow.

Name all the WDRs the reference could mean instead: over-reporting as a
source is safe, and as a sink each one is a may-write, so nothing
already tracked is erased. The index register becomes a source too.
Coarse DMEM writes use the same may-write path, replacing a special
case that only covered the last node evaluated.

- Based on #405 