### PR TITLE
[dvsim] Apply job limits to Slurm jobs and reuse the results repository

### DIFF
--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -5,6 +5,7 @@
 import logging as log
 import os
 import pprint
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -585,7 +586,7 @@ class FlowCfg():
         repo_dir = os.path.expanduser("./scratch/results_repo")
 
         env = self._setup_ssh_env()
-        self.clone_or_pull(repository, repo_dir, env)
+        remote = self.clone_or_pull(repository, repo_dir, env)
 
         latest_batch_report = os.path.join(self.scratch_path, 'reports', 'latest', 'report.html')
         # Destination directory should be
@@ -643,7 +644,7 @@ class FlowCfg():
         subprocess.run(["git", "-C", repo_dir, "commit", "-m",
                         f"[dashboard] Update {self.name}_{test}_{self.flow} {self.timestamp}"],
                        check=True, env=env)
-        subprocess.run(["git", "-C", repo_dir, "push", "origin", self.branch],
+        subprocess.run(["git", "-C", repo_dir, "push", remote, f"HEAD:{self.branch}"],
                        check=True, env=env)
         log.info("Results published successfully.")
 
@@ -712,43 +713,72 @@ class FlowCfg():
             os.unlink(askpass_script)
         return env
 
-    def clone_or_pull(self, repository: str, local_path: str, env: dict):
-        """Clone the repo if it doesn't exist locally, otherwise pull latest.
+    @staticmethod
+    def remote_name_for(repository: str) -> str:
+        """Pick a stable git remote name for a dashboard repository.
+
+        Derived from the repository name, so that a staging directory serving
+        more than one dashboard ends up with one clearly named remote per
+        dashboard instead of a single `origin` that has to be repointed.
+        """
+        name = repository.rstrip("/").rsplit("/", 1)[-1]
+        if name.endswith(".git"):
+            name = name[:-len(".git")]
+        name = re.sub(r"[^A-Za-z0-9._-]", "-", name)
+        return name or "dashboard"
+
+    def _ensure_remote(self, local_path: str, remote: str, repository: str,
+                       env: dict) -> None:
+        """Make `remote` exist in local_path and point at `repository`."""
+        result = subprocess.run(["git", "-C", local_path, "remote"],
+                                check=True, capture_output=True, text=True, env=env)
+        action = "set-url" if remote in result.stdout.split() else "add"
+        subprocess.run(["git", "-C", local_path, "remote", action, remote, repository],
+                       check=True, env=env)
+
+    def clone_or_pull(self, repository: str, local_path: str, env: dict) -> str:
+        """Make local_path a checkout of `repository` at `self.branch`.
 
         Operates on `self.branch`: we expect a matching branch on the dashboard
-        repository (verified up-front by check_remote_branch_exists).
+        repository (verified up-front by check_remote_branch_exists). Returns
+        the name of the remote that tracks `repository`, which is the one the
+        results have to be pushed back to.
+
+        A staging directory that already exists is reused whatever dashboard it
+        was last pointed at: the remote is added or repointed and the branch is
+        fetched, rather than the whole thing being cloned again. Cloning a
+        dashboard afresh every time the publication target alternates is slow
+        anywhere and painful over NFS.
         """
         branch = self.branch
+        remote = self.remote_name_for(repository)
         try:
-            if os.path.exists(local_path):
-                result = subprocess.run(
-                    ["git", "-C", local_path, "remote", "get-url", "origin"],
-                    check=True, capture_output=True, text=True, env=env
-                )
-                existing_remote = result.stdout.strip()
-                if existing_remote != repository:
-                    log.warning("Existing repo at %s points to %s, expected %s. Recloning.",
-                                local_path, existing_remote, repository)
-                    shutil.rmtree(local_path)
-                    subprocess.run(
-                        ["git", "clone", "-b", branch, repository, local_path],
-                        check=True, env=env)
-                else:
-                    # The local clone may have been left on a different branch
-                    # by a previous run, so fetch + checkout + pull explicitly.
-                    subprocess.run(
-                        ["git", "-C", local_path, "fetch", "origin", branch],
-                        check=True, env=env)
-                    subprocess.run(
-                        ["git", "-C", local_path, "checkout", branch],
-                        check=True, env=env)
-                    subprocess.run(
-                        ["git", "-C", local_path, "pull", "origin", branch],
-                        check=True, env=env)
-            else:
+            if not os.path.exists(local_path):
                 subprocess.run(
-                    ["git", "clone", "-b", branch, repository, local_path],
+                    ["git", "clone", "-b", branch, "-o", remote, repository, local_path],
                     check=True, env=env)
+                return remote
+
+            self._ensure_remote(local_path, remote, repository, env)
+            subprocess.run(["git", "-C", local_path, "fetch", remote, branch],
+                           check=True, env=env)
+            # Forced, because this directory is a staging area for reports and
+            # never a place where work happens: whatever a previous run left
+            # behind is of no value.
+            # Detached, because nothing here reads a branch name and the push
+            # below names HEAD. A local branch called `<remote>/<branch>` would
+            # collide with the remote-tracking ref the fetch just wrote.
+            subprocess.run(
+                ["git", "-C", local_path, "checkout", "-f", "--detach",
+                 "FETCH_HEAD"],
+                check=True, env=env)
+            # One directory can serve several dashboards, and the private one
+            # receives native artifacts that the public one must never be
+            # given. Everything untracked and everything ignored goes before
+            # the caller's `git add -A` can sweep it into the wrong repository.
+            subprocess.run(["git", "-C", local_path, "clean", "-ffdx"],
+                           check=True, env=env)
+            return remote
         except FileNotFoundError:
             log.error("git is not installed or not on PATH. Cannot publish results.")
             raise

--- a/util/dvsim/Launcher.py
+++ b/util/dvsim/Launcher.py
@@ -310,6 +310,16 @@ class Launcher:
         """
         return None
 
+    def _record_peak_rss(self, peak_rss_mb: Union[float, None]) -> None:
+        """Keep the largest peak resident set size seen for this job, in MB."""
+        if peak_rss_mb is None:
+            return
+        if (
+            self.deploy.job_peak_rss is None
+            or peak_rss_mb > self.deploy.job_peak_rss  # noqa: W503
+        ):
+            self.deploy.job_peak_rss = peak_rss_mb
+
     def _limit_exceeded(self) -> Union[str, None]:
         """Return why the job ought to be killed, or None to let it run on.
 

--- a/util/dvsim/Launcher.py
+++ b/util/dvsim/Launcher.py
@@ -14,6 +14,11 @@ from typing import Union
 
 from utils import VERBOSE, clean_odirs, dir_size_mb, mk_symlink, rm_path
 
+# How much of the end of each log read to carry over to the next one, so that a
+# start marker split across two reads is still matched. Comfortably longer than
+# the lines being looked for
+_LOG_SCAN_TAIL_CHARS = 256
+
 
 # Failure message used when a job returns a non-zero exit code without any of
 # its fail patterns matching. _check_status() keys off this to tell a job that
@@ -211,6 +216,20 @@ class Launcher:
         # The actual job runtime computed by dvsim, in seconds.
         self.job_runtime_secs = 0
 
+        # Ceiling on how long the job may run once it has started doing its
+        # work, in seconds. None lets it run indefinitely.
+        self.timeout_secs = None
+
+        # When the job was seen to start doing its work, as opposed to when it
+        # was launched. None until one of the deploy's started_patterns turns up
+        # in the log.
+        self._run_start_time = None
+
+        # How far the log has been read looking for that marker, and the tail
+        # carried over so that a marker split across two reads still matches.
+        self._log_scan_offset = 0
+        self._log_scan_tail = ""
+
         # Whether the job's log has already been mined for information about
         # the job. Guards against reading it twice, since the job's outcome
         # decides which of the two code paths gets there first.
@@ -262,6 +281,150 @@ class Launcher:
         self.deploy.pre_launch()
         self._make_odir()
         self.start_time = datetime.datetime.now()
+
+        # Read here rather than in each launcher, because a job's ceiling is a
+        # property of the job and not of how it is dispatched.
+        timeout_mins = self.deploy.get_timeout_mins()
+        self.timeout_secs = timeout_mins * 60 if timeout_mins else None
+
+    def _tick_runtime(self) -> None:
+        """Record how long the job has been going.
+
+        This is dvsim's own measurement, which is what the results table falls
+        back to when the tool's log does not report a runtime of its own. A
+        launcher that never calls this reports every job as having taken no
+        time at all.
+        """
+        elapsed = datetime.datetime.now() - self.start_time
+        self.job_runtime_secs = elapsed.total_seconds()
+
+    def _peak_mem_mb(self) -> Union[float, None]:
+        """Return the job's peak resident set size so far in MB, or None.
+
+        None means this launcher cannot measure a running job, so
+        max_job_mem_gb goes unenforced. That is the honest answer whenever the
+        work happens somewhere the launcher cannot see, as it does for a batch
+        system that runs the job on another machine. Such a system usually
+        applies a memory limit of its own, which is what enforces the ceiling
+        there instead.
+        """
+        return None
+
+    def _limit_exceeded(self) -> Union[str, None]:
+        """Return why the job ought to be killed, or None to let it run on.
+
+        Both ceilings are policy that every launcher shares, so they live here.
+        What differs between launchers is only what they are able to measure,
+        which is _peak_mem_mb().
+        """
+        reason = self._timeout_reason()
+        if reason is not None:
+            return reason
+
+        limit_gb = self.max_job_mem_gb
+        if limit_gb is None:
+            return None
+
+        peak_mb = self._peak_mem_mb()
+        if peak_mb is None or peak_mb <= limit_gb * 1024:
+            return None
+
+        return (f"Job exceeded the {limit_gb} GB memory limit "
+                f"(peak resident set size {peak_mb / 1024:.2f} GB)")
+
+    def _kill(self) -> None:
+        """Terminate the running job without recording an outcome.
+
+        Separated from kill() so that the shared limit checks can stop a job
+        and attribute it to the limit that stopped it.
+        """
+        raise NotImplementedError
+
+    def _detect_job_start(self) -> None:
+        """Look for the point in the log where the job started doing its work.
+
+        Sets _run_start_time when one of the deploy's started_patterns turns up.
+        Only the bytes added to the log since the last look are read, so the cost
+        does not grow with the log, and nothing is read at all once the job has
+        started.
+        """
+        patterns = self.deploy.started_patterns
+        if not patterns:
+            # Nothing marks the start for this flow, so treat the job as under
+            # way from the moment it was launched.
+            self._run_start_time = self.start_time
+            return
+
+        try:
+            with open(self.deploy.get_log_path(), "rb") as f:
+                f.seek(self._log_scan_offset)
+                chunk = f.read()
+                self._log_scan_offset = f.tell()
+        except OSError:
+            # The log is not there yet, or cannot be read. Try again next poll.
+            return
+
+        if not chunk:
+            return
+
+        text = self._log_scan_tail + chunk.decode("UTF-8", errors="surrogateescape")
+        for pattern in patterns:
+            if re.search(pattern, text, re.MULTILINE):
+                self._run_start_time = datetime.datetime.now()
+                self._log_scan_tail = ""
+                return
+
+        # Hold on to the tail, so that a marker straddling two reads still
+        # matches when the rest of it arrives
+        self._log_scan_tail = text[-_LOG_SCAN_TAIL_CHARS:]
+
+    def _timeout_reason(self) -> Union[str, None]:
+        """Return why the job ought to be killed for taking too long, or None.
+
+        A job is timed from the point where it starts doing its work rather than
+        from the point where it was launched, because the gap between the two is
+        spent queueing for a license.
+
+        The waiting and the running phases therefore get separate limits and
+        separate messages, so that a report can tell a job that never got a
+        license apart from one that genuinely ran too long.
+        """
+        if self.deploy.gui:
+            # The user is driving, so nothing counts as too slow
+            return None
+
+        if self._run_start_time is None:
+            self._detect_job_start()
+
+        if self._run_start_time is None:
+            wait_mins = Launcher.max_job_wait_mins
+            if wait_mins and self.job_runtime_secs > wait_mins * 60:
+                return (
+                    f"Job did not start running within {wait_mins} minutes of "
+                    f"being launched, so it was most likely still waiting for a "
+                    f"license"
+                )
+            return None
+
+        if not self.timeout_secs:
+            return None
+
+        run_secs = (
+            datetime.datetime.now() - self._run_start_time
+        ).total_seconds()
+        if run_secs > self.timeout_secs:
+            timeout_mins = self.deploy.get_timeout_mins()
+            return f"Job timed out after running for {timeout_mins} minutes"
+
+        return None
+
+    def _kill_with_reason(self, message: str) -> None:
+        """Kill the job and record why dvsim decided to kill it."""
+        self._kill()
+        self._post_finish(
+            "K",
+            ErrorMessage(line_number=None, message=message, context=[message]),
+        )
 
     def _do_launch(self) -> None:
         """Launch the job."""

--- a/util/dvsim/LocalLauncher.py
+++ b/util/dvsim/LocalLauncher.py
@@ -3,9 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Launcher implementation to run jobs as subprocesses on the local machine."""
 
-import datetime
 import os
-import re
 import shlex
 import signal
 import subprocess
@@ -14,11 +12,6 @@ from typing import Union
 import logging as log
 
 from Launcher import ErrorMessage, Launcher, LauncherBusy, LauncherError
-
-# How much of the end of each log read to carry over to the next one, so that a
-# start marker split across two reads is still matched. Comfortably longer than
-# the lines being looked for
-_LOG_SCAN_TAIL_CHARS = 256
 
 
 def _read_vmhwm_mb(pid: int) -> Union[float, None]:
@@ -102,7 +95,7 @@ class LocalLauncher(Launcher):
     """Implementation of Launcher to launch jobs in the user's local workstation."""
 
     # Re-discover the job's process tree once every this many polls. See
-    # _sample_peak_rss() for why the tree is not walked afresh every time.
+    # _peak_mem_mb() for why the tree is not walked afresh every time.
     pid_walk_interval = 30
 
     def __init__(self, deploy) -> None:
@@ -116,15 +109,6 @@ class LocalLauncher(Launcher):
         # The job's process tree, and the countdown to re-walking it.
         self._job_pids = []
         self._pid_walk_countdown = 0
-
-        # When the job started doing its work, as opposed to when it was
-        # launched. None until we see it start. See _detect_job_start().
-        self._run_start_time = None
-
-        # How far through the log we have looked for the job starting, and the
-        # tail of what we read, so a marker split across two reads is not missed.
-        self._log_scan_offset = 0
-        self._log_scan_tail = ""
 
     def _do_launch(self) -> None:
         # Update the shell's env vars with self.exports. Values in exports must
@@ -144,10 +128,6 @@ class LocalLauncher(Launcher):
 
         if not self.deploy.sim_cfg.interactive:
             log_path = Path(self.deploy.get_log_path())
-            timeout_mins = self.deploy.get_timeout_mins()
-
-            self.timeout_secs = timeout_mins * 60 if timeout_mins else None
-
             try:
                 self._log_file = log_path.open(
                     "w",
@@ -217,25 +197,13 @@ class LocalLauncher(Launcher):
         if self._process is None:
             return "E"
 
-        elapsed_time = datetime.datetime.now() - self.start_time
-        self.job_runtime_secs = elapsed_time.total_seconds()
+        self._tick_runtime()
         if self._reap() is None:
             # Still running.
-            timeout_reason = self._timeout_reason()
-            if timeout_reason is not None:
-                self._kill_with_reason(timeout_reason)
+            reason = self._limit_exceeded()
+            if reason is not None:
+                self._kill_with_reason(reason)
                 return "K"
-
-            mem_limit_gb = Launcher.max_job_mem_gb
-            if mem_limit_gb is not None:
-                peak_rss_mb = self._sample_peak_rss()
-                if peak_rss_mb is not None and peak_rss_mb > mem_limit_gb * 1024:
-                    self._kill_with_reason(
-                        f"Job exceeded the {mem_limit_gb} GB memory limit "
-                        f"(peak resident set size "
-                        f"{peak_rss_mb / 1024:.2f} GB)",
-                    )
-                    return "K"
 
             return "D"
 
@@ -243,84 +211,6 @@ class LocalLauncher(Launcher):
         self._post_finish(status, err_msg)
 
         return self.status
-
-    def _detect_job_start(self) -> None:
-        """Look for the point in the log where the job started doing its work.
-
-        Sets _run_start_time when one of the deploy's started_patterns turns up.
-        Only the bytes added to the log since the last look are read, so the cost
-        does not grow with the log, and nothing is read at all once the job has
-        started.
-        """
-        patterns = self.deploy.started_patterns
-        if not patterns:
-            # Nothing marks the start for this flow, so treat the job as under
-            # way from the moment it was launched.
-            self._run_start_time = self.start_time
-            return
-
-        try:
-            with open(self.deploy.get_log_path(), "rb") as f:
-                f.seek(self._log_scan_offset)
-                chunk = f.read()
-                self._log_scan_offset = f.tell()
-        except OSError:
-            # The log is not there yet, or cannot be read. Try again next poll.
-            return
-
-        if not chunk:
-            return
-
-        text = self._log_scan_tail + chunk.decode("UTF-8", errors="surrogateescape")
-        for pattern in patterns:
-            if re.search(pattern, text, re.MULTILINE):
-                self._run_start_time = datetime.datetime.now()
-                self._log_scan_tail = ""
-                return
-
-        # Hold on to the tail, so that a marker straddling two reads still
-        # matches when the rest of it arrives
-        self._log_scan_tail = text[-_LOG_SCAN_TAIL_CHARS:]
-
-    def _timeout_reason(self) -> Union[str, None]:
-        """Return why the job ought to be killed for taking too long, or None.
-
-        A job is timed from the point where it starts doing its work rather than
-        from the point where it was launched, because the gap between the two is
-        spent queueing for a license.
-
-        The waiting and the running phases therefore get separate limits and
-        separate messages, so that a report can tell a job that never got a
-        license apart from one that genuinely ran too long.
-        """
-        if self.deploy.gui:
-            # The user is driving, so nothing counts as too slow
-            return None
-
-        if self._run_start_time is None:
-            self._detect_job_start()
-
-        if self._run_start_time is None:
-            wait_mins = Launcher.max_job_wait_mins
-            if wait_mins and self.job_runtime_secs > wait_mins * 60:
-                return (
-                    f"Job did not start running within {wait_mins} minutes of "
-                    f"being launched, so it was most likely still waiting for a "
-                    f"license"
-                )
-            return None
-
-        if not self.timeout_secs:
-            return None
-
-        run_secs = (
-            datetime.datetime.now() - self._run_start_time
-        ).total_seconds()
-        if run_secs > self.timeout_secs:
-            timeout_mins = self.deploy.get_timeout_mins()
-            return f"Job timed out after running for {timeout_mins} minutes"
-
-        return None
 
     def _reap(self) -> Union[int, None]:
         """Reap the process if it has finished, returning its exit code.
@@ -365,7 +255,7 @@ class LocalLauncher(Launcher):
         ):
             self.deploy.job_peak_rss = peak_rss_mb
 
-    def _sample_peak_rss(self) -> Union[float, None]:
+    def _peak_mem_mb(self) -> Union[float, None]:
         """Read the running job's peak resident set size so far, in MB.
 
         The process dvsim launches is a make wrapper, and the simulator it goes
@@ -411,14 +301,6 @@ class LocalLauncher(Launcher):
 
         self._record_peak_rss(peak_rss_mb)
         return peak_rss_mb
-
-    def _kill_with_reason(self, message: str) -> None:
-        """Kill the job and record why dvsim decided to kill it."""
-        self._kill()
-        self._post_finish(
-            "K",
-            ErrorMessage(line_number=None, message=message, context=[message]),
-        )
 
     def _signal_job_group(self, sig: int) -> None:
         """Send a signal to every process belonging to the job.
@@ -471,7 +353,7 @@ class LocalLauncher(Launcher):
         # Read the job's peak memory before signaling it. This is the last
         # moment at which procfs can still tell us, and a killed job is exactly
         # the case where the tool never gets to report the figure itself.
-        self._sample_peak_rss()
+        self._peak_mem_mb()
 
         self._signal_job_group(signal.SIGTERM)
         try:
@@ -505,7 +387,7 @@ class LocalLauncher(Launcher):
         if self._process is not None:
             # One cheap procfs read before it dies, so that even a force-quit
             # leaves the job's memory figure behind for the report.
-            self._sample_peak_rss()
+            self._peak_mem_mb()
             self._signal_job_group(signal.SIGKILL)
             self._process.poll()
 

--- a/util/dvsim/LocalLauncher.py
+++ b/util/dvsim/LocalLauncher.py
@@ -245,16 +245,6 @@ class LocalLauncher(Launcher):
         self.exit_code = self._process.returncode
         return self.exit_code
 
-    def _record_peak_rss(self, peak_rss_mb: Union[float, None]) -> None:
-        """Keep the largest peak resident set size seen for this job, in MB."""
-        if peak_rss_mb is None:
-            return
-        if (
-            self.deploy.job_peak_rss is None
-            or peak_rss_mb > self.deploy.job_peak_rss  # noqa: W503
-        ):
-            self.deploy.job_peak_rss = peak_rss_mb
-
     def _peak_mem_mb(self) -> Union[float, None]:
         """Read the running job's peak resident set size so far, in MB.
 

--- a/util/dvsim/SlurmLauncher.py
+++ b/util/dvsim/SlurmLauncher.py
@@ -8,10 +8,36 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+import time
 from pathlib import Path
+from typing import Union
 
 from Launcher import ErrorMessage, Launcher, LauncherError
 from utils import VERBOSE
+
+
+def _parse_size_mb(text: str) -> Union[float, None]:
+    """Convert a size as Slurm writes it into MB, or None if it is not one.
+
+    sacct and sstat report sizes with a single letter unit and sometimes a
+    decimal point, as in `1234K` or `1.50G`. A bare number means bytes. An
+    empty field, which is what a step that has reported nothing yet gives, is
+    not a size.
+    """
+    text = text.strip()
+    if not text:
+        return None
+
+    scale = {'K': 1 / 1024, 'M': 1.0, 'G': 1024.0, 'T': 1024.0 * 1024}
+    factor = 1 / (1024 * 1024)
+    if text[-1].upper() in scale:
+        factor = scale[text[-1].upper()]
+        text = text[:-1]
+
+    try:
+        return float(text) * factor
+    except ValueError:
+        return None
 
 
 SLURM_QUEUE = os.environ.get("SLURM_QUEUE", "hw-m")
@@ -23,6 +49,12 @@ SLURM_SETUP_CMD = os.environ.get("SLURM_SETUP_CMD", "")
 
 
 class SlurmLauncher(Launcher):
+    # How long to leave between asking Slurm for a job's memory. Each ask is a
+    # subprocess and a round trip to the controller, so at one poll a second
+    # across a full regression an unthrottled check would be a considerable
+    # load on the controller for a figure that moves slowly.
+    mem_poll_interval_secs = 30
+
     def __init__(self, deploy):
         '''Initialize common class members.'''
 
@@ -32,6 +64,12 @@ class SlurmLauncher(Launcher):
         self.process = None
         self.slurm_log_file = Path(self.deploy.get_log_path() + '.slurm')
         self.slurm_script_file = None
+
+        # Where the job writes its own Slurm job id, so that the peak memory
+        # can be asked for without having to search the queue for the job.
+        self.slurm_jobid_file = Path(f'{self.slurm_log_file}.jobid')
+        self._slurm_job_id = None
+        self._last_mem_poll = None
 
     def _do_launch(self):
         # replace the values in the shell's env vars if the keys match.
@@ -56,7 +94,11 @@ class SlurmLauncher(Launcher):
             raise LauncherError(f'File Error: {e}\n'
                                 f'Could not create the job directory {script_dir}')
 
+        # The job reports its own id, which is the cheapest way for the
+        # launcher to learn it: srun does not hand it back, and searching the
+        # queue for the job by name costs a round trip per job.
         script_body = '#!/bin/bash\n'
+        script_body += f'echo "${{SLURM_JOB_ID}}" > {self.slurm_jobid_file}\n'
         if SLURM_SETUP_CMD:
             script_body += f'{SLURM_SETUP_CMD}\n'
         script_body += f'{self.deploy.cmd}\n'
@@ -154,7 +196,82 @@ class SlurmLauncher(Launcher):
             'K',
             ErrorMessage(line_number=None, message='Job killed!', context=[]))
 
-    def _kill(self):
+    def _job_id(self) -> Union[str, None]:
+        """Return the job's Slurm id, or None before the job has reported it.
+
+        The job writes it once, at the top of the generated script, so there is
+        nothing to re-read after the first success.
+        """
+        if self._slurm_job_id is None:
+            try:
+                self._slurm_job_id = self.slurm_jobid_file.read_text().strip() or None
+            except OSError:
+                return None
+        return self._slurm_job_id
+
+    def _peak_mem_mb(self) -> Union[float, None]:
+        """Return the largest peak resident set size seen for this job, in MB.
+
+        Slurm measures the job on the node that runs it and sstat reports that
+        without needing the accounting database, which is what makes a memory
+        ceiling enforceable for a job dvsim cannot see. Asking is expensive
+        enough to be throttled, so between asks the figure already recorded is
+        returned unchanged.
+        """
+        job_id = self._job_id()
+        if job_id is None:
+            return self.deploy.job_peak_rss
+
+        now = time.monotonic()
+        if (self._last_mem_poll is not None and
+                now - self._last_mem_poll < self.mem_poll_interval_secs):
+            return self.deploy.job_peak_rss
+        self._last_mem_poll = now
+
+        try:
+            result = subprocess.run(
+                ['sstat', '-a', '-n', '-P', '-j', job_id, '-o', 'MaxRSS'],
+                capture_output=True, text=True, timeout=30)
+        except (OSError, subprocess.SubprocessError):
+            return self.deploy.job_peak_rss
+
+        # A job between steps, or one that has just finished, reports nothing.
+        for line in result.stdout.splitlines():
+            self._record_peak_rss(_parse_size_mb(line))
+
+        return self.deploy.job_peak_rss
+
+    def _sample_before_ending(self) -> None:
+        """Ask for the job's memory one last time while it can still answer.
+
+        A job that is about to be killed is exactly the job whose tool never
+        gets to report the figure itself, and sstat has nothing to say about a
+        job that has gone. The throttle is cleared so that this ask is not the
+        one that gets skipped.
+        """
+        self._last_mem_poll = None
+        self._peak_mem_mb()
+
+    def force_kill(self) -> None:
+        """Kill the job at once, without waiting for it to wind down.
+
+        Invoked when dvsim is force-quit. Terminating srun releases the
+        allocation, and not waiting matters because a job stuck writing a wave
+        dump over NFS does not die promptly and a force-quit must not hang on
+        it.
+        """
+        if self.process is not None:
+            self._sample_before_ending()
+            self.process.kill()
+            self.process.poll()
+
+        self._post_finish(
+            'K',
+            ErrorMessage(line_number=None,
+                         message='Job force-killed when dvsim was force-quit.',
+                         context=[]))
+
+    def _kill(self) -> None:
         '''Cancel the job by terminating the srun that holds it.
 
         srun forwards the signal to the job and releases the allocation, so
@@ -162,6 +279,8 @@ class SlurmLauncher(Launcher):
         '''
         if self.process is None:
             return
+
+        self._sample_before_ending()
 
         # Send SIGTERM first, wait a bit, and then send SIGKILL if it did not
         # work.
@@ -176,6 +295,8 @@ class SlurmLauncher(Launcher):
         if self.slurm_script_file and self.slurm_script_file.exists():
             self.slurm_script_file.unlink()
             self.slurm_script_file = None
+        if self.slurm_jobid_file.exists():
+            self.slurm_jobid_file.unlink()
         self._close_process()
         self.process = None
 

--- a/util/dvsim/SlurmLauncher.py
+++ b/util/dvsim/SlurmLauncher.py
@@ -114,7 +114,13 @@ class SlurmLauncher(Launcher):
         '''
 
         assert self.process is not None
+        self._tick_runtime()
         if self.process.poll() is None:
+            reason = self._limit_exceeded()
+            if reason is not None:
+                self._kill_with_reason(reason)
+                return 'K'
+
             return 'D'
 
         # Copy slurm job results to log file
@@ -143,18 +149,27 @@ class SlurmLauncher(Launcher):
         This must be called between dispatching and reaping the process (the
         same window as poll()).
         '''
-        assert self.process is not None
+        self._kill()
+        self._post_finish(
+            'K',
+            ErrorMessage(line_number=None, message='Job killed!', context=[]))
 
-        # Try to kill the running process. Send SIGTERM first, wait a bit,
-        # and then send SIGKILL if it didn't work.
+    def _kill(self):
+        '''Cancel the job by terminating the srun that holds it.
+
+        srun forwards the signal to the job and releases the allocation, so
+        there is no need to reach for scancel.
+        '''
+        if self.process is None:
+            return
+
+        # Send SIGTERM first, wait a bit, and then send SIGKILL if it did not
+        # work.
         self.process.terminate()
         try:
             self.process.wait(timeout=2)
         except subprocess.TimeoutExpired:
             self.process.kill()
-        self._post_finish(
-            'K',
-            ErrorMessage(line_number=None, message='Job killed!', context=[]))
 
     def _post_finish(self, status, err_msg):
         super()._post_finish(status, err_msg)


### PR DESCRIPTION
This PR contains three commits:
- The first commit stops publishing from deleting and re-cloning the dashboard staging directory whenever the target changes, so a run that publishes to both the private and the public dashboard no longer clones a dashboard twice. `clone_or_pull` keeps one remote per dashboard and returns the one to push to.
- The second commit moves the run timeout, the license wait detection and the memory ceiling out of `LocalLauncher` and into `Launcher`, so a job dispatched through Slurm is subject to all three and reports its wall clock time instead of leaving that column empty.
- The third commit gives `SlurmLauncher` a way to measure a running job: the generated script reports its own job id and the launcher asks `sstat` for the peak. `max_job_mem_gb` is therefore enforced for Slurm jobs, and `force_kill` records the figure before the job goes.