### PR TITLE
[ci] Migrate all non-PQ CW340 tests to nightly CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,15 +322,6 @@ jobs:
       top_name: egret
       design_suffix: cw310_hyperdebug
 
-  chip_egret_cw340:
-    name: Egret for CW340
-    needs: quick_lint
-    uses: ./.github/workflows/bitstream.yml
-    secrets: inherit
-    with:
-      top_name: egret
-      design_suffix: cw340
-
   chip_egret_cw340_pqc:
     name: Egret for CW340 (PQC)
     needs: quick_lint
@@ -353,7 +344,6 @@ jobs:
   execute_tests_cw340:
     name: Egret CW340 Tests
     needs:
-      - chip_egret_cw340
       - chip_egret_cw340_pqc
     uses: ./.github/workflows/egret-cw340-pr.yml
     secrets: inherit

--- a/.github/workflows/egret-cw340-nightly.yml
+++ b/.github/workflows/egret-cw340-nightly.yml
@@ -12,104 +12,89 @@ on:
 
 jobs:
   # CW340 FPGA jobs
-  execute_long_test_rom_fpga_tests_cw340:
+  execute_test_rom_fpga_tests_cw340:
     name: CW340 Test ROM Long Tests
     uses: ./.github/workflows/fpga.yml
     secrets: inherit
     with:
       name: CW340 Test ROM Long Tests
-      job_name: execute_long_test_rom_fpga_tests_cw340
+      job_name: execute_test_rom_fpga_tests_cw340
       bitstream: ${{ inputs.bitstream }}
       board: cw340
       interface: cw340
       tag_filters: cw340_test_rom
-      timeout_filters: 'long,eternal'
+      timeout_filters: 'short,moderate,long,eternal'
       timeout: 300
 
-  execute_long_rom_fpga_tests_cw340:
+  execute_rom_fpga_tests_cw340:
     name: CW340 ROM Long Tests
     uses: ./.github/workflows/fpga.yml
     secrets: inherit
     with:
       name: CW340 ROM Long Tests
-      job_name: execute_long_rom_fpga_tests_cw340
+      job_name: execute_rom_fpga_tests_cw340
       bitstream: ${{ inputs.bitstream }}
       board: cw340
       interface: cw340
       tag_filters: "cw340_rom_with_fake_keys,cw340_rom_with_real_keys,-manuf"
-      timeout_filters: 'long,eternal'
+      timeout_filters: 'short,moderate,long,eternal'
       timeout: 300
 
-  execute_long_rom_ext_fpga_tests_cw340:
+  execute_rom_ext_fpga_tests_cw340:
     name: CW340 ROM_EXT Long Tests
     uses: ./.github/workflows/fpga.yml
     secrets: inherit
     with:
       name: CW340 ROM_EXT Long Tests
-      job_name: execute_long_rom_ext_fpga_tests_cw340
+      job_name: execute_rom_ext_fpga_tests_cw340
       bitstream: ${{ inputs.bitstream }}
       board: cw340
       interface: cw340
       tag_filters: cw340_rom_ext
-      timeout_filters: 'long,eternal'
+      timeout_filters: 'short,moderate,long,eternal'
       timeout: 300
 
-  execute_long_sival_fpga_tests_cw340:
+  execute_sival_fpga_tests_cw340:
     name: CW340 SiVal Long Tests
     uses: ./.github/workflows/fpga.yml
     secrets: inherit
     with:
       name: CW340 SiVal Long Tests
-      job_name: execute_long_sival_fpga_tests_cw340
+      job_name: execute_sival_fpga_tests_cw340
       bitstream: ${{ inputs.bitstream }}
       board: cw340
       interface: cw340
       tag_filters: "cw340_sival,-manuf"
-      timeout_filters: 'long,eternal'
+      timeout_filters: 'short,moderate,long,eternal'
       timeout: 300
 
-  execute_long_sival_rom_ext_fpga_tests_cw340:
+  execute_sival_rom_ext_fpga_tests_cw340:
     name: CW340 SiVal ROM_EXT Long Tests
     uses: ./.github/workflows/fpga.yml
     secrets: inherit
     with:
       name: CW340 SiVal ROM_EXT Long Tests
-      job_name: execute_long_sival_rom_ext_fpga_tests_cw340
+      job_name: execute_sival_rom_ext_fpga_tests_cw340
       bitstream: ${{ inputs.bitstream }}
       board: cw340
       interface: cw340
       tag_filters: cw340_sival_rom_ext
-      timeout_filters: 'long,eternal'
+      timeout_filters: 'short,moderate,long,eternal'
       timeout: 300
 
-  execute_long_manuf_fpga_tests_cw340:
+  execute_manuf_fpga_tests_cw340:
     name: CW340 Manufacturing Long Tests
     uses: ./.github/workflows/fpga.yml
     secrets: inherit
     with:
       name: CW340 Manufacturing Long Tests
-      job_name: execute_long_manuf_fpga_tests_cw340
+      job_name: execute_manuf_fpga_tests_cw340
       bitstream: ${{ inputs.bitstream }}
       board: cw340
       interface: cw340
       tag_filters: "manuf,-cw310"
-      timeout_filters: 'long,eternal'
+      timeout_filters: 'short,moderate,long,eternal'
       timeout: 300
-
-  execute_long_pqc_fpga_tests_cw340:
-    name: CW340 PQCEn=1 Long Tests
-    uses: ./.github/workflows/fpga.yml
-    secrets: inherit
-    with:
-      name: CW340 PQCEn=1 Long Tests
-      job_name: execute_long_pqc_fpga_tests_cw340
-      bitstream: chip_egret_cw340_pqc
-      board: cw340
-      interface: cw340
-      tag_filters: cw340_pqc_test_rom
-      timeout_filters: 'long,eternal'
-      timeout: 300
-      extra_bazel_flags: --define=acc_has_pqc=true
 
   verify_fpga_jobs:
     name: Verify FPGA jobs
@@ -117,13 +102,12 @@ jobs:
     with:
       test_group: "cw340-nightly"
       tag_filters: "cw340"
-      timeout_filters: 'long,eternal'
+      timeout_filters: 'short,moderate,long,eternal'
     needs:
-      - execute_long_test_rom_fpga_tests_cw340
-      - execute_long_rom_fpga_tests_cw340
-      - execute_long_rom_ext_fpga_tests_cw340
-      - execute_long_sival_fpga_tests_cw340
-      - execute_long_sival_rom_ext_fpga_tests_cw340
-      - execute_long_manuf_fpga_tests_cw340
-      - execute_long_pqc_fpga_tests_cw340
+      - execute_test_rom_fpga_tests_cw340
+      - execute_rom_fpga_tests_cw340
+      - execute_rom_ext_fpga_tests_cw340
+      - execute_sival_fpga_tests_cw340
+      - execute_sival_rom_ext_fpga_tests_cw340
+      - execute_manuf_fpga_tests_cw340
     if: success() || failure()

--- a/.github/workflows/egret-cw340-pr.yml
+++ b/.github/workflows/egret-cw340-pr.yml
@@ -11,86 +11,6 @@ on:
         type: string
 
 jobs:
-  execute_test_rom_fpga_tests_cw340:
-    name: CW340 Test ROM Tests
-    uses: ./.github/workflows/fpga.yml
-    if: ${{ github.event_name != 'merge_group' }}
-    secrets: inherit
-    with:
-      name: CW340 Test ROM Tests
-      job_name: execute_test_rom_fpga_tests_cw340
-      bitstream: ${{ inputs.bitstream }}
-      board: cw340
-      interface: cw340
-      tag_filters: cw340_test_rom
-
-  execute_rom_fpga_tests_cw340:
-    name: CW340 ROM Tests
-    uses: ./.github/workflows/fpga.yml
-    if: ${{ github.event_name != 'merge_group' }}
-    secrets: inherit
-    with:
-      name: CW340 ROM Tests
-      job_name: execute_rom_fpga_tests_cw340
-      bitstream: ${{ inputs.bitstream }}
-      board: cw340
-      interface: cw340
-      tag_filters: "cw340_rom_with_fake_keys,cw340_rom_with_real_keys,-manuf"
-
-  execute_rom_ext_fpga_tests_cw340:
-    name: CW340 ROM_EXT Tests
-    uses: ./.github/workflows/fpga.yml
-    if: ${{ github.event_name != 'merge_group' }}
-    secrets: inherit
-    with:
-      name: CW340 ROM_EXT Tests
-      job_name: execute_rom_ext_fpga_tests_cw340
-      bitstream: ${{ inputs.bitstream }}
-      board: cw340
-      interface: cw340
-      tag_filters: cw340_rom_ext
-      timeout: 180
-
-  execute_sival_fpga_tests_cw340:
-    name: CW340 SiVal Tests
-    uses: ./.github/workflows/fpga.yml
-    if: ${{ github.event_name != 'merge_group' }}
-    secrets: inherit
-    with:
-      name: CW340 SiVal Tests
-      job_name: execute_sival_fpga_tests_cw340
-      bitstream: ${{ inputs.bitstream }}
-      board: cw340
-      interface: cw340
-      tag_filters: "cw340_sival,-manuf"
-
-  execute_sival_rom_ext_fpga_tests_cw340:
-    name: CW340 SiVal ROM_EXT Tests
-    uses: ./.github/workflows/fpga.yml
-    if: ${{ github.event_name != 'merge_group' }}
-    secrets: inherit
-    with:
-      name: CW340 SiVal ROM_EXT Tests
-      job_name: execute_sival_rom_ext_fpga_tests_cw340
-      bitstream: ${{ inputs.bitstream }}
-      board: cw340
-      interface: cw340
-      tag_filters: cw340_sival_rom_ext
-      timeout: 180
-
-  execute_manuf_fpga_tests_cw340:
-    name: CW340 Manufacturing Tests
-    uses: ./.github/workflows/fpga.yml
-    if: ${{ github.event_name != 'merge_group' }}
-    secrets: inherit
-    with:
-      name: CW340 Manufacturing Tests
-      job_name: execute_manuf_fpga_tests_cw340
-      bitstream: ${{ inputs.bitstream }}
-      board: cw340
-      interface: cw340
-      tag_filters: "manuf,-cw310"
-
   execute_pqc_fpga_tests_cw340:
     name: CW340 PQCEn=1 Tests
     uses: ./.github/workflows/fpga.yml
@@ -111,14 +31,9 @@ jobs:
     name: Verify FPGA jobs
     uses: ./.github/workflows/verify-fpga.yml
     with:
-      test_group: "cw340-pr"
-      tag_filters: "cw340"
+      test_group: cw340-pr
+      tag_filters: cw340_pqc_test_rom
+      timeout_filters: 'short,moderate,long,eternal'
     needs:
-      - execute_test_rom_fpga_tests_cw340
-      - execute_rom_fpga_tests_cw340
-      - execute_rom_ext_fpga_tests_cw340
-      - execute_sival_fpga_tests_cw340
-      - execute_sival_rom_ext_fpga_tests_cw340
-      - execute_manuf_fpga_tests_cw340
       - execute_pqc_fpga_tests_cw340
     if: success() || failure()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,6 +26,15 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 
+  # Build non-PQC CW340 bitstream
+  chip_egret_cw340:
+    name: Egret for CW340
+    uses: ./.github/workflows/bitstream.yml
+    secrets: inherit
+    with:
+      top_name: egret
+      design_suffix: cw340
+
   # Hyper310 nightly FPGA jobs
   execute_nightly_tests_egret_cw310:
     name: Egret CW310 Nightly Tests
@@ -39,7 +48,9 @@ jobs:
   # CW340 nightly FPGA jobs
   execute_nightly_tests_egret_cw340:
     name: Egret CW340 Nightly Tests
-    needs: on-demand
+    needs:
+      - on-demand 
+      - chip_egret_cw340
     if: success() || failure()
     uses: ./.github/workflows/egret-cw340-nightly.yml
     secrets: inherit


### PR DESCRIPTION
CW340 runner wait time has been long due to limited hardware bandwidth, so this PR migrates the non-PQ CW340 tests to the nightly CI to speed up PR approvals.