### PR TITLE
[bazel] Make bazelisk.sh work on AArch64 macOS 

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -89,17 +89,17 @@ jobs:
           echo "$HOME/.local/share/venv/bin" >> "$GITHUB_PATH"
           ~/.local/share/venv/bin/pip install -r python-requirements.txt --require-hashes
       - name: Build device software
-        run: bazelisk build //sw/device/examples/hello_world:hello_world_sim_dv
+        run: ./bazelisk.sh build //sw/device/examples/hello_world:hello_world_sim_dv
       - name: Run UART smoketest on Verilator
         run: |
-          bazelisk test \
+          ./bazelisk.sh test \
             --build_tests_only=true \
             --test_timeout=2400,2400,4000,-1 \
             --test_output=errors \
             --//hw:verilator_options=--threads,1 \
             //sw/device/tests:uart_smoketest_sim_verilator
       - name: Run ACC ISS test
-        run: make -C hw/ip/acc/dv/accsim test bazel=bazelisk
+        run: make -C hw/ip/acc/dv/accsim test
 
   container_verilator_smoketest:
     name: Container Verilator smoketest (${{ matrix.image }}, ${{ matrix.runner }})

--- a/Brewfile
+++ b/Brewfile
@@ -6,7 +6,6 @@
 #
 # Keep it sorted.
 brew "autoconf"
-brew "bazelisk"
 brew "bison"
 brew "flex"
 brew "help2man"

--- a/bazelisk.sh
+++ b/bazelisk.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -13,10 +14,8 @@ set -eo pipefail
 cd "$(dirname "$0")"
 
 : "${CURL_FLAGS:=--silent}"
-: "${REPO_TOP:=$(git rev-parse --show-toplevel)}"
-: "${REPO_TOP:=$(dirname $0)}"
 : "${BINDIR:=.bin}"
-: "${BAZEL_BIN:=$(which bazel 2>/dev/null)}"
+: "${BAZEL_BIN:=$(command -v bazel 2>/dev/null)}"
 
 # Bazelisk (not Bazel) release. Keep this in sync with `util/container/Dockerfile`.
 readonly release="v1.24.1"
@@ -46,16 +45,19 @@ function check_hash() {
 }
 
 function prepare() {
+    local file="$1"
     local target
     target="$(os_arch)"
-    local bindir="${REPO_TOP}/${BINDIR}"
-    local file="${bindir}/bazelisk"
     local url="https://github.com/bazelbuild/bazelisk/releases/download/${release}/bazelisk-${target}"
+    local tmp
 
-    mkdir -p "$bindir"
-    echo "Downloading bazelisk ${release} (${url})." >> $bindir/bazelisk.log
-    curl ${CURL_FLAGS} --location "$url" --output "$file"
-    chmod +x "$file"
+    mkdir -p "$BINDIR"
+    echo "Downloading bazelisk ${release} (${url})." >> "${BINDIR}/bazelisk.log"
+    tmp="$(mktemp "${BINDIR}/bazelisk.XXXXXX")"
+    curl ${CURL_FLAGS} --location "$url" --output "$tmp"
+    chmod 755 "$tmp"
+    # Install atomically, so concurrent runs never see a partial download.
+    mv -f "$tmp" "$file"
 }
 
 function up_to_date() {
@@ -109,29 +111,17 @@ function do_outquery() {
 }
 
 function main() {
-    local bindir="${REPO_TOP}/${BINDIR}"
-    local file="${BAZEL_BIN:-${bindir}/bazelisk}"
-    local lockfile="${bindir}/bazelisk.lock"
+    local file="${BINDIR}/bazelisk"
 
     # If the user has Bazel in their PATH, check its version.
     # Fallback to bazelisk if it doesn't match.
-    if [ -x "$BAZEL_BIN" ]; then
-        if [ "$("$BAZEL_BIN" --version)" != "bazel $(cat .bazelversion)" ]; then
-            file="${bindir}/bazelisk"
-        fi
-    fi
-
-    # Are we using bazel from the user's PATH or using bazelisk?
-    if expr match "${file}" ".*bazelisk$" >/dev/null; then
+    if [ -x "$BAZEL_BIN" ] &&
+       [ "$("$BAZEL_BIN" --version)" = "bazel $(cat .bazelversion)" ]; then
+        file="$BAZEL_BIN"
+    elif ! up_to_date "$file"; then
+        prepare "$file"
         if ! up_to_date "$file"; then
-            # Grab the lock, blocking until success. Upon success, check again
-            # whether we're up to date (because some other process might have
-            # downloaded bazelisk in the meantime). If not, download it ourselves.
-            mkdir -p "$bindir"
-            (flock -x 9; up_to_date "$file" || prepare) 9>>"$lockfile"
-        fi
-        if ! check_hash "$file"; then
-            echo "sha256sum doesn't match expected value"
+            echo "sha256sum doesn't match expected value" >&2
             exit 1
         fi
     fi

--- a/bazelisk.sh
+++ b/bazelisk.sh
@@ -19,35 +19,37 @@ cd "$(dirname "$0")"
 
 # Bazelisk (not Bazel) release. Keep this in sync with `util/container/Dockerfile`.
 readonly release="v1.24.1"
-declare -A hashes=(
-    # sha256sums for v1.24.1.  Update this if you update the release.
-    [linux-amd64]="0aee09c71828b0012750cb9b689ce3575da8e230f265bf8d6dcd454eee6ea842"
-    [linux-arm64]="2a0e5d397f7ddbdac1deff4167c7681d9d1d025c5dfa979c2b37f091f032d01a"
-)
 
-declare -A architectures=(
-    # Map `uname -m -o` to bazelisk's precompiled binary target names.
-    [aarch64 GNU/Linux]="linux-arm64"
-    [x86_64 GNU/Linux]="linux-amd64"
-)
+case "$(uname -s -m)" in
+    "Linux x86_64")
+        readonly target="linux-amd64"
+        readonly hash="0aee09c71828b0012750cb9b689ce3575da8e230f265bf8d6dcd454eee6ea842"
+        ;;
+    "Linux aarch64")
+        readonly target="linux-arm64"
+        readonly hash="2a0e5d397f7ddbdac1deff4167c7681d9d1d025c5dfa979c2b37f091f032d01a"
+        ;;
+    "Darwin arm64")
+        readonly target="darwin-arm64"
+        readonly hash="1fb16a7fcf5b014e8a4179a3588a79e9b953ed69f2f22b612b2770150485e8d9"
+        ;;
+    *)
+        echo "No bazelisk release for $(uname -s -m)." >&2
+        exit 1
+        ;;
+esac
 
-function os_arch() {
-    local arch
-    arch="$(uname -m -o)"
-    echo "${architectures[$arch]:-${arch}}"
-}
-
-function check_hash() {
-    local file target
-    file="$1"
-    target="$(os_arch)"
-    echo "${hashes[$target]}  $file" | sha256sum --check --quiet
+# macOS has no `sha256sum`.
+function sha256() {
+    if command -v sha256sum >/dev/null; then
+        sha256sum "$1"
+    else
+        shasum -a 256 "$1"
+    fi | cut -d" " -f1
 }
 
 function prepare() {
     local file="$1"
-    local target
-    target="$(os_arch)"
     local url="https://github.com/bazelbuild/bazelisk/releases/download/${release}/bazelisk-${target}"
     local tmp
 
@@ -64,8 +66,7 @@ function up_to_date() {
     local file="$1"
     # We need an update if the file doesn't exist or it has the wrong hash
     test -f "$file" || return 1
-    check_hash "$file" || return 1
-    return 0
+    test "$(sha256 "$file")" = "$hash"
 }
 
 function outquery_starlark_expr() {


### PR DESCRIPTION
#385 added partial macOS support but skipped making bazelisk.sh portable. As bazelisk.sh is the recommended way of using Pavona right now, this PR makes bazelisk.sh portable. I've done a few simplifications on the way. See the individual commits. 

- Resolves #413 