### PR TITLE
[reggen,rtl] Reapply "Derive alert fatality from reg metadata"

### DIFF
--- a/hw/ip/acc/rtl/acc.sv
+++ b/hw/ip/acc/rtl/acc.sv
@@ -1033,27 +1033,27 @@ module acc
   // Alerts ====================================================================
 
   logic [NumAlerts-1:0] alert_test;
-  assign alert_test[AlertFatal] = reg2hw.alert_test.fatal.q & reg2hw.alert_test.fatal.qe;
-  assign alert_test[AlertRecov] = reg2hw.alert_test.recov.q & reg2hw.alert_test.recov.qe;
+  assign alert_test[AlertFatalIdx] = reg2hw.alert_test.fatal.q & reg2hw.alert_test.fatal.qe;
+  assign alert_test[AlertRecovIdx] = reg2hw.alert_test.recov.q & reg2hw.alert_test.recov.qe;
 
   logic [NumAlerts-1:0] alerts;
-  assign alerts[AlertFatal] = |{err_bits.kmac_fatal_error,
-                                err_bits.fatal_software,
-                                err_bits.lifecycle_escalation,
-                                err_bits.illegal_bus_access,
-                                err_bits.bad_internal_state,
-                                err_bits.bus_intg_violation,
-                                err_bits.reg_intg_violation,
-                                err_bits.dmem_intg_violation,
-                                err_bits.imem_intg_violation};
+  assign alerts[AlertFatalIdx] = |{err_bits.kmac_fatal_error,
+                                   err_bits.fatal_software,
+                                   err_bits.lifecycle_escalation,
+                                   err_bits.illegal_bus_access,
+                                   err_bits.bad_internal_state,
+                                   err_bits.bus_intg_violation,
+                                   err_bits.reg_intg_violation,
+                                   err_bits.dmem_intg_violation,
+                                   err_bits.imem_intg_violation};
 
-  assign alerts[AlertRecov] = (core_recoverable_err | recoverable_err_q) & done_core;
+  assign alerts[AlertRecovIdx] = (core_recoverable_err | recoverable_err_q) & done_core;
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(i == AlertFatal)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni       (rst_n),
@@ -1264,7 +1264,7 @@ module acc
     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(
       LoopStackCntAlertCheck_A,
       u_acc_core.u_acc_controller.u_acc_loop_controller.g_loop_counters[i].u_loop_count,
-      alert_tx_o[AlertFatal]
+      alert_tx_o[AlertFatalIdx]
     )
   end
 
@@ -1454,46 +1454,46 @@ module acc
   `ASSERT_INIT(WsrESizeMatchesParameter_A, $bits(wsr_e) == WsrNumWidth)
 
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(AccStartStopFsmCheck_A,
-    u_acc_core.u_acc_start_stop_control.u_state_regs, alert_tx_o[AlertFatal])
+    u_acc_core.u_acc_start_stop_control.u_state_regs, alert_tx_o[AlertFatalIdx])
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(AccControllerFsmCheck_A,
-    u_acc_core.u_acc_controller.u_state_regs, alert_tx_o[AlertFatal])
+    u_acc_core.u_acc_controller.u_state_regs, alert_tx_o[AlertFatalIdx])
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(AccScrambleCtrlFsmCheck_A,
-    u_acc_scramble_ctrl.u_state_regs, alert_tx_o[AlertFatal])
+    u_acc_scramble_ctrl.u_state_regs, alert_tx_o[AlertFatalIdx])
 
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(AccCallStackWrPtrAlertCheck_A,
-    u_acc_core.u_acc_rf_base.u_call_stack.u_stack_wr_ptr, alert_tx_o[AlertFatal])
+    u_acc_core.u_acc_rf_base.u_call_stack.u_stack_wr_ptr, alert_tx_o[AlertFatalIdx])
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(AccLoopInfoStackWrPtrAlertCheck_A,
     u_acc_core.u_acc_controller.u_acc_loop_controller.loop_info_stack.u_stack_wr_ptr,
-    alert_tx_o[AlertFatal])
+    alert_tx_o[AlertFatalIdx])
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A,
-      u_reg, alert_tx_o[AlertFatal])
+      u_reg, alert_tx_o[AlertFatalIdx])
   // other onehot checks
   `ASSERT_PRIM_ONEHOT_ERROR_TRIGGER_ALERT(RfBaseOnehotCheck_A,
       u_acc_core.u_acc_rf_base.gen_rf_base_ff.u_acc_rf_base_inner.u_prim_onehot_check,
-      alert_tx_o[AlertFatal])
+      alert_tx_o[AlertFatalIdx])
   `ASSERT_PRIM_ONEHOT_ERROR_TRIGGER_ALERT(RfBignumOnehotCheck_A,
       u_acc_core.u_acc_rf_bignum.gen_rf_bignum_ff.u_acc_rf_bignum_inner.u_prim_onehot_check,
-      alert_tx_o[AlertFatal])
+      alert_tx_o[AlertFatalIdx])
 
   `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1(DmemRspFifo,
                                                u_tlul_adapter_sram_dmem.u_rspfifo,
-                                               alert_tx_o[AlertFatal])
+                                               alert_tx_o[AlertFatalIdx])
   `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1(DmemSramReqFifo,
                                                u_tlul_adapter_sram_dmem.u_sramreqfifo,
-                                               alert_tx_o[AlertFatal])
+                                               alert_tx_o[AlertFatalIdx])
   `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1(DmemReqFifo,
                                                u_tlul_adapter_sram_dmem.u_reqfifo,
-                                               alert_tx_o[AlertFatal])
+                                               alert_tx_o[AlertFatalIdx])
 
   `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1(ImemRspFifo,
                                                u_tlul_adapter_sram_imem.u_rspfifo,
-                                               alert_tx_o[AlertFatal])
+                                               alert_tx_o[AlertFatalIdx])
   `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1(ImemSramReqFifo,
                                                u_tlul_adapter_sram_imem.u_sramreqfifo,
-                                               alert_tx_o[AlertFatal])
+                                               alert_tx_o[AlertFatalIdx])
   `ASSERT_PRIM_FIFO_SYNC_ERROR_TRIGGERS_ALERT1(ImemReqFifo,
                                                u_tlul_adapter_sram_imem.u_reqfifo,
-                                               alert_tx_o[AlertFatal])
+                                               alert_tx_o[AlertFatalIdx])
 endmodule

--- a/hw/ip/acc/rtl/acc_pkg.sv
+++ b/hw/ip/acc/rtl/acc_pkg.sv
@@ -71,9 +71,6 @@ package acc_pkg;
 
   // Toplevel constants ============================================================================
 
-  parameter int AlertFatal = 0;
-  parameter int AlertRecov = 1;
-
   // Register file implementation selection enum.
   typedef enum integer {
     RegFileFF    = 0, // Generic flip-flop based implementation

--- a/hw/ip/acc/rtl/acc_reg_pkg.sv
+++ b/hw/ip/acc/rtl/acc_reg_pkg.sv
@@ -21,6 +21,12 @@ package acc_reg_pkg;
     AlertRecovIdx = 1
   } acc_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b0, // recov
+    1'b1 // fatal
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl.sv
@@ -54,12 +54,12 @@ module adc_ctrl
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i (alert_test[i]),
-      .alert_req_i  (alerts[0]),
+      .alert_req_i  (alerts[i]),
       .alert_ack_o  (),
       .alert_state_o(),
       .alert_rx_i   (alert_rx_i[i]),

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
@@ -22,6 +22,11 @@ package adc_ctrl_reg_pkg;
     AlertFatalFaultIdx = 0
   } adc_ctrl_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -228,7 +228,7 @@ module aes
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(i == AlertFatalFaultIdx)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -24,6 +24,12 @@ package aes_reg_pkg;
     AlertFatalFaultIdx = 1
   } aes_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1, // fatal_fault
+    1'b0 // recov_ctrl_update_err
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/aon_timer/rtl/aon_timer.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer.sv
@@ -134,12 +134,12 @@ module aon_timer import aon_timer_reg_pkg::*;
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
@@ -20,6 +20,11 @@ package aon_timer_reg_pkg;
     AlertFatalFaultIdx = 0
   } aon_timer_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/ascon/rtl/ascon.sv
+++ b/hw/ip/ascon/rtl/ascon.sv
@@ -136,7 +136,7 @@ module ascon
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(i)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/ip/ascon/rtl/ascon_reg_pkg.sv
+++ b/hw/ip/ascon/rtl/ascon_reg_pkg.sv
@@ -16,6 +16,21 @@ package ascon_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 8;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 47;
+
+  // Alert indices
+  typedef enum int {
+    AlertRecovCtrlUpdateErrIdx = 0,
+    AlertFatalFaultIdx = 1
+  } ascon_alert_idx_t;
+
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b0, // recov_ctrl_update_err
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////
@@ -171,30 +186,18 @@ package ascon_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } start;
+    } wipe;
     struct packed {
       logic        d;
       logic        de;
-    } wipe;
+    } start;
   } ascon_hw2reg_trigger_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } idle;
-    struct packed {
-      logic        d;
-      logic        de;
-    } stall;
-    struct packed {
-      logic        d;
-      logic        de;
-    } wait_edn;
-    struct packed {
-      logic        d;
-      logic        de;
-    } ascon_error;
+    } alert_fatal_fault;
     struct packed {
       logic        d;
       logic        de;
@@ -202,22 +205,34 @@ package ascon_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } alert_fatal_fault;
+    } ascon_error;
+    struct packed {
+      logic        d;
+      logic        de;
+    } wait_edn;
+    struct packed {
+      logic        d;
+      logic        de;
+    } stall;
+    struct packed {
+      logic        d;
+      logic        de;
+    } idle;
   } ascon_hw2reg_status_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic        d;
+      logic [1:0]  d;
       logic        de;
-    } msg_valid;
+    } tag_comparison_valid;
     struct packed {
       logic        d;
       logic        de;
     } tag_valid;
     struct packed {
-      logic [1:0]  d;
+      logic        d;
       logic        de;
-    } tag_comparison_valid;
+    } msg_valid;
   } ascon_hw2reg_output_valid_reg_t;
 
   typedef struct packed {
@@ -228,11 +243,7 @@ package ascon_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } no_key;
-    struct packed {
-      logic        d;
-      logic        de;
-    } no_nonce;
+    } flag_input_missmatch;
     struct packed {
       logic        d;
       logic        de;
@@ -240,7 +251,11 @@ package ascon_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } flag_input_missmatch;
+    } no_nonce;
+    struct packed {
+      logic        d;
+      logic        de;
+    } no_key;
   } ascon_hw2reg_error_reg_t;
 
   // Register -> HW type

--- a/hw/ip/ascon/rtl/ascon_reg_top.sv
+++ b/hw/ip/ascon/rtl/ascon_reg_top.sv
@@ -2057,7 +2057,6 @@ module ascon_reg_top (
 
   logic [46:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == ASCON_ALERT_TEST_OFFSET);
     addr_hit[ 1] = (reg_addr == ASCON_KEY_SHARE0_0_OFFSET);
     addr_hit[ 2] = (reg_addr == ASCON_KEY_SHARE0_1_OFFSET);
@@ -2304,7 +2303,6 @@ module ascon_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = key_share0_0_we;
     reg_we_check[2] = key_share0_1_we;

--- a/hw/ip/csrng/rtl/csrng.sv
+++ b/hw/ip/csrng/rtl/csrng.sv
@@ -125,7 +125,7 @@ module csrng
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(i)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -22,6 +22,12 @@ package csrng_reg_pkg;
     AlertFatalAlertIdx = 1
   } csrng_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1, // fatal_alert
+    1'b0 // recov_alert
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -189,7 +189,7 @@ module dma
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/ip/dma/rtl/dma_reg_pkg.sv
+++ b/hw/ip/dma/rtl/dma_reg_pkg.sv
@@ -21,6 +21,11 @@ package dma_reg_pkg;
     AlertFatalFaultIdx = 0
   } dma_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/edn/rtl/edn.sv
+++ b/hw/ip/edn/rtl/edn.sv
@@ -97,7 +97,7 @@ module edn
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(i)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -25,6 +25,12 @@ package edn_reg_pkg;
     AlertFatalAlertIdx = 1
   } edn_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1, // fatal_alert
+    1'b0 // recov_alert
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/entropy_src/rtl/entropy_src.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src.sv
@@ -277,7 +277,7 @@ module entropy_src
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(i)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -22,6 +22,12 @@ package entropy_src_reg_pkg;
     AlertFatalAlertIdx = 1
   } entropy_src_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1, // fatal_alert
+    1'b0 // recov_alert
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -773,7 +773,6 @@ module hmac
     reg2hw.alert_test.qe
   };
 
-  localparam logic [NumAlerts-1:0] AlertIsFatal = {1'b1};
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
@@ -783,7 +782,7 @@ module hmac
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/ip/hmac/rtl/hmac_reg_pkg.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_pkg.sv
@@ -22,6 +22,11 @@ package hmac_reg_pkg;
     AlertFatalFaultIdx = 0
   } hmac_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/i2c/rtl/i2c.sv
+++ b/hw/ip/i2c/rtl/i2c.sv
@@ -93,12 +93,12 @@ module i2c
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -22,6 +22,11 @@ package i2c_reg_pkg;
     AlertFatalFaultIdx = 0
   } i2c_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -742,7 +742,7 @@ module keymgr
   prim_alert_sender #(
     .AsyncOn(AlertAsyncOn[1]),
     .SkewCycles(AlertSkewCycles),
-    .IsFatal(1)
+    .IsFatal(AlertIsFatal[1])
   ) u_fault_alert (
     .clk_i,
     .rst_ni,
@@ -760,7 +760,7 @@ module keymgr
   prim_alert_sender #(
     .AsyncOn(AlertAsyncOn[0]),
     .SkewCycles(AlertSkewCycles),
-    .IsFatal(0)
+    .IsFatal(AlertIsFatal[0])
   ) u_op_err_alert (
     .clk_i,
     .rst_ni,

--- a/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
@@ -25,6 +25,12 @@ package keymgr_reg_pkg;
     AlertFatalFaultErrIdx = 1
   } keymgr_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1, // fatal_fault_err
+    1'b0 // recov_operation_err
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
@@ -762,7 +762,7 @@ module keymgr_dpe
   prim_alert_sender #(
     .AsyncOn(AlertAsyncOn[1]),
     .SkewCycles(AlertSkewCycles),
-    .IsFatal(1)
+    .IsFatal(AlertIsFatal[1])
   ) u_fault_alert (
     .clk_i,
     .rst_ni,
@@ -780,7 +780,7 @@ module keymgr_dpe
   prim_alert_sender #(
     .AsyncOn(AlertAsyncOn[0]),
     .SkewCycles(AlertSkewCycles),
-    .IsFatal(0)
+    .IsFatal(AlertIsFatal[0])
   ) u_op_err_alert (
     .clk_i,
     .rst_ni,

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_pkg.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_pkg.sv
@@ -26,6 +26,12 @@ package keymgr_dpe_reg_pkg;
     AlertFatalFaultErrIdx = 1
   } keymgr_dpe_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1, // fatal_fault_err
+    1'b0 // recov_operation_err
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -1477,7 +1477,7 @@ module kmac
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(i)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -27,6 +27,12 @@ package kmac_reg_pkg;
     AlertFatalFaultErrIdx = 1
   } kmac_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1, // fatal_fault_err
+    1'b0 // recov_operation_err
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -651,7 +651,7 @@ module lc_ctrl
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[k]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1)
+      .IsFatal(AlertIsFatal[k])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
@@ -35,6 +35,13 @@ package lc_ctrl_reg_pkg;
     AlertFatalBusIntegErrorIdx = 2
   } lc_ctrl_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1, // fatal_bus_integ_error
+    1'b1, // fatal_state_error
+    1'b1 // fatal_prog_error
+  };
+
   ///////////////////////////////////////////////
   // Typedefs for registers for regs interface //
   ///////////////////////////////////////////////

--- a/hw/ip/mbx/rtl/mbx_hostif.sv
+++ b/hw/ip/mbx/rtl/mbx_hostif.sv
@@ -88,12 +88,11 @@ module mbx_hostif
   assign alerts[0] = tlul_intg_err | intg_err_i;
   assign alerts[1] = sram_err_i;
 
-  localparam logic [NumAlerts-1:0] IsFatal = {1'b0, 1'b1};
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn   ( AlertAsyncOn[i] ),
       .SkewCycles( AlertSkewCycles ),
-      .IsFatal   ( IsFatal[i]      )
+      .IsFatal   ( AlertIsFatal[i] )
     ) u_prim_alert_sender (
     .clk_i          ( clk_i         ),
     .rst_ni         ( rst_ni        ),

--- a/hw/ip/mbx/rtl/mbx_reg_pkg.sv
+++ b/hw/ip/mbx/rtl/mbx_reg_pkg.sv
@@ -23,6 +23,12 @@ package mbx_reg_pkg;
     AlertRecovFaultIdx = 1
   } mbx_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b0, // recov_fault
+    1'b1 // fatal_fault
+  };
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/ip/pattgen/rtl/pattgen.sv
+++ b/hw/ip/pattgen/rtl/pattgen.sv
@@ -57,12 +57,12 @@ module pattgen
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/ip/pattgen/rtl/pattgen_reg_pkg.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_pkg.sv
@@ -21,6 +21,11 @@ package pattgen_reg_pkg;
     AlertFatalFaultIdx = 0
   } pattgen_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -503,7 +503,7 @@ module rom_ctrl
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(i == AlertFatalIdx)
+      .IsFatal(AlertIsFatal[i])
     ) u_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_reg_pkg.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_reg_pkg.sv
@@ -20,6 +20,11 @@ package rom_ctrl_reg_pkg;
     AlertFatalIdx = 0
   } rom_ctrl_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal
+  };
+
   ///////////////////////////////////////////////
   // Typedefs for registers for regs interface //
   ///////////////////////////////////////////////

--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -166,12 +166,12 @@ module rv_dm
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/ip/rv_dm/rtl/rv_dm_reg_pkg.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_reg_pkg.sv
@@ -25,6 +25,11 @@ package rv_dm_reg_pkg;
     AlertFatalFaultIdx = 0
   } rv_dm_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ///////////////////////////////////////////////
   // Typedefs for registers for regs interface //
   ///////////////////////////////////////////////

--- a/hw/ip/rv_timer/rtl/rv_timer.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer.sv
@@ -154,12 +154,12 @@ module rv_timer import rv_timer_reg_pkg::*;
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
@@ -22,6 +22,11 @@ package rv_timer_reg_pkg;
     AlertFatalFaultIdx = 0
   } rv_timer_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl.sv
+++ b/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl.sv
@@ -65,12 +65,11 @@ module soc_dbg_ctrl
   assign alert_test[1] = core_reg2hw.alert_test.recov_ctrl_update_err.q &
                          core_reg2hw.alert_test.recov_ctrl_update_err.qe;
 
-  localparam logic [NumAlerts-1:0] IsFatal = {1'b0, 1'b1};
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(IsFatal[i])
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_reg_pkg.sv
+++ b/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_reg_pkg.sv
@@ -23,6 +23,12 @@ package soc_dbg_ctrl_reg_pkg;
     AlertRecovCtrlUpdateErrIdx = 1
   } soc_dbg_ctrl_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b0, // recov_ctrl_update_err
+    1'b1 // fatal_fault
+  };
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -1941,12 +1941,12 @@ module spi_device
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -43,6 +43,11 @@ package spi_device_reg_pkg;
     AlertFatalFaultIdx = 0
   } spi_device_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -115,12 +115,12 @@ module spi_host
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
@@ -24,6 +24,11 @@ package spi_host_reg_pkg;
     AlertFatalFaultIdx = 0
   } spi_host_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -207,7 +207,7 @@ module sram_ctrl
   prim_alert_sender #(
     .AsyncOn(AlertAsyncOn[0]),
     .SkewCycles(AlertSkewCycles),
-    .IsFatal(1)
+    .IsFatal(AlertIsFatal[0])
   ) u_prim_alert_sender_parity (
     .clk_i,
     .rst_ni,

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
@@ -20,6 +20,11 @@ package sram_ctrl_reg_pkg;
     AlertFatalErrorIdx = 0
   } sram_ctrl_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_error
+  };
+
   ///////////////////////////////////////////////
   // Typedefs for registers for regs interface //
   ///////////////////////////////////////////////

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl.sv
@@ -73,12 +73,12 @@ module sysrst_ctrl
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i (alert_test[i]),
-      .alert_req_i  (alerts[0]),
+      .alert_req_i  (alerts[i]),
       .alert_ack_o  (),
       .alert_state_o(),
       .alert_rx_i   (alert_rx_i[i]),

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_pkg.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_pkg.sv
@@ -24,6 +24,11 @@ package sysrst_ctrl_reg_pkg;
     AlertFatalFaultIdx = 0
   } sysrst_ctrl_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/uart/rtl/uart.sv
+++ b/hw/ip/uart/rtl/uart.sv
@@ -103,12 +103,12 @@ module uart
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/ip/uart/rtl/uart_reg_pkg.sv
+++ b/hw/ip/uart/rtl/uart_reg_pkg.sv
@@ -22,6 +22,11 @@ package uart_reg_pkg;
     AlertFatalFaultIdx = 0
   } uart_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -927,7 +927,6 @@ module usbdev
   };
 
   // Alerts not stubbed off because registers and T-L access still present.
-  localparam logic [NumAlerts-1:0] AlertIsFatal = {NumAlerts{1'b1}};
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
@@ -937,7 +936,7 @@ module usbdev
       .clk_i,
       .rst_ni, // this reset is not stubbed off so that the pings still work.
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -21,6 +21,11 @@ package usbdev_reg_pkg;
     AlertFatalFaultIdx = 0
   } usbdev_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
+++ b/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
@@ -88,7 +88,7 @@ module ${module_instance_name}
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(i == AlertFatalFaultIdx)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i         ( clk_i         ),
       .rst_ni        ( rst_ni        ),

--- a/hw/ip_templates/clkmgr/rtl/clkmgr.sv.tpl
+++ b/hw/ip_templates/clkmgr/rtl/clkmgr.sv.tpl
@@ -254,13 +254,11 @@ rg_srcs = get_rg_srcs(typed_clocks)
     recov_alert
   };
 
-  localparam logic [NumAlerts-1:0] AlertFatal = {1'b1, 1'b0};
-
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(AlertFatal[i])
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/ip_templates/flash_ctrl/rtl/flash_ctrl.sv.tpl
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_ctrl.sv.tpl
@@ -955,12 +955,11 @@ module flash_ctrl
   // reset for these bits.
   //
   // For more details, refer to lowRISC/OpenTitan#21353.
-  localparam logic [NumAlerts-1:0] IsFatal = {1'b0, 1'b1, 1'b0, 1'b1, 1'b0};
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(IsFatal[i])
+      .IsFatal(i == AlertFatalErrIdx? 1'b0 : AlertIsFatal[i])
     ) u_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/ip_templates/gpio/rtl/gpio.sv.tpl
+++ b/hw/ip_templates/gpio/rtl/gpio.sv.tpl
@@ -379,12 +379,12 @@ module ${module_instance_name}
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/ip_templates/pinmux/rtl/pinmux.sv.tpl
+++ b/hw/ip_templates/pinmux/rtl/pinmux.sv.tpl
@@ -153,12 +153,12 @@ module pinmux
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/ip_templates/pwm/rtl/pwm.sv.tpl
+++ b/hw/ip_templates/pwm/rtl/pwm.sv.tpl
@@ -66,12 +66,12 @@ module ${module_instance_name}
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/ip_templates/pwrmgr/rtl/pwrmgr.sv.tpl
+++ b/hw/ip_templates/pwrmgr/rtl/pwrmgr.sv.tpl
@@ -401,7 +401,7 @@ module pwrmgr
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i         ( clk_lc        ),
       .rst_ni        ( rst_lc_n      ),

--- a/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
+++ b/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
@@ -93,9 +93,9 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
-      .AsyncOn    ( AlertAsyncOn[i]         ),
-      .SkewCycles ( AlertSkewCycles         ),
-      .IsFatal    ( i == AlertFatalFaultIdx )
+      .AsyncOn    ( AlertAsyncOn[i] ),
+      .SkewCycles ( AlertSkewCycles ),
+      .IsFatal    ( AlertIsFatal[i] )
     ) u_prim_alert_sender (
       .clk_i         ( clk_i         ),
       .rst_ni        ( rst_ni        ),

--- a/hw/ip_templates/rstmgr/rtl/rstmgr.sv.tpl
+++ b/hw/ip_templates/rstmgr/rtl/rstmgr.sv.tpl
@@ -224,7 +224,7 @@ module rstmgr
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
+++ b/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
@@ -925,8 +925,6 @@ module ${module_instance_name}
   assign alert_test[3] = reg2hw.alert_test.recov_hw_err.q &
                          reg2hw.alert_test.recov_hw_err.qe;
 
-  localparam bit [NumAlerts-1:0] AlertFatal = '{1'b0, 1'b1, 1'b0, 1'b1};
-
   logic [NumAlerts-1:0] alert_events;
   logic [NumAlerts-1:0] alert_acks;
 
@@ -947,9 +945,9 @@ module ${module_instance_name}
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
-      .AsyncOn(AlertAsyncOn[0]),
+      .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(AlertFatal[i])
+      .IsFatal(AlertIsFatal[i])
     ) u_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex_peri.sv.tpl
+++ b/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex_peri.sv.tpl
@@ -99,8 +99,6 @@ module ${module_instance_name}_peri
   assign alert_test[3] = reg2hw.alert_test.recov_hw_err.q &
                          reg2hw.alert_test.recov_hw_err.qe;
 
-  localparam bit [NumAlerts-1:0] AlertFatal = '{1, 0, 1, 0};
-
   logic [NumAlerts-1:0] alert_events;
 
   assign alert_events[0] = reg2hw.sw_alert[0].q != EventOff;
@@ -110,9 +108,9 @@ module ${module_instance_name}_peri
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
-      .AsyncOn(AlertAsyncOn[0]),
+      .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(AlertFatal[i])
+      .IsFatal(AlertIsFatal[i])
     ) u_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/top_dragonfly/ip/soc_proxy/rtl/soc_proxy_reg_pkg.sv
+++ b/hw/top_dragonfly/ip/soc_proxy/rtl/soc_proxy_reg_pkg.sv
@@ -20,6 +20,11 @@ package soc_proxy_reg_pkg;
     AlertFatalAlertIntgIdx = 0
   } soc_proxy_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_alert_intg
+  };
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/top_dragonfly/ip_autogen/ac_range_check/rtl/ac_range_check.sv
+++ b/hw/top_dragonfly/ip_autogen/ac_range_check/rtl/ac_range_check.sv
@@ -88,7 +88,7 @@ module ac_range_check
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(i == AlertFatalFaultIdx)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i         ( clk_i         ),
       .rst_ni        ( rst_ni        ),

--- a/hw/top_dragonfly/ip_autogen/ac_range_check/rtl/ac_range_check_reg_pkg.sv
+++ b/hw/top_dragonfly/ip_autogen/ac_range_check/rtl/ac_range_check_reg_pkg.sv
@@ -23,6 +23,12 @@ package ac_range_check_reg_pkg;
     AlertFatalFaultIdx = 1
   } ac_range_check_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1, // fatal_fault
+    1'b0 // recov_ctrl_update_err
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_dragonfly/ip_autogen/clkmgr/rtl/clkmgr.sv
+++ b/hw/top_dragonfly/ip_autogen/clkmgr/rtl/clkmgr.sv
@@ -158,13 +158,11 @@
     recov_alert
   };
 
-  localparam logic [NumAlerts-1:0] AlertFatal = {1'b1, 1'b0};
-
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(AlertFatal[i])
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/top_dragonfly/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/top_dragonfly/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -24,6 +24,12 @@ package clkmgr_reg_pkg;
     AlertFatalFaultIdx = 1
   } clkmgr_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1, // fatal_fault
+    1'b0 // recov_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_dragonfly/ip_autogen/gpio/rtl/gpio.sv
+++ b/hw/top_dragonfly/ip_autogen/gpio/rtl/gpio.sv
@@ -375,12 +375,12 @@ module gpio
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/top_dragonfly/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
+++ b/hw/top_dragonfly/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
@@ -22,6 +22,11 @@ package gpio_reg_pkg;
     AlertFatalFaultIdx = 0
   } gpio_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_dragonfly/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/top_dragonfly/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -426,6 +426,15 @@ package otp_ctrl_reg_pkg;
     AlertRecovPrimOtpAlertIdx = 4
   } otp_ctrl_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b0, // recov_prim_otp_alert
+    1'b1, // fatal_prim_otp_alert
+    1'b1, // fatal_bus_integ_error
+    1'b1, // fatal_check_error
+    1'b1 // fatal_macro_error
+  };
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/top_dragonfly/ip_autogen/pinmux/rtl/pinmux.sv
+++ b/hw/top_dragonfly/ip_autogen/pinmux/rtl/pinmux.sv
@@ -92,12 +92,12 @@ module pinmux
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/top_dragonfly/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/top_dragonfly/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
@@ -26,6 +26,11 @@ package pinmux_reg_pkg;
     AlertFatalFaultIdx = 0
   } pinmux_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_dragonfly/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_dragonfly/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -386,7 +386,7 @@ module pwrmgr
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i         ( clk_lc        ),
       .rst_ni        ( rst_lc_n      ),

--- a/hw/top_dragonfly/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/top_dragonfly/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -31,6 +31,11 @@ package pwrmgr_reg_pkg;
     AlertFatalFaultIdx = 0
   } pwrmgr_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_dragonfly/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
+++ b/hw/top_dragonfly/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
@@ -76,9 +76,9 @@ module racl_ctrl import racl_ctrl_reg_pkg::*; #(
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
-      .AsyncOn    ( AlertAsyncOn[i]         ),
-      .SkewCycles ( AlertSkewCycles         ),
-      .IsFatal    ( i == AlertFatalFaultIdx )
+      .AsyncOn    ( AlertAsyncOn[i] ),
+      .SkewCycles ( AlertSkewCycles ),
+      .IsFatal    ( AlertIsFatal[i] )
     ) u_prim_alert_sender (
       .clk_i         ( clk_i         ),
       .rst_ni        ( rst_ni        ),

--- a/hw/top_dragonfly/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
+++ b/hw/top_dragonfly/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
@@ -21,6 +21,12 @@ package racl_ctrl_reg_pkg;
     AlertRecovCtrlUpdateErrIdx = 1
   } racl_ctrl_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b0, // recov_ctrl_update_err
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_dragonfly/ip_autogen/rstmgr/rtl/rstmgr.sv
+++ b/hw/top_dragonfly/ip_autogen/rstmgr/rtl/rstmgr.sv
@@ -218,7 +218,7 @@ module rstmgr
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/top_dragonfly/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
+++ b/hw/top_dragonfly/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
@@ -26,6 +26,12 @@ package rstmgr_reg_pkg;
     AlertFatalCnstyFaultIdx = 1
   } rstmgr_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1, // fatal_cnsty_fault
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_dragonfly/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_dragonfly/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -900,8 +900,6 @@ module rv_core_ibex
   assign alert_test[3] = reg2hw.alert_test.recov_hw_err.q &
                          reg2hw.alert_test.recov_hw_err.qe;
 
-  localparam bit [NumAlerts-1:0] AlertFatal = '{1'b0, 1'b1, 1'b0, 1'b1};
-
   logic [NumAlerts-1:0] alert_events;
   logic [NumAlerts-1:0] alert_acks;
 
@@ -922,9 +920,9 @@ module rv_core_ibex
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
-      .AsyncOn(AlertAsyncOn[0]),
+      .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(AlertFatal[i])
+      .IsFatal(AlertIsFatal[i])
     ) u_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/top_dragonfly/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_peri.sv
+++ b/hw/top_dragonfly/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_peri.sv
@@ -99,8 +99,6 @@ module rv_core_ibex_peri
   assign alert_test[3] = reg2hw.alert_test.recov_hw_err.q &
                          reg2hw.alert_test.recov_hw_err.qe;
 
-  localparam bit [NumAlerts-1:0] AlertFatal = '{1, 0, 1, 0};
-
   logic [NumAlerts-1:0] alert_events;
 
   assign alert_events[0] = reg2hw.sw_alert[0].q != EventOff;
@@ -110,9 +108,9 @@ module rv_core_ibex_peri
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
-      .AsyncOn(AlertAsyncOn[0]),
+      .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(AlertFatal[i])
+      .IsFatal(AlertIsFatal[i])
     ) u_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/top_dragonfly/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/top_dragonfly/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -26,6 +26,14 @@ package rv_core_ibex_reg_pkg;
     AlertRecovHwErrIdx = 3
   } rv_core_ibex_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b0, // recov_hw_err
+    1'b1, // fatal_hw_err
+    1'b0, // recov_sw_err
+    1'b1 // fatal_sw_err
+  };
+
   //////////////////////////////////////////////
   // Typedefs for registers for cfg interface //
   //////////////////////////////////////////////

--- a/hw/top_dragonfly/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
+++ b/hw/top_dragonfly/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
@@ -23,6 +23,11 @@ package rv_plic_reg_pkg;
     AlertFatalFaultIdx = 0
   } rv_plic_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_egret/ip/sensor_ctrl/rtl/sensor_ctrl_reg_pkg.sv
+++ b/hw/top_egret/ip/sensor_ctrl/rtl/sensor_ctrl_reg_pkg.sv
@@ -25,6 +25,12 @@ package sensor_ctrl_reg_pkg;
     AlertFatalAlertIdx = 1
   } sensor_ctrl_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1, // fatal_alert
+    1'b0 // recov_alert
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_egret/ip_autogen/clkmgr/rtl/clkmgr.sv
+++ b/hw/top_egret/ip_autogen/clkmgr/rtl/clkmgr.sv
@@ -283,13 +283,11 @@
     recov_alert
   };
 
-  localparam logic [NumAlerts-1:0] AlertFatal = {1'b1, 1'b0};
-
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(AlertFatal[i])
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/top_egret/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/top_egret/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -24,6 +24,12 @@ package clkmgr_reg_pkg;
     AlertFatalFaultIdx = 1
   } clkmgr_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1, // fatal_fault
+    1'b0 // recov_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_egret/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/top_egret/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
@@ -956,12 +956,11 @@ module flash_ctrl
   // reset for these bits.
   //
   // For more details, refer to lowRISC/OpenTitan#21353.
-  localparam logic [NumAlerts-1:0] IsFatal = {1'b0, 1'b1, 1'b0, 1'b1, 1'b0};
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(IsFatal[i])
+      .IsFatal(i == AlertFatalErrIdx? 1'b0 : AlertIsFatal[i])
     ) u_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/top_egret/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/top_egret/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -41,6 +41,15 @@ package flash_ctrl_reg_pkg;
     AlertRecovPrimFlashAlertIdx = 4
   } flash_ctrl_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b0, // recov_prim_flash_alert
+    1'b1, // fatal_prim_flash_alert
+    1'b1, // fatal_err
+    1'b1, // fatal_std_err
+    1'b0 // recov_err
+  };
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/top_egret/ip_autogen/gpio/rtl/gpio.sv
+++ b/hw/top_egret/ip_autogen/gpio/rtl/gpio.sv
@@ -203,12 +203,12 @@ module gpio
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/top_egret/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
+++ b/hw/top_egret/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
@@ -22,6 +22,11 @@ package gpio_reg_pkg;
     AlertFatalFaultIdx = 0
   } gpio_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_egret/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/top_egret/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -288,6 +288,15 @@ package otp_ctrl_reg_pkg;
     AlertRecovPrimOtpAlertIdx = 4
   } otp_ctrl_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b0, // recov_prim_otp_alert
+    1'b1, // fatal_prim_otp_alert
+    1'b1, // fatal_bus_integ_error
+    1'b1, // fatal_check_error
+    1'b1 // fatal_macro_error
+  };
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/top_egret/ip_autogen/pinmux/rtl/pinmux.sv
+++ b/hw/top_egret/ip_autogen/pinmux/rtl/pinmux.sv
@@ -143,12 +143,12 @@ module pinmux
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/top_egret/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/top_egret/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
@@ -26,6 +26,11 @@ package pinmux_reg_pkg;
     AlertFatalFaultIdx = 0
   } pinmux_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_egret/ip_autogen/pwm/rtl/pwm.sv
+++ b/hw/top_egret/ip_autogen/pwm/rtl/pwm.sv
@@ -66,12 +66,12 @@ module pwm
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/top_egret/ip_autogen/pwm/rtl/pwm_reg_pkg.sv
+++ b/hw/top_egret/ip_autogen/pwm/rtl/pwm_reg_pkg.sv
@@ -21,6 +21,11 @@ package pwm_reg_pkg;
     AlertFatalFaultIdx = 0
   } pwm_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_egret/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_egret/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -390,7 +390,7 @@ module pwrmgr
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i         ( clk_lc        ),
       .rst_ni        ( rst_lc_n      ),

--- a/hw/top_egret/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/top_egret/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -34,6 +34,11 @@ package pwrmgr_reg_pkg;
     AlertFatalFaultIdx = 0
   } pwrmgr_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_egret/ip_autogen/rstmgr/rtl/rstmgr.sv
+++ b/hw/top_egret/ip_autogen/rstmgr/rtl/rstmgr.sv
@@ -221,7 +221,7 @@ module rstmgr
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/top_egret/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
+++ b/hw/top_egret/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
@@ -26,6 +26,12 @@ package rstmgr_reg_pkg;
     AlertFatalCnstyFaultIdx = 1
   } rstmgr_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1, // fatal_cnsty_fault
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_egret/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_egret/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -900,8 +900,6 @@ module rv_core_ibex
   assign alert_test[3] = reg2hw.alert_test.recov_hw_err.q &
                          reg2hw.alert_test.recov_hw_err.qe;
 
-  localparam bit [NumAlerts-1:0] AlertFatal = '{1'b0, 1'b1, 1'b0, 1'b1};
-
   logic [NumAlerts-1:0] alert_events;
   logic [NumAlerts-1:0] alert_acks;
 
@@ -922,9 +920,9 @@ module rv_core_ibex
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
-      .AsyncOn(AlertAsyncOn[0]),
+      .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(AlertFatal[i])
+      .IsFatal(AlertIsFatal[i])
     ) u_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/top_egret/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_peri.sv
+++ b/hw/top_egret/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_peri.sv
@@ -99,8 +99,6 @@ module rv_core_ibex_peri
   assign alert_test[3] = reg2hw.alert_test.recov_hw_err.q &
                          reg2hw.alert_test.recov_hw_err.qe;
 
-  localparam bit [NumAlerts-1:0] AlertFatal = '{1, 0, 1, 0};
-
   logic [NumAlerts-1:0] alert_events;
 
   assign alert_events[0] = reg2hw.sw_alert[0].q != EventOff;
@@ -110,9 +108,9 @@ module rv_core_ibex_peri
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
-      .AsyncOn(AlertAsyncOn[0]),
+      .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(AlertFatal[i])
+      .IsFatal(AlertIsFatal[i])
     ) u_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/top_egret/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/top_egret/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -26,6 +26,14 @@ package rv_core_ibex_reg_pkg;
     AlertRecovHwErrIdx = 3
   } rv_core_ibex_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b0, // recov_hw_err
+    1'b1, // fatal_hw_err
+    1'b0, // recov_sw_err
+    1'b1 // fatal_sw_err
+  };
+
   //////////////////////////////////////////////
   // Typedefs for registers for cfg interface //
   //////////////////////////////////////////////

--- a/hw/top_egret/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
+++ b/hw/top_egret/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
@@ -23,6 +23,11 @@ package rv_plic_reg_pkg;
     AlertFatalFaultIdx = 0
   } rv_plic_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_scafi_deprecated/ip_autogen/clkmgr/rtl/clkmgr.sv
+++ b/hw/top_scafi_deprecated/ip_autogen/clkmgr/rtl/clkmgr.sv
@@ -279,13 +279,11 @@
     recov_alert
   };
 
-  localparam logic [NumAlerts-1:0] AlertFatal = {1'b1, 1'b0};
-
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(AlertFatal[i])
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/top_scafi_deprecated/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/top_scafi_deprecated/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -24,6 +24,12 @@ package clkmgr_reg_pkg;
     AlertFatalFaultIdx = 1
   } clkmgr_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1, // fatal_fault
+    1'b0 // recov_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_scafi_deprecated/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/top_scafi_deprecated/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
@@ -956,12 +956,11 @@ module flash_ctrl
   // reset for these bits.
   //
   // For more details, refer to lowRISC/OpenTitan#21353.
-  localparam logic [NumAlerts-1:0] IsFatal = {1'b0, 1'b1, 1'b0, 1'b1, 1'b0};
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(IsFatal[i])
+      .IsFatal(i == AlertFatalErrIdx? 1'b0 : AlertIsFatal[i])
     ) u_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/top_scafi_deprecated/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/top_scafi_deprecated/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -41,6 +41,15 @@ package flash_ctrl_reg_pkg;
     AlertRecovPrimFlashAlertIdx = 4
   } flash_ctrl_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b0, // recov_prim_flash_alert
+    1'b1, // fatal_prim_flash_alert
+    1'b1, // fatal_err
+    1'b1, // fatal_std_err
+    1'b0 // recov_err
+  };
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/top_scafi_deprecated/ip_autogen/gpio/rtl/gpio.sv
+++ b/hw/top_scafi_deprecated/ip_autogen/gpio/rtl/gpio.sv
@@ -203,12 +203,12 @@ module gpio
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/top_scafi_deprecated/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
+++ b/hw/top_scafi_deprecated/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
@@ -22,6 +22,11 @@ package gpio_reg_pkg;
     AlertFatalFaultIdx = 0
   } gpio_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_scafi_deprecated/ip_autogen/pinmux/rtl/pinmux.sv
+++ b/hw/top_scafi_deprecated/ip_autogen/pinmux/rtl/pinmux.sv
@@ -143,12 +143,12 @@ module pinmux
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,
       .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[0]     ),
+      .alert_req_i   ( alerts[i]     ),
       .alert_ack_o   (               ),
       .alert_state_o (               ),
       .alert_rx_i    ( alert_rx_i[i] ),

--- a/hw/top_scafi_deprecated/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/top_scafi_deprecated/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
@@ -26,6 +26,11 @@ package pinmux_reg_pkg;
     AlertFatalFaultIdx = 0
   } pinmux_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_scafi_deprecated/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_scafi_deprecated/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -390,7 +390,7 @@ module pwrmgr
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i         ( clk_lc        ),
       .rst_ni        ( rst_lc_n      ),

--- a/hw/top_scafi_deprecated/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/top_scafi_deprecated/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -31,6 +31,11 @@ package pwrmgr_reg_pkg;
     AlertFatalFaultIdx = 0
   } pwrmgr_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_scafi_deprecated/ip_autogen/rstmgr/rtl/rstmgr.sv
+++ b/hw/top_scafi_deprecated/ip_autogen/rstmgr/rtl/rstmgr.sv
@@ -221,7 +221,7 @@ module rstmgr
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(1'b1)
+      .IsFatal(AlertIsFatal[i])
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/top_scafi_deprecated/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
+++ b/hw/top_scafi_deprecated/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
@@ -26,6 +26,12 @@ package rstmgr_reg_pkg;
     AlertFatalCnstyFaultIdx = 1
   } rstmgr_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1, // fatal_cnsty_fault
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_scafi_deprecated/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_scafi_deprecated/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -900,8 +900,6 @@ module rv_core_ibex
   assign alert_test[3] = reg2hw.alert_test.recov_hw_err.q &
                          reg2hw.alert_test.recov_hw_err.qe;
 
-  localparam bit [NumAlerts-1:0] AlertFatal = '{1'b0, 1'b1, 1'b0, 1'b1};
-
   logic [NumAlerts-1:0] alert_events;
   logic [NumAlerts-1:0] alert_acks;
 
@@ -922,9 +920,9 @@ module rv_core_ibex
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
-      .AsyncOn(AlertAsyncOn[0]),
+      .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(AlertFatal[i])
+      .IsFatal(AlertIsFatal[i])
     ) u_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/top_scafi_deprecated/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_peri.sv
+++ b/hw/top_scafi_deprecated/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_peri.sv
@@ -99,8 +99,6 @@ module rv_core_ibex_peri
   assign alert_test[3] = reg2hw.alert_test.recov_hw_err.q &
                          reg2hw.alert_test.recov_hw_err.qe;
 
-  localparam bit [NumAlerts-1:0] AlertFatal = '{1, 0, 1, 0};
-
   logic [NumAlerts-1:0] alert_events;
 
   assign alert_events[0] = reg2hw.sw_alert[0].q != EventOff;
@@ -110,9 +108,9 @@ module rv_core_ibex_peri
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_senders
     prim_alert_sender #(
-      .AsyncOn(AlertAsyncOn[0]),
+      .AsyncOn(AlertAsyncOn[i]),
       .SkewCycles(AlertSkewCycles),
-      .IsFatal(AlertFatal[i])
+      .IsFatal(AlertIsFatal[i])
     ) u_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/top_scafi_deprecated/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/top_scafi_deprecated/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -26,6 +26,14 @@ package rv_core_ibex_reg_pkg;
     AlertRecovHwErrIdx = 3
   } rv_core_ibex_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b0, // recov_hw_err
+    1'b1, // fatal_hw_err
+    1'b0, // recov_sw_err
+    1'b1 // fatal_sw_err
+  };
+
   //////////////////////////////////////////////
   // Typedefs for registers for cfg interface //
   //////////////////////////////////////////////

--- a/hw/top_scafi_deprecated/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
+++ b/hw/top_scafi_deprecated/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
@@ -23,6 +23,11 @@ package rv_plic_reg_pkg;
     AlertFatalFaultIdx = 0
   } rv_plic_alert_idx_t;
 
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+    1'b1 // fatal_fault
+  };
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/util/reggen/reg_pkg.sv.tpl
+++ b/util/reggen/reg_pkg.sv.tpl
@@ -393,6 +393,13 @@ package ${lblock}${"_" + block.alias_impl if block.alias_impl else ""}_reg_pkg;
     Alert${lib.Name.to_camel_case(alert.name)}Idx = ${idx}${"" if idx == len(block.alerts) - 1 else ","}
 % endfor
   } ${block.name.lower()}_alert_idx_t;
+
+  // Fatal alert classification
+  localparam bit [NumAlerts-1:0] AlertIsFatal = {
+% for idx, alert in enumerate(reversed(block.alerts)):
+    1'b${int(alert.fatal)}${"" if idx == len(block.alerts) - 1 else ","} // ${alert.name}
+% endfor
+  };
 % endif
 <%
   just_default = len(block.reg_blocks) == 1 and None in block.reg_blocks


### PR DESCRIPTION
This is PR #310 (which was reverted in PR #442) with a one line fix kindly provided by @matutem: 
```patch
diff --git a/hw/ip/acc/rtl/acc.sv b/hw/ip/acc/rtl/acc.sv
index 46207a417a..c9abaffb72 100644
--- a/hw/ip/acc/rtl/acc.sv
+++ b/hw/ip/acc/rtl/acc.sv
@@ -1034,7 +1034,7 @@ module acc
 
   logic [NumAlerts-1:0] alert_test;
   assign alert_test[AlertFatalIdx] = reg2hw.alert_test.fatal.q & reg2hw.alert_test.fatal.qe;
-  assign alert_test[AlertFatalIdx] = reg2hw.alert_test.recov.q & reg2hw.alert_test.recov.qe;
+  assign alert_test[AlertRecovIdx] = reg2hw.alert_test.recov.q & reg2hw.alert_test.recov.qe;
 
   logic [NumAlerts-1:0] alerts;
   assign alerts[AlertFatalIdx] = |{err_bits.kmac_fatal_error,
```

