### PR TITLE
[acc,crypto] Drop redundant `.globl` before `.weak`

### DIFF
--- a/sw/acc/crypto/p384_base_mult.s
+++ b/sw/acc/crypto/p384_base_mult.s
@@ -135,25 +135,21 @@ p384_base_mult:
 .balign 32
 
 /* 1st private key share d0 */
-.globl d0
 .weak d0
 d0:
   .zero 64
 
 /* 2nd private key share d1 */
-.globl d1
 .weak d1
 d1:
   .zero 64
 
 /* buffer for x-coordinate */
-.globl x
 .weak x
 x:
   .zero 64
 
 /* buffer for y-coordinate */
-.globl y
 .weak y
 y:
   .zero 64

--- a/sw/acc/crypto/p384_isoncurve.s
+++ b/sw/acc/crypto/p384_isoncurve.s
@@ -357,28 +357,24 @@ ok:
   .zero 4
 
 /* x-coordinate */
-.globl x
 .weak x
 .balign 32
 x:
   .zero 64
 
 /* y-coordinate */
-.globl y
 .weak y
 .balign 32
 y:
   .zero 64
 
 /* Right side of Weierstrass equation */
-.globl rhs
 .weak rhs
 .balign 32
 rhs:
   .zero 64
 
 /* Left side of Weierstrass equation */
-.globl lhs
 .weak lhs
 .balign 32
 lhs:

--- a/sw/acc/crypto/p384_keygen.s
+++ b/sw/acc/crypto/p384_keygen.s
@@ -258,25 +258,21 @@ p384_generate_k:
 .balign 32
 
 /* 1st scalar share d0 */
-.globl k0
 .weak k0
 k0:
   .zero 64
 
 /* 2nd scalar share d1 */
-.globl k1
 .weak k1
 k1:
   .zero 64
 
 /* 1st private key share d0 */
-.globl d0
 .weak d0
 d0:
   .zero 64
 
 /* 2nd private key share d1 */
-.globl d1
 .weak d1
 d1:
   .zero 64

--- a/sw/acc/crypto/p384_keygen_from_seed.s
+++ b/sw/acc/crypto/p384_keygen_from_seed.s
@@ -221,13 +221,11 @@ p384_key_from_seed:
 .balign 32
 
 /* 1st private key share d0 */
-.globl d0
 .weak d0
 d0:
   .zero 64
 
 /* 2nd private key share d1 */
-.globl d1
 .weak d1
 d1:
   .zero 64

--- a/sw/acc/crypto/p384_scalar_mult.s
+++ b/sw/acc/crypto/p384_scalar_mult.s
@@ -199,25 +199,21 @@ p384_scalar_mult:
 .balign 32
 
 /* 1st scalar share d0 */
-.globl d0
 .weak d0
 d0:
   .zero 64
 
 /* 2nd scalar share d1 */
-.globl d1
 .weak d1
 d1:
   .zero 64
 
 /* x-coordinate */
-.globl x
 .weak x
 x:
   .zero 64
 
 /* y-coordinate */
-.globl y
 .weak y
 y:
   .zero 64

--- a/sw/acc/crypto/p384_sign.s
+++ b/sw/acc/crypto/p384_sign.s
@@ -351,43 +351,36 @@ p384_sign:
 .balign 32
 
 /* message to be signed */
-.globl msg
 .weak msg
 msg:
   .zero 64
 
 /* r component of signature */
-.globl r
 .weak r
 r:
   .zero 64
 
 /* s component of signature */
-.globl s
 .weak s
 s:
   .zero 64
 
 /* 1st scalar share d0 */
-.globl k0
 .weak k0
 k0:
   .zero 64
 
 /* 2nd scalar share d1 */
-.globl k1
 .weak k1
 k1:
   .zero 64
 
 /* 1st private key share d0 */
-.globl d0
 .weak d0
 d0:
   .zero 64
 
 /* 2nd private key share d1 */
-.globl d1
 .weak d1
 d1:
   .zero 64

--- a/sw/acc/crypto/p384_verify.s
+++ b/sw/acc/crypto/p384_verify.s
@@ -450,37 +450,31 @@ p384_verify:
 .balign 32
 
 /* message to be signed */
-.globl msg
 .weak msg
 msg:
   .zero 64
 
 /* r component of signature */
-.globl r
 .weak r
 r:
   .zero 64
 
 /* s component of signature */
-.globl s
 .weak s
 s:
   .zero 64
 
 /* public key x-coordinate */
-.globl x
 .weak x
 x:
   .zero 64
 
 /* public key y-coordinate */
-.globl y
 .weak y
 y:
   .zero 64
 
 /* verification result (x1-coordinate) */
-.globl x_r
 .weak x_r
 x_r:
   .zero 64

--- a/sw/acc/crypto/sha256.s
+++ b/sw/acc/crypto/sha256.s
@@ -500,7 +500,6 @@ sha256_K:
 
 /* Working state. */
 .balign 32
-.globl state
 .weak state
 state:
 .zero 32

--- a/sw/acc/crypto/sha512.s
+++ b/sw/acc/crypto/sha512.s
@@ -866,7 +866,6 @@ ret
 .bss
 
 /* number of chunks to process */
-.globl n_chunks
 .weak n_chunks
 .balign 4
 n_chunks:

--- a/sw/acc/crypto/sha512_compact.s
+++ b/sw/acc/crypto/sha512_compact.s
@@ -342,7 +342,6 @@ sha512_compact:
 .bss
 
 /* number of chunks to process */
-.globl sha512_n_chunks
 .weak sha512_n_chunks
 .balign 4
 sha512_n_chunks:


### PR DESCRIPTION
The LLVM assembler warns "changed binding to STB_WEAK" whenever .globl is followed by .weak for the same symbol. .weak already gives the symbol external linkage, so the .globl is redundant.

- Fixes #434