### PR TITLE
[bazel] Do not create `__init__.py` files implicitly

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -169,6 +169,10 @@ common:macos --repo_env=C_INCLUDE_PATH=/opt/homebrew/include:/opt/homebrew/inclu
 common:macos --repo_env=CPLUS_INCLUDE_PATH=/opt/homebrew/include:/opt/homebrew/include/libelf
 common:macos --repo_env=LIBRARY_PATH=/opt/homebrew/lib
 
+# Do not implicitly create `__init__.py` files in the runfiles of Python
+# targets. A future rules_python release makes this the default.
+build --incompatible_default_to_explicit_init_py
+
 # Bazel remote cache configuration.
 common --remote_cache=https://storage.googleapis.com/pavona-bazel-cache"
 build --remote_upload_local_results=false


### PR DESCRIPTION
rules_python warns on every `py_binary` and `py_test` that leaves `legacy_create_init` at its default:

X is using implicit `__init__.py` creation.
This diabolic behavior is deprecated and will be disabled by default in a future release.
See https://github.com/bazel-contrib/rules_python/issues/2945

None of those actually need the generated `__init__.py`, so we can simply disable the implicit `__init__.py` creation by setting incompatible_default_to_explicit_init_py.

 - Resolves https://github.com/pavona/pavona/issues/382