### PR TITLE
[acvp,mldsa] Cover the HashML-DSA and external-mu modes in ACVP tests

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -497,7 +497,10 @@ To run the known-answer tests with the software backend, both configuration sett
 ML-DSA (Module-Lattice-Based Digital Signature Algorithm) is a post-quantum signature scheme standardized in [FIPS 204][fips-204].
 Cryptolib supports the ML-DSA-44, ML-DSA-65, and ML-DSA-87 parameter sets, each offering key-pair generation, signing, and verification.
 Public keys are unblinded keys and secret keys are blinded keys.
-Signing and verification take an optional context string (which may be empty) and a signature mode selected with **otcrypto\_mldsa\_sign\_mode\_t**; currently only pure ML-DSA is supported (HashML-DSA is not yet integrated).
+Signing and verification take an optional context string (which may be empty) and a signature mode selected with **otcrypto\_mldsa\_sign\_mode\_t**.
+Pure ML-DSA, HashML-DSA, and external-mu signing are supported.
+HashML-DSA is available with the pre-hash functions the cryptolib implements: SHA2-{256,384,512}, SHA3-{224,256,384,512}, and SHAKE{128,256}.
+In external-mu mode the caller passes the 64-byte message representative mu in place of the message, and the context string must be empty.
 Each operation takes a caller-allocated work buffer sized by the `kOtcryptoMldsa*WorkBuffer*Words` constants in `mldsa.h`.
 The `keygen` and `sign` functions sample randomness internally; the `_derand` variants instead take caller-supplied randomness and are intended only for testing.
 

--- a/sw/host/cryptotest/testvectors/data/schemas/mldsa_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/mldsa_schema.json
@@ -36,6 +36,11 @@
         "type": "integer",
         "enum": [44, 65, 87]
       },
+      "sign_mode": {
+        "description": "ML-DSA signature mode: pure, a HashML-DSA pre-hash function, or external_mu (message is a precomputed mu)",
+        "type": "string",
+        "enum": ["pure", "hash_mldsa_sha2_256", "hash_mldsa_sha2_384", "hash_mldsa_sha2_512", "hash_mldsa_sha3_224", "hash_mldsa_sha3_256", "hash_mldsa_sha3_384", "hash_mldsa_sha3_512", "hash_mldsa_shake128", "hash_mldsa_shake256", "external_mu"]
+      },
       "seed": {
         "description": "Seed for keygen",
         "$ref": "#/$defs/byte_array"

--- a/sw/host/cryptotest/testvectors/parsers/nist_acvp_mldsa_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_acvp_mldsa_parser.py
@@ -15,8 +15,14 @@ For keygen and siggen, the parser pre-computes a SHA3-256 hash of the
 expected outputs. The firmware computes the same hash and returns only
 the 32-byte digest, avoiding expensive transfer of large outputs.
 
-Only pure ML-DSA (external interface, no preHash, no externalMu) is
-supported for now.
+Within the external interface, pure ML-DSA and HashML-DSA are supported
+for the hash functions the cryptolib implements (SHA2-256/384/512,
+SHA3-224/256/384/512, SHAKE-128/256); other HashML-DSA groups are
+skipped.
+
+The internal signature interface is only supported with externalMu=true
+(a precomputed mu); externalMu=false groups are skipped, since this
+cryptolib has no path to derive mu from a raw message internally.
 """
 
 import argparse
@@ -32,10 +38,50 @@ PARAMETER_SETS = {
     "ML-DSA-87": 87,
 }
 
+# Maps ACVP's `hashAlg` test field to our `sign_mode` test-vector field.
+# SHA2-224, SHA2-512/224, and SHA2-512/256 are intentionally omitted: the
+# cryptolib doesn't implement those hash functions.
+HASH_ALGS = {
+    "SHA2-256": "hash_mldsa_sha2_256",
+    "SHA2-384": "hash_mldsa_sha2_384",
+    "SHA2-512": "hash_mldsa_sha2_512",
+    "SHA3-224": "hash_mldsa_sha3_224",
+    "SHA3-256": "hash_mldsa_sha3_256",
+    "SHA3-384": "hash_mldsa_sha3_384",
+    "SHA3-512": "hash_mldsa_sha3_512",
+    "SHAKE-128": "hash_mldsa_shake128",
+    "SHAKE-256": "hash_mldsa_shake256",
+}
+
+
+def sign_mode_for_test(group, test):
+    """Returns the `sign_mode` value for a test, or None if unsupported."""
+    if group["preHash"] == "pure":
+        return "pure"
+    return HASH_ALGS.get(test["hashAlg"])
+
 
 def compute_hash(data):
     """Compute SHA3-256 hash."""
     return list(hashlib.sha3_256(data).digest())
+
+
+def message_and_sign_mode(group, test):
+    """Returns the `(message, sign_mode, context)` to send for a test, or
+    `(None, None, None)` if unsupported.
+
+    Only the externalMu=true flavor of the internal signature interface is
+    supported (the caller filters out externalMu=false groups before
+    reaching here); `message` is then the mu supplied directly by the test
+    vector, matching the cryptolib's external-mu mode exactly."""
+    if group.get("signatureInterface") == "internal":
+        return bytes.fromhex(test["mu"]), "external_mu", b""
+    sign_mode = sign_mode_for_test(group, test)
+    if sign_mode is None:
+        return None, None, None
+    message = bytes.fromhex(test["message"])
+    context = bytes.fromhex(test.get("context", ""))
+    return message, sign_mode, context
 
 
 def parse_keygen(data):
@@ -62,24 +108,31 @@ def parse_keygen(data):
 
 def parse_siggen(data):
     """Parse ML-DSA-sigGen internalProjection.
-    Only deterministic, pure ML-DSA (external, no preHash, no externalMu).
-    Output hash: SHA3-256(signature)."""
+    Deterministic and randomized; pure ML-DSA, HashML-DSA, and the internal
+    signature interface with externalMu=true. Output hash:
+    SHA3-256(signature)."""
     test_vectors = []
+    skipped_hash_alg = 0
+    skipped_interface = 0
     for group in data["testGroups"]:
-        # Only support pure ML-DSA (external, no preHash, no externalMu).
-        if group.get("signatureInterface") != "external":
+        interface = group.get("signatureInterface")
+        if interface not in ("external", "internal"):
             continue
-        if group.get("preHash") != "pure":
+        if interface == "external" and group.get("externalMu", False):
             continue
-        if group.get("externalMu", False):
+        if interface == "internal" and not group.get("externalMu", False):
+            skipped_interface += len(group["tests"])
             continue
 
         deterministic = group.get("deterministic", False)
         param_set = PARAMETER_SETS[group["parameterSet"]]
         for test in group["tests"]:
+            message, sign_mode, context = message_and_sign_mode(group, test)
+            if sign_mode is None:
+                skipped_hash_alg += 1
+                continue
+
             sk = bytes.fromhex(test["sk"])
-            message = bytes.fromhex(test["message"])
-            context = bytes.fromhex(test.get("context", ""))
             sig = bytes.fromhex(test["signature"])
             rnd = bytes(32) if deterministic else bytes.fromhex(test["rnd"])
             test_vectors.append({
@@ -87,6 +140,7 @@ def parse_siggen(data):
                 "test_case_id": test["tcId"],
                 "operation": "siggen",
                 "parameter_set": param_set,
+                "sign_mode": sign_mode,
                 "sk": list(sk),
                 "message": list(message),
                 "context": list(context),
@@ -94,39 +148,63 @@ def parse_siggen(data):
                 "expected_hash": compute_hash(sig),
                 "result": True,
             })
+    if skipped_hash_alg:
+        print(f"parse_siggen: skipped {skipped_hash_alg} test(s) with an "
+              "unsupported hash algorithm", file=sys.stderr)
+    if skipped_interface:
+        print(f"parse_siggen: skipped {skipped_interface} test(s) using the "
+              "internal signature interface without a precomputed mu "
+              "(this cryptolib has no on-device path to compute mu from a "
+              "raw message)", file=sys.stderr)
     return test_vectors
 
 
 def parse_sigver(data):
     """Parse ML-DSA-sigVer internalProjection.
-    Only pure ML-DSA (external, no preHash, no externalMu)."""
+    Pure ML-DSA, HashML-DSA, and the internal signature interface with
+    externalMu=true."""
     test_vectors = []
+    skipped_hash_alg = 0
+    skipped_interface = 0
     for group in data["testGroups"]:
-        # Only support pure ML-DSA for now.
-        if group.get("signatureInterface") != "external":
+        interface = group.get("signatureInterface")
+        if interface not in ("external", "internal"):
             continue
-        if group.get("preHash") != "pure":
+        if interface == "external" and group.get("externalMu", False):
             continue
-        if group.get("externalMu", False):
+        if interface == "internal" and not group.get("externalMu", False):
+            skipped_interface += len(group["tests"])
             continue
 
         param_set = PARAMETER_SETS[group["parameterSet"]]
         for test in group["tests"]:
+            message, sign_mode, context = message_and_sign_mode(group, test)
+            if sign_mode is None:
+                skipped_hash_alg += 1
+                continue
+
             pk = bytes.fromhex(test["pk"])
-            message = bytes.fromhex(test["message"])
-            context = bytes.fromhex(test.get("context", ""))
             sig = bytes.fromhex(test["signature"])
             test_vectors.append({
                 "vendor": "acvp",
                 "test_case_id": test["tcId"],
                 "operation": "sigver",
                 "parameter_set": param_set,
+                "sign_mode": sign_mode,
                 "pk": list(pk),
                 "message": list(message),
                 "context": list(context),
                 "signature": list(sig),
                 "result": test["testPassed"],
             })
+    if skipped_hash_alg:
+        print(f"parse_sigver: skipped {skipped_hash_alg} test(s) with an "
+              "unsupported hash algorithm", file=sys.stderr)
+    if skipped_interface:
+        print(f"parse_sigver: skipped {skipped_interface} test(s) using the "
+              "internal signature interface without a precomputed mu "
+              "(this cryptolib has no on-device path to compute mu from a "
+              "raw message)", file=sys.stderr)
     return test_vectors
 
 


### PR DESCRIPTION
Add tests for HashML-DSA w/ SHA2-256/384/512, SHA3-224/256/384/512,
SHAKE128/256 as pre hash.
SHA2-224, SHA2-512/224, SHA2-512/256 are not (yet) supported as the
cryptolib doesn't currently support those hash functions.


- Depends on #353 