### PR TITLE
[acc,mlkem] Improve whitening in ML-KEM.

### DIFF
--- a/sw/acc/crypto/mlkem/basemul.s
+++ b/sw/acc/crypto/mlkem/basemul.s
@@ -29,7 +29,7 @@
  *
  * @param[in]  x10: dmem pointer to x
  * @param[in]  x11: dmem pointer to y
- * @param[in]  x12: dmem pointer to the twiddle factors twiddles_basemul
+ * @param[in]  x12: dmem pointer to the twiddle factors const_tw_basemul
  * @param[out] x13: dmem pointer to r
  * @param[in]  w16 (sw0): sw0.0 = q = 3329 (1st 16-bit lane),
  *                        sw0.2 = -q^-1 mod 2^16 = 3327 (3rd 16-bit lane)
@@ -82,7 +82,7 @@ basemul:
  *
  * @param[in]     x10: dmem pointer to x
  * @param[in]     x11: dmem pointer to y
- * @param[in]     x12: dmem pointer to the twiddle factors twiddles_basemul
+ * @param[in]     x12: dmem pointer to the twiddle factors const_tw_basemul
  * @param[in,out] x13: dmem pointer to r
  * @param[in]     w16 (sw0): sw0.0 = q = 3329 (1st 16-bit lane),
  *                           sw0.2 = -q^-1 mod 2^16 = 3327 (3rd 16-bit lane)

--- a/sw/acc/crypto/mlkem/cbd.s
+++ b/sw/acc/crypto/mlkem/cbd.s
@@ -125,7 +125,7 @@ poly_getnoise_eta_2:
 .globl cbd2
 .type cbd2, @function
 cbd2:
-  la     x5, cbd2_const
+  la     x5, const_cbd2
   addi   x4, x0, 3
   bn.lid x4++, 0(x5)
   bn.lid x4, 32(x5)
@@ -185,7 +185,7 @@ cbd2:
 .globl cbd3
 .type cbd3, @function
 cbd3:
-  la     x5, cbd3_const
+  la     x5, const_cbd3
   addi   x4, x0, 20
   bn.lid x4++, 0(x5)
   bn.lid x4, 32(x5)

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -68,9 +68,9 @@
 .type secand, @function
 secand:
   /* Save addresses. */
-  addi x5, x10, 0
-  addi x6, x12, 0
-  addi x7, x15, 0
+  add x5, x10, x0
+  add x6, x12, x0
+  add x7, x15, x0
 
   /* Load x. */
   bn.xor w0, w0, w0   /* Whitening. */
@@ -288,16 +288,16 @@ secadd:
 
   /* Initialize c = 0. */
   bn.xor w0, w0, w0
-  addi   x5, x2, 0
+  add    x5, x2, x0
   loopi 2, 1
     bn.sid x0, 0(x5++)
   endloop
 
   /* Ripple-carry adder. */
   addi x8, x17, -1
-  addi x17, x2, 0
+  add  x17, x2, x0
   addi x29, x0, 32
-  addi x30, x2, 0
+  add  x30, x2, x0
   addi x31, x0, 32
   /* Handle bit i = 0..k - 2. */
   loop x8, 2
@@ -306,7 +306,7 @@ secadd:
   endloop
 
   /* Handle bit k - 1. */
-  addi x5, x2, 0
+  add  x5, x2, x0
   addi x4, x0, 1
   addi x6, x0, 2
   addi x7, x0, 3
@@ -598,8 +598,8 @@ poly_to_bitsliced:
   jal x1, _bitslice_transpose
 
   /* Store the 12 bitsliced words r[0..11] via x10 so x11 is left unchanged. */
-  addi   x4, x0, 0
-  addi   x10, x11, 0
+  add x4, x0, x0
+  add x10, x11, x0
   loopi 12, 2
     bn.sid x4, 0(x10++)
     addi   x4, x4, 1
@@ -629,7 +629,7 @@ poly_to_bitsliced:
 .type poly_from_bitsliced, @function
 poly_from_bitsliced:
   /* Load x[0..11] into w0..w11; zero the upper bit positions w12..w15. */
-  addi x4, x0, 0
+  add x4, x0, x0
   loopi 12, 2
     bn.lid x4, 0(x10++)
     addi   x4, x4, 1
@@ -896,7 +896,7 @@ seca2b:
   /* Save x3 to stack */
   addi x2, x2, -32
   sw   x3, 0(x2)
-  addi x3, x2, 0
+  add  x3, x2, x0
 
   /* Adjust stack for temp variables. */
   slli x5, x12, 1
@@ -935,17 +935,17 @@ seca2b:
   add x28, x14, x0
 
   /* Compute r = secadd(s, s', k). */
-  addi x10, x7, 0
-  addi x11, x6, 0
-  addi x12, x2, 0
-  addi x13, x6, 0
-  addi x15, x28, 0
-  addi x16, x6, 0
-  addi x17, x5, 0
-  jal  x1, secadd
+  add x10, x7, x0
+  add x11, x6, x0
+  add x12, x2, x0
+  add x13, x6, x0
+  add x15, x28, x0
+  add x16, x6, x0
+  add x17, x5, x0
+  jal x1, secadd
 
   /* Restore x2 and x3. */
-  addi x2, x3, 0
+  add  x2, x3, x0
   lw   x3, 0(x2)
   addi x2, x2, 32
   ret
@@ -983,7 +983,7 @@ seca2bmodq:
    *   x2 + 1728 : saved x18 */
   addi x2, x2, -1760
   sw   x18, 1728(x2)
-  addi x18, x12, 0
+  add  x18, x12, x0
 
   /* Compute s = p + x_0, k + 1 bits (one share).
    * p = 2^(k + 1) - q = 4863 = 0b1001011111111.
@@ -1068,7 +1068,7 @@ seca2bmodq:
   endloop
 
   /* Build s' = (0, x_1) for (k + 1) bits. */
-  addi x5, x2, 0 /* s' */
+  add x5, x2, x0 /* s' */
   loopi 13, 1
     bn.sid x0, 0(x5++)
   endloop
@@ -1090,7 +1090,7 @@ seca2bmodq:
 
   addi x10, x2, 896
   addi x11, x0, 416
-  addi x12, x2, 0
+  add  x12, x2, x0
   addi x13, x0, 416
   addi x15, x2, 896
   addi x16, x0, 416
@@ -1130,7 +1130,7 @@ seca2bmodq:
   /* Compute a = bitcopymask(u[k], (k + 1) * 32). */
   addi x10, x2, 1280
   addi x11, x0, 416
-  addi x13, x2, 0
+  add  x13, x2, x0
   jal  x1, bitcopymask
 
   /********** Start inline r = secadd(a, u, k). **********/
@@ -1141,11 +1141,11 @@ seca2bmodq:
     bn.sid x0, 0(x5++)
   endloop
 
-  addi x10, x2, 0
+  add  x10, x2, x0
   addi x11, x0, 384
   addi x12, x2, 896
   addi x13, x0, 416
-  addi x15, x18, 0
+  add  x15, x18, x0
   addi x16, x0, 384
   addi x17, x2, 832
   addi x29, x0, 32
@@ -1216,12 +1216,12 @@ seconebitb2amodq:
   addi x2, x2, -1056
   sw   x8, 1024(x2)
   sw   x18, 1028(x2)
-  addi x8, x10, 0
-  addi x18, x12, 0
+  add  x8, x10, x0
+  add  x18, x12, x0
 
   /* Build v = (x_0, 0). */
-  addi x5, x2, 0
-  add  x6, x10, x0
+  add x5, x2, x0
+  add x6, x10, x0
   loopi 16, 2
     bn.lid x0, 0(x6++)
     bn.sid x0, 0(x5++)
@@ -1237,9 +1237,9 @@ seconebitb2amodq:
   bn.shv.16h w30, w30 >> 15
 
   /* Compute v = refreshmodq(v). */
-  addi x10, x2, 0
-  addi x12, x10, 0
-  jal  x1, refreshmodq
+  add x10, x2, x0
+  add x12, x10, x0
+  jal x1, refreshmodq
 
   /* We need to compute r = (1 - 2 * x_1) * v_j for j = 0..1.
    * Since x_1 is either 0 or 1, this translates to:
@@ -1260,12 +1260,12 @@ seconebitb2amodq:
    *    Then (t1 - v_j) mod q = (-v_j) mod q.
    */
   addi x5, x8, 512 /* x_1 */
-  addi x6, x2, 0   /* v */
+  add  x6, x2, x0  /* v */
   addi x4, x0, 1
   loopi 16, 16
     bn.lid         x0, 0(x5++)
     bn.subv.16h    w2, w0, w30
-    addi           x7, x6, 0
+    add            x7, x6, x0
     /* Handle v_0. */
     bn.lid       x4, 0(x6)
     bn.and       w3, w1, w2
@@ -1284,9 +1284,9 @@ seconebitb2amodq:
   endloop
 
   /* Compute r = refreshmodq(v). */
-  addi x10, x2, 0
-  addi x12, x18, 0
-  jal  x1, refreshmodq
+  add x10, x2, x0
+  add x12, x18, x0
+  jal x1, refreshmodq
 
   /* Restore registers and frame. */
   lw   x8, 1024(x2)
@@ -1338,8 +1338,8 @@ secb2amodq:
   sw x21, 16(x2)
 
   /* Save input/output addresses and buffer bases. */
-  addi x8, x10, 0
-  addi x18, x12, 0
+  add  x8, x10, x0
+  add  x18, x12, x0
   addi x19, x2, 1888 /* a, b, c, zp (bitsliced) */
   addi x20, x2, 1056 /* s */
   /* zp = x2 + 32 */
@@ -1348,7 +1348,7 @@ secb2amodq:
   addi    x4, x0, 30
   la      x5, modulus_bn
   bn.lid  x4, 0(x5)
-  addi    x10, x12, 0
+  add     x10, x12, x0
   addi    x7, x2, 32
   bn.wsrr w16, mod
   jal x1, poly_rej_samp
@@ -1360,7 +1360,7 @@ secb2amodq:
 
   /* Bitslice zp_0 and clear zp_1 (bitsliced). */
   addi x10, x2, 32
-  addi x11, x19, 0
+  add  x11, x19, x0
   jal  x1, poly_to_bitsliced
   addi x11, x11, 384
   bn.xor w0, w0, w0
@@ -1369,8 +1369,8 @@ secb2amodq:
   endloop
 
   /* Compute a = seca2bmodq(zp). */
-  addi x10, x19, 0
-  addi x12, x19, 0
+  add  x10, x19, x0
+  add  x12, x19, x0
   jal  x1, seca2bmodq
 
   /* Compute b = secaddmodq(a, x). */
@@ -1384,11 +1384,11 @@ secb2amodq:
     addi   x5, x5, 416
   endloop
 
-  addi x10, x19, 0
+  add  x10, x19, x0
   addi x11, x0, 384
-  addi x12, x8, 0
+  add  x12, x8, x0
   addi x13, x0, 384
-  addi x15, x20, 0
+  add  x15, x20, x0
   addi x16, x0, 416
   addi x17, x20, 384
   addi x29, x0, 416
@@ -1409,19 +1409,19 @@ secb2amodq:
   loopi 2, 1
     bn.sid x0, 0(x5++)
   endloop
-  addi x21, x5, 0 /* p */
+  add x21, x5, x0 /* p */
 
-  addi    x5, x21, 0
+  add     x5, x21, x0
   bn.subi w1, w0, 1
   addi    x4, x0, 1
   bn.sid  x4, 0(x5++)
   bn.sid  x0, 0(x5++)
 
-  addi x10, x21, 0
+  add  x10, x21, x0
   addi x11, x0, 32
-  addi x12, x20, 0
+  add  x12, x20, x0
   addi x13, x0, 416
-  addi x15, x20, 0
+  add  x15, x20, x0
   addi x16, x0, 416
   addi x17, x2, 32
   addi x29, x0, 32
@@ -1436,20 +1436,20 @@ secb2amodq:
   /* Bit 8: p[i] = 0. */
   bn.xor w0, w0, w0
   bn.sid x0, 0(x10)
-  addi   x10, x21, 0
+  add    x10, x21, x0
   jal    x1, secfulladder
   /* Bit 9: p[i] = 1. */
   bn.xor  w0, w0, w0
   bn.subi w0, w0, 1
-  addi    x10, x21, 0
+  add     x10, x21, x0
   bn.sid  x0, 0(x10)
   jal     x1, secfulladder
   /* Bits 10..11: p[i] = 0. */
   bn.xor w0, w0, w0
-  addi   x10, x21, 0
+  add    x10, x21, x0
   bn.sid x0, 0(x10)
   jal    x1, secfulladder
-  addi   x10, x21, 0
+  add    x10, x21, x0
   jal    x1, secfulladder
 
   /* Bit 12: p[i] = 1. */
@@ -1484,29 +1484,29 @@ secb2amodq:
   /* Compute a = bitcopymask(s[k], (k + 1) * 32). */
   addi x10, x20, 384
   addi x11, x0, 416
-  addi x13, x19, 0
+  add  x13, x19, x0
   jal  x1, bitcopymask
 
   /* Compute r = secadd(a, s, k). */
-  addi x10, x19, 0
+  add  x10, x19, x0
   addi x11, x0, 384
-  addi x12, x20, 0
+  add  x12, x20, x0
   addi x13, x0, 416
-  addi x15, x19, 0
+  add  x15, x19, x0
   addi x16, x0, 384
   addi x17, x0, 12
   jal  x1, secadd
   /********** End inline b = secaddmodq(a, x). **********/
 
   /* Compute c = refreshios(b, k, k * 32). */
-  addi x10, x19, 0
+  add  x10, x19, x0
   addi x11, x0, 12
   addi x12, x0, 384
-  addi x14, x19, 0
+  add  x14, x19, x0
   jal  x1, refreshios
 
   /* Unmask c. */
-  addi x5, x19, 0
+  add  x5, x19, x0
   addi x4, x0, 1
   loopi 12, 5
     addi   x6, x5, 384
@@ -1517,8 +1517,8 @@ secb2amodq:
   endloop
 
   /* Convert c from bitsliced to normal representation, into r_1. */
-  addi x10, x19, 0
-  addi x11, x18, 0
+  add  x10, x19, x0
+  add  x11, x18, x0
   addi x11, x11, 512
   jal x1, poly_from_bitsliced
 
@@ -1571,7 +1571,7 @@ poly_hocompress:
   sw   x9, 1152(x2)
   sw   x18, 1156(x2)
   sw   x19, 1160(x2)
-  addi x9, x12, 0
+  add  x9, x12, x0
 
   /* Load all constants. */
   addi      x4, x0, 17
@@ -1597,7 +1597,7 @@ poly_hocompress:
   addi      x19, x0, 4
 _dv_params_done:
 
-  addi x6, x2, 0 /* z */
+  add  x6, x2, x0 /* z */
   addi x28, x6, 512
 
   /* Compute z_0 = Compressq(x_0, dv + alpha) + 2^(alpha - 1),
@@ -1692,16 +1692,16 @@ _dv_params_done:
   endloop
 
   /* Compute c = seca2b(z), k = dv + alpha = 18, share bytes = 576. */
-  addi x10, x2, 0
+  add  x10, x2, x0
   addi x11, x0, 18
   addi x12, x0, 576
-  addi x14, x2, 0
+  add  x14, x2, x0
   jal  x1, seca2b
 
   /* Compute r = c >> alpha: keep the bits c[alpha]...c[dv + alpha]. */
-  addi x5, x2, 0
-  add  x5, x5, x18
-  addi x6, x9, 0
+  add x5, x2, x0
+  add x5, x5, x18
+  add x6, x9, x0
   loopi 2, 5
     loop x19, 3
       /* Whitening. */
@@ -1759,7 +1759,7 @@ polyvec_hocompress:
   sw   x9, 1536(x2)
   sw   x18, 1540(x2)
   sw   x19, 1544(x2)
-  addi x9, x12, 0
+  add  x9, x12, x0
 
   /* Create 2^(alpha - 1). */
   bn.subi   w30, w31, 1
@@ -1785,7 +1785,7 @@ _du_params_done:
   bn.lid     x4, 0(x5)
 
   addi x5, x0, 21
-  addi x6, x2, 0    /* z */
+  add  x6, x2, x0   /* z */
   addi x28, x6, 512 /* Skip the first 16 bits. */
 
   /* Compute z_0 = Compressq(x_0, du + alpha) + 2^(alpha - 1),
@@ -1916,16 +1916,16 @@ _du_params_done:
   endloop
 
   /* Compute c = seca2b(z), k = du + alpha = 24, share bytes = 768. */
-  addi x10, x2, 0
+  add  x10, x2, x0
   addi x11, x0, 24
   addi x12, x0, 768
-  addi x14, x2, 0
+  add  x14, x2, x0
   jal  x1, seca2b
 
   /* Compute r = c >> alpha: keep the bits c[alpha]...c[du + alpha]. */
-  addi x5, x2, 0
-  add  x5, x5, x18
-  addi x6, x9, 0
+  add x5, x2, x0
+  add x5, x5, x18
+  add x6, x9, x0
   loopi 2, 5
     loop x19, 3
       /* Whitening. */
@@ -1975,7 +1975,7 @@ onebitdecompress:
   /* Save the output base pointer; reused as scratch across the call. */
   addi x2, x2, -32
   sw   x8, 0(x2)
-  addi x8, x12, 0
+  add  x8, x12, x0
 
   /* Unpack m, matching the bitslice layout from masked_poly_tomsg. */
   addi x4, x0, 1
@@ -1992,8 +1992,8 @@ onebitdecompress:
   endloop
 
   /* Compute mp = seconebitb2amodq(m). */
-  addi x10, x8, 0
-  addi x12, x8, 0
+  add  x10, x8, x0
+  add  x12, x8, x0
   jal  x1, seconebitb2amodq
 
   /* mp *= (q + 1) / 2 mod q, coefficient-wise (Montgomery). */
@@ -2064,15 +2064,15 @@ masked_cbd:
   sw x22, 1236(x2)
 
   /* Save input/output addresses and set the scratch pointers. */
-  addi x8, x10, 0
-  addi x9, x11, 0
-  addi x18, x12, 0
-  addi x20, x14, 0
+  add  x8, x10, x0
+  add  x9, x11, x0
+  add  x18, x12, x0
+  add  x20, x14, x0
   addi x21, x2, 832 /* s */
   addi x22, x2, 768 /* a */
 
   /* Copy x to s[0..eta - 1] and ~y to s[eta..2 * eta - 1]. */
-  addi x5, x21, 0
+  add  x5, x21, x0
   slli x4, x12, 5 /* eta * 32 */
   add  x6, x21, x4
   /* Share 0. */
@@ -2117,7 +2117,7 @@ masked_cbd:
    */
   /********** Iteration i = 0, ell = 2 * eta. **********/
   /* Since ell mod 2 = 0, we clear a. */
-  addi   x5, x22, 0
+  add    x5, x22, x0
   bn.xor w0, w0, w0
   loopi 2, 1
     bn.sid x0, 0(x5++)
@@ -2126,16 +2126,16 @@ masked_cbd:
   /* Loop j = 0..eta - 1. */
   /* Compute (a, s[j]) = secfulladder(s[2 * j], s[2 * j + 1], a). */
   slli x5, x12, 6 /* (2 * eta) * 32 */
-  addi x10, x21, 0
-  addi x11, x5, 0
+  add  x10, x21, x0
+  add  x11, x5, x0
   addi x12, x21, 32
-  addi x13, x5, 0
-  addi x15, x22, 0
+  add  x13, x5, x0
+  add  x15, x22, x0
   addi x16, x0, 32
-  addi x17, x22, 0
+  add  x17, x22, x0
   addi x29, x0, 32
-  addi x30, x21, 0
-  addi x31, x5, 0
+  add  x30, x21, x0
+  add  x31, x5, x0
   loop x18, 5
     jal  x1, secfulladder
     addi x10, x10, 32  /* s[2 * (j + 1)] */
@@ -2145,7 +2145,7 @@ masked_cbd:
   endloop
 
   /* b[0] <- a. */
-  addi x5, x2, 0
+  add x5, x2, x0
   loopi 2, 4
     /* Whitening. */
     bn.xor w0, w0, w0
@@ -2158,8 +2158,8 @@ masked_cbd:
   addi x5, x0, 2
   beq  x18, x5, _cbd_eta_2
   /* Since ell mod 2 = 1 if eta = 3, we compute a = s[ell - 1]. */
-  addi x5, x22, 0
-  addi x6, x21, 0
+  add  x5, x22, x0
+  add  x6, x21, x0
   addi x6, x6, 64
   slli x4, x18, 6 /* (2 * eta) * 32 */
   loopi 2, 4
@@ -2173,7 +2173,7 @@ masked_cbd:
 
 _cbd_eta_2:
   /* Since ell mod 2 = 0 if eta = 2, we clear a. */
-  addi   x5, x22, 0
+  add    x5, x22, x0
   bn.xor w0, w0, w0
   loopi 2, 1
     bn.sid x0, 0(x5++)
@@ -2183,16 +2183,16 @@ _continue_1:
   /* Loop j = 0. */
   /* Compute (a, s[0]) = secfulladder(s[0], s[1], a). */
   slli x5, x18, 6
-  addi x10, x21, 0
-  addi x11, x5, 0
+  add  x10, x21, x0
+  add  x11, x5, x0
   addi x12, x21, 32
-  addi x13, x5, 0
-  addi x15, x22, 0
+  add  x13, x5, x0
+  add  x15, x22, x0
   addi x16, x0, 32
-  addi x17, x22, 0
+  add  x17, x22, x0
   addi x29, x0, 32
-  addi x30, x21, 0
-  addi x31, x5, 0
+  add  x30, x21, x0
+  add  x31, x5, x0
   jal  x1, secfulladder
 
   /* b[1] <- a. */
@@ -2207,9 +2207,9 @@ _continue_1:
 
   /********** Iteration i = 2, ell = eta // 2 = 1. **********/
   /* Since ell mod 2 = 1, we compute b[2] = s[ell - 1] = s[0] directly. */
-  addi x5, x2, 0
+  add  x5, x2, x0
   addi x5, x5, 64
-  addi x6, x21, 0
+  add  x6, x21, x0
   slli x7, x18, 6
 
   loopi 2, 5
@@ -2222,7 +2222,7 @@ _continue_1:
   endloop
 
   /* Clear bits b[3..k - 1]. */
-  addi   x5, x2, 0
+  add    x5, x2, x0
   addi   x5, x5, 96
   bn.xor w0, w0, w0
   loopi 2, 3
@@ -2233,13 +2233,13 @@ _continue_1:
   endloop
 
   /* Compute r = secb2amodq(b). */
-  addi x10, x2, 0
-  addi x12, x20, 0
-  jal  x1, secb2amodq
+  add x10, x2, x0
+  add x12, x20, x0
+  jal x1, secb2amodq
 
   /* Compute r_0 = (r_0 - eta) mod q. */
-  addi   x5, x20, 0
-  addi   x6, x21, 0
+  add    x5, x20, x0
+  add    x6, x21, x0
   sw     x18, 0(x6)
   bn.lid x0, 0(x6)
   loopi 16, 1
@@ -2375,14 +2375,14 @@ masked_poly_getnoise_eta_1:
   sw   x9, 388(x2)
   sw   x18, 392(x2)
   sw   x19, 396(x2)
-  addi x8, x10, 0
-  addi x9, x11, 0
+  add  x8, x10, x0
+  add  x9, x11, x0
   addi x18, x2, 192
 
   addi x4, x0, 3
   bne  x10, x4, _getnoise_eta_2
 
-  addi x5, x2, 0
+  add  x5, x2, x0
 
   bn.wsrr w17, kmac_digest
   bn.wsrr w23, kmac_digest1
@@ -2451,7 +2451,7 @@ _getnoise_eta_2:
   addi x5, x0, 25
   addi x6, x0, 17
   addi x7, x0, 26
-  addi x28, x2, 0
+  add  x28, x2, x0
   loopi 2, 38
     /* Whitening. */
     bn.xor w0, w0, w0
@@ -2503,13 +2503,13 @@ _getnoise_eta_2:
 _getnoise_common:
   /* Compute r = masked_cbd(x, y, eta). */
   addi x10, x2, 192
-  addi x11, x2, 0
-  addi x12, x8, 0
-  addi x14, x9, 0
+  add  x11, x2, x0
+  add  x12, x8, x0
+  add  x14, x9, x0
   jal  x1, masked_cbd
 
   /* Restore inputs. */
-  addi x10, x8, 0
+  add  x10, x8, x0
   /* We want to point r to the next polynomial for next cbd. */
   addi x11, x9, 512
 
@@ -2702,7 +2702,7 @@ masked_poly_tomsg:
   /* Allocate the z scratch and save callee-saved registers. */
   addi x2, x2, -1056
   sw   x8, 1024(x2)
-  addi x8, x12, 0
+  add  x8, x12, x0
 
   /* Load all constants. */
   addi      x4, x0, 17
@@ -2729,7 +2729,7 @@ masked_poly_tomsg:
    *  - x &= ((1 << (1 + alpha)) - 1).
    */
   addi x5, x0, 21
-  addi x6, x2, 0 /* z */
+  add  x6, x2, x0 /* z */
 
   loopi 2, 44
     /* Whitening. */
@@ -2791,16 +2791,16 @@ masked_poly_tomsg:
   endloop
 
   /* Compute c = seca2b(z), k = 1 + alpha = 16, share bytes = 512. */
-  addi x10, x2, 0
+  add  x10, x2, x0
   addi x11, x0, 16
   addi x12, x0, 512
-  addi x14, x2, 0
+  add  x14, x2, x0
   jal  x1, seca2b
 
   /* Compute c >>= alpha, i.e. keep only bit c[alpha], the message bit. */
-  addi x5, x2, 0
+  add  x5, x2, x0
   addi x5, x5, 480
-  addi x6, x8, 0
+  add  x6, x8, x0
   loopi 2, 4
     /* Whitening. */
     bn.xor w0, w0, w0
@@ -2847,19 +2847,19 @@ poly_masked_compare_dv:
   sw   x15, 344(x2)
 
   /* Save input/output addresses. */
-  addi x8, x10, 0
-  addi x9, x11, 0
-  addi x18, x12, 0
-  addi x20, x14, 0
+  add x8, x10, x0
+  add x9, x11, x0
+  add x18, x12, x0
+  add x20, x14, x0
 
   /* Compute t = poly_hocompress(c'). */
-  addi x10, x8, 0
-  addi x12, x2, 0
-  addi x13, x15, 0
-  jal  x1, poly_hocompress
+  add x10, x8, x0
+  add x12, x2, x0
+  add x13, x15, x0
+  jal x1, poly_hocompress
 
   /* Decode + bitslice c. */
-  addi x11, x9, 0
+  add  x11, x9, x0
 
   addi x4, x0, 4
   lw   x15, 344(x2)
@@ -3079,7 +3079,7 @@ _handle_common_dv:
   /* t_0 ^= ~c, so that t is 1 exactly where the bits match. The c
    * bit-planes are w0..w3 for dv = 4 and w0..w4 for dv = 5. */
   bn.subi w15, w31, 1
-  addi    x5, x2, 0 /* ptr_t */
+  add     x5, x2, x0 /* ptr_t */
 
   bn.lid  x4, 0(x5)
   bn.xor  w0, w0, w15
@@ -3112,15 +3112,15 @@ _handle_common_dv:
 _skip_bit_4:
   /* Compute r = secand(r, t). */
   addi x11, x0, 32
-  addi x12, x2, 0
-  addi x13, x18, 0
+  add  x12, x2, x0
+  add  x13, x18, x0
   addi x16, x0, 32
   /* After the secand, the input and output pointers will point to
    * next bit so we don't have to pass all the arguments above to secand again. */
   loop x9, 4
-    addi x10, x20, 0
-    addi x15, x20, 0
-    jal  x1, secand
+    add x10, x20, x0
+    add x15, x20, x0
+    jal x1, secand
     nop
   endloop
 
@@ -3166,19 +3166,19 @@ poly_masked_compare_du:
   sw   x15, 728(x2)
 
   /* Save input/output addresses. */
-  addi x8, x10, 0
-  addi x9, x11, 0
-  addi x18, x12, 0
-  addi x20, x14, 0
+  add x8, x10, x0
+  add x9, x11, x0
+  add x18, x12, x0
+  add x20, x14, x0
 
   /* Compute t = poly_hocompress(c'). */
-  addi x10, x8, 0
-  addi x12, x2, 0
-  addi x13, x15, 0
-  jal  x1, polyvec_hocompress
+  add x10, x8, x0
+  add x12, x2, x0
+  add x13, x15, x0
+  jal x1, polyvec_hocompress
 
   /* Decode + bitslice c. */
-  addi x11, x9, 0
+  add  x11, x9, x0
 
   addi x4, x0, 4
   lw   x15, 728(x2)
@@ -3473,7 +3473,7 @@ _handle_common_du:
   /* t_0 ^= ~c, so that t is 1 exactly where the bits match. The c
    * bit-planes are w0..w9 for du = 10 and w0..w10 for du = 11. */
   bn.subi w15, w31, 1
-  addi    x5, x2, 0
+  add     x5, x2, x0
 
   bn.lid x4, 0(x5)
   bn.xor w0, w0, w15
@@ -3536,15 +3536,15 @@ _handle_common_du:
 _skip_bit_10:
   /* Compute r = secand(r, t). */
   addi x11, x0, 32
-  addi x12, x2, 0
-  addi x13, x18, 0
+  add  x12, x2, x0
+  add  x13, x18, x0
   addi x16, x0, 32
   /* After the secand, the input and output pointers will point to
    * next bit so we don't have to pass all the arguments above to secand again. */
   loop x9, 4
-    addi x10, x20, 0
-    addi x15, x20, 0
-    jal  x1, secand
+    add x10, x20, x0
+    add x15, x20, x0
+    jal x1, secand
     nop
   endloop
 
@@ -3582,12 +3582,12 @@ finalize_cmp:
   sw x8, 68(x2)
 
   /* Save the in/out address. */
-  addi x8, x10, 0
+  add  x8, x10, x0
 
   /* Compute r &= (r >> 128). */
   /* Compute t = r >> 128. */
   addi x4, x0, 1
-  addi x5, x2, 0
+  add  x5, x2, x0
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
@@ -3597,19 +3597,19 @@ finalize_cmp:
     bn.sid  x4, 0(x5++)
   endloop
   /* Compute r &= t. */
-  addi x10, x8, 0
+  add  x10, x8, x0
   addi x11, x0, 32
-  addi x12, x2, 0
+  add  x12, x2, x0
   addi x13, x0, 32
-  addi x15, x8, 0
+  add  x15, x8, x0
   addi x16, x0, 32
   jal  x1, secand
 
   /* Compute r &= (r >> 64). */
   /* Compute t = r >> 64. */
   addi x4, x0, 1
-  addi x10, x8, 0
-  addi x5, x2, 0
+  add  x10, x8, x0
+  add  x5, x2, x0
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
@@ -3619,19 +3619,19 @@ finalize_cmp:
     bn.sid  x4, 0(x5++)
   endloop
   /* Compute r &= t. */
-  addi x10, x8, 0
+  add  x10, x8, x0
   /* x11 is still 32. */
-  addi x12, x2, 0
+  add  x12, x2, x0
   /* x13 is still 32. */
-  addi x15, x8, 0
+  add  x15, x8, x0
   /* x16 is still 32. */
   jal  x1, secand
 
   /* Compute r &= (r >> 32). */
   /* Compute t = r >> 32. */
   addi x4, x0, 1
-  addi x10, x8, 0
-  addi x5, x2, 0
+  add  x10, x8, x0
+  add  x5, x2, x0
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
@@ -3641,19 +3641,19 @@ finalize_cmp:
     bn.sid  x4, 0(x5++)
   endloop
   /* Compute r &= t. */
-  addi x10, x8, 0
+  add  x10, x8, x0
   /* x11 is still 32. */
-  addi x12, x2, 0
+  add  x12, x2, x0
   /* x13 is still 32. */
-  addi x15, x8, 0
+  add  x15, x8, x0
   /* x16 is still 32. */
   jal  x1, secand
 
   /* Compute r &= (r >> 16). */
   /* Compute t = r >> 16. */
   addi x4, x0, 1
-  addi x10, x8, 0
-  addi x5, x2, 0
+  add  x10, x8, x0
+  add  x5, x2, x0
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
@@ -3663,19 +3663,19 @@ finalize_cmp:
     bn.sid  x4, 0(x5++)
   endloop
   /* Compute r &= t. */
-  addi x10, x8, 0
+  add  x10, x8, x0
   /* x11 is still 32. */
-  addi x12, x2, 0
+  add  x12, x2, x0
   /* x13 is still 32. */
-  addi x15, x8, 0
+  add  x15, x8, x0
   /* x16 is still 32. */
   jal  x1, secand
 
   /* Compute r &= (r >> 8). */
   /* Compute t = r >> 8. */
   addi x4, x0, 1
-  addi x10, x8, 0
-  addi x5, x2, 0
+  add  x10, x8, x0
+  add  x5, x2, x0
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
@@ -3685,19 +3685,19 @@ finalize_cmp:
     bn.sid  x4, 0(x5++)
   endloop
   /* Compute r &= t. */
-  addi x10, x8, 0
+  add  x10, x8, x0
   /* x11 is still 32. */
-  addi x12, x2, 0
+  add  x12, x2, x0
   /* x13 is still 32. */
-  addi x15, x8, 0
+  add  x15, x8, x0
   /* x16 is still 32. */
   jal  x1, secand
 
   /* Compute r &= (r >> 4). */
   /* Compute t = r >> 4. */
   addi x4, x0, 1
-  addi x10, x8, 0
-  addi x5, x2, 0
+  add  x10, x8, x0
+  add  x5, x2, x0
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
@@ -3707,19 +3707,19 @@ finalize_cmp:
     bn.sid  x4, 0(x5++)
   endloop
   /* Compute r &= t. */
-  addi x10, x8, 0
+  add  x10, x8, x0
   /* x11 is still 32. */
-  addi x12, x2, 0
+  add  x12, x2, x0
   /* x13 is still 32. */
-  addi x15, x8, 0
+  add  x15, x8, x0
   /* x16 is still 32. */
   jal  x1, secand
 
   /* Compute r &= (r >> 2). */
   /* Compute t = r >> 2. */
   addi x4, x0, 1
-  addi x10, x8, 0
-  addi x5, x2, 0
+  add  x10, x8, x0
+  add  x5, x2, x0
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
@@ -3729,19 +3729,19 @@ finalize_cmp:
     bn.sid  x4, 0(x5++)
   endloop
   /* Compute r &= t. */
-  addi x10, x8, 0
+  add  x10, x8, x0
   /* x11 is still 32. */
-  addi x12, x2, 0
+  add  x12, x2, x0
   /* x13 is still 32. */
-  addi x15, x8, 0
+  add  x15, x8, x0
   /* x16 is still 32. */
   jal  x1, secand
 
   /* Compute r &= (r >> 1). */
   /* Compute t = r >> 1. */
   addi x4, x0, 1
-  addi x10, x8, 0
-  addi x5, x2, 0
+  add  x10, x8, x0
+  add  x5, x2, x0
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
@@ -3751,11 +3751,11 @@ finalize_cmp:
     bn.sid  x4, 0(x5++)
   endloop
   /* Compute r &= t. */
-  addi x10, x8, 0
+  add  x10, x8, x0
   /* x11 is still 32. */
-  addi x12, x2, 0
+  add  x12, x2, x0
   /* x13 is still 32. */
-  addi x15, x8, 0
+  add  x15, x8, x0
   /* x16 is still 32. */
   jal  x1, secand
 

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -4,39 +4,6 @@
 
 .text
 
-/* Register aliases */
-.equ x0, zero
-.equ x2, sp
-.equ x3, fp
-.equ x5, t0
-#define t1 x6
-.equ x7, t2
-.equ x8, s0
-.equ x9, s1
-.equ x10, a0
-.equ x11, a1
-.equ x12, a2
-.equ x13, a3
-.equ x14, a4
-.equ x15, a5
-.equ x16, a6
-.equ x17, a7
-.equ x18, s2
-.equ x19, s3
-.equ x20, s4
-.equ x21, s5
-.equ x22, s6
-.equ x23, s7
-.equ x24, s8
-.equ x25, s9
-.equ x26, s10
-.equ x27, s11
-.equ x28, t3
-.equ x29, t4
-.equ x30, t5
-.equ x31, t6
-
-
 /*
  * Bibliography
  *
@@ -101,24 +68,24 @@
 .type secand, @function
 secand:
   /* Save addresses. */
-  addi t0, a0, 0
-  addi t1, a2, 0
-  addi t2, a5, 0
+  addi x5, x10, 0
+  addi x6, x12, 0
+  addi x7, x15, 0
 
   /* Load x. */
   bn.xor w0, w0, w0
-  bn.lid x0, 0(t0) /* x[0] */
+  bn.lid x0, 0(x5) /* x[0] */
   bn.xor w1, w1, w1
-  add    t0, t0, a1
+  add    x5, x5, x11
   addi   x4, x0, 1
-  bn.lid x4++, 0(t0) /* x[1] */
+  bn.lid x4++, 0(x5) /* x[1] */
 
   /* Load y. */
   bn.xor w2, w2, w2
-  bn.lid x4++, 0(t1) /* y[0] */
+  bn.lid x4++, 0(x6) /* y[0] */
   bn.xor w3, w3, w3
-  add    t1, t1, a3
-  bn.lid x4, 0(t1) /* y[1] */
+  add    x6, x6, x13
+  bn.lid x4, 0(x6) /* y[1] */
 
   addi    x4, x0, 6
   bn.wsrr w5, urnd
@@ -133,8 +100,8 @@ secand:
   bn.and  w8, w8, w5 /* &= r */
   bn.xor  w7, w7, w8 /* w7 ^= w8 */
   bn.xor  w6, w6, w7
-  bn.sid  x4, 0(t2) /* Save r[0]. */
-  add     t2, t2, a6
+  bn.sid  x4, 0(x7) /* Save r[0]. */
+  add     x7, x7, x16
   /* Handle z_10. */
   bn.xor  w6, w6, w6
   bn.and  w6, w1, w3 /* x[1] & y[1] */
@@ -146,12 +113,12 @@ secand:
   bn.and  w8, w8, w5 /* &= r */
   bn.xor  w7, w7, w8 /* w7 ^= w8 */
   bn.xor  w6, w6, w7
-  bn.sid  x4, 0(t2) /* Save r[1]. */
+  bn.sid  x4, 0(x7) /* Save r[1]. */
 
-  /* Advance a0, a2, a5 to the next bit. */
-  addi a0, a0, 32
-  addi a2, a2, 32
-  addi a5, a5, 32
+  /* Advance x10, x12, x15 to the next bit. */
+  addi x10, x10, 32
+  addi x12, x12, 32
+  addi x15, x15, 32
   ret
 
 /*
@@ -185,24 +152,24 @@ secand:
 .type secfulladder, @function
 secfulladder:
   /* Save addresses. */
-  add t0, a0, x0
-  add t1, a2, x0
-  add t2, a5, x0
-  add t3, a7, x0
+  add x5, x10, x0
+  add x6, x12, x0
+  add x7, x15, x0
+  add x28, x17, x0
 
   /* Load x. */
   bn.xor w0, w0, w0
-  bn.lid x0, 0(t0) /* x[0] */
-  add    t0, t0, a1
+  bn.lid x0, 0(x5) /* x[0] */
+  add    x5, x5, x11
   addi   x4, x0, 1
   bn.xor w1, w1, w1
-  bn.lid x4++, 0(t0) /* x[1] */
+  bn.lid x4++, 0(x5) /* x[1] */
   /* Load y. */
   bn.xor w2, w2, w2
-  bn.lid x4++, 0(t1) /* y[0] */
-  add    t1, t1, a3
+  bn.lid x4++, 0(x6) /* y[0] */
+  add    x6, x6, x13
   bn.xor w3, w3, w3
-  bn.lid x4, 0(t1) /* y[1] */
+  bn.lid x4, 0(x6) /* y[1] */
 
   /* Compute sharewise a = x ^ y. */
   bn.xor w4, w4, w4
@@ -213,19 +180,19 @@ secfulladder:
   /* Compute r = cin ^ a. */
   bn.xor w2, w2, w2
   addi   x4, x0, 2
-  bn.lid x4++, 0(t3)
-  add    t3, t3, t4
+  bn.lid x4++, 0(x28)
+  add    x28, x28, x29
   bn.xor w3, w3, w3
-  bn.lid x4++, 0(t3)
+  bn.lid x4++, 0(x28)
 
   bn.xor w6, w6, w6
   bn.xor w6, w4, w2
   addi   x4, x0, 6
-  bn.sid x4, 0(t2)
-  add    t2, t2, a6
+  bn.sid x4, 0(x7)
+  add    x7, x7, x16
   bn.xor w6, w6, w6
   bn.xor w6, w5, w3
-  bn.sid x4, 0(t2)
+  bn.sid x4, 0(x7)
 
   /* Compute cout = x ^ secand(a, x ^ cin). */
   /* a: w4 -- w5
@@ -253,10 +220,10 @@ secfulladder:
   bn.xor  w2, w2, w3
   bn.xor  w3, w3, w3
   bn.xor  w3, w2, w0
-  add     t2, t5, x0
+  add     x7, x30, x0
   addi    x4, x0, 3
-  bn.sid  x4, 0(t2)
-  add     t2, t2, t6
+  bn.sid  x4, 0(x7)
+  add     x7, x7, x31
   /* Handle cout_10. */
   bn.xor  w2, w2, w2
   bn.and  w2, w5, w7
@@ -270,12 +237,12 @@ secfulladder:
   bn.xor  w2, w2, w3
   bn.xor  w3, w3, w3
   bn.xor  w3, w2, w1
-  bn.sid  x4, 0(t2)
+  bn.sid  x4, 0(x7)
 
   /* Point to next bit. */
-  addi a0, a0, 32
-  addi a2, a2, 32
-  addi a5, a5, 32
+  addi x10, x10, 32
+  addi x12, x12, 32
+  addi x15, x15, 32
   ret
 
 /*
@@ -305,55 +272,55 @@ secfulladder:
 .globl secadd
 .type secadd, @function
 secadd:
-  /* Reserve frame: 64 B carry c at 0(sp), plus saved s0, a7. */
-  addi sp, sp, -96
-  sw   s0, 64(sp)
-  sw   a7, 68(sp)
+  /* Reserve frame: 64 B carry c at 0(x2), plus saved x8, x17. */
+  addi x2, x2, -96
+  sw   x8, 64(x2)
+  sw   x17, 68(x2)
 
   /* Initialize c = 0. */
   bn.xor w0, w0, w0
-  addi   t0, sp, 0 /* ptr_c */
+  addi   x5, x2, 0 /* ptr_c */
   loopi 2, 1
-    bn.sid x0, 0(t0++)
+    bn.sid x0, 0(x5++)
   endloop
 
   /* Ripple-carry adder. */
-  addi s0, a7, -1
-  addi a7, sp, 0 /* ptr_c = cin */
-  addi t4, x0, 32
-  addi t5, sp, 0 /* ptr_c = cout */
-  addi t6, x0, 32
+  addi x8, x17, -1
+  addi x17, x2, 0 /* ptr_c = cin */
+  addi x29, x0, 32
+  addi x30, x2, 0 /* ptr_c = cout */
+  addi x31, x0, 32
   /* Loop over i=0,...,k-2. */
-  loop s0, 2
-    /* a0 already points to x[i] */
-    /* a1 is already share stride of x. */
-    /* a2 already points to y[i] */
-    /* a3 is already share stride of y. */
-    /* a5 already points to r. */
-    /* a6 is already share stride of r. */
-    /* a7 already points to ptr_c = cin. */
-    /* t4 is already share stride of cin. */
-    /* t5 already points to ptr_c = cout. */
-    /* t6 is already share stride of cout. */
+  loop x8, 2
+    /* x10 already points to x[i] */
+    /* x11 is already share stride of x. */
+    /* x12 already points to y[i] */
+    /* x13 is already share stride of y. */
+    /* x15 already points to r. */
+    /* x16 is already share stride of r. */
+    /* x17 already points to ptr_c = cin. */
+    /* x29 is already share stride of cin. */
+    /* x30 already points to ptr_c = cout. */
+    /* x31 is already share stride of cout. */
     jal  x1, secfulladder
     /* After secfulladder:
-     *  - a0 and a2 points to x[i + 1] and y[i + 1].
-     *  - a1 and a3 are still share stride of x and y.
-     *  - a5 points to r[i + 1].
-     *  - a6 is still share stride of r.
-     *  - a7 points to cin.
-     *  - t4 is still share stride of cin.
-     *  - t5 points to cout.
-     *  - t6 is still share stride of cout. */
+     *  - x10 and x12 points to x[i + 1] and y[i + 1].
+     *  - x11 and x13 are still share stride of x and y.
+     *  - x15 points to r[i + 1].
+     *  - x16 is still share stride of r.
+     *  - x17 points to cin.
+     *  - x29 is still share stride of cin.
+     *  - x30 points to cout.
+     *  - x31 is still share stride of cout. */
     nop
   endloop
 
   /* Handle bit i = k-1. */
   /* Compute r[k-1] = x[k-1] ^ y[k-1] ^ c. */
-  addi t0, sp, 0 /* ptr_c */
+  addi x5, x2, 0 /* ptr_c */
   addi x4, x0, 1
-  addi t1, x0, 2
-  addi t2, x0, 3
+  addi x6, x0, 2
+  addi x7, x0, 3
   loopi 2, 14
     /* Whitening. */
     bn.xor w0, w0, w0
@@ -361,23 +328,23 @@ secadd:
     bn.xor w2, w2, w2
     bn.xor w3, w3, w3
     /* Computation. */
-    bn.lid x0, 0(a0)
-    bn.lid x4, 0(a2)
-    bn.lid t1, 0(t0)
+    bn.lid x0, 0(x10)
+    bn.lid x4, 0(x12)
+    bn.lid x6, 0(x5)
     bn.xor w3, w0, w1
     bn.xor w3, w3, w2
-    bn.sid t2, 0(a5)
+    bn.sid x7, 0(x15)
     /* Adjust addresses. */
-    add    a0, a0, a1
-    add    a2, a2, a3
-    add    t0, t0, t4
-    add    a5, a5, a6
+    add    x10, x10, x11
+    add    x12, x12, x13
+    add    x5, x5, x29
+    add    x15, x15, x16
   endloop
 
   /* Restore registers and frame. */
-  lw   s0, 64(sp)
-  lw   a7, 68(sp)
-  addi sp, sp, 96
+  lw   x8, 64(x2)
+  lw   x17, 68(x2)
+  addi x2, x2, 96
   ret
 
 /*
@@ -407,21 +374,21 @@ bitcopymask:
   loopi 2, 10
     /* Whitening. */
     bn.xor w0, w0, w0
-    bn.lid x0, 0(a0)
-    add    a0, a0, a1
+    bn.lid x0, 0(x10)
+    add    x10, x10, x11
     /* Copy x to bit 0. */
-    bn.sid x0, 0(a3++)
+    bn.sid x0, 0(x13++)
     /* Clear bit 1 -- 7. */
     loopi 7, 1
-      bn.sid x4, 0(a3++)
+      bn.sid x4, 0(x13++)
     endloop
     /* Copy x to bit 8. */
-    bn.sid x0, 0(a3++)
+    bn.sid x0, 0(x13++)
     /* Clear bit 9. */
-    bn.sid x4, 0(a3++)
+    bn.sid x4, 0(x13++)
     /* Copy x to bit 10 -- 11. */
-    bn.sid x0, 0(a3++)
-    bn.sid x0, 0(a3++)
+    bn.sid x0, 0(x13++)
+    bn.sid x0, 0(x13++)
   endloop
   ret
 
@@ -449,23 +416,23 @@ bitcopymask:
 .globl refreshios
 .type refreshios, @function
 refreshios:
-  add  t0, a0, a2 /* 2nd share of x */
-  add  t1, a4, a2 /* 2nd share of r */
+  add  x5, x10, x12 /* 2nd share of x */
+  add  x6, x14, x12 /* 2nd share of r */
   addi x4, x0, 1
-  loop a1, 11
+  loop x11, 11
     bn.wsrr w2, urnd
     /* Whitening. */
     bn.xor  w0, w0, w0
     bn.xor  w1, w1, w1
-    bn.lid  x0, 0(a0++)
+    bn.lid  x0, 0(x10++)
     bn.xor  w1, w0, w2
-    bn.sid  x4, 0(a4++)
+    bn.sid  x4, 0(x14++)
     /* Whitening. */
     bn.xor  w0, w0, w0
     bn.xor  w1, w1, w1
-    bn.lid  x0, 0(t0++)
+    bn.lid  x0, 0(x5++)
     bn.xor  w1, w0, w2
-    bn.sid  x4, 0(t1++)
+    bn.sid  x4, 0(x6++)
   endloop
   ret
 
@@ -476,8 +443,8 @@ refreshios:
  * rejection sampling on uniform random bytes from URND.
  *
  * @param[in]  w16: sw0, R | Q
- * @param[out] a0: ptr_r, dmem pointer to output polynomial
- * @param[in]  a1: dmem pointer to random input words (MLKEM_REJ_SAMPLE_TEST only)
+ * @param[out] x10: ptr_r, dmem pointer to output polynomial
+ * @param[in]  x11: dmem pointer to random input words (MLKEM_REJ_SAMPLE_TEST only)
  * @param[in]  w31: all-zero register
  *
  * clobbered registers: x5 to x6, x10, w0 to w5, acch, acc
@@ -488,27 +455,27 @@ refreshios:
 .type poly_rej_samp, @function
 poly_rej_samp:
   /* Load 19*Q - 1 into w1. */
-  addi      t0, x0, 1
-  la        t1, modulus_times_19_minus_1
-  bn.lid    t0++, 0(t1)
+  addi      x5, x0, 1
+  la        x6, modulus_times_19_minus_1
+  bn.lid    x5++, 0(x6)
   bn.shv.8s w1, w1 >> 16
   
   /* Load mont = 2**16 % Q into w2. */
-  la     t1, mont
-  bn.lid t0, 0(t1)
+  la     x6, mont
+  bn.lid x5, 0(x6)
   
-  /* a0 + 512 is the last valid address. */
-  addi t0, a0, 512
+  /* x10 + 512 is the last valid address. */
+  addi x5, x10, 512
 
 #if defined(MLKEM_REJ_SAMPLE_TEST)
-  addi t5, x0, 3
+  addi x30, x0, 3
 #endif
   
   /* Loop until 256 coefficients have been written to the output */
 _rej_sample_loop:
   /* Get 16 randoms. */
 #if defined(MLKEM_REJ_SAMPLE_TEST)
-  bn.lid      t5, 0(a1++)
+  bn.lid      x30, 0(x11++)
 #else
   bn.wsrr     w3, urnd
 #endif
@@ -520,12 +487,12 @@ _rej_sample_loop:
   bn.shv.8s   w5, w5 >> 31
   bn.trn1.16h w4, w4, w5
   bn.xor      w4, w4, w31, FG0
-  csrrs       t1, fg0, x0 /* Read flag fg0. */
-  srli        t1, t1, 3 /* Extract FG0.z */
+  csrrs       x6, fg0, x0 /* Read flag fg0. */
+  srli        x6, x6, 3 /* Extract FG0.z */
   
   /* If FG0.z == 0, there is at least one bad coeff. We throw away this
    * vector and sample again. */
-  beq t1, x0, _rej_sample_loop
+  beq x6, x0, _rej_sample_loop
   
   /* Once the whole vector is accepted, reduce the accepted candidates mod Q
    * using Montgomery. */
@@ -533,10 +500,10 @@ _rej_sample_loop:
   bn.mulv.l.16h.lo     w0, w0, sw0.2
   bn.mulv.l.16h.acc.hi w0, w0, sw0.0
   bn.addvm.16h         w0, w0, w31
-  bn.sid               x0, 0(a0++)
+  bn.sid               x0, 0(x10++)
   
-  /* If a0 == t0, we've filled up a polynomial. Otherwise, continue to sample. */
-  beq a0, t0, _end_rej_sample_loop
+  /* If x10 == x5, we've filled up a polynomial. Otherwise, continue to sample. */
+  beq x10, x5, _end_rej_sample_loop
   beq x0, x0, _rej_sample_loop
 
 _end_rej_sample_loop:
@@ -564,38 +531,38 @@ _end_rej_sample_loop:
 .globl refreshmodq
 .type refreshmodq, @function
 refreshmodq:
-  /* Reserve frame: 512 B for rand at 0(sp), plus saved a0, a2. */
-  addi sp, sp, -544
-  sw a0, 512(sp)
-  sw a2, 516(sp)
+  /* Reserve frame: 512 B for rand at 0(x2), plus saved x10, x12. */
+  addi x2, x2, -544
+  sw x10, 512(x2)
+  sw x12, 516(x2)
 
   /* Generate rand. */
-  add a0, sp, x0
+  add x10, x2, x0
   jal x1, poly_rej_samp
 
   /* r[0] = x[0] + rand. */
   /* r[1] = x[1] - rand. */
-  add  t0, sp, 0 /* rand */
-  lw   a0, 512(sp)
-  addi t1, a0, 512 /* x[1] */
-  lw   a2, 516(sp)
-  addi t2, a2, 512 /* r[1] */
+  add  x5, x2, 0 /* rand */
+  lw   x10, 512(x2)
+  addi x6, x10, 512 /* x[1] */
+  lw   x12, 516(x2)
+  addi x7, x12, 512 /* r[1] */
   addi x4, x0, 1
-  addi t3, x0, 2
+  addi x28, x0, 2
   loopi 16, 9
-    bn.lid       x0, 0(t0++)
-    bn.lid       x4, 0(a0++)
+    bn.lid       x0, 0(x5++)
+    bn.lid       x4, 0(x10++)
     bn.addvm.16h w2, w1, w0
-    bn.sid       t3, 0(a2++)
+    bn.sid       x28, 0(x12++)
     bn.xor       w1, w1, w1
     bn.xor       w2, w2, w2
-    bn.lid       x4, 0(t1++)
+    bn.lid       x4, 0(x6++)
     bn.subvm.16h w2, w1, w0
-    bn.sid       t3, 0(t2++)
+    bn.sid       x28, 0(x7++)
   endloop
 
   /* Restore stack. */
-  addi sp, sp, 544
+  addi x2, x2, 544
   ret
 
 /*
@@ -619,17 +586,17 @@ poly_to_bitsliced:
   /* Reverse-load the 16 input WDRs: coefficient WDR i -> w[15 - i]. */
   addi x4, x0, 15
   loopi 16, 2
-    bn.lid x4, 0(a0++)
+    bn.lid x4, 0(x10++)
     addi   x4, x4, -1
   endloop
 
   jal x1, _bitslice_transpose
 
-  /* Store the 12 bitsliced words bs[0..11] via a0 so a1 is left unchanged. */
+  /* Store the 12 bitsliced words bs[0..11] via x10 so x11 is left unchanged. */
   addi   x4, x0, 0
-  addi   a0, a1, 0
+  addi   x10, x11, 0
   loopi 12, 2
-    bn.sid x4, 0(a0++)
+    bn.sid x4, 0(x10++)
     addi   x4, x4, 1
   endloop
   ret
@@ -656,7 +623,7 @@ poly_from_bitsliced:
   /* Load bs[0..11] into w0..w11; zero the upper bit positions w12..w15. */
   addi x4, x0, 0
   loopi 12, 2
-    bn.lid x4, 0(a0++)
+    bn.lid x4, 0(x10++)
     addi   x4, x4, 1
   endloop
   bn.xor w12, w12, w12
@@ -669,7 +636,7 @@ poly_from_bitsliced:
   /* Reverse-store: w[b] -> coefficient WDR (15 - b). */
   addi x4, x0, 15
   loopi 16, 2
-    bn.sid x4, 0(a1++)
+    bn.sid x4, 0(x11++)
     addi   x4, x4, -1
   endloop
   ret
@@ -908,59 +875,59 @@ _bitslice_transpose:
 .globl seca2b
 .type seca2b, @function
 seca2b:
-  /* Save fp to stack */
-  addi sp, sp, -32
-  sw   fp, 0(sp)
-  addi fp, sp, 0
+  /* Save x3 to stack */
+  addi x2, x2, -32
+  sw   x3, 0(x2)
+  addi x3, x2, 0
 
   /* Adjust stack for temp variables. */
-  slli t0, a2, 1
-  sub  sp, sp, t0 /* ptr_s */
-  add  t1, sp, x0
-  sub  sp, sp, t0 /* ptr_sp */
+  slli x5, x12, 1
+  sub  x2, x2, x5 /* ptr_s */
+  add  x6, x2, x0
+  sub  x2, x2, x5 /* ptr_sp */
 
   /* Build s = (x[0], 0). */
-  add t2, t1, x0 /* Save ptr_s. */
-  loop a1, 3
+  add x7, x6, x0 /* Save ptr_s. */
+  loop x11, 3
     bn.xor w0, w0, w0
-    bn.lid x0, 0(a0++)
-    bn.sid x0, 0(t1++)
+    bn.lid x0, 0(x10++)
+    bn.sid x0, 0(x6++)
   endloop
   bn.xor w0, w0, w0
-  loop a1, 1
-    bn.sid x0, 0(t1++)
+  loop x11, 1
+    bn.sid x0, 0(x6++)
   endloop
 
   /* Build s' = (0, x[1]). */
-  add t0, sp, x0
-  loop a1, 1
-    bn.sid x0, 0(t0++)
+  add x5, x2, x0
+  loop x11, 1
+    bn.sid x0, 0(x5++)
   endloop
-  loop a1, 3
-    bn.lid x0, 0(a0++)
-    bn.sid x0, 0(t0++)
+  loop x11, 3
+    bn.lid x0, 0(x10++)
+    bn.sid x0, 0(x5++)
     bn.xor w0, w0, w0
   endloop
 
   /* Save registers. */
-  add t0, a1, x0
-  add t1, a2, x0
-  add t3, a4, x0
+  add x5, x11, x0
+  add x6, x12, x0
+  add x28, x14, x0
 
   /* Compute r = secadd(s, s', k). */
-  addi a0, t2, 0 /* ptr_s */
-  addi a1, t1, 0
-  addi a2, sp, 0 /* ptr_sp */
-  addi a3, t1, 0
-  addi a5, t3, 0 /* ptr_r */
-  addi a6, t1, 0
-  addi a7, t0, 0 /* k */
+  addi x10, x7, 0 /* ptr_s */
+  addi x11, x6, 0
+  addi x12, x2, 0 /* ptr_sp */
+  addi x13, x6, 0
+  addi x15, x28, 0 /* ptr_r */
+  addi x16, x6, 0
+  addi x17, x5, 0 /* k */
   jal  x1, secadd
 
-  /* Restore sp and fp. */
-  addi sp, fp, 0
-  lw   fp, 0(sp)
-  addi sp, sp, 32
+  /* Restore x2 and x3. */
+  addi x2, x3, 0
+  lw   x3, 0(x2)
+  addi x2, x2, 32
   ret
 
 /*
@@ -987,19 +954,19 @@ seca2b:
 .globl seca2bmodq
 .type seca2bmodq, @function
 seca2bmodq:
-  /* Frame below sp:
-   *   sp +    0 : s' / a   (832 B)
-   *   sp +  832 : carry c  ( 64 B)
-   *   sp +  896 : s / u    (832 B)
-   *   sp + 1728 : saved s2 */
-  addi sp, sp, -1760
-  sw   s2, 1728(sp)
-  addi s2, a2, 0 /* output pointer */
+  /* Frame below x2:
+   *   x2 +    0 : s' / a   (832 B)
+   *   x2 +  832 : carry c  ( 64 B)
+   *   x2 +  896 : s / u    (832 B)
+   *   x2 + 1728 : saved x18 */
+  addi x2, x2, -1760
+  sw   x18, 1728(x2)
+  addi x18, x12, 0 /* output pointer */
 
   /* Compute s = p + x[0], k + 1 bits (one share).
    * p = 2**(k + 1) - q = 4863 = b1001011111111. */
-  addi t0, sp, 896 /* ptr_s */
-  /* a0 already points to x[0]. */
+  addi x5, x2, 896 /* ptr_s */
+  /* x10 already points to x[0]. */
   addi x4, x0, 1
   /* cin = 0 */
   bn.xor w2, w2, w2
@@ -1010,10 +977,10 @@ seca2bmodq:
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
     /* Compute r = x ^ p ^ cin. */
-    bn.lid x0, 0(a0++)
+    bn.lid x0, 0(x10++)
     bn.not w3, w0 /* a = x ^ p */
     bn.xor w1, w3, w2 /* r = a ^ cin */
-    bn.sid x4, 0(t0++) /* Save r. */
+    bn.sid x4, 0(x5++) /* Save r. */
     /* Compute cout = x ^ ((x ^ p) & (x ^ cin)) = x ^ (a & (x ^ cin)). */
     bn.xor w2, w0, w2 /* cout = x ^ cin */
     bn.and w2, w3, w2 /* cout &= a */
@@ -1025,9 +992,9 @@ seca2bmodq:
   bn.xor w0, w0, w0
   bn.xor w1, w1, w1
   /* Compute r = x ^ 0 ^ cin = x ^ cin. */
-  bn.lid x0, 0(a0++)
+  bn.lid x0, 0(x10++)
   bn.xor w1, w0, w2 /* r = x ^ cin */
-  bn.sid x4, 0(t0++) /* Save r. */
+  bn.sid x4, 0(x5++) /* Save r. */
   /* Compute cout = x ^ ((x ^ p) & (x ^ cin)) = x ^ (x & r). */
   bn.and w2, w0, w1 /* cout = x & r */
   bn.xor w2, w2, w0 /* cout ^= x */
@@ -1037,10 +1004,10 @@ seca2bmodq:
   bn.xor w0, w0, w0
   bn.xor w1, w1, w1
   /* Compute r = x ^ p ^ cin. */
-  bn.lid x0, 0(a0++)
+  bn.lid x0, 0(x10++)
   bn.not w3, w0 /* a = x ^ p */
   bn.xor w1, w3, w2 /* r = a ^ cin */
-  bn.sid x4, 0(t0++) /* Save r. */
+  bn.sid x4, 0(x5++) /* Save r. */
   /* Compute cout = x ^ ((x ^ p) & (x ^ cin)) = x ^ (a & (x ^ cin)). */
   bn.xor w2, w0, w2 /* cout = x ^ cin */
   bn.and w2, w3, w2 /* cout &= a */
@@ -1052,9 +1019,9 @@ seca2bmodq:
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
     /* Compute r = x ^ 0 ^ cin = x ^ cin. */
-    bn.lid x0, 0(a0++)
+    bn.lid x0, 0(x10++)
     bn.xor w1, w0, w2 /* r = x ^ cin */
-    bn.sid x4, 0(t0++) /* Save r. */
+    bn.sid x4, 0(x5++) /* Save r. */
     /* Compute cout = x ^ ((x ^ p) & (x ^ cin)) = x ^ (x & r). */
     bn.and w2, w0, w1 /* cout = x & r */
     bn.xor w2, w2, w0 /* cout ^= x */
@@ -1065,46 +1032,46 @@ seca2bmodq:
   bn.xor w1, w1, w1
   /* Compute r = x ^ p ^ cin = p ^ cin. (x only has k bits, while p has k + 1 bits). */
   bn.not w1, w2 /* r = p ^ cin */
-  bn.sid x4, 0(t0++) /* Save r. */
+  bn.sid x4, 0(x5++) /* Save r. */
 
   /* Extend s to 2 shares, i.e., clear next share of s. */
   bn.xor w0, w0, w0
   loopi 13, 1
-    bn.sid x0, 0(t0++)
+    bn.sid x0, 0(x5++)
   endloop
 
   /* Clear first share of sprime and copy x[1] to second share of sprime with
    * share stride = 416. */
-  addi t0, sp, 0 /* ptr_sprime */
+  addi x5, x2, 0 /* ptr_sprime */
   loopi 13, 1
-    bn.sid x0, 0(t0++)
+    bn.sid x0, 0(x5++)
   endloop
   loopi 12, 3
-    bn.lid x0, 0(a0++) /* a0 already points to x[1]. */
-    bn.sid x0, 0(t0++)
+    bn.lid x0, 0(x10++) /* x10 already points to x[1]. */
+    bn.sid x0, 0(x5++)
     /* Whitening. */
     bn.xor w0, w0, w0
   endloop
-  bn.sid x0, 0(t0++)
+  bn.sid x0, 0(x5++)
 
   /* Compute u = secadd(s, sprime, k + 1). */
   /* Initialize c = 0. */
-  addi  t0, sp, 832 /* ptr_c */
+  addi  x5, x2, 832 /* ptr_c */
   bn.xor w0, w0, w0
   loopi 2, 1
-    bn.sid x0, 0(t0++)
+    bn.sid x0, 0(x5++)
   endloop
 
-  addi a0, sp, 896 /* ptr_s */
-  addi a1, x0, 416
-  addi a2, sp, 0 /* ptr_sprime */
-  addi a3, x0, 416
-  addi a5, sp, 896 /* ptr_u */
-  addi a6, x0, 416
-  addi a7, sp, 832 /* ptr_c */
-  addi t4, x0, 32
-  addi t5, sp, 832 /* ptr_c */
-  addi t6, x0, 32
+  addi x10, x2, 896 /* ptr_s */
+  addi x11, x0, 416
+  addi x12, x2, 0 /* ptr_sprime */
+  addi x13, x0, 416
+  addi x15, x2, 896 /* ptr_u */
+  addi x16, x0, 416
+  addi x17, x2, 832 /* ptr_c */
+  addi x29, x0, 32
+  addi x30, x2, 832 /* ptr_c */
+  addi x31, x0, 32
   loopi 12, 2
     jal x1, secfulladder
     nop
@@ -1112,8 +1079,8 @@ seca2bmodq:
   /* Handle bit 12. */
   /* Compute r[12] = x[12] ^ y[12] ^ c. */
   addi x4, x0, 1
-  addi t1, x0, 2
-  addi t2, x0, 3
+  addi x6, x0, 2
+  addi x7, x0, 3
   loopi 2, 14
     /* Whitening. */
     bn.xor w0, w0, w0
@@ -1121,43 +1088,43 @@ seca2bmodq:
     bn.xor w2, w2, w2
     bn.xor w3, w3, w3
     /* Computation. */
-    bn.lid x0, 0(a0)
-    bn.lid x4, 0(a2)
-    bn.lid t1, 0(a7)
+    bn.lid x0, 0(x10)
+    bn.lid x4, 0(x12)
+    bn.lid x6, 0(x17)
     bn.xor w3, w0, w1
     bn.xor w3, w3, w2
-    bn.sid t2, 0(a5)
+    bn.sid x7, 0(x15)
     /* Adjust addresses. */
-    add    a0, a0, a1
-    add    a2, a2, a3
-    add    a7, a7, t4
-    add    a5, a5, a6
+    add    x10, x10, x11
+    add    x12, x12, x13
+    add    x17, x17, x29
+    add    x15, x15, x16
   endloop
 
   /* Compute a = bitcopymask(u[k], (k + 1) * 32). */
-  addi a0, sp, 1280 /* ptr_u[k] */
-  addi a1, x0, 416
-  addi a3, sp, 0 /* ptr_a */
+  addi x10, x2, 1280 /* ptr_u[k] */
+  addi x11, x0, 416
+  addi x13, x2, 0 /* ptr_a */
   jal  x1, bitcopymask
 
   /* Compute u = secadd(a, u, k). */
   /* Initialize c = 0. */
-  addi  t0, sp, 832 /* ptr_c */
+  addi  x5, x2, 832 /* ptr_c */
   bn.xor w0, w0, w0
   loopi 2, 1
-    bn.sid x0, 0(t0++)
+    bn.sid x0, 0(x5++)
   endloop
 
-  addi a0, sp, 0 /* ptr_a */
-  addi a1, x0, 384
-  addi a2, sp, 896 /* ptr_u */
-  addi a3, x0, 416
-  addi a5, s2, 0 /* ptr_r */
-  addi a6, x0, 384
-  addi a7, sp, 832 /* ptr_c */
-  addi t4, x0, 32
-  addi t5, sp, 832 /* ptr_c */
-  addi t6, x0, 32
+  addi x10, x2, 0 /* ptr_a */
+  addi x11, x0, 384
+  addi x12, x2, 896 /* ptr_u */
+  addi x13, x0, 416
+  addi x15, x18, 0 /* ptr_r */
+  addi x16, x0, 384
+  addi x17, x2, 832 /* ptr_c */
+  addi x29, x0, 32
+  addi x30, x2, 832 /* ptr_c */
+  addi x31, x0, 32
   loopi 11, 2
     jal x1, secfulladder
     nop
@@ -1165,8 +1132,8 @@ seca2bmodq:
   /* Handle bit 11. */
   /* Compute r[11] = x[11] ^ y[11] ^ c. */
   addi x4, x0, 1
-  addi t1, x0, 2
-  addi t2, x0, 3
+  addi x6, x0, 2
+  addi x7, x0, 3
   loopi 2, 14
     /* Whitening. */
     bn.xor w0, w0, w0
@@ -1174,22 +1141,22 @@ seca2bmodq:
     bn.xor w2, w2, w2
     bn.xor w3, w3, w3
     /* Computation. */
-    bn.lid x0, 0(a0)
-    bn.lid x4, 0(a2)
-    bn.lid t1, 0(a7)
+    bn.lid x0, 0(x10)
+    bn.lid x4, 0(x12)
+    bn.lid x6, 0(x17)
     bn.xor w3, w0, w1
     bn.xor w3, w3, w2
-    bn.sid t2, 0(a5)
+    bn.sid x7, 0(x15)
     /* Adjust addresses. */
-    add    a0, a0, a1
-    add    a2, a2, a3
-    add    a7, a7, t4
-    add    a5, a5, a6
+    add    x10, x10, x11
+    add    x12, x12, x13
+    add    x17, x17, x29
+    add    x15, x15, x16
   endloop
 
-  /* Restore s2 and frame. */
-  lw   s2, 1728(sp)
-  addi sp, sp, 1760
+  /* Restore x18 and frame. */
+  lw   x18, 1728(x2)
+  addi x2, x2, 1760
   ret
 
 /*
@@ -1216,24 +1183,24 @@ seca2bmodq:
 .globl seconebitb2amodq
 .type seconebitb2amodq, @function
 seconebitb2amodq:
-  /* Frame: v[0..1] at sp+0 (1024 B), saved s0/s2 above. */
-  addi sp, sp, -1056
-  sw   s0, 1024(sp)
-  sw   s2, 1028(sp)
-  addi s0, a0, 0 /* ptr_x */
-  addi s2, a2, 0 /* ptr_r */
+  /* Frame: v[0..1] at x2+0 (1024 B), saved x8/x18 above. */
+  addi x2, x2, -1056
+  sw   x8, 1024(x2)
+  sw   x18, 1028(x2)
+  addi x8, x10, 0 /* ptr_x */
+  addi x18, x12, 0 /* ptr_r */
 
   /* Copy x[0] to v[0]. */
-  addi t0, sp, 0 /* ptr_v */
-  add  t1, a0, x0 /* ptr_x[0] */
+  addi x5, x2, 0 /* ptr_v */
+  add  x6, x10, x0 /* ptr_x[0] */
   loopi 16, 2
-    bn.lid x0, 0(t1++)
-    bn.sid x0, 0(t0++)
+    bn.lid x0, 0(x6++)
+    bn.sid x0, 0(x5++)
   endloop
   /* Zeroize v[1]. */
   bn.xor w0, w0, w0
   loopi 16, 1
-    bn.sid x0, 0(t0++)
+    bn.sid x0, 0(x5++)
   endloop
 
   /* Construct the vector of 1s. */
@@ -1241,55 +1208,55 @@ seconebitb2amodq:
   bn.shv.16h w30, w30 >> 15
 
   /* Refresh v in place. */
-  addi a0, sp, 0 /* ptr_v */
-  addi a2, a0, 0 /* in-place */
+  addi x10, x2, 0 /* ptr_v */
+  addi x12, x10, 0 /* in-place */
   jal  x1, refreshmodq
 
   /* To avoid use modular multiplication, we compute (1 - 2*x[1]) * v[j]
    * as follows:
-   *  - t0 = x[1] - 1
-   *  - We have t0 = 0xFFFF if x[1] = 0 and t0 = 0 if x[1] = 1.
-   *  - t1 = v[j] & t0
-   *  - t1 <<= 1
-   *  - r = bn.subvm(t1, v[j]) with MOD = Q. This works because if x[1] = 0,
-   *    then t1 = 2*v[j] and r = 2*v[j] - v[j] = v[j]. Otherwise,
-   *    t1 = (0 - v[j]) mod Q.
+   *  - x5 = x[1] - 1
+   *  - We have x5 = 0xFFFF if x[1] = 0 and x5 = 0 if x[1] = 1.
+   *  - x6 = v[j] & x5
+   *  - x6 <<= 1
+   *  - r = bn.subvm(x6, v[j]) with MOD = Q. This works because if x[1] = 0,
+   *    then x6 = 2*v[j] and r = 2*v[j] - v[j] = v[j]. Otherwise,
+   *    x6 = (0 - v[j]) mod Q.
    * For v[0], we continue with v[0] = (v[0] + x[1]) mod Q before
    * saving the result to memory.
    */
-  addi t0, s0, 512 /* ptr_x[1] */
-  addi t1, sp, 0 /* ptr_v */
+  addi x5, x8, 512 /* ptr_x[1] */
+  addi x6, x2, 0 /* ptr_v */
   addi x4, x0, 1
   loopi 16, 16
-    bn.lid         x0, 0(t0++) /* x[1] */
+    bn.lid         x0, 0(x5++) /* x[1] */
     bn.subv.16h    w2, w0, w30
-    addi           t2, t1, 0
+    addi           x7, x6, 0
     /* v[0]: also add x[1] before storing. */
-    bn.lid       x4, 0(t1) /* v[0] */
+    bn.lid       x4, 0(x6) /* v[0] */
     bn.and       w3, w1, w2
     bn.shv.16h   w3, w3 << 1
     bn.subvm.16h w1, w3, w1
     bn.addvm.16h w1, w0, w1
-    bn.sid       x4, 0(t1)
-    addi         t1, t1, 512 /* Point to v[1]. */
+    bn.sid       x4, 0(x6)
+    addi         x6, x6, 512 /* Point to v[1]. */
     /* v[1]. */
-    bn.lid       x4, 0(t1) /* v[1] */
+    bn.lid       x4, 0(x6) /* v[1] */
     bn.and       w3, w1, w2
     bn.shv.16h   w3, w3 << 1
     bn.subvm.16h w1, w3, w1
-    bn.sid       x4, 0(t1)
-    addi t1, t2, 32
+    bn.sid       x4, 0(x6)
+    addi x6, x7, 32
   endloop
 
   /* Final refresh: r = refreshmodq(v). */
-  addi a0, sp, 0 /* ptr_v */
-  addi a2, s2, 0 /* ptr_r */
+  addi x10, x2, 0 /* ptr_v */
+  addi x12, x18, 0 /* ptr_r */
   jal  x1, refreshmodq
 
   /* Restore registers and frame. */
-  lw   s0, 1024(sp)
-  lw   s2, 1028(sp)
-  addi sp, sp, 1056
+  lw   x8, 1024(x2)
+  lw   x18, 1028(x2)
+  addi x2, x2, 1056
   ret
 
 /*
@@ -1318,53 +1285,53 @@ seconebitb2amodq:
 .type secb2amodq, @function
 secb2amodq:
   /* Frame (2656 B, 2 shares):
-   *   sp +    0 : saved s0, s2, s3, s4, s5
-   *   sp +   32 : ptr_zp / scratch (1024 B)
-   *   sp + 1056 : ptr_s            ( 832 B)
-   *   sp + 1888 : ptr_a, ptr_b, ptr_c (bitsliced, 768 B) */
-  addi sp, sp, -2048
-  addi sp, sp, -608
-  sw s0, 0(sp)
-  sw s2, 4(sp)
-  sw s3, 8(sp)
-  sw s4, 12(sp)
-  sw s5, 16(sp)
+   *   x2 +    0 : saved x8, x18, x19, x20, x21
+   *   x2 +   32 : ptr_zp / scratch (1024 B)
+   *   x2 + 1056 : ptr_s            ( 832 B)
+   *   x2 + 1888 : ptr_a, ptr_b, ptr_c (bitsliced, 768 B) */
+  addi x2, x2, -2048
+  addi x2, x2, -608
+  sw x8, 0(x2)
+  sw x18, 4(x2)
+  sw x19, 8(x2)
+  sw x20, 12(x2)
+  sw x21, 16(x2)
 
   /* Save input/output addresses and buffer bases. */
-  addi s0, a0, 0 /* ptr_x */
-  addi s2, a2, 0 /* ptr_r */
-  addi s3, sp, 1888 /* ptr_a, ptr_b, ptr_c (bitsliced) */
-  addi s4, sp, 1056 /* ptr_s */
-  /* ptr_zp = sp + 32 */
+  addi x8, x10, 0 /* ptr_x */
+  addi x18, x12, 0 /* ptr_r */
+  addi x19, x2, 1888 /* ptr_a, ptr_b, ptr_c (bitsliced) */
+  addi x20, x2, 1056 /* ptr_s */
+  /* ptr_zp = x2 + 32 */
 
   /* Sample rand, then compute zp = q - rand. */
   addi    x4, x0, 30
-  la      t0, modulus_bn
-  bn.lid  x4, 0(t0)
-  addi    a0, a2, 0 /* ptr_r */
-  addi    t2, sp, 32 /* ptr_zp */
+  la      x5, modulus_bn
+  bn.lid  x4, 0(x5)
+  addi    x10, x12, 0 /* ptr_r */
+  addi    x7, x2, 32 /* ptr_zp */
   bn.wsrr w16, mod
   jal x1, poly_rej_samp
   loopi 16, 3
-    bn.lid      x0, 0(a2++)
+    bn.lid      x0, 0(x12++)
     bn.subv.16h w0, w30, w0 /* Since inputs are < q, we need to only use bn.subv. */
-    bn.sid      x0, 0(t2++)
+    bn.sid      x0, 0(x7++)
   endloop
 
   /* Bitslice share 0 of zp; the last share (bitsliced) is cleared below. */
-  addi a0, sp, 32 /* ptr_zp */
-  addi a1, s3, 0 /* ptr_zp (bitsliced) */
+  addi x10, x2, 32 /* ptr_zp */
+  addi x11, x19, 0 /* ptr_zp (bitsliced) */
   jal  x1, poly_to_bitsliced
-  addi a1, a1, 384
+  addi x11, x11, 384
   /* Clear the last share of zp (bitsliced). */
   bn.xor w0, w0, w0
   loopi 12, 1
-    bn.sid x0, 0(a1++)
+    bn.sid x0, 0(x11++)
   endloop
 
   /* Compute a = seca2bmodq(zp). */
-  addi a0, s3, 0 /* ptr_zp (bitsliced) */
-  addi a2, s3, 0 /* ptr_a */
+  addi x10, x19, 0 /* ptr_zp (bitsliced) */
+  addi x12, x19, 0 /* ptr_a */
   jal  x1, seca2bmodq
 
   /* Compute b = secaddmodq(a, x). */
@@ -1372,176 +1339,176 @@ secb2amodq:
   /* Compute s = secadd(a, x, k + 1). */
   /* Initialize c = 0. */
   bn.xor w0, w0, w0
-  addi   t0, s4, 384 /* ptr_c */
+  addi   x5, x20, 384 /* ptr_c */
   loopi 2, 2
-    bn.sid x0, 0(t0)
-    addi   t0, t0, 416
+    bn.sid x0, 0(x5)
+    addi   x5, x5, 416
   endloop
 
   /* Ripple-carry adder. */
-  addi a0, s3, 0 /* ptr_a */
-  addi a1, x0, 384
-  addi a2, s0, 0 /* ptr_x */
-  addi a3, x0, 384
-  addi a5, s4, 0 /* ptr_s */
-  addi a6, x0, 416
-  addi a7, s4, 384 /* ptr_c = cin */
-  addi t4, x0, 416
-  addi t5, s4, 384 /* ptr_c = cout */
-  addi t6, x0, 416
+  addi x10, x19, 0 /* ptr_a */
+  addi x11, x0, 384
+  addi x12, x8, 0 /* ptr_x */
+  addi x13, x0, 384
+  addi x15, x20, 0 /* ptr_s */
+  addi x16, x0, 416
+  addi x17, x20, 384 /* ptr_c = cin */
+  addi x29, x0, 416
+  addi x30, x20, 384 /* ptr_c = cout */
+  addi x31, x0, 416
   /* Loop over i=1,...,k-1. */
   loopi 12, 2
-    /* a0 already points to x[i] */
-    /* a1 is already share stride of x. */
-    /* a2 already points to y[i] */
-    /* a3 is already share stride of y. */
-    /* a5 already points to r. */
-    /* a6 is already share stride of r. */
-    /* a7 already points to ptr_c = cin. */
-    /* t4 is already share stride of cin. */
-    /* t5 already points to ptr_c = cout. */
-    /* t6 is already share stride of cout. */
+    /* x10 already points to x[i] */
+    /* x11 is already share stride of x. */
+    /* x12 already points to y[i] */
+    /* x13 is already share stride of y. */
+    /* x15 already points to r. */
+    /* x16 is already share stride of r. */
+    /* x17 already points to ptr_c = cin. */
+    /* x29 is already share stride of cin. */
+    /* x30 already points to ptr_c = cout. */
+    /* x31 is already share stride of cout. */
     jal  x1, secfulladder
     /* After secfulladder:
-     *  - a0 and a2 points to x[i + 1] and y[i + 1].
-     *  - a1 and a3 are still share stride of x and y.
-     *  - a5 points to r[i + 1].
-     *  - a6 is still share stride of r.
-     *  - a7 points to cin.
-     *  - t4 is still share stride of cin.
-     *  - t5 points to cout.
-     *  - t6 is still share stride of cout. */
+     *  - x10 and x12 points to x[i + 1] and y[i + 1].
+     *  - x11 and x13 are still share stride of x and y.
+     *  - x15 points to r[i + 1].
+     *  - x16 is still share stride of r.
+     *  - x17 points to cin.
+     *  - x29 is still share stride of cin.
+     *  - x30 points to cout.
+     *  - x31 is still share stride of cout. */
     nop
   endloop
   /* Bit i = k + 1 is already x[k + 1] ^ y[k + 1] ^ c = cout since x[k + 1] = y[k + 1] = 0. */
 
   /* Compute s = secadd(s, p, k + 1) where p = 2**(k + 1) - q = 4863 = b1001011111111. */
   /* Initialize c = 0. */
-  addi   t0, sp, 32 /* ptr_c */
+  addi   x5, x2, 32 /* ptr_c */
   bn.xor w0, w0, w0
   loopi 2, 1
-    bn.sid x0, 0(t0++)
+    bn.sid x0, 0(x5++)
   endloop
-  addi s5, t0, 0 /* ptr_p */
+  addi x21, x5, 0 /* ptr_p */
 
-  addi    t0, s5, 0 /* ptr_p */
+  addi    x5, x21, 0 /* ptr_p */
   bn.subi w1, w0, 1
   addi    x4, x0, 1
-  bn.sid  x4, 0(t0++)
-  bn.sid  x0, 0(t0++)
+  bn.sid  x4, 0(x5++)
+  bn.sid  x0, 0(x5++)
 
-  addi a0, s5, 0 /* ptr_p */
-  addi a1, x0, 32
-  addi a2, s4, 0 /* ptr_s */
-  addi a3, x0, 416
-  addi a5, s4, 0 /* ptr_s */
-  addi a6, x0, 416
-  addi a7, sp, 32 /* cin */
-  addi t4, x0, 32
-  addi t5, sp, 32 /* cout */
-  addi t6, x0, 32
+  addi x10, x21, 0 /* ptr_p */
+  addi x11, x0, 32
+  addi x12, x20, 0 /* ptr_s */
+  addi x13, x0, 416
+  addi x15, x20, 0 /* ptr_s */
+  addi x16, x0, 416
+  addi x17, x2, 32 /* cin */
+  addi x29, x0, 32
+  addi x30, x2, 32 /* cout */
+  addi x31, x0, 32
   /* Bit 0 -- 7: p = 1. */
   loopi 8, 2
     jal  x1, secfulladder
-    addi a0, a0, -32 /* Reset a0 to ptr_p. */
+    addi x10, x10, -32 /* Reset x10 to ptr_p. */
   endloop
 
   /* Bit 8: p = 0. */
   bn.xor w0, w0, w0
-  bn.sid x0, 0(a0)
-  addi   a0, s5, 0
+  bn.sid x0, 0(x10)
+  addi   x10, x21, 0
   jal    x1, secfulladder
   /* Bit 9: p = 1. */
   bn.xor  w0, w0, w0
   bn.subi w0, w0, 1
-  addi    a0, s5, 0
-  bn.sid  x0, 0(a0)
+  addi    x10, x21, 0
+  bn.sid  x0, 0(x10)
   jal     x1, secfulladder
   /* Bit 10 -- 11: p = 0. */
   bn.xor w0, w0, w0
-  addi   a0, s5, 0
-  bn.sid x0, 0(a0)
+  addi   x10, x21, 0
+  bn.sid x0, 0(x10)
   jal    x1, secfulladder
-  addi   a0, s5, 0
+  addi   x10, x21, 0
   jal    x1, secfulladder
 
   /* Bit 12: p = 1. */
   /* Compute r[12] = p[12] ^ s[12] ^ c = ~(s[12] ^ c) since p[12] = 1. */
   addi x4, x0, 1
-  addi t1, x0, 2
+  addi x6, x0, 2
   /* Whitening. */
   bn.xor w0, w0, w0
   bn.xor w1, w1, w1
   bn.xor w2, w2, w2
   bn.xor w3, w3, w3
   /* Computation. */
-  bn.lid x0, 0(a2)
-  bn.lid x4, 0(a7)
+  bn.lid x0, 0(x12)
+  bn.lid x4, 0(x17)
   bn.xor w3, w0, w1
   bn.not w2, w3
-  bn.sid t1, 0(a2)
-  add    a2, a2, a3
-  add    a7, a7, t4
+  bn.sid x6, 0(x12)
+  add    x12, x12, x13
+  add    x17, x17, x29
 
   /* Whitening. */
   bn.xor w0, w0, w0
   bn.xor w1, w1, w1
   bn.xor w2, w2, w2
   /* Computation. */
-  bn.lid x0, 0(a2)
-  bn.lid x4, 0(a7)
+  bn.lid x0, 0(x12)
+  bn.lid x4, 0(x17)
   bn.xor w2, w0, w1
-  bn.sid t1, 0(a2)
+  bn.sid x6, 0(x12)
 
   /* Compute a = bitcopymask(s[k], (k + 1) * 32). */
-  addi a0, s4, 384 /* ptr_s[k] */
-  addi a1, x0, 416 /* share_str = (k + 1) * 32 */
-  addi a3, s3, 0 /* ptr_a */
+  addi x10, x20, 384 /* ptr_s[k] */
+  addi x11, x0, 416 /* share_str = (k + 1) * 32 */
+  addi x13, x19, 0 /* ptr_a */
   jal  x1, bitcopymask
 
   /* Compute r = secadd(a, s, k). */
-  addi a0, s3, 0 /* ptr_a */
-  addi a1, x0, 384
-  addi a2, s4, 0 /* ptr_s */
-  addi a3, x0, 416
-  addi a5, s3, 0 /* ptr_b */
-  addi a6, x0, 384
-  addi a7, x0, 12 /* k */
+  addi x10, x19, 0 /* ptr_a */
+  addi x11, x0, 384
+  addi x12, x20, 0 /* ptr_s */
+  addi x13, x0, 416
+  addi x15, x19, 0 /* ptr_b */
+  addi x16, x0, 384
+  addi x17, x0, 12 /* k */
   jal  x1, secadd
   /* End inlining secaddmodq. */
 
   /* Compute c = refreshios(b, k, k * 32). */
-  addi a0, s3, 0 /* ptr_b */
-  addi a1, x0, 12 /* k */
-  addi a2, x0, 384 /* k * 32 */
-  addi a4, s3, 0 /* ptr_c */
+  addi x10, x19, 0 /* ptr_b */
+  addi x11, x0, 12 /* k */
+  addi x12, x0, 384 /* k * 32 */
+  addi x14, x19, 0 /* ptr_c */
   jal  x1, refreshios
 
   /* Unmask c. */
-  addi t0, s3, 0 /* ptr_c */
+  addi x5, x19, 0 /* ptr_c */
   addi x4, x0, 1
   loopi 12, 5
-    addi   t1, t0, 384
-    bn.lid x0, 0(t0)
-    bn.lid x4, 0(t1)
+    addi   x6, x5, 384
+    bn.lid x0, 0(x5)
+    bn.lid x4, 0(x6)
     bn.xor w0, w0, w1
-    bn.sid x0, 0(t0++)
+    bn.sid x0, 0(x5++)
   endloop
 
   /* Convert c from bitsliced to normal representation, into share 1. */
-  addi a0, s3, 0 /* ptr_c */
-  addi a1, s2, 0 /* ptr_r */
-  addi a1, a1, 512 /* r[1] */
+  addi x10, x19, 0 /* ptr_c */
+  addi x11, x18, 0 /* ptr_r */
+  addi x11, x11, 512 /* r[1] */
   jal x1, poly_from_bitsliced
 
   /* Restore registers. */
-  lw s0, 0(sp)
-  lw s2, 4(sp)
-  lw s3, 8(sp)
-  lw s4, 12(sp)
-  lw s5, 16(sp)
-  addi sp, sp, 2047
-  addi sp, sp, 609
+  lw x8, 0(x2)
+  lw x18, 4(x2)
+  lw x19, 8(x2)
+  lw x20, 12(x2)
+  lw x21, 16(x2)
+  addi x2, x2, 2047
+  addi x2, x2, 609
   ret
 
 /*
@@ -1576,20 +1543,20 @@ secb2amodq:
 .type poly_hocompress, @function
 poly_hocompress:
   /* Allocate y[0], y[1] scratch and save callee-saved registers. */
-  addi sp, sp, -1024
-  add  t2, sp, x0
-  addi sp, sp, -1184
-  sw   s1, 1152(sp)
-  sw   s2, 1156(sp)
-  sw   s3, 1160(sp)
-  addi s1, a2, 0
+  addi x2, x2, -1024
+  add  x7, x2, x0
+  addi x2, x2, -1184
+  sw   x9, 1152(x2)
+  sw   x18, 1156(x2)
+  sw   x19, 1160(x2)
+  addi x9, x12, 0
 
   /* Load all constants. */
   addi      x4, x0, 17
-  la        t0, const_m_dv
-  bn.lid    x4++, 0(t0)
-  la        t0, modulus_over_2
-  bn.lid    x4++, 0(t0)
+  la        x5, const_m_dv
+  bn.lid    x4++, 0(x5)
+  la        x5, modulus_over_2
+  bn.lid    x4++, 0(x5)
   bn.shv.8s w18, w18 >> 16
 
   /* Create 1-bit mask and 2**(alpha - 1). */
@@ -1597,19 +1564,19 @@ poly_hocompress:
   bn.shv.8s w19, w19 >> 31
   bn.shv.8s w19, w19 << 12  /* alpha - 1 */
 
-  /* Select alpha-dependent parameters: w3 = 2**(alpha - 1), s2 = the
-   * extraction byte offset alpha * 32, s3 = dv. */
+  /* Select alpha-dependent parameters: w3 = 2**(alpha - 1), x18 = the
+   * extraction byte offset alpha * 32, x19 = dv. */
   addi      x4, x0, 4
-  addi      s2, x0, 416  /* alpha * 32, alpha = 13 */
-  addi      s3, x0, 5
-  beq       a3, x4, _dv_params_done
+  addi      x18, x0, 416  /* alpha * 32, alpha = 13 */
+  addi      x19, x0, 5
+  beq       x13, x4, _dv_params_done
   bn.shv.8s w19, w19 << 1
-  addi      s2, x0, 448  /* alpha * 32, alpha = 14 (k != 4) */
-  addi      s3, x0, 4
+  addi      x18, x0, 448  /* alpha * 32, alpha = 14 (k != 4) */
+  addi      x19, x0, 4
 _dv_params_done:
 
-  addi t1, sp, 0 /* ptr_z */
-  addi t3, t1, 512 /* Skip the first 16 bits. */
+  addi x6, x2, 0 /* ptr_z */
+  addi x28, x6, 512 /* Skip the first 16 bits. */
 
   /* For DV in {4,5}, in order to avoid division by Q, we need to compute:
    *  - x << (DV + ALPHA) --> x is maximum 20 bits.
@@ -1664,7 +1631,7 @@ _dv_params_done:
 
     addi x4, x0, 15
     loopi 16, 18  /* 16 WDRs hold the 256 coeffs */
-      bn.lid             x0, 0(a0++)
+      bn.lid             x0, 0(x10++)
       /* Handle even-positioned coeffs. */
       bn.trn1.16h        w20, w0, w31
       bn.shv.8s          w20, w20 << 18
@@ -1681,7 +1648,7 @@ _dv_params_done:
       bn.add             w20, w19, w20 >> 8
       /* Combine the results before bitslicing. */
       bn.trn2.16h        w0, w21, w20
-      bn.sid             x0, 0(t2++)
+      bn.sid             x0, 0(x7++)
       bn.trn1.16h        w0, w21, w20
       bn.movr            x4, x0
       addi               x4, x4, -1
@@ -1696,16 +1663,16 @@ _dv_params_done:
 
     add x4, x0, x0
     loopi 16, 2
-      bn.sid x4, 0(t1++)
+      bn.sid x4, 0(x6++)
       addi   x4, x4, 1
     endloop
-    addi t1, t1, 64 /* Skip the last 2 bits. */
+    addi x6, x6, 64 /* Skip the last 2 bits. */
 
     /* Bitslice the last 2 bits. */
     addi x4, x0, 15
-    addi t2, t2, -512
+    addi x7, x7, -512
     loopi 16, 2
-      bn.lid x4, 0(t2++)
+      bn.lid x4, 0(x7++)
       addi   x4, x4, -1
     endloop
 
@@ -1713,40 +1680,40 @@ _dv_params_done:
 
     add x4, x0, x0
     loopi 2, 2
-      bn.sid x4, 0(t3++)
+      bn.sid x4, 0(x28++)
       addi   x4, x4, 1
     endloop
-    addi t3, t3, 512 /* Skip the first 16 bits. */
+    addi x28, x28, 512 /* Skip the first 16 bits. */
   endloop
 
   /* Compute c = seca2b(z), k = dv + alpha, share bytes = 576. */
-  addi a0, sp, 0 /* ptr_z */
-  addi a1, x0, 18 /* dv + alpha */
-  addi a2, x0, 576
-  addi a4, sp, 0 /* ptr_c */
+  addi x10, x2, 0 /* ptr_z */
+  addi x11, x0, 18 /* dv + alpha */
+  addi x12, x0, 576
+  addi x14, x2, 0 /* ptr_c */
   jal  x1, seca2b
 
   /* Compute r = c >> alpha: keep the bits c[alpha]...c[alpha + dv]. */
-  addi t0, sp, 0 /* ptr_c */
-  add  t0, t0, s2
-  addi t1, s1, 0 /* ptr_r */
+  addi x5, x2, 0 /* ptr_c */
+  add  x5, x5, x18
+  addi x6, x9, 0 /* ptr_r */
   loopi 2, 5
-    loop s3, 3
+    loop x19, 3
       /* Whitening. */
       bn.xor w0, w0, w0
-      bn.lid x0, 0(t0++)
-      bn.sid x0, 0(t1++)
+      bn.lid x0, 0(x5++)
+      bn.sid x0, 0(x6++)
     endloop
     /* After copy DV bits of z to r, we need to adjust address of z again. */
-    add t0, t0, s2
+    add x5, x5, x18
   endloop
 
   /* Restore registers. */
-  lw   s1, 1152(sp)
-  lw   s2, 1156(sp)
-  lw   s3, 1160(sp)
-  addi sp, sp, 1184
-  addi sp, sp, 1024
+  lw   x9, 1152(x2)
+  lw   x18, 1156(x2)
+  lw   x19, 1160(x2)
+  addi x2, x2, 1184
+  addi x2, x2, 1024
   ret
 
 /*
@@ -1779,43 +1746,43 @@ _dv_params_done:
 .type polyvec_hocompress, @function
 polyvec_hocompress:
   /* Allocate y[0], y[1] scratch and save callee-saved registers. */
-  addi sp, sp, -1024
-  add  t2, sp, x0
-  addi sp, sp, -1568
-  sw   s1, 1536(sp)
-  sw   s2, 1540(sp)
-  sw   s3, 1544(sp)
-  addi s1, a2, 0
+  addi x2, x2, -1024
+  add  x7, x2, x0
+  addi x2, x2, -1568
+  sw   x9, 1536(x2)
+  sw   x18, 1540(x2)
+  sw   x19, 1544(x2)
+  addi x9, x12, 0
 
   /* Create 2**(alpha - 1). */
   bn.subi   w30, w31, 1
   bn.shv.8s w30, w30 >> 31
   bn.shv.8s w30, w30 << 12  /* alpha - 1 */
 
-  /* Select alpha-dependent parameters: s2 = the extraction byte offset
-   * alpha * 32, s3 = du. The in-loop computation of 2**(alpha - 1)
-   * branches on a3 (k) directly. */
+  /* Select alpha-dependent parameters: x18 = the extraction byte offset
+   * alpha * 32, x19 = du. The in-loop computation of 2**(alpha - 1)
+   * branches on x13 (k) directly. */
   addi      x4, x0, 4
-  addi      s2, x0, 416  /* alpha * 32, alpha = 13 */
-  addi      s3, x0, 11
-  beq       a3, x4, _du_params_done
+  addi      x18, x0, 416  /* alpha * 32, alpha = 13 */
+  addi      x19, x0, 11
+  beq       x13, x4, _du_params_done
   bn.shv.8s w30, w30 << 1
-  addi      s2, x0, 448  /* alpha * 32, alpha = 14 (k != 4) */
-  addi      s3, x0, 10
+  addi      x18, x0, 448  /* alpha * 32, alpha = 14 (k != 4) */
+  addi      x19, x0, 10
 _du_params_done:
 
   /* Load all constants. */
   addi       x4, x0, 17
-  la         t0, const_m_du
-  bn.lid     x4++, 0(t0)
+  la         x5, const_m_du
+  bn.lid     x4++, 0(x5)
 
-  la         t0, const_1664
-  bn.lid     x4, 0(t0)
+  la         x5, const_1664
+  bn.lid     x4, 0(x5)
 
   /* Adjust space for temporary variable y. */
-  addi t0, x0, 21
-  addi t1, sp, 0 /* ptr_z */
-  addi t3, t1, 512 /* Skip the first 16 bits. */
+  addi x5, x0, 21
+  addi x6, x2, 0 /* ptr_z */
+  addi x28, x6, 512 /* Skip the first 16 bits. */
 
   loopi 2, 85
     /* Whitening. */
@@ -1843,7 +1810,7 @@ _du_params_done:
 
     addi x4, x0, 15
     loopi 16, 44  /* 16 WDRs hold the 256 coeffs */
-      bn.lid           x0, 0(a0++)
+      bn.lid           x0, 0(x10++)
       /* Handle even-positioned coeffs. */
       bn.trn1.16h      w19, w0, w31
       /* Handle coeff[0] - coeff[4] - coeff[8] - coeff[12]. */
@@ -1897,10 +1864,10 @@ _du_params_done:
       bn.addv.8s      w20, w20, w30
       /* Combine the results before bitslicing. */
       bn.trn1.16h     w21, w19, w20
-      bn.movr         x4, t0
+      bn.movr         x4, x5
       addi            x4, x4, -1
       bn.trn2.16h     w21, w19, w20
-      bn.sid          t0, 0(t2++)
+      bn.sid          x5, 0(x7++)
     endloop
 
     /* Clear w30. */
@@ -1911,16 +1878,16 @@ _du_params_done:
 
     add x4, x0, x0
     loopi 16, 2
-      bn.sid x4, 0(t1++)
+      bn.sid x4, 0(x6++)
       addi   x4, x4, 1
     endloop
-    addi t1, t1, 256 /* Skip the last 8 bits. */
+    addi x6, x6, 256 /* Skip the last 8 bits. */
 
     /* Bitslice the last 8 bits. */
     addi x4, x0, 15
-    addi t2, t2, -512
+    addi x7, x7, -512
     loopi 16, 2
-      bn.lid x4, 0(t2++)
+      bn.lid x4, 0(x7++)
       addi   x4, x4, -1
     endloop
 
@@ -1928,40 +1895,40 @@ _du_params_done:
 
     add x4, x0, x0
     loopi 8, 2
-      bn.sid x4, 0(t3++)
+      bn.sid x4, 0(x28++)
       addi   x4, x4, 1
     endloop
-    addi t3, t3, 512 /* Skip the first 16 bits. */
+    addi x28, x28, 512 /* Skip the first 16 bits. */
   endloop
 
   /* Compute c = seca2b(z), k = du + alpha, share bytes = 768. */
-  addi a0, sp, 0 /* ptr_z */
-  addi a1, x0, 24 /* du + alpha */
-  addi a2, x0, 768
-  addi a4, sp, 0 /* ptr_c */
+  addi x10, x2, 0 /* ptr_z */
+  addi x11, x0, 24 /* du + alpha */
+  addi x12, x0, 768
+  addi x14, x2, 0 /* ptr_c */
   jal  x1, seca2b
 
   /* Compute r = c >> alpha: keep the bits c[alpha]...c[alpha + du]. */
-  addi t0, sp, 0 /* ptr_c */
-  add  t0, t0, s2
-  addi t1, s1, 0 /* ptr_r */
+  addi x5, x2, 0 /* ptr_c */
+  add  x5, x5, x18
+  addi x6, x9, 0 /* ptr_r */
   loopi 2, 5
-    loop s3, 3
+    loop x19, 3
       /* Whitening. */
       bn.xor w0, w0, w0
-      bn.lid x0, 0(t0++)
-      bn.sid x0, 0(t1++)
+      bn.lid x0, 0(x5++)
+      bn.sid x0, 0(x6++)
     endloop
     /* After copy DV bits of z to r, we need to adjust address of z again. */
-    add t0, t0, s2
+    add x5, x5, x18
   endloop
 
   /* Restore registers. */
-  lw   s1, 1536(sp)
-  lw   s2, 1540(sp)
-  lw   s3, 1544(sp)
-  addi sp, sp, 1568
-  addi sp, sp, 1024
+  lw   x9, 1536(x2)
+  lw   x18, 1540(x2)
+  lw   x19, 1544(x2)
+  addi x2, x2, 1568
+  addi x2, x2, 1024
   ret
 
 /*
@@ -1989,50 +1956,50 @@ _du_params_done:
 .type onebitdecompress, @function
 onebitdecompress:
   /* Save the output base pointer; reused as scratch across the call. */
-  addi sp, sp, -32
-  sw   s0, 0(sp)
-  addi s0, a2, 0
+  addi x2, x2, -32
+  sw   x8, 0(x2)
+  addi x8, x12, 0
 
   /* Unpack m, matching the bitslice layout from masked_poly_tomsg. */
   addi x4, x0, 1
   loopi 2, 7
     /* Whitening. */
     bn.xor w0, w0, w0
-    bn.lid x0, 0(a0++)
+    bn.lid x0, 0(x10++)
     loopi 16, 3
       bn.shv.16h w1, w0 >> 15
       bn.shv.16h w0, w0 << 1
-      bn.sid     x4, 0(a2++)
+      bn.sid     x4, 0(x12++)
     endloop
     nop
   endloop
 
   /* mp = seconebitb2amodq(m), with w16 = R | Q. */
-  addi a0, s0, 0 /* ptr_m */
-  addi a2, s0, 0 /* ptr_r */
+  addi x10, x8, 0 /* ptr_m */
+  addi x12, x8, 0 /* ptr_r */
   jal  x1, seconebitb2amodq
 
   /* mp *= (q + 1) / 2 mod q, coefficient-wise (Montgomery). */
-  la      t0, modulus_over_2_m2_16 /* ((Q + 1) / 2) * (2^16) % Q. */
+  la      x5, modulus_over_2_m2_16 /* ((Q + 1) / 2) * (2^16) % Q. */
   addi    x4, x0, 1
-  bn.lid  x4, 0(t0)
+  bn.lid  x4, 0(x5)
   loopi 2, 9
     /* Whitening. */
     bn.xor w0, w0, w0
     loopi 16, 6
-      bn.lid               x0, 0(s0)
+      bn.lid               x0, 0(x8)
       bn.mulv.16h.acc.z.lo w0, w0, w1
       bn.mulv.l.16h.lo     w0, w0, sw0.2
       bn.mulv.l.16h.acc.hi w0, w0, sw0.0
       bn.addvm.16h         w0, w0, w31
-      bn.sid               x0, 0(s0++)
+      bn.sid               x0, 0(x8++)
     endloop
     nop
   endloop
 
   /* Restore the output base pointer and stack. */
-  lw   s0, 0(sp)
-  addi sp, sp, 32
+  lw   x8, 0(x2)
+  addi x2, x2, 32
   ret
 
 /*
@@ -2061,54 +2028,54 @@ onebitdecompress:
 masked_cbd:
   /* Frame: tmp at 0 (768 B), sum at 768 (64 B), s at 832 (384 B, sized for
    * the worst case eta = 3), saved registers at 1216. */
-  addi sp, sp, -1248
-  sw s0, 1216(sp)
-  sw s1, 1220(sp)
-  sw s2, 1224(sp)
-  sw s4, 1228(sp)
-  sw s5, 1232(sp)
-  sw s6, 1236(sp)
+  addi x2, x2, -1248
+  sw x8, 1216(x2)
+  sw x9, 1220(x2)
+  sw x18, 1224(x2)
+  sw x20, 1228(x2)
+  sw x21, 1232(x2)
+  sw x22, 1236(x2)
 
   /* Save input/output addresses and set the scratch pointers. */
-  addi s0, a0, 0
-  addi s1, a1, 0
-  addi s2, a2, 0
-  addi s4, a4, 0
-  addi s5, sp, 832 /* ptr_s */
-  addi s6, sp, 768 /* ptr_sum */
+  addi x8, x10, 0
+  addi x9, x11, 0
+  addi x18, x12, 0
+  addi x20, x14, 0
+  addi x21, x2, 832 /* ptr_s */
+  addi x22, x2, 768 /* ptr_sum */
 
   /* Copy x to s[1,..,eta] and ~y to s[eta + 1,..,2 * eta]. */
-  addi t0, s5, 0 /* ptr_s */
-  slli x4, a2, 5 /* eta * 32 */
-  add  t1, s5, x4 /* ptr_s[eta + 1] */
+  addi x5, x21, 0 /* ptr_s */
+  slli x4, x12, 5 /* eta * 32 */
+  add  x6, x21, x4 /* ptr_s[eta + 1] */
   /* Share 0: copy x[0] and ~y[0]. */
-  loop a2, 7
+  loop x12, 7
     /* Whitening. */
     bn.xor w0, w0, w0
     /* Copy x[0]. */
-    bn.lid x0, 0(a0++)
-    bn.sid x0, 0(t0++)
+    bn.lid x0, 0(x10++)
+    bn.sid x0, 0(x5++)
     /* Whitening. */
     bn.xor w0, w0, w0
     /* Copy ~y[0]. */
-    bn.lid x0, 0(a1++)
+    bn.lid x0, 0(x11++)
     bn.not w0, w0
-    bn.sid x0, 0(t1++)
+    bn.sid x0, 0(x6++)
   endloop
-  add t0, t0, x4
-  add t1, t1, x4
+  add x5, x5, x4
+  add x6, x6, x4
   /* Share 1: copy x[1] and y[1]. */
-  loop a2, 6
+  loop x12, 6
     /* Whitening. */
     bn.xor w0, w0, w0
     /* Copy x[1]. */
-    bn.lid x0, 0(a0++)
-    bn.sid x0, 0(t0++)
+    bn.lid x0, 0(x10++)
+    bn.sid x0, 0(x5++)
     /* Whitening. */
     bn.xor w0, w0, w0
     /* Copy y[1]. */
-    bn.lid x0, 0(a1++)
-    bn.sid x0, 0(t1++)
+    bn.lid x0, 0(x11++)
+    bn.sid x0, 0(x6++)
   endloop
 
   /* We need to loop over i = 1,...,k where k = ceil(log2(l + 1)) = 3 for both
@@ -2118,189 +2085,189 @@ masked_cbd:
    * is not executed at all. */
   /*----------------------- Iteration i = 1, l = 2 * eta -----------------------*/
   /* Since l mod 2 = 0, we clear the carry sum. */
-  addi   t0, s6, 0 /* ptr_sum */
+  addi   x5, x22, 0 /* ptr_sum */
   bn.xor w0, w0, w0
   loopi 2, 1
-    bn.sid x0, 0(t0++)
+    bn.sid x0, 0(x5++)
   endloop
 
   /* l >>= 1: loop j = 1,..., l = 1,...,eta. */
   /* Inputs to secfulladder. */
-  slli t0, a2, 6 /* (2 * eta) * 32 */
-  addi a0, s5, 0 /* s[0] */
-  addi a1, t0, 0
-  addi a2, s5, 32 /* s[1] */
-  addi a3, t0, 0
-  addi a5, s6, 0 /* ptr_sum = r */
-  addi a6, x0, 32
-  addi a7, s6, 0 /* ptr_sum = cin */
-  addi t4, x0, 32
-  addi t5, s5, 0 /* s[0] = cout */
-  addi t6, t0, 0
-  loop s2, 5
+  slli x5, x12, 6 /* (2 * eta) * 32 */
+  addi x10, x21, 0 /* s[0] */
+  addi x11, x5, 0
+  addi x12, x21, 32 /* s[1] */
+  addi x13, x5, 0
+  addi x15, x22, 0 /* ptr_sum = r */
+  addi x16, x0, 32
+  addi x17, x22, 0 /* ptr_sum = cin */
+  addi x29, x0, 32
+  addi x30, x21, 0 /* s[0] = cout */
+  addi x31, x5, 0
+  loop x18, 5
     /* Compute c, s[j] = secfulladder(s[2j], s[2j + 1], c). */
-    /* a0 already points to s[2j] */
-    /* a1 is already share stride of s. */
-    /* a2 already points to s[2j + 1] */
-    /* a3 is already share stride of s. */
-    /* a5 already points to sum = r. */
-    /* a6 is already share stride of sum = r. */
-    /* a7 already points to sum = cin. */
-    /* t4 is already share stride of sum = cin. */
-    /* t5 already points to s[j] = cout. */
-    /* t6 is already share stride of s = cout. */
+    /* x10 already points to s[2j] */
+    /* x11 is already share stride of s. */
+    /* x12 already points to s[2j + 1] */
+    /* x13 is already share stride of s. */
+    /* x15 already points to sum = r. */
+    /* x16 is already share stride of sum = r. */
+    /* x17 already points to sum = cin. */
+    /* x29 is already share stride of sum = cin. */
+    /* x30 already points to s[j] = cout. */
+    /* x31 is already share stride of s = cout. */
     jal  x1, secfulladder
     /* After secfulladder:
-    *  - a0 and a2 points to s[2j + 1] and s[2j + 2] --> need to be adjusted.
-    *  - a1 and a3 are still share stride of s.
-    *  - a5 points to sum + 32 (output) --> need to be adjusted to sum.
-    *  - a6 is still share stride of sum.
-    *  - a7 points to sum (cin).
-    *  - t4 is still share stride of sum.
-    *  - t5 points to s[j] (cout) --> need to be adjusted to s[j + 1].
-    *  - t6 is still share stride of s. */
+    *  - x10 and x12 points to s[2j + 1] and s[2j + 2] --> need to be adjusted.
+    *  - x11 and x13 are still share stride of s.
+    *  - x15 points to sum + 32 (output) --> need to be adjusted to sum.
+    *  - x16 is still share stride of sum.
+    *  - x17 points to sum (cin).
+    *  - x29 is still share stride of sum.
+    *  - x30 points to s[j] (cout) --> need to be adjusted to s[j + 1].
+    *  - x31 is still share stride of s. */
     /* Adjust addresses. */
-    addi a0, a0, 32 /* s[2 * (j + 1)] */
-    addi a2, a2, 32 /* s[2 * (j + 1) + 1] */
-    addi a5, a5, -32 /* sum */
-    addi t5, t5, 32 /* s[j + 1] */
+    addi x10, x10, 32 /* s[2 * (j + 1)] */
+    addi x12, x12, 32 /* s[2 * (j + 1) + 1] */
+    addi x15, x15, -32 /* sum */
+    addi x30, x30, 32 /* s[j + 1] */
   endloop
 
   /* Copy sum to ptr_tmp[1]. */
-  addi t0, sp, 0 /* ptr_tmp[1] */
+  addi x5, x2, 0 /* ptr_tmp[1] */
   loopi 2, 4
     /* Whitening. */
     bn.xor w0, w0, w0
-    bn.lid x0, 0(a5++) /* a5 still points to sum. */
-    bn.sid x0, 0(t0)
-    addi   t0, t0, 384
+    bn.lid x0, 0(x15++) /* x15 still points to sum. */
+    bn.sid x0, 0(x5)
+    addi   x5, x5, 384
   endloop
 
   /*----------------------- Iteration i = 2, l = eta -----------------------*/
-  addi t0, x0, 2
-  beq  s2, t0, _cbd_eta_2
+  addi x5, x0, 2
+  beq  x18, x5, _cbd_eta_2
   /* Since l mod 2 = 1 if eta = 3, we compute sum = s[l] = s[3]. */
-  addi t0, s6, 0 /* ptr_sum */
-  addi t1, s5, 0 /* ptr_s */
-  addi t1, t1, 64 /* 2 * 32 */
-  slli x4, s2, 6 /* (2 * eta) * 32 */
+  addi x5, x22, 0 /* ptr_sum */
+  addi x6, x21, 0 /* ptr_s */
+  addi x6, x6, 64 /* 2 * 32 */
+  slli x4, x18, 6 /* (2 * eta) * 32 */
   loopi 2, 4
     /* Whitening. */
     bn.xor w0, w0, w0
-    bn.lid x0, 0(t1)
-    bn.sid x0, 0(t0++)
-    add    t1, t1, x4
+    bn.lid x0, 0(x6)
+    bn.sid x0, 0(x5++)
+    add    x6, x6, x4
   endloop
   beq x0, x0, _continue_1
 
 _cbd_eta_2:
   /* Since l mod 2 = 0 if eta = 2, we clear the carry sum. */
-  addi   t0, s6, 0 /* ptr_sum */
+  addi   x5, x22, 0 /* ptr_sum */
   bn.xor w0, w0, w0
   loopi 2, 1
-    bn.sid x0, 0(t0++)
+    bn.sid x0, 0(x5++)
   endloop
 
 _continue_1:
   /* l >> 1: loop j = 1,...,l // 2 --> 1 iteration. */
   /* Inputs to secfulladder. */
-  slli t0, s2, 6
-  addi a0, s5, 0 /* s[0] */
-  addi a1, t0, 0
-  addi a2, s5, 32 /* s[1] */
-  addi a3, t0, 0
-  addi a5, s6, 0 /* ptr_sum = r */
-  addi a6, x0, 32
-  addi a7, s6, 0 /* ptr_sum = cin */
-  addi t4, x0, 32
-  addi t5, s5, 0 /* s[0] = cout */
-  addi t6, t0, 0
+  slli x5, x18, 6
+  addi x10, x21, 0 /* s[0] */
+  addi x11, x5, 0
+  addi x12, x21, 32 /* s[1] */
+  addi x13, x5, 0
+  addi x15, x22, 0 /* ptr_sum = r */
+  addi x16, x0, 32
+  addi x17, x22, 0 /* ptr_sum = cin */
+  addi x29, x0, 32
+  addi x30, x21, 0 /* s[0] = cout */
+  addi x31, x5, 0
   /* Compute c, s[j] = secfulladder(s[2j], s[2j + 1], c). */
-  /* a0 already points to s[2j] */
-  /* a1 is already share stride of s. */
-  /* a2 already points to s[2j + 1] */
-  /* a3 is already share stride of s. */
-  /* a5 already points to sum = r. */
-  /* a6 is already share stride of sum = r. */
-  /* a7 already points to sum = cin. */
-  /* t4 is already share stride of sum = cin. */
-  /* t5 already points to s[j] = cout. */
-  /* t6 is already share stride of s = cout. */
+  /* x10 already points to s[2j] */
+  /* x11 is already share stride of s. */
+  /* x12 already points to s[2j + 1] */
+  /* x13 is already share stride of s. */
+  /* x15 already points to sum = r. */
+  /* x16 is already share stride of sum = r. */
+  /* x17 already points to sum = cin. */
+  /* x29 is already share stride of sum = cin. */
+  /* x30 already points to s[j] = cout. */
+  /* x31 is already share stride of s = cout. */
   jal  x1, secfulladder
   /* After secfulladder:
-  *  - a0 and a2 points to s[2j + 1] and s[2j + 2] --> need to be adjusted.
-  *  - a1 and a3 are still share stride of s.
-  *  - a5 points to sum + 32 (output) --> need to be adjusted to sum.
-  *  - a6 is still share stride of sum.
-  *  - a7 points to sum (cin).
-  *  - t4 is still share stride of sum.
-  *  - t5 points to s[j] (cout) --> need to be adjusted to s[j + 1].
-  *  - t6 is still share stride of s. */
+  *  - x10 and x12 points to s[2j + 1] and s[2j + 2] --> need to be adjusted.
+  *  - x11 and x13 are still share stride of s.
+  *  - x15 points to sum + 32 (output) --> need to be adjusted to sum.
+  *  - x16 is still share stride of sum.
+  *  - x17 points to sum (cin).
+  *  - x29 is still share stride of sum.
+  *  - x30 points to s[j] (cout) --> need to be adjusted to s[j + 1].
+  *  - x31 is still share stride of s. */
 
   /* Copy sum to ptr_tmp[2]. */
-  addi t0, sp, 32 /* ptr_tmp[2] */
+  addi x5, x2, 32 /* ptr_tmp[2] */
   loopi 2, 4
     /* Whitening. */
     bn.xor w0, w0, w0
-    bn.lid x0, 0(a7++) /* a7 still points to sum. */
-    bn.sid x0, 0(t0)
-    addi   t0, t0, 384
+    bn.lid x0, 0(x17++) /* x17 still points to sum. */
+    bn.sid x0, 0(x5)
+    addi   x5, x5, 384
   endloop
 
   /*----------------------- Iteration i = 3, l = eta / 2 -----------------------*/
   /* Since l mod 2 = 1, we compute tmp[3] = s[l] = s[1]. */
-  addi t0, sp, 0 /* ptr_tmp */
-  addi t0, t0, 64
-  addi t1, s5, 0 /* ptr_s */
-  slli t2, s2, 6
+  addi x5, x2, 0 /* ptr_tmp */
+  addi x5, x5, 64
+  addi x6, x21, 0 /* ptr_s */
+  slli x7, x18, 6
 
   loopi 2, 5
     /* Whitening. */
     bn.xor w0, w0, w0
-    bn.lid x0, 0(t1)
-    bn.sid x0, 0(t0)
-    add    t1, t1, t2
-    addi   t0, t0, 384
+    bn.lid x0, 0(x6)
+    bn.sid x0, 0(x5)
+    add    x6, x6, x7
+    addi   x5, x5, 384
   endloop
 
   /* Clear bit k --> 12 of tmp. */
-  addi   t0, sp, 0 /* ptr_tmp */
-  addi   t0, t0, 96
+  addi   x5, x2, 0 /* ptr_tmp */
+  addi   x5, x5, 96
   bn.xor w0, w0, w0
   loopi 2, 3
     loopi 9, 1
-      bn.sid x0, 0(t0++)
+      bn.sid x0, 0(x5++)
     endloop
-    addi t0, t0, 96 /* point to next share. */
+    addi x5, x5, 96 /* point to next share. */
   endloop
 
   /* Compute r = secb2amodq(tmp). */
-  addi a0, sp, 0 /* ptr_tmp */
-  addi a2, s4, 0 /* ptr_r */
+  addi x10, x2, 0 /* ptr_tmp */
+  addi x12, x20, 0 /* ptr_r */
   jal  x1, secb2amodq
 
   /* Compute r[0] = r[0] - eta mod q. */
-  addi   t0, s4, 0 /* ptr_r */
-  addi   t1, s5, 0 /* ptr_s */
-  sw     s2, 0(t1)
-  bn.lid x0, 0(t1)
+  addi   x5, x20, 0 /* ptr_r */
+  addi   x6, x21, 0 /* ptr_s */
+  sw     x18, 0(x6)
+  bn.lid x0, 0(x6)
   loopi 16, 1
     bn.rshi w1, w0, w1 >> 16
   endloop
   loopi 16, 3
-    bn.lid       x0, 0(t0)
+    bn.lid       x0, 0(x5)
     bn.subvm.16h w0, w0, w1
-    bn.sid       x0, 0(t0++)
+    bn.sid       x0, 0(x5++)
   endloop
 
   /* Restore registers and stack. */
-  lw s0, 1216(sp)
-  lw s1, 1220(sp)
-  lw s2, 1224(sp)
-  lw s4, 1228(sp)
-  lw s5, 1232(sp)
-  lw s6, 1236(sp)
-  addi sp, sp, 1248
+  lw x8, 1216(x2)
+  lw x9, 1220(x2)
+  lw x18, 1224(x2)
+  lw x20, 1228(x2)
+  lw x21, 1232(x2)
+  lw x22, 1236(x2)
+  addi x2, x2, 1248
   ret
 
 
@@ -2323,24 +2290,24 @@ _continue_1:
 .type masked_poly_getnoise_eta_init, @function
 masked_poly_getnoise_eta_init:
   /* Initialize a SHAKE256 operation. */
-  addi  t0, x0, 33
-  slli  t0, t0, 5
-  addi  t0, t0, SHAKE256_CFG
-  addi  t1, x0, 1
-  slli  t1, t1, 20
-  add   t0, t0, t1
-  csrrw x0, kmac_cfg, t0
+  addi  x5, x0, 33
+  slli  x5, x5, 5
+  addi  x5, x5, SHAKE256_CFG
+  addi  x6, x0, 1
+  slli  x6, x6, 20
+  add   x5, x5, x6
+  csrrw x0, kmac_cfg, x5
 
   /* Send the message to the Keccak core. */
   bn.xor  w0, w0, w0 /* Whitening. */
-  bn.lid  x0, 0(a0++)
+  bn.lid  x0, 0(x10++)
   bn.wsrw kmac_msg, w0
   bn.xor  w0, w0, w0 /* Whitening. */
-  bn.lid  x0, 0(a0++)
+  bn.lid  x0, 0(x10++)
   bn.wsrw kmac_msg1, w0
-  li      t0, 1
-  csrrw   x0, kmac_partial_write, t0
-  bn.lid  x0, 0(a1)
+  li      x5, 1
+  csrrw   x0, kmac_partial_write, x5
+  bn.lid  x0, 0(x11)
   bn.wsrw kmac_msg, w0
   bn.xor  w0, w0, w0
   bn.wsrw kmac_msg1, w0
@@ -2386,19 +2353,19 @@ masked_poly_getnoise_eta_2:
 masked_poly_getnoise_eta_1:
   /* Frame: ptr_y at 0, ptr_x at 192 (each 2 * eta * 32, sized for the worst
    * case eta = 3), saved registers at 384. */
-  addi sp, sp, -416
-  sw   s0, 384(sp)
-  sw   s1, 388(sp)
-  sw   s2, 392(sp)
-  sw   s3, 396(sp)
-  addi s0, a0, 0
-  addi s1, a1, 0
-  addi s2, sp, 192 /* ptr_x */
+  addi x2, x2, -416
+  sw   x8, 384(x2)
+  sw   x9, 388(x2)
+  sw   x18, 392(x2)
+  sw   x19, 396(x2)
+  addi x8, x10, 0
+  addi x9, x11, 0
+  addi x18, x2, 192 /* ptr_x */
 
   addi x4, x0, 3
-  bne  a0, x4, _getnoise_eta_2
+  bne  x10, x4, _getnoise_eta_2
 
-  addi t0, sp, 0 /* ptr_y */
+  addi x5, x2, 0 /* ptr_y */
 
   bn.wsrr w17, kmac_digest
   bn.wsrr w23, kmac_digest1
@@ -2418,11 +2385,11 @@ masked_poly_getnoise_eta_1:
 
   add x4, x0, x0
   loopi 3, 2
-    bn.sid x4, 0(s2++)
+    bn.sid x4, 0(x18++)
     addi   x4, x4, 1
   endloop
   loopi 3, 2
-    bn.sid x4, 0(t0++)
+    bn.sid x4, 0(x5++)
     addi   x4, x4, 1
   endloop
 
@@ -2443,11 +2410,11 @@ masked_poly_getnoise_eta_1:
 
   add x4, x0, x0
   loopi 3, 2
-    bn.sid x4, 0(s2++)
+    bn.sid x4, 0(x18++)
     addi   x4, x4, 1
   endloop
   loopi 3, 2
-    bn.sid x4, 0(t0++)
+    bn.sid x4, 0(x5++)
     addi   x4, x4, 1
   endloop
 
@@ -2464,10 +2431,10 @@ _getnoise_eta_2:
   bn.wsrr w20, kmac_digest
   bn.wsrr w24, kmac_digest1
 
-  addi t0, x0, 25
-  addi t1, x0, 17
-  addi t2, x0, 26
-  addi t3, sp, 0 /* ptr_y */
+  addi x5, x0, 25
+  addi x6, x0, 17
+  addi x7, x0, 26
+  addi x28, x2, 0 /* ptr_y */
   loopi 2, 38
     /* Whitening. */
     bn.xor w0, w0, w0
@@ -2493,48 +2460,48 @@ _getnoise_eta_2:
 
     addi x4, x0, 15
     loopi 4, 8
-      bn.movr t0, t1
+      bn.movr x5, x6
       loopi 4, 5
         loopi 16, 2
           bn.rshi w26, w25, w26 >> 16
           bn.rshi w25, w31, w25 >> 4
         endloop
-        bn.movr x4, t2
+        bn.movr x4, x7
         addi    x4, x4, -1
       endloop
-      addi t1, t1, 1
+      addi x6, x6, 1
     endloop
 
     jal x1, _bitslice_transpose
 
-    bn.sid x0, 0(s2++)
+    bn.sid x0, 0(x18++)
     addi   x4, x0, 1
-    bn.sid x4, 0(s2++)
+    bn.sid x4, 0(x18++)
     addi   x4, x4, 1
-    bn.sid x4, 0(t3++)
+    bn.sid x4, 0(x28++)
     addi   x4, x4, 1
-    bn.sid x4, 0(t3++)
+    bn.sid x4, 0(x28++)
   endloop
 
 _getnoise_common:
   /* Compute r = masked_cbd(x, y, eta). */
-  addi a0, sp, 192 /* ptr_x */
-  addi a1, sp, 0 /* ptr_y */
-  addi a2, s0, 0 /* eta */
-  addi a4, s1, 0 /* ptr_r */
+  addi x10, x2, 192 /* ptr_x */
+  addi x11, x2, 0 /* ptr_y */
+  addi x12, x8, 0 /* eta */
+  addi x14, x9, 0 /* ptr_r */
   jal  x1, masked_cbd
 
   /* Restore inputs. */
-  addi a0, s0, 0
+  addi x10, x8, 0
   /* We want to point r to the next polynomial for next cbd. */
-  addi a1, s1, 512
+  addi x11, x9, 512
 
   /* Restore registers and stack. */
-  lw   s0, 384(sp)
-  lw   s1, 388(sp)
-  lw   s2, 392(sp)
-  lw   s3, 396(sp)
-  addi sp, sp, 416
+  lw   x8, 384(x2)
+  lw   x9, 388(x2)
+  lw   x18, 392(x2)
+  lw   x19, 396(x2)
+  addi x2, x2, 416
   ret
 
 /* Bitslice the SHAKE-256 digests in w17-w22 into the eta = 3 x and y
@@ -2704,16 +2671,16 @@ _bitslice_eta_3:
 .type masked_poly_tomsg, @function
 masked_poly_tomsg:
   /* Allocate y[0], y[1] scratch and save callee-saved registers. */
-  addi sp, sp, -1056
-  sw   s0, 1024(sp)
-  addi s0, a2, 0
+  addi x2, x2, -1056
+  sw   x8, 1024(x2)
+  addi x8, x12, 0
 
   /* Load all constants. */
   addi      x4, x0, 17
-  la        t0, const_m_dv
-  bn.lid    x4++, 0(t0)
-  la        t0, modulus_over_2
-  bn.lid    x4++, 0(t0)
+  la        x5, const_m_dv
+  bn.lid    x4++, 0(x5)
+  la        x5, modulus_over_2
+  bn.lid    x4++, 0(x5)
   bn.shv.8s w18, w18 >> 16
 
   /* Create 2**(alpha - 1), alpha = 15. */
@@ -2729,8 +2696,8 @@ masked_poly_tomsg:
    *  - x >>= k where k = 37. */
   /* Compute y[i] = Compressq(x[i], 1 + alpha); share 0 also adds
    * 2**(alpha - 1). */
-  addi t0, x0, 21
-  addi t1, sp, 0 /* ptr_y */
+  addi x5, x0, 21
+  addi x6, x2, 0 /* ptr_y */
 
   loopi 2, 44
     /* Whitening. */
@@ -2757,7 +2724,7 @@ masked_poly_tomsg:
 
     addi x4, x0, 15
     loopi 16, 16
-      bn.lid             x0, 0(a0++)
+      bn.lid             x0, 0(x10++)
       /* Handle even-positioned coeffs. */
       bn.trn1.16h        w20, w0, w31
       bn.shv.8s          w20, w20 << 16
@@ -2774,7 +2741,7 @@ masked_poly_tomsg:
       bn.add             w20, w19, w20 >> 8
       /* Combine results. */
       bn.trn1.16h        w21, w21, w20
-      bn.movr            x4, t0
+      bn.movr            x4, x5
       addi               x4, x4, -1
     endloop
 
@@ -2782,7 +2749,7 @@ masked_poly_tomsg:
 
     add x4, x0, x0
     loopi 16, 2
-      bn.sid x4, 0(t1++)
+      bn.sid x4, 0(x6++)
       addi   x4, x4, 1
     endloop
 
@@ -2791,28 +2758,28 @@ masked_poly_tomsg:
   endloop
 
   /* Compute z = seca2b(y, k = 1 + alpha, share bytes = k * 32). */
-  addi a0, sp, 0 /* ptr_y */
-  addi a1, x0, 16 /* 1 + alpha */
-  addi a2, x0, 512
-  addi a4, sp, 0 /* ptr_z */
+  addi x10, x2, 0 /* ptr_y */
+  addi x11, x0, 16 /* 1 + alpha */
+  addi x12, x0, 512
+  addi x14, x2, 0 /* ptr_z */
   jal  x1, seca2b
 
   /* Compute z >>= alpha, i.e. keep only bit z[alpha], the message bit. */
-  addi t0, sp, 0 /* ptr_z */
-  addi t0, t0, 480 /* skip to bit-plane alpha = 15 */
-  addi t1, s0, 0 /* ptr_r */
+  addi x5, x2, 0 /* ptr_z */
+  addi x5, x5, 480 /* skip to bit-plane alpha = 15 */
+  addi x6, x8, 0 /* ptr_r */
   loopi 2, 4
     /* Whitening. */
     bn.xor w0, w0, w0
-    bn.lid x0, 0(t0++)
-    bn.sid x0, 0(t1++)
+    bn.lid x0, 0(x5++)
+    bn.sid x0, 0(x6++)
     /* Advance to bit-plane alpha of the next share. */
-    addi t0, t0, 480
+    addi x5, x5, 480
   endloop
 
   /* Restore registers. */
-  lw   s0, 1024(sp)
-  addi sp, sp, 1056
+  lw   x8, 1024(x2)
+  addi x2, x2, 1056
   ret
 
 #define N_COEFFS 16
@@ -2839,35 +2806,35 @@ masked_poly_tomsg:
 .type poly_masked_compare_dv, @function
 poly_masked_compare_dv:
   /* Allocate t scratch (2 shares * 160 B, dv = 5 worst case) + saves. */
-  addi sp, sp, -352
-  sw   s0, 324(sp)
-  sw   s1, 328(sp)
-  sw   s2, 332(sp)
-  sw   s4, 340(sp)
-  sw   a5, 344(sp)
+  addi x2, x2, -352
+  sw   x8, 324(x2)
+  sw   x9, 328(x2)
+  sw   x18, 332(x2)
+  sw   x20, 340(x2)
+  sw   x15, 344(x2)
 
   /* Save input/output addresses. */
-  addi s0, a0, 0
-  addi s1, a1, 0
-  addi s2, a2, 0
-  addi s4, a4, 0
+  addi x8, x10, 0
+  addi x9, x11, 0
+  addi x18, x12, 0
+  addi x20, x14, 0
 
   /* Compute t = poly_hocompress(cprime). */
-  addi a0, s0, 0 /* ptr_cprime */
-  addi a2, sp, 0 /* ptr_t */
-  addi a3, a5, 0 /* k */
+  addi x10, x8, 0 /* ptr_cprime */
+  addi x12, x2, 0 /* ptr_t */
+  addi x13, x15, 0 /* k */
   jal  x1, poly_hocompress
 
   /* Decode + bitslice c. */
-  addi a1, s1, 0 /* ptr_c */
+  addi x11, x9, 0 /* ptr_c */
 
   addi x4, x0, 4
-  lw   a5, 344(sp)
-  bne  a5, x4, _handle_kn4_dv
+  lw   x15, 344(x2)
+  bne  x15, x4, _handle_kn4_dv
 
 _handle_k4_dv:
   addi   x4, x0, 17
-  bn.lid x4, 0(a1++)
+  bn.lid x4, 0(x11++)
   /* group 0 -> w15 */
   loopi 16, 2
     bn.rshi w15, w17, w15 >> 16
@@ -2889,7 +2856,7 @@ _handle_k4_dv:
     bn.rshi w17, w31, w17 >> 5
   endloop
   bn.rshi w12, w17, w12 >> 1
-  bn.lid  x4, 0(a1++)
+  bn.lid  x4, 0(x11++)
   bn.rshi w12, w17, w12 >> 15
   bn.rshi w17, w31, w17 >> 4
   loopi 12, 2
@@ -2912,7 +2879,7 @@ _handle_k4_dv:
     bn.rshi w17, w31, w17 >> 5
   endloop
   bn.rshi w9, w17, w9 >> 2
-  bn.lid  x4, 0(a1++)
+  bn.lid  x4, 0(x11++)
   bn.rshi w9, w17, w9 >> 14
   bn.rshi w17, w31, w17 >> 3
   loopi 9, 2
@@ -2935,7 +2902,7 @@ _handle_k4_dv:
     bn.rshi w17, w31, w17 >> 5
   endloop
   bn.rshi w6, w17, w6 >> 3
-  bn.lid  x4, 0(a1++)
+  bn.lid  x4, 0(x11++)
   bn.rshi w6, w17, w6 >> 13
   bn.rshi w17, w31, w17 >> 2
   loopi 6, 2
@@ -2958,7 +2925,7 @@ _handle_k4_dv:
     bn.rshi w17, w31, w17 >> 5
   endloop
   bn.rshi w3, w17, w3 >> 4
-  bn.lid  x4, 0(a1++)
+  bn.lid  x4, 0(x11++)
   bn.rshi w3, w17, w3 >> 12
   bn.rshi w17, w31, w17 >> 1
   loopi 3, 2
@@ -2982,12 +2949,12 @@ _handle_k4_dv:
   endloop
   jal x1, _bitslice_transpose
 
-  addi    s1, x0, 5
+  addi    x9, x0, 5
   beq     x0, x0, _handle_common_dv
 
 _handle_kn4_dv:
   addi x4, x0, 17
-  bn.lid x4, 0(a1++)
+  bn.lid x4, 0(x11++)
   /* group 0 -> w15 */
   loopi 16, 2
     bn.rshi w15, w17, w15 >> 16
@@ -3008,7 +2975,7 @@ _handle_kn4_dv:
     bn.rshi w12, w17, w12 >> 16
     bn.rshi w17, w31, w17 >> 4
   endloop
-  bn.lid x4, 0(a1++)
+  bn.lid x4, 0(x11++)
   /* group 4 -> w11 */
   loopi 16, 2
     bn.rshi w11, w17, w11 >> 16
@@ -3029,7 +2996,7 @@ _handle_kn4_dv:
     bn.rshi w8, w17, w8 >> 16
     bn.rshi w17, w31, w17 >> 4
   endloop
-  bn.lid x4, 0(a1++)
+  bn.lid x4, 0(x11++)
   /* group 8 -> w7 */
   loopi 16, 2
     bn.rshi w7, w17, w7 >> 16
@@ -3050,7 +3017,7 @@ _handle_kn4_dv:
     bn.rshi w4, w17, w4 >> 16
     bn.rshi w17, w31, w17 >> 4
   endloop
-  bn.lid x4, 0(a1++)
+  bn.lid x4, 0(x11++)
   /* group 12 -> w3 */
   loopi 16, 2
     bn.rshi w3, w17, w3 >> 16
@@ -3073,63 +3040,63 @@ _handle_kn4_dv:
   endloop
   jal x1, _bitslice_transpose
 
-  addi    s1, x0, 4
+  addi    x9, x0, 4
 
 _handle_common_dv:
-  /* t[0] ^= c ^ ((1 << N) - 1):  c-planes are now w0..w3 if s1 != 4 else w0..w4. */
+  /* t[0] ^= c ^ ((1 << N) - 1):  c-planes are now w0..w3 if x9 != 4 else w0..w4. */
   bn.subi w15, w31, 1
-  addi    t0, sp, 0 /* ptr_t */
+  addi    x5, x2, 0 /* ptr_t */
 
-  bn.lid  x4, 0(t0)
+  bn.lid  x4, 0(x5)
   bn.xor  w0, w0, w15
   bn.xor  w17, w17, w0
-  bn.sid  x4, 0(t0++)
+  bn.sid  x4, 0(x5++)
 
-  bn.lid  x4, 0(t0)
+  bn.lid  x4, 0(x5)
   bn.xor  w1, w1, w15
   bn.xor  w17, w17, w1
-  bn.sid  x4, 0(t0++)
+  bn.sid  x4, 0(x5++)
 
-  bn.lid  x4, 0(t0)
+  bn.lid  x4, 0(x5)
   bn.xor  w2, w2, w15
   bn.xor  w17, w17, w2
-  bn.sid  x4, 0(t0++)
+  bn.sid  x4, 0(x5++)
 
-  bn.lid  x4, 0(t0)
+  bn.lid  x4, 0(x5)
   bn.xor  w3, w3, w15
   bn.xor  w17, w17, w3
-  bn.sid  x4, 0(t0++)
+  bn.sid  x4, 0(x5++)
 
-  addi    t1, x0, 4
-  beq     s1, t1, _skip_bit_4
+  addi    x6, x0, 4
+  beq     x9, x6, _skip_bit_4
 
-  bn.lid  x4, 0(t0)
+  bn.lid  x4, 0(x5)
   bn.xor  w4, w4, w15
   bn.xor  w17, w17, w4
-  bn.sid  x4, 0(t0++)
+  bn.sid  x4, 0(x5++)
 
 _skip_bit_4:
   /* Compute r = secand(r, t). */
-  addi a1, x0, 32
-  addi a2, sp, 0 /* ptr_t */
-  addi a3, s2, 0 /* share_str */
-  addi a6, x0, 32 /* output share_str */
+  addi x11, x0, 32
+  addi x12, x2, 0 /* ptr_t */
+  addi x13, x18, 0 /* share_str */
+  addi x16, x0, 32 /* output share_str */
   /* After the secand, the input and output pointers will point to
    * next bit so we don't have to pass all the arguments above to secand again. */
-  loop s1, 4
-    addi a0, s4, 0 /* ptr_r */
-    addi a5, s4, 0 /* ptr_r */
+  loop x9, 4
+    addi x10, x20, 0 /* ptr_r */
+    addi x15, x20, 0 /* ptr_r */
     jal  x1, secand
     nop
   endloop
 
   /* Restore registers. */
-  lw   s0, 324(sp)
-  lw   s1, 328(sp)
-  lw   s2, 332(sp)
-  lw   s4, 340(sp)
-  lw   a5, 344(sp)
-  addi sp, sp, 352
+  lw   x8, 324(x2)
+  lw   x9, 328(x2)
+  lw   x18, 332(x2)
+  lw   x20, 340(x2)
+  lw   x15, 344(x2)
+  addi x2, x2, 352
   ret
 
 
@@ -3155,36 +3122,36 @@ _skip_bit_4:
 .type poly_masked_compare_du, @function
 poly_masked_compare_du:
   /* Allocate t scratch (2 shares * 352 B, du = 11 worst case) + saves. */
-  addi sp, sp, -736
-  sw   s0, 708(sp)
-  sw   s1, 712(sp)
-  sw   s2, 716(sp)
-  sw   s4, 724(sp)
-  sw   a5, 728(sp)
+  addi x2, x2, -736
+  sw   x8, 708(x2)
+  sw   x9, 712(x2)
+  sw   x18, 716(x2)
+  sw   x20, 724(x2)
+  sw   x15, 728(x2)
 
   /* Save input/output addresses. */
-  addi s0, a0, 0
-  addi s1, a1, 0
-  addi s2, a2, 0
-  addi s4, a4, 0
+  addi x8, x10, 0
+  addi x9, x11, 0
+  addi x18, x12, 0
+  addi x20, x14, 0
 
   /* Compute t = poly_hocompress(cprime). */
-  addi a0, s0, 0 /* ptr_cprime */
-  addi a2, sp, 0 /* ptr_t */
-  addi a3, a5, 0 /* k */
+  addi x10, x8, 0 /* ptr_cprime */
+  addi x12, x2, 0 /* ptr_t */
+  addi x13, x15, 0 /* k */
   jal  x1, polyvec_hocompress
 
   /* Decode + bitslice c. */
-  addi a1, s1, 0 /* ptr_c */
+  addi x11, x9, 0 /* ptr_c */
 
   addi x4, x0, 4
-  lw   a5, 728(sp)
-  bne  a5, x4, _handle_kn4_du
+  lw   x15, 728(x2)
+  bne  x15, x4, _handle_kn4_du
 
 _handle_k4_du:
   /* group 0 -> w15 */
   addi   x4, x0, 17
-  bn.lid x4, 0(a1++)
+  bn.lid x4, 0(x11++)
   loopi 16, 2
     bn.rshi w15, w17, w15 >> 16
     bn.rshi w17, w31, w17 >> 11
@@ -3196,7 +3163,7 @@ _handle_k4_du:
     bn.rshi w17, w31, w17 >> 11
   endloop
   bn.rshi w14, w17, w14 >> 3
-  bn.lid  x4, 0(a1++)
+  bn.lid  x4, 0(x11++)
   bn.rshi w14, w17, w14 >> 13
   bn.rshi w17, w31, w17 >> 8
   loopi 8, 2
@@ -3210,7 +3177,7 @@ _handle_k4_du:
     bn.rshi w17, w31, w17 >> 11
   endloop
   bn.rshi w13, w17, w13 >> 6
-  bn.lid  x4, 0(a1++)
+  bn.lid  x4, 0(x11++)
   bn.rshi w13, w17, w13 >> 10
   bn.rshi w17, w31, w17 >> 5
   bn.rshi w13, w17, w13 >> 16
@@ -3228,7 +3195,7 @@ _handle_k4_du:
     bn.rshi w17, w31, w17 >> 11
   endloop
   bn.rshi w11, w17, w11 >> 9
-  bn.lid  x4, 0(a1++)
+  bn.lid  x4, 0(x11++)
   bn.rshi w11, w17, w11 >> 7
   bn.rshi w17, w31, w17 >> 2
   loopi 10, 2
@@ -3242,7 +3209,7 @@ _handle_k4_du:
     bn.rshi w17, w31, w17 >> 11
   endloop
   bn.rshi w10, w17, w10 >> 1
-  bn.lid  x4, 0(a1++)
+  bn.lid  x4, 0(x11++)
   bn.rshi w10, w17, w10 >> 15
   bn.rshi w17, w31, w17 >> 10
   loopi 2, 2
@@ -3262,7 +3229,7 @@ _handle_k4_du:
     bn.rshi w17, w31, w17 >> 11
   endloop
   bn.rshi w8, w17, w8 >> 4
-  bn.lid  x4, 0(a1++)
+  bn.lid  x4, 0(x11++)
   bn.rshi w8, w17, w8 >> 12
   bn.rshi w17, w31, w17 >> 7
   loopi 11, 2
@@ -3276,7 +3243,7 @@ _handle_k4_du:
     bn.rshi w17, w31, w17 >> 11
   endloop
   bn.rshi w7, w17, w7 >> 7
-  bn.lid  x4, 0(a1++)
+  bn.lid  x4, 0(x11++)
   bn.rshi w7, w17, w7 >> 9
   bn.rshi w17, w31, w17 >> 4
   loopi 4, 2
@@ -3296,7 +3263,7 @@ _handle_k4_du:
     bn.rshi w17, w31, w17 >> 11
   endloop
   bn.rshi w5, w17, w5 >> 10
-  bn.lid  x4, 0(a1++)
+  bn.lid  x4, 0(x11++)
   bn.rshi w5, w17, w5 >> 6
   bn.rshi w17, w31, w17 >> 1
   loopi 13, 2
@@ -3310,7 +3277,7 @@ _handle_k4_du:
     bn.rshi w17, w31, w17 >> 11
   endloop
   bn.rshi w4, w17, w4 >> 2
-  bn.lid  x4, 0(a1++)
+  bn.lid  x4, 0(x11++)
   bn.rshi w4, w17, w4 >> 14
   bn.rshi w17, w31, w17 >> 9
   loopi 5, 2
@@ -3328,7 +3295,7 @@ _handle_k4_du:
   bn.rshi w2, w17, w2 >> 16
   bn.rshi w17, w31, w17 >> 11
   bn.rshi w2, w17, w2 >> 5
-  bn.lid  x4, 0(a1++)
+  bn.lid  x4, 0(x11++)
   bn.rshi w2, w17, w2 >> 11
   bn.rshi w17, w31, w17 >> 6
   loopi 14, 2
@@ -3342,7 +3309,7 @@ _handle_k4_du:
     bn.rshi w17, w31, w17 >> 11
   endloop
   bn.rshi w1, w17, w1 >> 8
-  bn.lid  x4, 0(a1++)
+  bn.lid  x4, 0(x11++)
   bn.rshi w1, w17, w1 >> 8
   bn.rshi w17, w31, w17 >> 3
   loopi 7, 2
@@ -3357,22 +3324,22 @@ _handle_k4_du:
   endloop
   jal x1, _bitslice_transpose
   
-  addi s1, x0, 11 /* du */
+  addi x9, x0, 11 /* du */
   beq  x0, x0, _handle_common_du
 
 _handle_kn4_du:
   addi x4, x0, 17
-  addi t0, x0, 15
-  addi t1, x0, 18
+  addi x5, x0, 15
+  addi x6, x0, 18
   loopi 2, 69
     /* group i + 0 */
-    bn.lid x4, 0(a1++)
+    bn.lid x4, 0(x11++)
     loopi 16, 2
       bn.rshi w18, w17, w18 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.movr t0, t1
-    addi    t0, t0, -1
+    bn.movr x5, x6
+    addi    x5, x5, -1
     
     /* group i + 1 */
     loopi 9, 2
@@ -3380,23 +3347,23 @@ _handle_kn4_du:
       bn.rshi w17, w31, w17 >> 10
     endloop
     bn.rshi w18, w17, w18 >> 6
-    bn.lid  x4, 0(a1++)
+    bn.lid  x4, 0(x11++)
     bn.rshi w18, w17, w18 >> 10
     bn.rshi w17, w31, w17 >> 4
     loopi 6, 2
       bn.rshi w18, w17, w18 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.movr t0, t1
-    addi    t0, t0, -1
+    bn.movr x5, x6
+    addi    x5, x5, -1
     
     /* group i + 2 */
     loopi 16, 2
       bn.rshi w18, w17, w18 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.movr t0, t1
-    addi    t0, t0, -1
+    bn.movr x5, x6
+    addi    x5, x5, -1
     
     /* group i + 3 */
     loopi 3, 2
@@ -3404,15 +3371,15 @@ _handle_kn4_du:
       bn.rshi w17, w31, w17 >> 10
     endloop
     bn.rshi w18, w17, w18 >> 2
-    bn.lid  x4, 0(a1++)
+    bn.lid  x4, 0(x11++)
     bn.rshi w18, w17, w18 >> 14
     bn.rshi w17, w31, w17 >> 8
     loopi 12, 2
       bn.rshi w18, w17, w18 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.movr t0, t1
-    addi    t0, t0, -1
+    bn.movr x5, x6
+    addi    x5, x5, -1
     
     /* group i + 4 */
     loopi 12, 2
@@ -3420,23 +3387,23 @@ _handle_kn4_du:
       bn.rshi w17, w31, w17 >> 10
     endloop
     bn.rshi w18, w17, w18 >> 8
-    bn.lid  x4, 0(a1++)
+    bn.lid  x4, 0(x11++)
     bn.rshi w18, w17, w18 >> 8
     bn.rshi w17, w31, w17 >> 2
     loopi 3, 2
       bn.rshi w18, w17, w18 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.movr t0, t1
-    addi    t0, t0, -1
+    bn.movr x5, x6
+    addi    x5, x5, -1
     
     /* group i + 5 */
     loopi 16, 2
       bn.rshi w18, w17, w18 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.movr t0, t1
-    addi    t0, t0, -1
+    bn.movr x5, x6
+    addi    x5, x5, -1
     
     /* group i + 6 */
     loopi 6, 2
@@ -3444,113 +3411,113 @@ _handle_kn4_du:
       bn.rshi w17, w31, w17 >> 10
     endloop
     bn.rshi w18, w17, w18 >> 4
-    bn.lid  x4, 0(a1++)
+    bn.lid  x4, 0(x11++)
     bn.rshi w18, w17, w18 >> 12
     bn.rshi w17, w31, w17 >> 6
     loopi 9, 2
       bn.rshi w18, w17, w18 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.movr t0, t1
-    addi    t0, t0, -1
+    bn.movr x5, x6
+    addi    x5, x5, -1
     
     /* group i + 7 */
     loopi 16, 2
       bn.rshi w18, w17, w18 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.movr t0, t1
-    addi    t0, t0, -1
+    bn.movr x5, x6
+    addi    x5, x5, -1
   endloop
   jal x1, _bitslice_transpose
     
-  addi s1, x0, 10 /* du */
+  addi x9, x0, 10 /* du */
 
 _handle_common_du:
   /* t[0] ^= c ^ ((1 << N) - 1):  c-planes are now w0..w9. */
   bn.subi w15, w31, 1
-  addi    t0, sp, 0 /* ptr_t */
+  addi    x5, x2, 0 /* ptr_t */
 
-  bn.lid x4, 0(t0)
+  bn.lid x4, 0(x5)
   bn.xor w0, w0, w15
   bn.xor w17, w17, w0
-  bn.sid x4, 0(t0++)
+  bn.sid x4, 0(x5++)
 
-  bn.lid x4, 0(t0)
+  bn.lid x4, 0(x5)
   bn.xor w1, w1, w15
   bn.xor w17, w17, w1
-  bn.sid x4, 0(t0++)
+  bn.sid x4, 0(x5++)
 
-  bn.lid x4, 0(t0)
+  bn.lid x4, 0(x5)
   bn.xor w2, w2, w15
   bn.xor w17, w17, w2
-  bn.sid x4, 0(t0++)
+  bn.sid x4, 0(x5++)
 
-  bn.lid x4, 0(t0)
+  bn.lid x4, 0(x5)
   bn.xor w3, w3, w15
   bn.xor w17, w17, w3
-  bn.sid x4, 0(t0++)
+  bn.sid x4, 0(x5++)
 
-  bn.lid x4, 0(t0)
+  bn.lid x4, 0(x5)
   bn.xor w4, w4, w15
   bn.xor w17, w17, w4
-  bn.sid x4, 0(t0++)
+  bn.sid x4, 0(x5++)
 
-  bn.lid x4, 0(t0)
+  bn.lid x4, 0(x5)
   bn.xor w5, w5, w15
   bn.xor w17, w17, w5
-  bn.sid x4, 0(t0++)
+  bn.sid x4, 0(x5++)
 
-  bn.lid x4, 0(t0)
+  bn.lid x4, 0(x5)
   bn.xor w6, w6, w15
   bn.xor w17, w17, w6
-  bn.sid x4, 0(t0++)
+  bn.sid x4, 0(x5++)
 
-  bn.lid x4, 0(t0)
+  bn.lid x4, 0(x5)
   bn.xor w7, w7, w15
   bn.xor w17, w17, w7
-  bn.sid x4, 0(t0++)
+  bn.sid x4, 0(x5++)
 
-  bn.lid x4, 0(t0)
+  bn.lid x4, 0(x5)
   bn.xor w8, w8, w15
   bn.xor w17, w17, w8
-  bn.sid x4, 0(t0++)
+  bn.sid x4, 0(x5++)
 
-  bn.lid x4, 0(t0)
+  bn.lid x4, 0(x5)
   bn.xor w9, w9, w15
   bn.xor w17, w17, w9
-  bn.sid x4, 0(t0++)
+  bn.sid x4, 0(x5++)
 
-  addi   t1, x0, 10
-  beq    s1, t1, _skip_bit_10
+  addi   x6, x0, 10
+  beq    x9, x6, _skip_bit_10
 
-  bn.lid x4, 0(t0)
+  bn.lid x4, 0(x5)
   bn.xor w10, w10, w15
   bn.xor w17, w17, w10
-  bn.sid x4, 0(t0++)
+  bn.sid x4, 0(x5++)
 
 _skip_bit_10:
   /* Compute r = secand(r, t). */
-  addi a1, x0, 32
-  addi a2, sp, 0 /* ptr_t */
-  addi a3, s2, 0 /* share_str */
-  addi a6, x0, 32 /* output share_str */
+  addi x11, x0, 32
+  addi x12, x2, 0 /* ptr_t */
+  addi x13, x18, 0 /* share_str */
+  addi x16, x0, 32 /* output share_str */
   /* After the secand, the input and output pointers will point to
    * next bit so we don't have to pass all the arguments above to secand again. */
-  loop s1, 4
-    addi a0, s4, 0 /* ptr_r */
-    addi a5, s4, 0 /* ptr_r */
+  loop x9, 4
+    addi x10, x20, 0 /* ptr_r */
+    addi x15, x20, 0 /* ptr_r */
     jal  x1, secand
     nop
   endloop
 
   /* Restore registers. */
-  lw   s0, 708(sp)
-  lw   s1, 712(sp)
-  lw   s2, 716(sp)
-  lw   s4, 724(sp)
-  lw   a5, 728(sp)
-  addi sp, sp, 736
+  lw   x8, 708(x2)
+  lw   x9, 712(x2)
+  lw   x18, 716(x2)
+  lw   x20, 724(x2)
+  lw   x15, 728(x2)
+  addi x2, x2, 736
   ret
 
 /*
@@ -3570,190 +3537,190 @@ _skip_bit_10:
 .globl finalize_cmp
 .type finalize_cmp, @function
 finalize_cmp:
-  /* Allocate t scratch (2 shares * 32 B) and save s0. */
-  addi sp, sp, -96
-  sw s0, 68(sp)
+  /* Allocate t scratch (2 shares * 32 B) and save x8. */
+  addi x2, x2, -96
+  sw x8, 68(x2)
 
   /* Save the in/out address. */
-  addi s0, a0, 0
+  addi x8, x10, 0
 
   /* Compute x &= (x >> 128). */
   /* Compute t = x >> 128. */
   addi x4, x0, 1
-  addi t0, sp, 0 /* ptr_t */
+  addi x5, x2, 0 /* ptr_t */
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
     bn.xor  w1, w1, w1
-    bn.lid  x0, 0(a0++)
+    bn.lid  x0, 0(x10++)
     bn.rshi w1, w31, w0 >> 128
-    bn.sid  x4, 0(t0++)
+    bn.sid  x4, 0(x5++)
   endloop
   /* Compute x &= t. */
-  addi a0, s0, 0
-  addi a1, x0, 32
-  addi a2, sp, 0
-  addi a3, x0, 32
-  addi a5, s0, 0
-  addi a6, x0, 32
+  addi x10, x8, 0
+  addi x11, x0, 32
+  addi x12, x2, 0
+  addi x13, x0, 32
+  addi x15, x8, 0
+  addi x16, x0, 32
   jal  x1, secand
 
   /* Compute x &= (x >> 64). */
   /* Compute t = x >> 64. */
   addi x4, x0, 1
-  addi a0, s0, 0
-  addi t0, sp, 0 /* ptr_t */
+  addi x10, x8, 0
+  addi x5, x2, 0 /* ptr_t */
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
     bn.xor  w1, w1, w1
-    bn.lid  x0, 0(a0++)
+    bn.lid  x0, 0(x10++)
     bn.rshi w1, w31, w0 >> 64
-    bn.sid  x4, 0(t0++)
+    bn.sid  x4, 0(x5++)
   endloop
   /* Compute x &= t. */
-  addi a0, s0, 0
-  /* a1 is still 32. */
-  addi a2, sp, 0
-  /* a3 is still 32. */
-  addi a5, s0, 0
-  /* a6 is still 32. */
+  addi x10, x8, 0
+  /* x11 is still 32. */
+  addi x12, x2, 0
+  /* x13 is still 32. */
+  addi x15, x8, 0
+  /* x16 is still 32. */
   jal  x1, secand
 
   /* Compute x &= (x >> 32). */
   /* Compute t = x >> 32. */
   addi x4, x0, 1
-  addi a0, s0, 0
-  addi t0, sp, 0 /* ptr_t */
+  addi x10, x8, 0
+  addi x5, x2, 0 /* ptr_t */
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
     bn.xor  w1, w1, w1
-    bn.lid  x0, 0(a0++)
+    bn.lid  x0, 0(x10++)
     bn.rshi w1, w31, w0 >> 32
-    bn.sid  x4, 0(t0++)
+    bn.sid  x4, 0(x5++)
   endloop
   /* Compute x &= t. */
-  addi a0, s0, 0
-  /* a1 is still 32. */
-  addi a2, sp, 0
-  /* a3 is still 32. */
-  addi a5, s0, 0
-  /* a6 is still 32. */
+  addi x10, x8, 0
+  /* x11 is still 32. */
+  addi x12, x2, 0
+  /* x13 is still 32. */
+  addi x15, x8, 0
+  /* x16 is still 32. */
   jal  x1, secand
 
   /* Compute x &= (x >> 16). */
   /* Compute t = x >> 16. */
   addi x4, x0, 1
-  addi a0, s0, 0
-  addi t0, sp, 0 /* ptr_t */
+  addi x10, x8, 0
+  addi x5, x2, 0 /* ptr_t */
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
     bn.xor  w1, w1, w1
-    bn.lid  x0, 0(a0++)
+    bn.lid  x0, 0(x10++)
     bn.rshi w1, w31, w0 >> 16
-    bn.sid  x4, 0(t0++)
+    bn.sid  x4, 0(x5++)
   endloop
   /* Compute x &= t. */
-  addi a0, s0, 0
-  /* a1 is still 32. */
-  addi a2, sp, 0
-  /* a3 is still 32. */
-  addi a5, s0, 0
-  /* a6 is still 32. */
+  addi x10, x8, 0
+  /* x11 is still 32. */
+  addi x12, x2, 0
+  /* x13 is still 32. */
+  addi x15, x8, 0
+  /* x16 is still 32. */
   jal  x1, secand
 
   /* Compute x &= (x >> 8). */
   /* Compute t = x >> 8. */
   addi x4, x0, 1
-  addi a0, s0, 0
-  addi t0, sp, 0 /* ptr_t */
+  addi x10, x8, 0
+  addi x5, x2, 0 /* ptr_t */
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
     bn.xor  w1, w1, w1
-    bn.lid  x0, 0(a0++)
+    bn.lid  x0, 0(x10++)
     bn.rshi w1, w31, w0 >> 8
-    bn.sid  x4, 0(t0++)
+    bn.sid  x4, 0(x5++)
   endloop
   /* Compute x &= t. */
-  addi a0, s0, 0
-  /* a1 is still 32. */
-  addi a2, sp, 0
-  /* a3 is still 32. */
-  addi a5, s0, 0
-  /* a6 is still 32. */
+  addi x10, x8, 0
+  /* x11 is still 32. */
+  addi x12, x2, 0
+  /* x13 is still 32. */
+  addi x15, x8, 0
+  /* x16 is still 32. */
   jal  x1, secand
 
   /* Compute x &= (x >> 4). */
   /* Compute t = x >> 4. */
   addi x4, x0, 1
-  addi a0, s0, 0
-  addi t0, sp, 0 /* ptr_t */
+  addi x10, x8, 0
+  addi x5, x2, 0 /* ptr_t */
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
     bn.xor  w1, w1, w1
-    bn.lid  x0, 0(a0++)
+    bn.lid  x0, 0(x10++)
     bn.rshi w1, w31, w0 >> 4
-    bn.sid  x4, 0(t0++)
+    bn.sid  x4, 0(x5++)
   endloop
   /* Compute x &= t. */
-  addi a0, s0, 0
-  /* a1 is still 32. */
-  addi a2, sp, 0
-  /* a3 is still 32. */
-  addi a5, s0, 0
-  /* a6 is still 32. */
+  addi x10, x8, 0
+  /* x11 is still 32. */
+  addi x12, x2, 0
+  /* x13 is still 32. */
+  addi x15, x8, 0
+  /* x16 is still 32. */
   jal  x1, secand
 
   /* Compute x &= (x >> 2). */
   /* Compute t = x >> 2. */
   addi x4, x0, 1
-  addi a0, s0, 0
-  addi t0, sp, 0 /* ptr_t */
+  addi x10, x8, 0
+  addi x5, x2, 0 /* ptr_t */
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
     bn.xor  w1, w1, w1
-    bn.lid  x0, 0(a0++)
+    bn.lid  x0, 0(x10++)
     bn.rshi w1, w31, w0 >> 2
-    bn.sid  x4, 0(t0++)
+    bn.sid  x4, 0(x5++)
   endloop
   /* Compute x &= t. */
-  addi a0, s0, 0
-  /* a1 is still 32. */
-  addi a2, sp, 0
-  /* a3 is still 32. */
-  addi a5, s0, 0
-  /* a6 is still 32. */
+  addi x10, x8, 0
+  /* x11 is still 32. */
+  addi x12, x2, 0
+  /* x13 is still 32. */
+  addi x15, x8, 0
+  /* x16 is still 32. */
   jal  x1, secand
 
   /* Compute x &= (x >> 1). */
   /* Compute t = x >> 1. */
   addi x4, x0, 1
-  addi a0, s0, 0
-  addi t0, sp, 0 /* ptr_t */
+  addi x10, x8, 0
+  addi x5, x2, 0 /* ptr_t */
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
     bn.xor  w1, w1, w1
-    bn.lid  x0, 0(a0++)
+    bn.lid  x0, 0(x10++)
     bn.rshi w1, w31, w0 >> 1
-    bn.sid  x4, 0(t0++)
+    bn.sid  x4, 0(x5++)
   endloop
   /* Compute x &= t. */
-  addi a0, s0, 0
-  /* a1 is still 32. */
-  addi a2, sp, 0
-  /* a3 is still 32. */
-  addi a5, s0, 0
-  /* a6 is still 32. */
+  addi x10, x8, 0
+  /* x11 is still 32. */
+  addi x12, x2, 0
+  /* x13 is still 32. */
+  addi x15, x8, 0
+  /* x16 is still 32. */
   jal  x1, secand
 
-  /* Restore s0. */
-  lw s0, 68(sp)
+  /* Restore x8. */
+  lw x8, 68(x2)
 
-  addi sp, sp, 96
+  addi x2, x2, 96
   ret

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -42,28 +42,28 @@
  *           https://eprint.iacr.org/2019/910
  */
 
-/*
- * Name: secand
+/**
+ * Bitwise AND of two 1-bit Boolean-shared values.
  *
- * Return new Boolean shares of a value r = x & y.
- * Bitsliced.
+ * Return Boolean shares of r = x & y, given 1-bit Boolean shares of x and y.
  *
- *   s   <- URND
+ *   s   <- urnd
  *   r_0 <- (x_0 & y_0) ^ (x_0 & (y_1 ^ s)) ^ ((x_0 ^ 1) & s)
  *   r_1 <- (x_1 & y_1) ^ (x_1 & (y_0 ^ s)) ^ ((x_1 ^ 1) & s)
  *
  * Source: Alg.2 [CS20]
  *
- * @param[in]  x10: dptr_xb, dmem pointer to Boolean shares of x
- * @param[in]  x11: share stride, distance between shares of x
- * @param[in]  x12: dptr_yb, dmem pointer to Boolean shares of y
- * @param[in]  x13: share stride, distance between shares of y
- * @param[out] x15: dptr_rb, dmem pointer to Boolean shares of r
- * @param[in]  x16: share stride, distance between shares of r
+ * @param[in]  x10: dmem pointer to Boolean shares of x
+ * @param[in]  x11: share stride of x
+ * @param[in]  x12: dmem pointer to Boolean shares of y
+ * @param[in]  x13: share stride of y
+ * @param[out] x15: dmem pointer to Boolean shares of r
+ * @param[in]  x16: share stride of r
  *
  * clobbered registers: x4 to x7, x10, x12, x15, w0 to w3, w5 to w8
  * clobbered flag groups: FG0
  */
+
 .globl secand
 .type secand, @function
 secand:
@@ -121,33 +121,33 @@ secand:
   addi x15, x15, 32
   ret
 
-/*
- * Name: secfulladder
+/**
+ * Full adder on 1-bit Boolean-shared values.
  *
- * Return Boolean shares of a value r = (x + y + c) mod 2^2, given Boolean
- * shares of x and y mod 2.
- * Bitsliced.
+ * Return Boolean shares of (cout, r) = (x + y + cin), given 1-bit Boolean
+ * shares of x, y and cin.
  *
  *   a    <- x ^ y                   (sharewise)
  *   r    <- a ^ cin                 (sharewise; sum bit)
- *   cout <- x ^ SecAnd(a, x ^ cin)  (carry bit)
+ *   cout <- x ^ secand(a, x ^ cin)  (carry bit)
  *
  * Source: Alg.5 [BC22]
  *
- * @param[in]  x10: dptr_x, dmem pointer to Boolean shares of x
- * @param[in]  x11: share stride, distance between shares of x
- * @param[in]  x12: dptr_y, dmem pointer to Boolean shares of y
- * @param[in]  x13: share stride, distance between shares of y
- * @param[out] x15: dptr_r, dmem pointer to Boolean shares of r
- * @param[in]  x16: share stride, distance between shares of r
- * @param[in]  x17: dptr_c, dmem pointer to the Boolean shares of cin
- * @param[in]  x29: share stride, distance between shares of cin
- * @param[out] x30: dptr_c, dmem pointer to the Boolean shares of cout
- * @param[in]  x31: share stride, distance between shares of cout
+ * @param[in]  x10: dmem pointer to Boolean shares of x
+ * @param[in]  x11: share stride of x
+ * @param[in]  x12: dmem pointer to Boolean shares of y
+ * @param[in]  x13: share stride of y
+ * @param[out] x15: dmem pointer to Boolean shares of r
+ * @param[in]  x16: share stride of r
+ * @param[in]  x17: dmem pointer to Boolean shares of cin
+ * @param[in]  x29: share stride of cin
+ * @param[out] x30: dmem pointer to Boolean shares of cout
+ * @param[in]  x31: share stride of cout
  *
  * clobbered registers: x4 to x7, x10, x12, x15, x28, w0 to w9
  * clobbered flag groups: FG0
  */
+
 .globl secfulladder
 .type secfulladder, @function
 secfulladder:
@@ -245,30 +245,31 @@ secfulladder:
   addi x15, x15, 32
   ret
 
-/*
- * Name: secadd
+/**
+ * Addition of two k-bit Boolean-shared values.
  *
- * Return Boolean shares of a value r = (x + y) mod 2^k, given Boolean shares of
- * x and y mod 2^k.
+ * Return Boolean shares of r = (x + y) mod 2^k, given k-bit Boolean shares of
+ * x and y.
  * Bitsliced.
  *
  *   c <- 0
- *   for i = 0, ..., k-2:  (c, r[i]) <- SecFullAdder(x[i], y[i], c)
- *   r[k-1] <- x[k-1] ^ y[k-1] ^ c
+ *   for i = 0..k - 2:  (c, r[i]) <- secfulladder(x[i], y[i], c)
+ *   r[k - 1] <- x[k - 1] ^ y[k - 1] ^ c
  *
  * Source: Alg.6 [BC22]
  *
- * @param[in]  x10: dptr_x, dmem pointer to Boolean shares of x
- * @param[in]  x11: share stride, distance between shares of x
- * @param[in]  x12: dptr_y, dmem pointer to Boolean shares of y
- * @param[in]  x13: share stride, distance between shares of y
- * @param[out] x15: dptr_r, dmem pointer to Boolean shares of r
- * @param[in]  x16: share stride, distance between shares of r
- * @param[in]  x17: k, bitsize of x and y.
+ * @param[in]  x10: dmem pointer to Boolean shares of x
+ * @param[in]  x11: share stride of x
+ * @param[in]  x12: dmem pointer to Boolean shares of y
+ * @param[in]  x13: share stride of y
+ * @param[out] x15: dmem pointer to Boolean shares of r
+ * @param[in]  x16: share stride of r
+ * @param[in]  x17: k, bitsize of x and y
  *
  * clobbered registers: x2, x4 to x8, x10, x12, x15, x17, x28 to x31, w0 to w9
  * clobbered flag groups: FG0
  */
+
 .globl secadd
 .type secadd, @function
 secadd:
@@ -347,24 +348,25 @@ secadd:
   addi x2, x2, 96
   ret
 
-/*
- * Name: bitcopymask
+/**
+ * Boolean-shared product of the modulus q = 3329 and a single bit.
  *
- * Return k-bit Boolean shares of q * x, given 1-bit Boolean shares of x for
- * q = 3329 and the bitsize k = 12 (since q < 2**k).
+ * Return k-bit Boolean shares of r = q * x, given 1-bit Boolean
+ * shares of x for q = 3329 and the bitsize k = 12 (since q < 2^k).
  * Bitsliced.
  *
- *   for j = 0, ..., k-1:  r[j] <- q_j & x   (q = 3329 = 0b110100000001)
+ *   for j = 0..k - 1:  r[j] <- q[j] & x   (q = 3329 = 0b110100000001)
  *
  * Source: Alg.1 [BC22]
  *
- * @param[in]  x10: dptr_xb, dmem pointer to the input Boolean shares of x
- * @param[in]  x11: share stride, distance between shares of x
- * @param[out] x13: dptr_rb, dmem pointer to the output Boolean shares of r
+ * @param[in]  x10: dmem pointer to Boolean shares of x
+ * @param[in]  x11: share stride of x
+ * @param[out] x13: dmem pointer to Boolean shares of r
  *
  * clobbered registers: x4, x10, x13, w0
  * clobbered flag groups: FG0
  */
+
 .globl bitcopymask
 .type bitcopymask, @function
 bitcopymask:
@@ -392,27 +394,28 @@ bitcopymask:
   endloop
   ret
 
-/*
- * Name: refreshios
+/**
+ * Refresh of Boolean shares.
  *
- * Return new Boolean shares of x mod 2^k, given old Boolean shares of x.
+ * Return new k-bit Boolean shares of x, given k-bit Boolean shares of x.
  * Bitsliced.
  *
  *   for each bit-slice:
- *     s    <- URND
- *     r[0] <- x[0] ^ s
- *     r[1] <- x[1] ^ s
+ *     s   <- urnd
+ *     r_0 <- x_0 ^ s
+ *     r_1 <- x_1 ^ s
  *
  * Source: Alg.18 [BC22]
  *
- * @param[in]  x10: dptr_x, dmem pointer to Boolean shares of x
- * @param[in]  x11: k, bitsize of x.
- * @param[in]  x12: share stride, distance between shares
- * @param[out] x14: dptr_r, dmem pointer to the output Boolean shares of r
+ * @param[in]  x10: dmem pointer to Boolean shares of x
+ * @param[in]  x11: k, bitsize of x
+ * @param[in]  x12: share stride of x and r
+ * @param[out] x14: dmem pointer to Boolean shares of r
  *
  * clobbered registers: x4 to x6, x10, x14, w0 to w2
  * clobbered flag groups: FG0
  */
+
 .globl refreshios
 .type refreshios, @function
 refreshios:
@@ -436,16 +439,19 @@ refreshios:
   endloop
   ret
 
-/*
- * Name: poly_rej_samp
+/**
+ * Rejection sampling of a polynomial with coefficients mod q = 3329.
  *
  * Return a polynomial of random coefficients mod q, obtained by running
- * rejection sampling on uniform random bytes from URND.
+ * rejection sampling on uniform random bytes from urnd.
  *
- * @param[in]  w16: sw0, R | Q
- * @param[out] x10: ptr_r, dmem pointer to output polynomial
- * @param[in]  x11: dmem pointer to random input words (MLKEM_REJ_SAMPLE_TEST only)
+ * @param[out] x10: dmem pointer to output polynomial
+ * @param[in]  x11: dmem pointer to random input words
+ *                  (MLKEM_REJ_SAMPLE_TEST only)
+ * @param[in]  w16 (sw0): sw0.0 = q = 3329 (1st 16-bit lane),
+ *                        sw0.2 = -q^-1 mod 2^16 = 3327 (3rd 16-bit lane)
  * @param[in]  w31: all-zero register
+ * @param[in]  mod: q = 3329
  *
  * clobbered registers: x5 to x6, x10, w0 to w5, acch, acc
  * clobbered flag groups: FG0
@@ -509,25 +515,28 @@ _rej_sample_loop:
 _end_rej_sample_loop:
   ret
 
-/*
- * Name: refreshmodq
+/**
+ * Refresh of arithmetic shares mod q = 3329.
  *
  * Return new arithmetic shares mod q = 3329 of the value x.
  * Vectorized for polynomial.
  *
  *   rand <- poly_rej_samp()      uniform polynomial mod q
- *   r[0] <- x[0] + rand   mod q
- *   r[1] <- x[1] - rand   mod q
+ *   r_0  <- x_0 + rand   mod q
+ *   r_1  <- x_1 - rand   mod q
  *
  * Source: [BBD+16]
  *
- * @param[in]  w16: R | Q
- * @param[in]  x10: dptr_xa, dmem pointer to arithmetic shares of x
- * @param[out] x12: dptr_ra, dmem pointer to arithmetic shares of r
+ * @param[in]  x10: dmem pointer to arithmetic shares of x
+ * @param[out] x12: dmem pointer to arithmetic shares of r
+ * @param[in]  w16 (sw0): sw0.0 = q = 3329 (1st 16-bit lane),
+ *                        sw0.2 = -q^-1 mod 2^16 = 3327 (3rd 16-bit lane)
+ * @param[in]  mod: q = 3329
  *
  * clobbered registers: x2, x4 to x7, x10, x12, x28, w0 to w5, acch, acc
  * clobbered flag groups: FG0
  */
+
 .globl refreshmodq
 .type refreshmodq, @function
 refreshmodq:
@@ -565,20 +574,24 @@ refreshmodq:
   addi x2, x2, 544
   ret
 
-/*
- * Name: poly_to_bitsliced
+/**
+ * Bitsliced representation of a polynomial.
  *
- * Return bitsliced representation of a value x in [0, KYBER_Q).
+ * Return the bitsliced representation r of a value x in [0, q), q = 3329.
  * Vectorized for polynomial.
  *
- *   bs[j] <- bit j of x,  j = 0, ..., 11
+ *   r[j] <- bit j of x,  j = 0..11
  *
- * @param[in]  x10: dptr_x, dmem pointer to the input masked value
- * @param[out] x11: dptr_r, dmem pointer to the output bitslice representation
+ * Only 12 bitslices are needed since q < 2^12.
+ *
+ * @param[in]  x10: dmem pointer to x
+ * @param[out] x11: dmem pointer to bitsliced representation r
+ * @param[in]  w31: all-zero register
  *
  * clobbered registers: x4, x10, w0 to w15, w28 to w29
  * clobbered flag groups: FG0
  */
+
 .globl poly_to_bitsliced
 .type poly_to_bitsliced, @function
 poly_to_bitsliced:
@@ -601,21 +614,25 @@ poly_to_bitsliced:
   endloop
   ret
 
-/*
- * Name: poly_from_bitsliced
+/**
+ * Normal representation of a bitsliced polynomial.
  *
- * Return normal representation of a bitsliced value x in [0, KYBER_Q).
+ * Return the normal representation r of a bitsliced value x in [0, q),
+ * q = 3329.
  * Vectorized for polynomial.
  *
- *   x <- sum_{j=0}^{11} bs[j] << j
+ *   r <- sum_{j=0..11} x[j] << j
  *
- * @param[in]  x10: dptr_x, dmem pointer to the input bitsliced representation
+ * Only 12 bitslices are needed since q < 2^12.
+ *
+ * @param[in]  x10: dmem pointer to bitsliced representation x
+ * @param[out] x11: dmem pointer to r
  * @param[in]  w31: all-zero register
- * @param[out] x11: dptr_r, dmem pointer to the output masked value
  *
  * clobbered registers: x4, x10 to x11, w0 to w15, w28 to w29
  * clobbered flag groups: FG0
  */
+
 .globl poly_from_bitsliced
 .type poly_from_bitsliced, @function
 poly_from_bitsliced:
@@ -641,10 +658,19 @@ poly_from_bitsliced:
   endloop
   ret
 
-/*
- * 16x16 per-lane bit transpose of w0..w15, shared by poly_to_bitsliced and
- * poly_from_bitsliced.
+/**
+ * Per-lane 16x16 bit transpose.
+ *
+ * Transpose in place the 16x16 bit matrix held by each 16-bit lane of
+ * w0 to w15. Shared by poly_to_bitsliced and poly_from_bitsliced.
+ *
+ * @param[in,out] w0 to w15: bit matrices to transpose
+ * @param[in]     w31: all-zero register
+ *
+ * clobbered registers: w0 to w15, w28 to w29
+ * clobbered flag groups: FG0
  */
+
 _bitslice_transpose:
   /* Stage d=8. */
   bn.not     w28, w31
@@ -852,26 +878,27 @@ _bitslice_transpose:
   bn.xor     w14, w14, w29
   ret
 
-/*
- * Name: seca2b
+/**
+ * Arithmetic-to-Boolean conversion mod 2^k.
  *
- * Return Boolean shares mod 2**k of a value x given its arithmetic shares mod 2**k.
+ * Return k-bit Boolean shares r of x, given arithmetic shares of x mod 2^k.
  * Bitsliced.
  *
- *   s  <- (x[0], 0)
- *   s' <- (0, x[1])
+ *   s  <- (x_0, 0)
+ *   s' <- (0, x_1)
  *   r  <- secadd(s, s')
  *
  * Source: Alg.8 [BC22]
  *
- * @param[in]  x10: dptr_xa, dmem pointer to the input arithmetic shares mod 2**k of x
- * @param[in]  x11: k, bitsize of x.
- * @param[in]  x12: share bytes, bytes per bitsliced share
- * @param[out] x14: dptr_rb, dmem pointer to the output Boolean shares
+ * @param[in]  x10: dmem pointer to arithmetic shares of x
+ * @param[in]  x11: k, bitsize of x
+ * @param[in]  x12: share stride of x and r
+ * @param[out] x14: dmem pointer to Boolean shares of r
  *
  * clobbered registers: x2 to x8, x10 to x13, x15 to x17, x28 to x31, w0 to w9
  * clobbered flag groups: FG0
  */
+
 .globl seca2b
 .type seca2b, @function
 seca2b:
@@ -930,27 +957,29 @@ seca2b:
   addi x2, x2, 32
   ret
 
-/*
- * Name: seca2bmodq
+/**
+ * Arithmetic-to-Boolean conversion mod q = 3329.
  *
- * Return Boolean shares mod 2**k (k = 12) of a value x mod q = 3329 given its
- * arithmetic shares. (It is required that q < 2**k).
+ * Return k-bit Boolean shares r of x, given arithmetic shares of x mod
+ * q = 3329, with the bitsize k = 12 (since q < 2^k).
  * Bitsliced.
  *
- *   s  <- ((2^(k+1) - q) + x[0], 0)
- *   s' <- (0, x[1])
- *   u  <- secadd(s, s')
+ *   s  <- ((2^(k + 1) - q) + x_0, 0)    (k + 1 bits)
+ *   s' <- (0, x_1)                      (k + 1 bits)
+ *   u  <- secadd(s, s')                 (k + 1 bits)
  *   a  <- bitcopymask(u[k])
- *   r  <- secadd(a, u)
+ *   r  <- secadd(a, u)                  (k bits)
  *
  * Source: Alg.10 [BC22]
  *
- * @param[in]  x10: dptr_xa, dmem pointer to the input arithmetic shares mod q of x
- * @param[out] x12: dptr_rb, dmem pointer to the output Boolean shares
+ * @param[in]  x10: dmem pointer to arithmetic shares of x
+ * @param[out] x12: dmem pointer to Boolean shares of r
+ * @param[in]  w31: all-zero register
  *
  * clobbered registers: x2, x4 to x7, x10 to x13, x15 to x18, x28 to x31, w0 to w9
  * clobbered flag groups: FG0
  */
+
 .globl seca2bmodq
 .type seca2bmodq, @function
 seca2bmodq:
@@ -1159,27 +1188,30 @@ seca2bmodq:
   addi x2, x2, 1760
   ret
 
-/*
- * Name: seconebitb2amodq
+/**
+ * One-bit Boolean-to-Arithmetic conversion mod q = 3329.
  *
- * Return arithmetic shares mod q = 3329 of a bit x, given its Boolean shares.
+ * Return arithmetic shares mod q = 3329 r of a bit x, given its Boolean shares.
  * Vectorized for polynomial.
  *
- *   v    <- (x[0], 0)
+ *   v    <- (x_0, 0)
  *   v    <- refreshmodq(v)
- *   v[0] <- (1 - 2*x[1])*v[0] + x[1]   mod q
- *   v[1] <- (1 - 2*x[1])*v[1]          mod q
- *   r    <- refreshmodq(v[0], v[1])
+ *   v_0  <- (1 - 2 * x_1) * v_0 + x_1   mod q
+ *   v_1  <- (1 - 2 * x_1) * v_1         mod q
+ *   r    <- refreshmodq(v)
  *
  * Source: Alg.5 [SPOG19]
  *
- * @param[in]  w16: R | Q
- * @param[in]  x10: dptr_x, dmem pointer to Boolean shares of x
- * @param[out] x12: dptr_r, dmem pointer to arithmetic shares of r
+ * @param[in]  x10: dmem pointer to Boolean shares of x
+ * @param[out] x12: dmem pointer to arithmetic shares of r
+ * @param[in]  w16 (sw0): sw0.0 = q = 3329 (1st 16-bit lane),
+ *                        sw0.2 = -q^-1 mod 2^16 = 3327 (3rd 16-bit lane)
+ * @param[in]  mod: q = 3329
  *
  * clobbered registers: x2, x4 to x8, x10, x12, x18, x28, w0 to w5, w30, acch, acc
  * clobbered flag groups: FG0
  */
+
 .globl seconebitb2amodq
 .type seconebitb2amodq, @function
 seconebitb2amodq:
@@ -1259,14 +1291,14 @@ seconebitb2amodq:
   addi x2, x2, 1056
   ret
 
-/*
- * Name: secb2amodq
+/**
+ * Boolean-to-Arithmetic conversion mod q = 3329.
  *
- * Return arithmetic shares mod q = 3329 of x, given its Boolean shares mod 2^k,
- * with k = 12 (q < 2**k).
+ * Return arithmetic shares r of x mod q = 3329, given its Boolean
+ * shares mod 2^k, with k = 12 (q < 2^k).
  * Bitsliced.
  *
- *   rand <- poly_rej_samp()      uniform polynomial mod q
+ *   rand <- poly_rej_samp()      (uniform polynomial mod q)
  *   zp   <- q - rand
  *   a    <- seca2bmodq(zp)
  *   b    <- secaddmodq(a, x)
@@ -1275,12 +1307,17 @@ seconebitb2amodq:
  *
  * Source: Alg.11 [BC22]
  *
- * @param[in]  x10: dptr_x, dmem pointer to Boolean shares of x
- * @param[out] x12: dptr_r, dmem pointer to the output arithmetic shares of r
+ * @param[in]  x10: dmem pointer to Boolean shares of x
+ * @param[out] x12: dmem pointer to arithmetic shares of r
+ * @param[in]  w16 (sw0): sw0.0 = q = 3329 (1st 16-bit lane),
+ *                        sw0.2 = -q^-1 mod 2^16 = 3327 (3rd 16-bit lane)
+ * @param[in]  w31: all-zero register
+ * @param[in]  mod: q = 3329
  *
  * clobbered registers: x2, x4 to x8, x10 to x21, x28 to x31, w0 to w16, w28 to w30, acch, acc
  * clobbered flag groups: FG0
  */
+
 .globl secb2amodq
 .type secb2amodq, @function
 secb2amodq:
@@ -1511,27 +1548,28 @@ secb2amodq:
   addi x2, x2, 609
   ret
 
-/*
- * Name: poly_hocompress
+/**
+ * First-order masked compression of a polynomial with dv in {4, 5}.
  *
- * Return Boolean shares of Compressq(x, d) = round((2^d / q) * x) mod 2^d for
- * d in {4, 5}, given arithmetic shares mod q of x. Bitsliced.
+ * Return Boolean shares of r = Compressq(x, dv) = round((2^dv / q) * x) mod
+ * 2^dv for dv in {4, 5}, given arithmetic shares mod q of x. Here dv = 5 for
+ * k = 4, and 4 otherwise.
+ * Bitsliced.
  *
- * Each share is compressed to d + alpha bits, recombined (seca2b), then the low
- * alpha bits dropped. The alpha extra bits absorb the per-share rounding error
- * (2^alpha > q * nshares); nshares = 2 gives d + alpha = 18 (alpha = 13 for
- * d = 5, 14 for d = 4).
+ * Each share is compressed to dv + alpha bits, recombined (seca2b), then the
+ * low alpha bits dropped. The alpha extra bits absorb the per-share rounding
+ * error (2^alpha > q * nshares); nshares = 2 gives dv + alpha = 18 (alpha = 13
+ * for dv = 5, 14 for dv = 4).
  *
- *   z[0] <- Compressq(x[0], d + alpha) + 2^(alpha - 1)
- *   z[1] <- Compressq(x[1], d + alpha)
- *   c    <- seca2b(z[0], z[1])
+ *   z_0  <- Compressq(x_0, dv + alpha) + 2^(alpha - 1)
+ *   z_1  <- Compressq(x_1, dv + alpha)
+ *   c    <- seca2b(z)
  *   r    <- c >> alpha
  *
  * Source: Alg.2 [CGMZ21b]
  *
- * @param[in]  x10: dptr_xb, dmem pointer to the input arithmetic shares of x
- * @param[in]  x11: indicates du or dv (0: dv, 1: du)
- * @param[out] x12: dptr_rb, dmem pointer to the bitsliced compressed output
+ * @param[in]  x10: dmem pointer to arithmetic shares of x
+ * @param[out] x12: dmem pointer to bitsliced compressed output r
  * @param[in]  x13: k, the security level
  * @param[in]  w31: all-zero register
  *
@@ -1716,32 +1754,35 @@ _dv_params_done:
   addi x2, x2, 1024
   ret
 
-/*
- * Name: polyvec_hocompress
+/**
+ * First-order masked compression of a polynomial with du in {10, 11}.
  *
- * Return Boolean shares of Compressq(x, d) = round((2^d / q) * x) mod 2^d for
- * d in {10, 11}, given arithmetic shares mod q of x. Bitsliced.
+ * Return Boolean shares of r = Compressq(x, du) = round((2^du / q) * x) mod
+ * 2^du for du in {10, 11}, given arithmetic shares mod q of x. Here du = 11
+ * for k = 4, and 10 otherwise.
+ * Bitsliced.
  *
- * Each share is compressed to d + alpha bits, recombined (seca2b), then the low
- * alpha bits dropped. The alpha extra bits absorb the per-share rounding error
- * (2^alpha > q * nshares); nshares = 2 gives d + alpha = 24 (alpha = 13 for
- * d = 11, 14 for d = 10).
+ * Each share is compressed to du + alpha bits, recombined (seca2b), then the
+ * low alpha bits dropped. The alpha extra bits absorb the per-share rounding
+ * error (2^alpha > q * nshares); nshares = 2 gives du + alpha = 24 (alpha = 13
+ * for du = 11, 14 for du = 10).
  *
- *   z[0] <- Compressq(x[0], d + alpha) + 2^(alpha - 1)
- *   z[1] <- Compressq(x[1], d + alpha)
- *   c    <- seca2b(z[0], z[1])
+ *   z_0  <- Compressq(x_0, du + alpha) + 2^(alpha - 1)
+ *   z_1  <- Compressq(x_1, du + alpha)
+ *   c    <- seca2b(z)
  *   r    <- c >> alpha
  *
  * Source: Alg.2 [CGMZ21b]
  *
- * @param[in]  x10: dptr_xb, dmem pointer to the input arithmetic shares of x
- * @param[out] x12: dptr_rb, dmem pointer to the bitsliced compressed output
+ * @param[in]  x10: dmem pointer to arithmetic shares of x
+ * @param[out] x12: dmem pointer to bitsliced compressed output r
  * @param[in]  x13: k, the security level
  * @param[in]  w31: all-zero register
  *
  * clobbered registers: x2 to x19, x28 to x31, w0 to w15, w17 to w21, w28 to w30, acc
  * clobbered flag groups: FG0
  */
+
 .globl polyvec_hocompress
 .type polyvec_hocompress, @function
 polyvec_hocompress:
@@ -1931,27 +1972,31 @@ _du_params_done:
   addi x2, x2, 1024
   ret
 
-/*
- * Name: onebitdecompress
+/**
+ * Masked decompression of a 1-bit message.
  *
- * Given Boolean shares of a 32-byte message m, return arithmetic shares
- * mod q = 3329 of mp = Decompress_q(m, 1): coefficient i is (q + 1) / 2
- * if bit i of m is set, else 0. Vectorized for a polynomial.
+ * Return arithmetic shares mod q = 3329 of mp = Decompressq(m, 1), given
+ * Boolean shares of a 32-byte message m: coefficient i is (q + 1) / 2 if
+ * bit i of m is set, else 0.
+ * Vectorized for polynomial.
  *
- *   m  <- unpack(m)                ; one message bit per coefficient
- *   mp <- seconebitb2amodq(m)      ; Boolean to arithmetic shares mod q
+ *   m  <- unpack(m)                 (one message bit per coefficient)
+ *   mp <- seconebitb2amodq(m)       (Boolean to arithmetic shares mod q)
  *   mp <- mp * (q + 1) / 2   mod q
  *
  * Source: Section 3.3 [BGR+21]
  *
- * @param[in]  w16: R | Q
- * @param[in]  x10: dptr_m, dmem pointer to Boolean shares of m (bitsliced)
+ * @param[in]  x10: dmem pointer to Boolean shares of m (bitsliced)
+ * @param[out] x12: dmem pointer to arithmetic shares of mp
+ * @param[in]  w16 (sw0): sw0.0 = q = 3329 (1st 16-bit lane),
+ *                        sw0.2 = -q^-1 mod 2^16 = 3327 (3rd 16-bit lane)
  * @param[in]  w31: all-zero register
- * @param[out] x12: dptr_mp, dmem pointer to arithmetic shares of mp
+ * @param[in]  mod: q = 3329
  *
  * clobbered registers: x2, x4 to x8, x10, x12, x18, x28, w0 to w5, w30, acch, acc
  * clobbered flag groups: FG0
  */
+
 .globl onebitdecompress
 .type onebitdecompress, @function
 onebitdecompress:
@@ -2002,27 +2047,33 @@ onebitdecompress:
   addi x2, x2, 32
   ret
 
-/*
- * Name: masked_cbd
+/**
+ * First-order masked binomial sampler for q = 3329.
  *
  * Return arithmetic shares mod q = 3329 of the centered binomial sample
  * r = HW(x) - HW(y), given Boolean shares of the eta-bit values x and y.
  * Since HW(y) = eta - HW(~y), this sums the 2 * eta bit-planes of x and ~y.
- * k = 12 (q < 2**k). Bitsliced.
+ * k = 12 (q < 2^k).
+ * Bitsliced.
  *
- *   sum <- Hamming weight of (x, ~y) via a secfulladder tree
- *   r   <- secb2amodq(sum) - eta   mod q
+ *   a <- Hamming weight of (x, ~y) via a secfulladder tree
+ *   r <- secb2amodq(a) - eta   mod q
  *
  * Source: Alg.17 [BC22]
  *
- * @param[in]  x10: dptr_x, dmem pointer to Boolean shares of x
- * @param[in]  x11: dptr_y, dmem pointer to Boolean shares of y
- * @param[in]  x12: eta
- * @param[out] x14: dptr_r, dmem pointer to arithmetic shares of r
+ * @param[in]  x10: dmem pointer to Boolean shares of x
+ * @param[in]  x11: dmem pointer to Boolean shares of y
+ * @param[in]  x12: eta in {2, 3}
+ * @param[out] x14: dmem pointer to arithmetic shares of r
+ * @param[in]  w16 (sw0): sw0.0 = q = 3329 (1st 16-bit lane),
+ *                        sw0.2 = -q^-1 mod 2^16 = 3327 (3rd 16-bit lane)
+ * @param[in]  w31: all-zero register
+ * @param[in]  mod: q = 3329
  *
  * clobbered registers: x2, x4 to x22, x28 to x31, w0 to w16, w28 to w30, acch, acc
  * clobbered flag groups: FG0
  */
+
 .globl masked_cbd
 .type masked_cbd, @function
 masked_cbd:
@@ -2274,18 +2325,23 @@ _continue_1:
 /* Config to start a SHAKE-256 operation. */
 #define SHAKE256_CFG 0xA
 
-/*
- * Name: masked_poly_getnoise_eta_init
+/**
+ * Initialization of the SHAKE-256 operation for masked_poly_getnoise_eta_{1,2}.
  *
- * Initialize a SHAKE-256 operation for CBD noise sampling, absorbing the seed
- * and nonce. Call before masked_poly_getnoise_eta_1 or eta_2.
+ * Configure a SHAKE-256 operation for a 33-byte message and absorb
+ * seed || nonce, so that a subsequent call to `masked_poly_getnoise_eta_1`
+ * or `masked_poly_getnoise_eta_2` can squeeze the bytes it samples from.
+ * The seed is Boolean-shared across two 32-byte shares; the nonce is
+ * public, so its second share is zero.
  *
- * @param[in]  x10: dptr_seed, dmem pointer to the seed
- * @param[in]  x11: dptr_nonce, dmem pointer to the nonce
+ * @param[in]  x10: dmem pointer to the seed
+ * @param[in]  x11: dmem pointer to the nonce
+ * @param[in]  w31: all-zero register
  *
  * clobbered registers: x5 to x6, x10, w0
  * clobbered flag groups: FG0
  */
+
 .globl masked_poly_getnoise_eta_init
 .type masked_poly_getnoise_eta_init, @function
 masked_poly_getnoise_eta_init:
@@ -2314,40 +2370,59 @@ masked_poly_getnoise_eta_init:
 
   ret
 
-/*
- * Name: masked_poly_getnoise_eta_2
+/**
+ * Sampling of a masked polynomial from the centered binomial distribution
+ * with parameter KYBER_ETA2.
  *
- * Sample a polynomial deterministically from a seed and a nonce, with output
- * polynomial close to centered binomial distribution with parameter KYBER_ETA2;
- * this function assumes `masked_poly_getnoise_eta_init` has been called first with the
- * appropriate seed and nonce.
+ * Deterministically sample a polynomial whose coefficients follow a centered
+ * binomial distribution with parameter eta = KYBER_ETA2, and assume that
+ * `masked_poly_getnoise_eta_init` has been called beforehand with the
+ * appropriate seed and nonce. Since KYBER_ETA2 = 2 for every parameter set,
+ * callers pass eta = 2, and this entry point falls through into
+ * masked_poly_getnoise_eta_1.
  *
- * @param[in]  x10: eta
+ * On return, x10 holds the eta it was called with and x11 has been advanced
+ * by one polynomial (512 bytes).
+ *
+ * @param[in]  x10: eta, always 2
+ * @param[out] x11: dmem pointer to arithmetic shares of r
+ * @param[in]  w16 (sw0): sw0.0 = q = 3329 (1st 16-bit lane),
+ *                        sw0.2 = -q^-1 mod 2^16 = 3327 (3rd 16-bit lane)
  * @param[in]  w31: all-zero register
- * @param[out] x11: ptr_ra, dmem pointer to arithmetic shares of r
+ * @param[in]  mod: q = 3329
  *
  * clobbered registers: x2, x4 to x22, x28 to x31, w0 to w30, acch, acc
  * clobbered flag groups: FG0
  */
+
 .globl masked_poly_getnoise_eta_2
 .type masked_poly_getnoise_eta_2, @function
 masked_poly_getnoise_eta_2:
 
-/*
- * Name: masked_poly_getnoise_eta_1
+/**
+ * Sampling of a masked polynomial from the centered binomial distribution
+ * with parameter KYBER_ETA1.
  *
- * Sample a polynomial deterministically from a seed and a nonce, with output
- * polynomial close to centered binomial distribution with parameter KYBER_ETA1;
- * this function assumes `masked_poly_getnoise_eta_init` has been called first with the
+ * Deterministically sample a polynomial whose coefficients follow a centered
+ * binomial distribution with parameter eta = KYBER_ETA1, which is 3 for
+ * KYBER_K = 2 and 2 for KYBER_K = 3 and KYBER_K = 4. Assumes that
+ * `masked_poly_getnoise_eta_init` has been called beforehand with the
  * appropriate seed and nonce.
  *
- * @param[in]  x10: eta
+ * On return, x10 holds the eta it was called with and x11 has been advanced
+ * by one polynomial (512 bytes).
+ *
+ * @param[in]  x10: eta in {2, 3}
+ * @param[out] x11: dmem pointer to arithmetic shares of r
+ * @param[in]  w16 (sw0): sw0.0 = q = 3329 (1st 16-bit lane),
+ *                        sw0.2 = -q^-1 mod 2^16 = 3327 (3rd 16-bit lane)
  * @param[in]  w31: all-zero register
- * @param[out] x11: ptr_ra, dmem pointer to arithmetic shares of r
+ * @param[in]  mod: q = 3329
  *
  * clobbered registers: x2, x4 to x22, x28 to x31, w0 to w30, acch, acc
  * clobbered flag groups: FG0
  */
+
 .globl masked_poly_getnoise_eta_1
 .type masked_poly_getnoise_eta_1, @function
 masked_poly_getnoise_eta_1:
@@ -2504,9 +2579,23 @@ _getnoise_common:
   addi x2, x2, 416
   ret
 
-/* Bitslice the SHAKE-256 digests in w17-w22 into the eta = 3 x and y
- * bit-planes for masked_cbd. Called by masked_poly_getnoise_eta_1 on the
- * KYBER_K == 2 path. */
+/**
+ * Bitslicing of the SHAKE-256 digests for eta = 3.
+ *
+ * Split the six digest words in w17 to w22 into the 3 x and 3 y bit-planes
+ * that masked_cbd consumes, one share per call. Called by
+ * masked_poly_getnoise_eta_1 on the KYBER_K = 2 path.
+ *
+ * @param[in]     x7: dmem pointer to const_zero
+ * @param[in,out] x10: dmem pointer to the x bit-planes
+ * @param[in,out] x11: dmem pointer to the y bit-planes
+ * @param[in]     w17 to w22: the six digest words to bitslice
+ * @param[in]     w31: all-zero register
+ *
+ * clobbered registers: x4, x10 to x11, w0 to w15, w17 to w22, w28 to w29
+ * clobbered flag groups: FG0
+ */
+
 _bitslice_eta_3:
   /* Whitening. */
   bn.xor w0, w0, w0
@@ -2642,26 +2731,27 @@ _bitslice_eta_3:
 /* Undefine gadget-local macros. */
 #undef SHAKE256_CFG
 
-/*
- * Name: masked_poly_tomsg
+/**
+ * First-order masked compression of a polynomial to a message.
  *
- * Return Boolean shares of Compressq(x, 1) = round((2 / q) * x) mod 2, the
- * one-bit message compression, given arithmetic shares mod q of x. Bitsliced.
+ * Return Boolean shares of r = Compressq(x, 1) = round((2 / q) * x) mod 2, the
+ * one-bit message compression, given arithmetic shares mod q of x.
+ * Bitsliced.
  *
  * Each share is compressed to 1 + alpha bits, recombined (seca2b), then the low
  * alpha bits dropped. The alpha extra bits absorb the per-share rounding error
  * (2^alpha > q * nshares); nshares = 2 gives 1 + alpha = 16 (alpha = 15).
  *
- *   y[0] <- Compressq(x[0], 1 + alpha) + 2^(alpha - 1)
- *   y[1] <- Compressq(x[1], 1 + alpha)
- *   z    <- seca2b(y[0], y[1])
- *   r    <- z >> alpha
+ *   z_0  <- Compressq(x_0, 1 + alpha) + 2^(alpha - 1)
+ *   z_1  <- Compressq(x_1, 1 + alpha)
+ *   c    <- seca2b(z)
+ *   r    <- c >> alpha
  *
  * Source: Alg.2 [CGMZ21b]
  *
- * @param[in]  x10: dptr_xb, dmem pointer to arithmetic shares of x
+ * @param[in]  x10: dmem pointer to arithmetic shares of x
+ * @param[out] x12: dmem pointer to bitsliced compressed output r
  * @param[in]  w31: all-zero register
- * @param[out] x12: dptr_rb, dmem pointer to the bitsliced compressed output
  *
  * clobbered registers: x2 to x8, x10 to x17, x28 to x31, w0 to w15, w17 to w21, w28 to w29
  * clobbered flag groups: FG0
@@ -2784,24 +2874,27 @@ masked_poly_tomsg:
 
 #define N_COEFFS 16
 
-/*
- * Name: poly_masked_compare_dv
+/**
+ * First-order masked comparison of a polynomial compressed with dv in {4, 5}.
  *
- * For every coefficient of the polynomial, return 1 if Compressq(cprime, dv)
- * == c, else 0. Bitsliced.
+ * For every coefficient of the polynomial, AND into r a 1 if
+ * Compressq(c', dv) == c, else a 0. Here dv = 5 for k = 4, and 4 otherwise.
+ * Bitsliced.
  *
  * Source: Section 6.2 [BC22]
  *
- * @param[in]  x10: dptr_x, dmem pointer to arithmetic shares of cprime
- * @param[in]  x11: dptr_y, dmem pointer to the reference compressed polynomial c
- * @param[in]  x12: share stride, distance between shares
- * @param[in]  w31: all-zero register
- * @param[out] x14: dptr_r, dmem pointer to the output Boolean shares of r
- * @param[in]  x15: k, the security level
+ * @param[in]     x10: dmem pointer to arithmetic shares of c'
+ * @param[in]     x11: dmem pointer to reference compressed polynomial c
+ * @param[in]     x12: share stride of compressed c', i.e. dv * 32
+ * @param[in,out] x14: dmem pointer to Boolean shares of r, which must
+ *                     hold all-ones on entry
+ * @param[in]     x15: k, the security level
+ * @param[in]     w31: all-zero register
  *
  * clobbered registers: x2 to x20, x28 to x31, w0 to w15, w17 to w21, w28 to w29
  * clobbered flag groups: FG0
  */
+
 .globl poly_masked_compare_dv
 .type poly_masked_compare_dv, @function
 poly_masked_compare_dv:
@@ -3099,25 +3192,27 @@ _skip_bit_4:
   addi x2, x2, 352
   ret
 
-
-/*
- * Name: poly_masked_compare_du
+/**
+ * First-order masked comparison of a polynomial compressed with du in {10, 11}.
  *
- * For every coefficient of the polynomial, return 1 if Compressq(cprime, du)
- * == c, else 0. Bitsliced.
+ * For every coefficient of the polynomial, AND into r a 1 if
+ * Compressq(c', du) == c, else a 0. Here du = 11 for k = 4, and 10 otherwise.
+ * Bitsliced.
  *
  * Source: Section 6.2 [BC22]
  *
- * @param[in]  x10: dptr_x, dmem pointer to arithmetic shares of cprime
- * @param[in]  x11: dptr_y, dmem pointer to the reference compressed polynomial c
- * @param[in]  x12: share stride, distance between shares
- * @param[in]  w31: all-zero register
- * @param[out] x14: dptr_r, dmem pointer to the output Boolean shares of r
- * @param[in]  x15: k, the security level
+ * @param[in]     x10: dmem pointer to arithmetic shares of c'
+ * @param[in]     x11: dmem pointer to reference compressed polynomial c
+ * @param[in]     x12: share stride of compressed c', i.e. du * 32
+ * @param[in,out] x14: dmem pointer to Boolean shares of r, which must
+ *                     hold all-ones on entry
+ * @param[in]     x15: k, the security level
+ * @param[in]     w31: all-zero register
  *
  * clobbered registers: x2 to x20, x28 to x31, w0 to w15, w17 to w21, w28 to w30, acc
  * clobbered flag groups: FG0
  */
+
 .globl poly_masked_compare_du
 .type poly_masked_compare_du, @function
 poly_masked_compare_du:
@@ -3520,20 +3615,23 @@ _skip_bit_10:
   addi x2, x2, 736
   ret
 
-/*
- * Name: finalize_cmp
+/**
+ * First-order reduction of the masked comparison result to a single bit.
  *
- * Reduce the masked_compare output in place to Boolean shares of the single
- * comparison bit. Bitsliced.
+ * Reduce the masked_poly_compare_{du, dv} output in place to Boolean shares of
+ * the single comparison bit.
+ * Bitsliced.
  *
  * Source: Section 6.2 [BC22]
  *
- * @param[in/out] x10: dptr_x, dmem pointer to Boolean shares of output of masked_compare
+ * @param[in,out] x10: dmem pointer to Boolean shares of r, the output
+ *                     of masked_poly_compare_{du, dv}
  * @param[in]     w31: all-zero register
  *
  * clobbered registers: x2, x4 to x8, x10 to x13, x15 to x16, w0 to w3, w5 to w8
  * clobbered flag groups: FG0
  */
+
 .globl finalize_cmp
 .type finalize_cmp, @function
 finalize_cmp:

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -100,59 +100,59 @@
 .globl secand
 .type secand, @function
 secand:
-    /* Save addresses. */
-    addi t0, a0, 0
-    addi t1, a2, 0
-    addi t2, a5, 0
+  /* Save addresses. */
+  addi t0, a0, 0
+  addi t1, a2, 0
+  addi t2, a5, 0
 
-    /* Load x. */
-    bn.xor w0, w0, w0
-    bn.lid x0, 0(t0) /* x[0] */
-    bn.xor w1, w1, w1
-    add    t0, t0, a1
-    addi   x4, x0, 1
-    bn.lid x4++, 0(t0) /* x[1] */
+  /* Load x. */
+  bn.xor w0, w0, w0
+  bn.lid x0, 0(t0) /* x[0] */
+  bn.xor w1, w1, w1
+  add    t0, t0, a1
+  addi   x4, x0, 1
+  bn.lid x4++, 0(t0) /* x[1] */
 
-    /* Load y. */
-    bn.xor w2, w2, w2
-    bn.lid x4++, 0(t1) /* y[0] */
-    bn.xor w3, w3, w3
-    add    t1, t1, a3
-    bn.lid x4, 0(t1) /* y[1] */
+  /* Load y. */
+  bn.xor w2, w2, w2
+  bn.lid x4++, 0(t1) /* y[0] */
+  bn.xor w3, w3, w3
+  add    t1, t1, a3
+  bn.lid x4, 0(t1) /* y[1] */
 
-    addi    x4, x0, 6
-    bn.wsrr w5, urnd
-    /* Handle z_01. */
-    bn.xor  w6, w6, w6
-    bn.and  w6, w0, w2 /* x[0] & y[0] */
-    bn.xor  w7, w7, w7
-    bn.xor  w7, w3, w5 /* y[1] ^ r */
-    bn.and  w7, w0, w7 /* &= x[0] */
-    bn.xor  w8, w8, w8
-    bn.not  w8, w0 /* x[0] ^ 1 */
-    bn.and  w8, w8, w5 /* &= r */
-    bn.xor  w7, w7, w8 /* w7 ^= w8 */
-    bn.xor  w6, w6, w7
-    bn.sid  x4, 0(t2) /* Save r[0]. */
-    add     t2, t2, a6
-    /* Handle z_10. */
-    bn.xor  w6, w6, w6
-    bn.and  w6, w1, w3 /* x[1] & y[1] */
-    bn.xor  w7, w7, w7
-    bn.xor  w7, w2, w5 /* y[0] ^ r */
-    bn.and  w7, w1, w7 /* &= x[1] */
-    bn.xor  w8, w8, w8
-    bn.not  w8, w1 /* x[1] ^ 1 */
-    bn.and  w8, w8, w5 /* &= r */
-    bn.xor  w7, w7, w8 /* w7 ^= w8 */
-    bn.xor  w6, w6, w7
-    bn.sid  x4, 0(t2) /* Save r[1]. */
+  addi    x4, x0, 6
+  bn.wsrr w5, urnd
+  /* Handle z_01. */
+  bn.xor  w6, w6, w6
+  bn.and  w6, w0, w2 /* x[0] & y[0] */
+  bn.xor  w7, w7, w7
+  bn.xor  w7, w3, w5 /* y[1] ^ r */
+  bn.and  w7, w0, w7 /* &= x[0] */
+  bn.xor  w8, w8, w8
+  bn.not  w8, w0 /* x[0] ^ 1 */
+  bn.and  w8, w8, w5 /* &= r */
+  bn.xor  w7, w7, w8 /* w7 ^= w8 */
+  bn.xor  w6, w6, w7
+  bn.sid  x4, 0(t2) /* Save r[0]. */
+  add     t2, t2, a6
+  /* Handle z_10. */
+  bn.xor  w6, w6, w6
+  bn.and  w6, w1, w3 /* x[1] & y[1] */
+  bn.xor  w7, w7, w7
+  bn.xor  w7, w2, w5 /* y[0] ^ r */
+  bn.and  w7, w1, w7 /* &= x[1] */
+  bn.xor  w8, w8, w8
+  bn.not  w8, w1 /* x[1] ^ 1 */
+  bn.and  w8, w8, w5 /* &= r */
+  bn.xor  w7, w7, w8 /* w7 ^= w8 */
+  bn.xor  w6, w6, w7
+  bn.sid  x4, 0(t2) /* Save r[1]. */
 
-    /* Advance a0, a2, a5 to the next bit. */
-    addi a0, a0, 32
-    addi a2, a2, 32
-    addi a5, a5, 32
-    ret
+  /* Advance a0, a2, a5 to the next bit. */
+  addi a0, a0, 32
+  addi a2, a2, 32
+  addi a5, a5, 32
+  ret
 
 /*
  * Name: secfulladder
@@ -184,99 +184,99 @@ secand:
 .globl secfulladder
 .type secfulladder, @function
 secfulladder:
-    /* Save addresses. */
-    add t0, a0, x0
-    add t1, a2, x0
-    add t2, a5, x0
-    add t3, a7, x0
+  /* Save addresses. */
+  add t0, a0, x0
+  add t1, a2, x0
+  add t2, a5, x0
+  add t3, a7, x0
 
-    /* Load x. */
-    bn.xor w0, w0, w0
-    bn.lid x0, 0(t0) /* x[0] */
-    add    t0, t0, a1
-    addi   x4, x0, 1
-    bn.xor w1, w1, w1
-    bn.lid x4++, 0(t0) /* x[1] */
-    /* Load y. */
-    bn.xor w2, w2, w2
-    bn.lid x4++, 0(t1) /* y[0] */
-    add    t1, t1, a3
-    bn.xor w3, w3, w3
-    bn.lid x4, 0(t1) /* y[1] */
+  /* Load x. */
+  bn.xor w0, w0, w0
+  bn.lid x0, 0(t0) /* x[0] */
+  add    t0, t0, a1
+  addi   x4, x0, 1
+  bn.xor w1, w1, w1
+  bn.lid x4++, 0(t0) /* x[1] */
+  /* Load y. */
+  bn.xor w2, w2, w2
+  bn.lid x4++, 0(t1) /* y[0] */
+  add    t1, t1, a3
+  bn.xor w3, w3, w3
+  bn.lid x4, 0(t1) /* y[1] */
 
-    /* Compute sharewise a = x ^ y. */
-    bn.xor w4, w4, w4
-    bn.xor w4, w0, w2
-    bn.xor w5, w5, w5
-    bn.xor w5, w1, w3
+  /* Compute sharewise a = x ^ y. */
+  bn.xor w4, w4, w4
+  bn.xor w4, w0, w2
+  bn.xor w5, w5, w5
+  bn.xor w5, w1, w3
 
-    /* Compute r = cin ^ a. */
-    bn.xor w2, w2, w2
-    addi   x4, x0, 2
-    bn.lid x4++, 0(t3)
-    add    t3, t3, t4
-    bn.xor w3, w3, w3
-    bn.lid x4++, 0(t3)
+  /* Compute r = cin ^ a. */
+  bn.xor w2, w2, w2
+  addi   x4, x0, 2
+  bn.lid x4++, 0(t3)
+  add    t3, t3, t4
+  bn.xor w3, w3, w3
+  bn.lid x4++, 0(t3)
 
-    bn.xor w6, w6, w6
-    bn.xor w6, w4, w2
-    addi   x4, x0, 6
-    bn.sid x4, 0(t2)
-    add    t2, t2, a6
-    bn.xor w6, w6, w6
-    bn.xor w6, w5, w3
-    bn.sid x4, 0(t2)
+  bn.xor w6, w6, w6
+  bn.xor w6, w4, w2
+  addi   x4, x0, 6
+  bn.sid x4, 0(t2)
+  add    t2, t2, a6
+  bn.xor w6, w6, w6
+  bn.xor w6, w5, w3
+  bn.sid x4, 0(t2)
 
-    /* Compute cout = x ^ secand(a, x ^ cin). */
-    /* a: w4 -- w5
-     * x: w0 -- w1
-     * cin: w2 -- w3 */
-    bn.xor w6, w6, w6
-    bn.xor w6, w0, w2
-    bn.xor w7, w7, w7
-    bn.xor w7, w1, w3
+  /* Compute cout = x ^ secand(a, x ^ cin). */
+  /* a: w4 -- w5
+   * x: w0 -- w1
+   * cin: w2 -- w3 */
+  bn.xor w6, w6, w6
+  bn.xor w6, w0, w2
+  bn.xor w7, w7, w7
+  bn.xor w7, w1, w3
 
-    /* a: w4 -- w5
-     * x ^ cin: w6 -- w7
-     * x: w0 -- w1.  */
-    bn.wsrr w8, urnd
-    /* Handle cout_01. */
-    bn.xor  w2, w2, w2
-    bn.and  w2, w4, w6
-    bn.xor  w3, w3, w3
-    bn.xor  w3, w7, w8
-    bn.and  w3, w4, w3
-    bn.xor  w9, w9, w9
-    bn.not  w9, w4
-    bn.and  w9, w9, w8
-    bn.xor  w3, w3, w9
-    bn.xor  w2, w2, w3
-    bn.xor  w3, w3, w3
-    bn.xor  w3, w2, w0
-    add     t2, t5, x0
-    addi    x4, x0, 3
-    bn.sid  x4, 0(t2)
-    add     t2, t2, t6
-    /* Handle cout_10. */
-    bn.xor  w2, w2, w2
-    bn.and  w2, w5, w7
-    bn.xor  w3, w3, w3
-    bn.xor  w3, w6, w8
-    bn.and  w3, w5, w3
-    bn.xor  w9, w9, w9
-    bn.not  w9, w5
-    bn.and  w9, w9, w8
-    bn.xor  w3, w3, w9
-    bn.xor  w2, w2, w3
-    bn.xor  w3, w3, w3
-    bn.xor  w3, w2, w1
-    bn.sid  x4, 0(t2)
+  /* a: w4 -- w5
+   * x ^ cin: w6 -- w7
+   * x: w0 -- w1.  */
+  bn.wsrr w8, urnd
+  /* Handle cout_01. */
+  bn.xor  w2, w2, w2
+  bn.and  w2, w4, w6
+  bn.xor  w3, w3, w3
+  bn.xor  w3, w7, w8
+  bn.and  w3, w4, w3
+  bn.xor  w9, w9, w9
+  bn.not  w9, w4
+  bn.and  w9, w9, w8
+  bn.xor  w3, w3, w9
+  bn.xor  w2, w2, w3
+  bn.xor  w3, w3, w3
+  bn.xor  w3, w2, w0
+  add     t2, t5, x0
+  addi    x4, x0, 3
+  bn.sid  x4, 0(t2)
+  add     t2, t2, t6
+  /* Handle cout_10. */
+  bn.xor  w2, w2, w2
+  bn.and  w2, w5, w7
+  bn.xor  w3, w3, w3
+  bn.xor  w3, w6, w8
+  bn.and  w3, w5, w3
+  bn.xor  w9, w9, w9
+  bn.not  w9, w5
+  bn.and  w9, w9, w8
+  bn.xor  w3, w3, w9
+  bn.xor  w2, w2, w3
+  bn.xor  w3, w3, w3
+  bn.xor  w3, w2, w1
+  bn.sid  x4, 0(t2)
 
-    /* Point to next bit. */
-    addi a0, a0, 32
-    addi a2, a2, 32
-    addi a5, a5, 32
-    ret
+  /* Point to next bit. */
+  addi a0, a0, 32
+  addi a2, a2, 32
+  addi a5, a5, 32
+  ret
 
 /*
  * Name: secadd
@@ -305,80 +305,80 @@ secfulladder:
 .globl secadd
 .type secadd, @function
 secadd:
-    /* Reserve frame: 64 B carry c at 0(sp), plus saved s0, a7. */
-    addi sp, sp, -96
-    sw   s0, 64(sp)
-    sw   a7, 68(sp)
+  /* Reserve frame: 64 B carry c at 0(sp), plus saved s0, a7. */
+  addi sp, sp, -96
+  sw   s0, 64(sp)
+  sw   a7, 68(sp)
 
-    /* Initialize c = 0. */
+  /* Initialize c = 0. */
+  bn.xor w0, w0, w0
+  addi   t0, sp, 0 /* ptr_c */
+  loopi 2, 1
+    bn.sid x0, 0(t0++)
+  endloop
+
+  /* Ripple-carry adder. */
+  addi s0, a7, -1
+  addi a7, sp, 0 /* ptr_c = cin */
+  addi t4, x0, 32
+  addi t5, sp, 0 /* ptr_c = cout */
+  addi t6, x0, 32
+  /* Loop over i=0,...,k-2. */
+  loop s0, 2
+    /* a0 already points to x[i] */
+    /* a1 is already share stride of x. */
+    /* a2 already points to y[i] */
+    /* a3 is already share stride of y. */
+    /* a5 already points to r. */
+    /* a6 is already share stride of r. */
+    /* a7 already points to ptr_c = cin. */
+    /* t4 is already share stride of cin. */
+    /* t5 already points to ptr_c = cout. */
+    /* t6 is already share stride of cout. */
+    jal  x1, secfulladder
+    /* After secfulladder:
+     *  - a0 and a2 points to x[i + 1] and y[i + 1].
+     *  - a1 and a3 are still share stride of x and y.
+     *  - a5 points to r[i + 1].
+     *  - a6 is still share stride of r.
+     *  - a7 points to cin.
+     *  - t4 is still share stride of cin.
+     *  - t5 points to cout.
+     *  - t6 is still share stride of cout. */
+    nop
+  endloop
+
+  /* Handle bit i = k-1. */
+  /* Compute r[k-1] = x[k-1] ^ y[k-1] ^ c. */
+  addi t0, sp, 0 /* ptr_c */
+  addi x4, x0, 1
+  addi t1, x0, 2
+  addi t2, x0, 3
+  loopi 2, 14
+    /* Whitening. */
     bn.xor w0, w0, w0
-    addi   t0, sp, 0 /* ptr_c */
-    loopi 2, 1
-        bn.sid x0, 0(t0++)
-    endloop
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    /* Computation. */
+    bn.lid x0, 0(a0)
+    bn.lid x4, 0(a2)
+    bn.lid t1, 0(t0)
+    bn.xor w3, w0, w1
+    bn.xor w3, w3, w2
+    bn.sid t2, 0(a5)
+    /* Adjust addresses. */
+    add    a0, a0, a1
+    add    a2, a2, a3
+    add    t0, t0, t4
+    add    a5, a5, a6
+  endloop
 
-    /* Ripple-carry adder. */
-    addi s0, a7, -1
-    addi a7, sp, 0 /* ptr_c = cin */
-    addi t4, x0, 32
-    addi t5, sp, 0 /* ptr_c = cout */
-    addi t6, x0, 32
-    /* Loop over i=0,...,k-2. */
-    loop s0, 2
-        /* a0 already points to x[i] */
-        /* a1 is already share stride of x. */
-        /* a2 already points to y[i] */
-        /* a3 is already share stride of y. */
-        /* a5 already points to r. */
-        /* a6 is already share stride of r. */
-        /* a7 already points to ptr_c = cin. */
-        /* t4 is already share stride of cin. */
-        /* t5 already points to ptr_c = cout. */
-        /* t6 is already share stride of cout. */
-        jal  x1, secfulladder
-        /* After secfulladder:
-         *  - a0 and a2 points to x[i + 1] and y[i + 1].
-         *  - a1 and a3 are still share stride of x and y.
-         *  - a5 points to r[i + 1].
-         *  - a6 is still share stride of r.
-         *  - a7 points to cin.
-         *  - t4 is still share stride of cin.
-         *  - t5 points to cout.
-         *  - t6 is still share stride of cout. */
-        nop
-    endloop
-
-    /* Handle bit i = k-1. */
-    /* Compute r[k-1] = x[k-1] ^ y[k-1] ^ c. */
-    addi t0, sp, 0 /* ptr_c */
-    addi x4, x0, 1
-    addi t1, x0, 2
-    addi t2, x0, 3
-    loopi 2, 14
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        bn.xor w1, w1, w1
-        bn.xor w2, w2, w2
-        bn.xor w3, w3, w3
-        /* Computation. */
-        bn.lid x0, 0(a0)
-        bn.lid x4, 0(a2)
-        bn.lid t1, 0(t0)
-        bn.xor w3, w0, w1
-        bn.xor w3, w3, w2
-        bn.sid t2, 0(a5)
-        /* Adjust addresses. */
-        add    a0, a0, a1
-        add    a2, a2, a3
-        add    t0, t0, t4
-        add    a5, a5, a6
-    endloop
-
-    /* Restore registers and frame. */
-    lw   s0, 64(sp)
-    lw   a7, 68(sp)
-    addi sp, sp, 96
-    ret
+  /* Restore registers and frame. */
+  lw   s0, 64(sp)
+  lw   a7, 68(sp)
+  addi sp, sp, 96
+  ret
 
 /*
  * Name: bitcopymask
@@ -401,29 +401,29 @@ secadd:
 .globl bitcopymask
 .type bitcopymask, @function
 bitcopymask:
-    /* Since q = 3329 = b110100000001, we copy x to the 1st, 9th, 11th and 12th
-     * bit of r and zeroize the rest of r. */
-    addi   x4, x0, 31
-    loopi 2, 10
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        bn.lid x0, 0(a0)
-        add    a0, a0, a1
-        /* Copy x to bit 0. */
-        bn.sid x0, 0(a3++)
-        /* Clear bit 1 -- 7. */
-        loopi 7, 1
-            bn.sid x4, 0(a3++)
-        endloop
-        /* Copy x to bit 8. */
-        bn.sid x0, 0(a3++)
-        /* Clear bit 9. */
-        bn.sid x4, 0(a3++)
-        /* Copy x to bit 10 -- 11. */
-        bn.sid x0, 0(a3++)
-        bn.sid x0, 0(a3++)
+  /* Since q = 3329 = b110100000001, we copy x to the 1st, 9th, 11th and 12th
+   * bit of r and zeroize the rest of r. */
+  addi   x4, x0, 31
+  loopi 2, 10
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    bn.lid x0, 0(a0)
+    add    a0, a0, a1
+    /* Copy x to bit 0. */
+    bn.sid x0, 0(a3++)
+    /* Clear bit 1 -- 7. */
+    loopi 7, 1
+      bn.sid x4, 0(a3++)
     endloop
-    ret
+    /* Copy x to bit 8. */
+    bn.sid x0, 0(a3++)
+    /* Clear bit 9. */
+    bn.sid x4, 0(a3++)
+    /* Copy x to bit 10 -- 11. */
+    bn.sid x0, 0(a3++)
+    bn.sid x0, 0(a3++)
+  endloop
+  ret
 
 /*
  * Name: refreshios
@@ -449,25 +449,25 @@ bitcopymask:
 .globl refreshios
 .type refreshios, @function
 refreshios:
-    add  t0, a0, a2 /* 2nd share of x */
-    add  t1, a4, a2 /* 2nd share of r */
-    addi x4, x0, 1
-    loop a1, 11
-        bn.wsrr w2, urnd
-        /* Whitening. */
-        bn.xor  w0, w0, w0
-        bn.xor  w1, w1, w1
-        bn.lid  x0, 0(a0++)
-        bn.xor  w1, w0, w2
-        bn.sid  x4, 0(a4++)
-        /* Whitening. */
-        bn.xor  w0, w0, w0
-        bn.xor  w1, w1, w1
-        bn.lid  x0, 0(t0++)
-        bn.xor  w1, w0, w2
-        bn.sid  x4, 0(t1++)
-    endloop
-    ret
+  add  t0, a0, a2 /* 2nd share of x */
+  add  t1, a4, a2 /* 2nd share of r */
+  addi x4, x0, 1
+  loop a1, 11
+    bn.wsrr w2, urnd
+    /* Whitening. */
+    bn.xor  w0, w0, w0
+    bn.xor  w1, w1, w1
+    bn.lid  x0, 0(a0++)
+    bn.xor  w1, w0, w2
+    bn.sid  x4, 0(a4++)
+    /* Whitening. */
+    bn.xor  w0, w0, w0
+    bn.xor  w1, w1, w1
+    bn.lid  x0, 0(t0++)
+    bn.xor  w1, w0, w2
+    bn.sid  x4, 0(t1++)
+  endloop
+  ret
 
 /*
  * Name: poly_rej_samp
@@ -487,60 +487,60 @@ refreshios:
 .globl poly_rej_samp
 .type poly_rej_samp, @function
 poly_rej_samp:
-	/* Load 19*Q - 1 into w1. */
-	addi      t0, x0, 1
-	la        t1, modulus_times_19_minus_1
-	bn.lid    t0++, 0(t1)
-	bn.shv.8s w1, w1 >> 16
-
-	/* Load mont = 2**16 % Q into w2. */
-	la     t1, mont
-	bn.lid t0, 0(t1)
-
-	/* a0 + 512 is the last valid address. */
-	addi t0, a0, 512
+  /* Load 19*Q - 1 into w1. */
+  addi      t0, x0, 1
+  la        t1, modulus_times_19_minus_1
+  bn.lid    t0++, 0(t1)
+  bn.shv.8s w1, w1 >> 16
+  
+  /* Load mont = 2**16 % Q into w2. */
+  la     t1, mont
+  bn.lid t0, 0(t1)
+  
+  /* a0 + 512 is the last valid address. */
+  addi t0, a0, 512
 
 #if defined(MLKEM_REJ_SAMPLE_TEST)
-	addi t5, x0, 3
+  addi t5, x0, 3
 #endif
-
-	/* Loop until 256 coefficients have been written to the output */
+  
+  /* Loop until 256 coefficients have been written to the output */
 _rej_sample_loop:
-	/* Get 16 randoms. */
+  /* Get 16 randoms. */
 #if defined(MLKEM_REJ_SAMPLE_TEST)
-	bn.lid      t5, 0(a1++)
+  bn.lid      t5, 0(a1++)
 #else
-	bn.wsrr     w3, urnd
+  bn.wsrr     w3, urnd
 #endif
-	bn.trn1.16h w4, w3, w31
-	bn.subv.8s  w4, w1, w4
-	bn.shv.8s   w4, w4 >> 31
-	bn.trn2.16h w5, w3, w31
-	bn.subv.8s  w5, w1, w5
-	bn.shv.8s   w5, w5 >> 31
-	bn.trn1.16h w4, w4, w5
-	bn.xor      w4, w4, w31, FG0
-	csrrs       t1, fg0, x0 /* Read flag fg0. */
-	srli        t1, t1, 3 /* Extract FG0.z */
-
-	/* If FG0.z == 0, there is at least one bad coeff. We throw away this
-	 * vector and sample again. */
-	beq t1, x0, _rej_sample_loop
-
-	/* Once the whole vector is accepted, reduce the accepted candidates mod Q
-	 * using Montgomery. */
-	bn.mulv.16h.acc.z.lo w0, w3, w2
-	bn.mulv.l.16h.lo     w0, w0, sw0.2
-	bn.mulv.l.16h.acc.hi w0, w0, sw0.0
-	bn.addvm.16h         w0, w0, w31
-	bn.sid               x0, 0(a0++)
-
-	/* If a0 == t0, we've filled up a polynomial. Otherwise, continue to sample. */
-	beq a0, t0, _end_rej_sample_loop
-	beq x0, x0, _rej_sample_loop
+  bn.trn1.16h w4, w3, w31
+  bn.subv.8s  w4, w1, w4
+  bn.shv.8s   w4, w4 >> 31
+  bn.trn2.16h w5, w3, w31
+  bn.subv.8s  w5, w1, w5
+  bn.shv.8s   w5, w5 >> 31
+  bn.trn1.16h w4, w4, w5
+  bn.xor      w4, w4, w31, FG0
+  csrrs       t1, fg0, x0 /* Read flag fg0. */
+  srli        t1, t1, 3 /* Extract FG0.z */
+  
+  /* If FG0.z == 0, there is at least one bad coeff. We throw away this
+   * vector and sample again. */
+  beq t1, x0, _rej_sample_loop
+  
+  /* Once the whole vector is accepted, reduce the accepted candidates mod Q
+   * using Montgomery. */
+  bn.mulv.16h.acc.z.lo w0, w3, w2
+  bn.mulv.l.16h.lo     w0, w0, sw0.2
+  bn.mulv.l.16h.acc.hi w0, w0, sw0.0
+  bn.addvm.16h         w0, w0, w31
+  bn.sid               x0, 0(a0++)
+  
+  /* If a0 == t0, we've filled up a polynomial. Otherwise, continue to sample. */
+  beq a0, t0, _end_rej_sample_loop
+  beq x0, x0, _rej_sample_loop
 
 _end_rej_sample_loop:
-	ret
+  ret
 
 /*
  * Name: refreshmodq
@@ -564,39 +564,39 @@ _end_rej_sample_loop:
 .globl refreshmodq
 .type refreshmodq, @function
 refreshmodq:
-    /* Reserve frame: 512 B for rand at 0(sp), plus saved a0, a2. */
-    addi sp, sp, -544
-    sw a0, 512(sp)
-    sw a2, 516(sp)
+  /* Reserve frame: 512 B for rand at 0(sp), plus saved a0, a2. */
+  addi sp, sp, -544
+  sw a0, 512(sp)
+  sw a2, 516(sp)
 
-    /* Generate rand. */
-    add a0, sp, x0
-    jal x1, poly_rej_samp
+  /* Generate rand. */
+  add a0, sp, x0
+  jal x1, poly_rej_samp
 
-    /* r[0] = x[0] + rand. */
-    /* r[1] = x[1] - rand. */
-    add  t0, sp, 0 /* rand */
-    lw   a0, 512(sp)
-    addi t1, a0, 512 /* x[1] */
-    lw   a2, 516(sp)
-    addi t2, a2, 512 /* r[1] */
-    addi x4, x0, 1
-    addi t3, x0, 2
-    loopi 16, 9
-        bn.lid       x0, 0(t0++)
-        bn.lid       x4, 0(a0++)
-        bn.addvm.16h w2, w1, w0
-        bn.sid       t3, 0(a2++)
-        bn.xor       w1, w1, w1
-        bn.xor       w2, w2, w2
-        bn.lid       x4, 0(t1++)
-        bn.subvm.16h w2, w1, w0
-        bn.sid       t3, 0(t2++)
-    endloop
+  /* r[0] = x[0] + rand. */
+  /* r[1] = x[1] - rand. */
+  add  t0, sp, 0 /* rand */
+  lw   a0, 512(sp)
+  addi t1, a0, 512 /* x[1] */
+  lw   a2, 516(sp)
+  addi t2, a2, 512 /* r[1] */
+  addi x4, x0, 1
+  addi t3, x0, 2
+  loopi 16, 9
+    bn.lid       x0, 0(t0++)
+    bn.lid       x4, 0(a0++)
+    bn.addvm.16h w2, w1, w0
+    bn.sid       t3, 0(a2++)
+    bn.xor       w1, w1, w1
+    bn.xor       w2, w2, w2
+    bn.lid       x4, 0(t1++)
+    bn.subvm.16h w2, w1, w0
+    bn.sid       t3, 0(t2++)
+  endloop
 
-    /* Restore stack. */
-    addi sp, sp, 544
-    ret
+  /* Restore stack. */
+  addi sp, sp, 544
+  ret
 
 /*
  * Name: poly_to_bitsliced
@@ -616,23 +616,23 @@ refreshmodq:
 .type poly_to_bitsliced, @function
 poly_to_bitsliced:
 
-    /* Reverse-load the 16 input WDRs: coefficient WDR i -> w[15 - i]. */
-    addi x4, x0, 15
-    loopi 16, 2
-        bn.lid x4, 0(a0++)
-        addi   x4, x4, -1
-    endloop
+  /* Reverse-load the 16 input WDRs: coefficient WDR i -> w[15 - i]. */
+  addi x4, x0, 15
+  loopi 16, 2
+    bn.lid x4, 0(a0++)
+    addi   x4, x4, -1
+  endloop
 
-    jal x1, _bitslice_transpose
+  jal x1, _bitslice_transpose
 
-    /* Store the 12 bitsliced words bs[0..11] via a0 so a1 is left unchanged. */
-    addi   x4, x0, 0
-    addi   a0, a1, 0
-    loopi 12, 2
-        bn.sid x4, 0(a0++)
-        addi   x4, x4, 1
-    endloop
-    ret
+  /* Store the 12 bitsliced words bs[0..11] via a0 so a1 is left unchanged. */
+  addi   x4, x0, 0
+  addi   a0, a1, 0
+  loopi 12, 2
+    bn.sid x4, 0(a0++)
+    addi   x4, x4, 1
+  endloop
+  ret
 
 /*
  * Name: poly_from_bitsliced
@@ -653,237 +653,237 @@ poly_to_bitsliced:
 .type poly_from_bitsliced, @function
 poly_from_bitsliced:
 
-    /* Load bs[0..11] into w0..w11; zero the upper bit positions w12..w15. */
-    addi x4, x0, 0
-    loopi 12, 2
-        bn.lid x4, 0(a0++)
-        addi   x4, x4, 1
-    endloop
-    bn.xor w12, w12, w12
-    bn.xor w13, w13, w13
-    bn.xor w14, w14, w14
-    bn.xor w15, w15, w15
+  /* Load bs[0..11] into w0..w11; zero the upper bit positions w12..w15. */
+  addi x4, x0, 0
+  loopi 12, 2
+    bn.lid x4, 0(a0++)
+    addi   x4, x4, 1
+  endloop
+  bn.xor w12, w12, w12
+  bn.xor w13, w13, w13
+  bn.xor w14, w14, w14
+  bn.xor w15, w15, w15
 
-    jal x1, _bitslice_transpose
+  jal x1, _bitslice_transpose
 
-    /* Reverse-store: w[b] -> coefficient WDR (15 - b). */
-    addi x4, x0, 15
-    loopi 16, 2
-        bn.sid x4, 0(a1++)
-        addi   x4, x4, -1
-    endloop
-    ret
+  /* Reverse-store: w[b] -> coefficient WDR (15 - b). */
+  addi x4, x0, 15
+  loopi 16, 2
+    bn.sid x4, 0(a1++)
+    addi   x4, x4, -1
+  endloop
+  ret
 
 /*
  * 16x16 per-lane bit transpose of w0..w15, shared by poly_to_bitsliced and
  * poly_from_bitsliced.
  */
 _bitslice_transpose:
-    /* Stage d=8. */
-    bn.not     w28, w31
-    bn.shv.16h w28, w28 >> 8      /* 0x00ff */
-    bn.shv.16h w29, w0 >> 8
-    bn.xor     w29, w29, w8
-    bn.and     w29, w29, w28
-    bn.xor     w8, w8, w29
-    bn.shv.16h w29, w29 << 8
-    bn.xor     w0, w0, w29
-    bn.shv.16h w29, w1 >> 8
-    bn.xor     w29, w29, w9
-    bn.and     w29, w29, w28
-    bn.xor     w9, w9, w29
-    bn.shv.16h w29, w29 << 8
-    bn.xor     w1, w1, w29
-    bn.shv.16h w29, w2 >> 8
-    bn.xor     w29, w29, w10
-    bn.and     w29, w29, w28
-    bn.xor     w10, w10, w29
-    bn.shv.16h w29, w29 << 8
-    bn.xor     w2, w2, w29
-    bn.shv.16h w29, w3 >> 8
-    bn.xor     w29, w29, w11
-    bn.and     w29, w29, w28
-    bn.xor     w11, w11, w29
-    bn.shv.16h w29, w29 << 8
-    bn.xor     w3, w3, w29
-    bn.shv.16h w29, w4 >> 8
-    bn.xor     w29, w29, w12
-    bn.and     w29, w29, w28
-    bn.xor     w12, w12, w29
-    bn.shv.16h w29, w29 << 8
-    bn.xor     w4, w4, w29
-    bn.shv.16h w29, w5 >> 8
-    bn.xor     w29, w29, w13
-    bn.and     w29, w29, w28
-    bn.xor     w13, w13, w29
-    bn.shv.16h w29, w29 << 8
-    bn.xor     w5, w5, w29
-    bn.shv.16h w29, w6 >> 8
-    bn.xor     w29, w29, w14
-    bn.and     w29, w29, w28
-    bn.xor     w14, w14, w29
-    bn.shv.16h w29, w29 << 8
-    bn.xor     w6, w6, w29
-    bn.shv.16h w29, w7 >> 8
-    bn.xor     w29, w29, w15
-    bn.and     w29, w29, w28
-    bn.xor     w15, w15, w29
-    bn.shv.16h w29, w29 << 8
-    bn.xor     w7, w7, w29
-    /* Stage d=4. */
-    bn.shv.16h w29, w28 << 4
-    bn.xor     w28, w28, w29      /* 0x0f0f */
-    bn.shv.16h w29, w0 >> 4
-    bn.xor     w29, w29, w4
-    bn.and     w29, w29, w28
-    bn.xor     w4, w4, w29
-    bn.shv.16h w29, w29 << 4
-    bn.xor     w0, w0, w29
-    bn.shv.16h w29, w1 >> 4
-    bn.xor     w29, w29, w5
-    bn.and     w29, w29, w28
-    bn.xor     w5, w5, w29
-    bn.shv.16h w29, w29 << 4
-    bn.xor     w1, w1, w29
-    bn.shv.16h w29, w2 >> 4
-    bn.xor     w29, w29, w6
-    bn.and     w29, w29, w28
-    bn.xor     w6, w6, w29
-    bn.shv.16h w29, w29 << 4
-    bn.xor     w2, w2, w29
-    bn.shv.16h w29, w3 >> 4
-    bn.xor     w29, w29, w7
-    bn.and     w29, w29, w28
-    bn.xor     w7, w7, w29
-    bn.shv.16h w29, w29 << 4
-    bn.xor     w3, w3, w29
-    bn.shv.16h w29, w8 >> 4
-    bn.xor     w29, w29, w12
-    bn.and     w29, w29, w28
-    bn.xor     w12, w12, w29
-    bn.shv.16h w29, w29 << 4
-    bn.xor     w8, w8, w29
-    bn.shv.16h w29, w9 >> 4
-    bn.xor     w29, w29, w13
-    bn.and     w29, w29, w28
-    bn.xor     w13, w13, w29
-    bn.shv.16h w29, w29 << 4
-    bn.xor     w9, w9, w29
-    bn.shv.16h w29, w10 >> 4
-    bn.xor     w29, w29, w14
-    bn.and     w29, w29, w28
-    bn.xor     w14, w14, w29
-    bn.shv.16h w29, w29 << 4
-    bn.xor     w10, w10, w29
-    bn.shv.16h w29, w11 >> 4
-    bn.xor     w29, w29, w15
-    bn.and     w29, w29, w28
-    bn.xor     w15, w15, w29
-    bn.shv.16h w29, w29 << 4
-    bn.xor     w11, w11, w29
-    /* Stage d=2. */
-    bn.shv.16h w29, w28 << 2
-    bn.xor     w28, w28, w29      /* 0x3333 */
-    bn.shv.16h w29, w0 >> 2
-    bn.xor     w29, w29, w2
-    bn.and     w29, w29, w28
-    bn.xor     w2, w2, w29
-    bn.shv.16h w29, w29 << 2
-    bn.xor     w0, w0, w29
-    bn.shv.16h w29, w1 >> 2
-    bn.xor     w29, w29, w3
-    bn.and     w29, w29, w28
-    bn.xor     w3, w3, w29
-    bn.shv.16h w29, w29 << 2
-    bn.xor     w1, w1, w29
-    bn.shv.16h w29, w4 >> 2
-    bn.xor     w29, w29, w6
-    bn.and     w29, w29, w28
-    bn.xor     w6, w6, w29
-    bn.shv.16h w29, w29 << 2
-    bn.xor     w4, w4, w29
-    bn.shv.16h w29, w5 >> 2
-    bn.xor     w29, w29, w7
-    bn.and     w29, w29, w28
-    bn.xor     w7, w7, w29
-    bn.shv.16h w29, w29 << 2
-    bn.xor     w5, w5, w29
-    bn.shv.16h w29, w8 >> 2
-    bn.xor     w29, w29, w10
-    bn.and     w29, w29, w28
-    bn.xor     w10, w10, w29
-    bn.shv.16h w29, w29 << 2
-    bn.xor     w8, w8, w29
-    bn.shv.16h w29, w9 >> 2
-    bn.xor     w29, w29, w11
-    bn.and     w29, w29, w28
-    bn.xor     w11, w11, w29
-    bn.shv.16h w29, w29 << 2
-    bn.xor     w9, w9, w29
-    bn.shv.16h w29, w12 >> 2
-    bn.xor     w29, w29, w14
-    bn.and     w29, w29, w28
-    bn.xor     w14, w14, w29
-    bn.shv.16h w29, w29 << 2
-    bn.xor     w12, w12, w29
-    bn.shv.16h w29, w13 >> 2
-    bn.xor     w29, w29, w15
-    bn.and     w29, w29, w28
-    bn.xor     w15, w15, w29
-    bn.shv.16h w29, w29 << 2
-    bn.xor     w13, w13, w29
-    /* Stage d=1. */
-    bn.shv.16h w29, w28 << 1
-    bn.xor     w28, w28, w29      /* 0x5555 */
-    bn.shv.16h w29, w0 >> 1
-    bn.xor     w29, w29, w1
-    bn.and     w29, w29, w28
-    bn.xor     w1, w1, w29
-    bn.shv.16h w29, w29 << 1
-    bn.xor     w0, w0, w29
-    bn.shv.16h w29, w2 >> 1
-    bn.xor     w29, w29, w3
-    bn.and     w29, w29, w28
-    bn.xor     w3, w3, w29
-    bn.shv.16h w29, w29 << 1
-    bn.xor     w2, w2, w29
-    bn.shv.16h w29, w4 >> 1
-    bn.xor     w29, w29, w5
-    bn.and     w29, w29, w28
-    bn.xor     w5, w5, w29
-    bn.shv.16h w29, w29 << 1
-    bn.xor     w4, w4, w29
-    bn.shv.16h w29, w6 >> 1
-    bn.xor     w29, w29, w7
-    bn.and     w29, w29, w28
-    bn.xor     w7, w7, w29
-    bn.shv.16h w29, w29 << 1
-    bn.xor     w6, w6, w29
-    bn.shv.16h w29, w8 >> 1
-    bn.xor     w29, w29, w9
-    bn.and     w29, w29, w28
-    bn.xor     w9, w9, w29
-    bn.shv.16h w29, w29 << 1
-    bn.xor     w8, w8, w29
-    bn.shv.16h w29, w10 >> 1
-    bn.xor     w29, w29, w11
-    bn.and     w29, w29, w28
-    bn.xor     w11, w11, w29
-    bn.shv.16h w29, w29 << 1
-    bn.xor     w10, w10, w29
-    bn.shv.16h w29, w12 >> 1
-    bn.xor     w29, w29, w13
-    bn.and     w29, w29, w28
-    bn.xor     w13, w13, w29
-    bn.shv.16h w29, w29 << 1
-    bn.xor     w12, w12, w29
-    bn.shv.16h w29, w14 >> 1
-    bn.xor     w29, w29, w15
-    bn.and     w29, w29, w28
-    bn.xor     w15, w15, w29
-    bn.shv.16h w29, w29 << 1
-    bn.xor     w14, w14, w29
-    ret
+  /* Stage d=8. */
+  bn.not     w28, w31
+  bn.shv.16h w28, w28 >> 8      /* 0x00ff */
+  bn.shv.16h w29, w0 >> 8
+  bn.xor     w29, w29, w8
+  bn.and     w29, w29, w28
+  bn.xor     w8, w8, w29
+  bn.shv.16h w29, w29 << 8
+  bn.xor     w0, w0, w29
+  bn.shv.16h w29, w1 >> 8
+  bn.xor     w29, w29, w9
+  bn.and     w29, w29, w28
+  bn.xor     w9, w9, w29
+  bn.shv.16h w29, w29 << 8
+  bn.xor     w1, w1, w29
+  bn.shv.16h w29, w2 >> 8
+  bn.xor     w29, w29, w10
+  bn.and     w29, w29, w28
+  bn.xor     w10, w10, w29
+  bn.shv.16h w29, w29 << 8
+  bn.xor     w2, w2, w29
+  bn.shv.16h w29, w3 >> 8
+  bn.xor     w29, w29, w11
+  bn.and     w29, w29, w28
+  bn.xor     w11, w11, w29
+  bn.shv.16h w29, w29 << 8
+  bn.xor     w3, w3, w29
+  bn.shv.16h w29, w4 >> 8
+  bn.xor     w29, w29, w12
+  bn.and     w29, w29, w28
+  bn.xor     w12, w12, w29
+  bn.shv.16h w29, w29 << 8
+  bn.xor     w4, w4, w29
+  bn.shv.16h w29, w5 >> 8
+  bn.xor     w29, w29, w13
+  bn.and     w29, w29, w28
+  bn.xor     w13, w13, w29
+  bn.shv.16h w29, w29 << 8
+  bn.xor     w5, w5, w29
+  bn.shv.16h w29, w6 >> 8
+  bn.xor     w29, w29, w14
+  bn.and     w29, w29, w28
+  bn.xor     w14, w14, w29
+  bn.shv.16h w29, w29 << 8
+  bn.xor     w6, w6, w29
+  bn.shv.16h w29, w7 >> 8
+  bn.xor     w29, w29, w15
+  bn.and     w29, w29, w28
+  bn.xor     w15, w15, w29
+  bn.shv.16h w29, w29 << 8
+  bn.xor     w7, w7, w29
+  /* Stage d=4. */
+  bn.shv.16h w29, w28 << 4
+  bn.xor     w28, w28, w29      /* 0x0f0f */
+  bn.shv.16h w29, w0 >> 4
+  bn.xor     w29, w29, w4
+  bn.and     w29, w29, w28
+  bn.xor     w4, w4, w29
+  bn.shv.16h w29, w29 << 4
+  bn.xor     w0, w0, w29
+  bn.shv.16h w29, w1 >> 4
+  bn.xor     w29, w29, w5
+  bn.and     w29, w29, w28
+  bn.xor     w5, w5, w29
+  bn.shv.16h w29, w29 << 4
+  bn.xor     w1, w1, w29
+  bn.shv.16h w29, w2 >> 4
+  bn.xor     w29, w29, w6
+  bn.and     w29, w29, w28
+  bn.xor     w6, w6, w29
+  bn.shv.16h w29, w29 << 4
+  bn.xor     w2, w2, w29
+  bn.shv.16h w29, w3 >> 4
+  bn.xor     w29, w29, w7
+  bn.and     w29, w29, w28
+  bn.xor     w7, w7, w29
+  bn.shv.16h w29, w29 << 4
+  bn.xor     w3, w3, w29
+  bn.shv.16h w29, w8 >> 4
+  bn.xor     w29, w29, w12
+  bn.and     w29, w29, w28
+  bn.xor     w12, w12, w29
+  bn.shv.16h w29, w29 << 4
+  bn.xor     w8, w8, w29
+  bn.shv.16h w29, w9 >> 4
+  bn.xor     w29, w29, w13
+  bn.and     w29, w29, w28
+  bn.xor     w13, w13, w29
+  bn.shv.16h w29, w29 << 4
+  bn.xor     w9, w9, w29
+  bn.shv.16h w29, w10 >> 4
+  bn.xor     w29, w29, w14
+  bn.and     w29, w29, w28
+  bn.xor     w14, w14, w29
+  bn.shv.16h w29, w29 << 4
+  bn.xor     w10, w10, w29
+  bn.shv.16h w29, w11 >> 4
+  bn.xor     w29, w29, w15
+  bn.and     w29, w29, w28
+  bn.xor     w15, w15, w29
+  bn.shv.16h w29, w29 << 4
+  bn.xor     w11, w11, w29
+  /* Stage d=2. */
+  bn.shv.16h w29, w28 << 2
+  bn.xor     w28, w28, w29      /* 0x3333 */
+  bn.shv.16h w29, w0 >> 2
+  bn.xor     w29, w29, w2
+  bn.and     w29, w29, w28
+  bn.xor     w2, w2, w29
+  bn.shv.16h w29, w29 << 2
+  bn.xor     w0, w0, w29
+  bn.shv.16h w29, w1 >> 2
+  bn.xor     w29, w29, w3
+  bn.and     w29, w29, w28
+  bn.xor     w3, w3, w29
+  bn.shv.16h w29, w29 << 2
+  bn.xor     w1, w1, w29
+  bn.shv.16h w29, w4 >> 2
+  bn.xor     w29, w29, w6
+  bn.and     w29, w29, w28
+  bn.xor     w6, w6, w29
+  bn.shv.16h w29, w29 << 2
+  bn.xor     w4, w4, w29
+  bn.shv.16h w29, w5 >> 2
+  bn.xor     w29, w29, w7
+  bn.and     w29, w29, w28
+  bn.xor     w7, w7, w29
+  bn.shv.16h w29, w29 << 2
+  bn.xor     w5, w5, w29
+  bn.shv.16h w29, w8 >> 2
+  bn.xor     w29, w29, w10
+  bn.and     w29, w29, w28
+  bn.xor     w10, w10, w29
+  bn.shv.16h w29, w29 << 2
+  bn.xor     w8, w8, w29
+  bn.shv.16h w29, w9 >> 2
+  bn.xor     w29, w29, w11
+  bn.and     w29, w29, w28
+  bn.xor     w11, w11, w29
+  bn.shv.16h w29, w29 << 2
+  bn.xor     w9, w9, w29
+  bn.shv.16h w29, w12 >> 2
+  bn.xor     w29, w29, w14
+  bn.and     w29, w29, w28
+  bn.xor     w14, w14, w29
+  bn.shv.16h w29, w29 << 2
+  bn.xor     w12, w12, w29
+  bn.shv.16h w29, w13 >> 2
+  bn.xor     w29, w29, w15
+  bn.and     w29, w29, w28
+  bn.xor     w15, w15, w29
+  bn.shv.16h w29, w29 << 2
+  bn.xor     w13, w13, w29
+  /* Stage d=1. */
+  bn.shv.16h w29, w28 << 1
+  bn.xor     w28, w28, w29      /* 0x5555 */
+  bn.shv.16h w29, w0 >> 1
+  bn.xor     w29, w29, w1
+  bn.and     w29, w29, w28
+  bn.xor     w1, w1, w29
+  bn.shv.16h w29, w29 << 1
+  bn.xor     w0, w0, w29
+  bn.shv.16h w29, w2 >> 1
+  bn.xor     w29, w29, w3
+  bn.and     w29, w29, w28
+  bn.xor     w3, w3, w29
+  bn.shv.16h w29, w29 << 1
+  bn.xor     w2, w2, w29
+  bn.shv.16h w29, w4 >> 1
+  bn.xor     w29, w29, w5
+  bn.and     w29, w29, w28
+  bn.xor     w5, w5, w29
+  bn.shv.16h w29, w29 << 1
+  bn.xor     w4, w4, w29
+  bn.shv.16h w29, w6 >> 1
+  bn.xor     w29, w29, w7
+  bn.and     w29, w29, w28
+  bn.xor     w7, w7, w29
+  bn.shv.16h w29, w29 << 1
+  bn.xor     w6, w6, w29
+  bn.shv.16h w29, w8 >> 1
+  bn.xor     w29, w29, w9
+  bn.and     w29, w29, w28
+  bn.xor     w9, w9, w29
+  bn.shv.16h w29, w29 << 1
+  bn.xor     w8, w8, w29
+  bn.shv.16h w29, w10 >> 1
+  bn.xor     w29, w29, w11
+  bn.and     w29, w29, w28
+  bn.xor     w11, w11, w29
+  bn.shv.16h w29, w29 << 1
+  bn.xor     w10, w10, w29
+  bn.shv.16h w29, w12 >> 1
+  bn.xor     w29, w29, w13
+  bn.and     w29, w29, w28
+  bn.xor     w13, w13, w29
+  bn.shv.16h w29, w29 << 1
+  bn.xor     w12, w12, w29
+  bn.shv.16h w29, w14 >> 1
+  bn.xor     w29, w29, w15
+  bn.and     w29, w29, w28
+  bn.xor     w15, w15, w29
+  bn.shv.16h w29, w29 << 1
+  bn.xor     w14, w14, w29
+  ret
 
 /*
  * Name: seca2b
@@ -908,60 +908,60 @@ _bitslice_transpose:
 .globl seca2b
 .type seca2b, @function
 seca2b:
-    /* Save fp to stack */
-    addi sp, sp, -32
-    sw   fp, 0(sp)
-    addi fp, sp, 0
+  /* Save fp to stack */
+  addi sp, sp, -32
+  sw   fp, 0(sp)
+  addi fp, sp, 0
 
-    /* Adjust stack for temp variables. */
-    slli t0, a2, 1
-    sub  sp, sp, t0 /* ptr_s */
-    add  t1, sp, x0
-    sub  sp, sp, t0 /* ptr_sp */
+  /* Adjust stack for temp variables. */
+  slli t0, a2, 1
+  sub  sp, sp, t0 /* ptr_s */
+  add  t1, sp, x0
+  sub  sp, sp, t0 /* ptr_sp */
 
-    /* Build s = (x[0], 0). */
-    add t2, t1, x0 /* Save ptr_s. */
-    loop a1, 3
-        bn.xor w0, w0, w0
-        bn.lid x0, 0(a0++)
-        bn.sid x0, 0(t1++)
-    endloop
+  /* Build s = (x[0], 0). */
+  add t2, t1, x0 /* Save ptr_s. */
+  loop a1, 3
     bn.xor w0, w0, w0
-    loop a1, 1
-        bn.sid x0, 0(t1++)
-    endloop
+    bn.lid x0, 0(a0++)
+    bn.sid x0, 0(t1++)
+  endloop
+  bn.xor w0, w0, w0
+  loop a1, 1
+    bn.sid x0, 0(t1++)
+  endloop
 
-    /* Build s' = (0, x[1]). */
-    add t0, sp, x0
-    loop a1, 1
-        bn.sid x0, 0(t0++)
-    endloop
-    loop a1, 3
-        bn.lid x0, 0(a0++)
-        bn.sid x0, 0(t0++)
-        bn.xor w0, w0, w0
-    endloop
+  /* Build s' = (0, x[1]). */
+  add t0, sp, x0
+  loop a1, 1
+    bn.sid x0, 0(t0++)
+  endloop
+  loop a1, 3
+    bn.lid x0, 0(a0++)
+    bn.sid x0, 0(t0++)
+    bn.xor w0, w0, w0
+  endloop
 
-    /* Save registers. */
-    add t0, a1, x0
-    add t1, a2, x0
-    add t3, a4, x0
+  /* Save registers. */
+  add t0, a1, x0
+  add t1, a2, x0
+  add t3, a4, x0
 
-    /* Compute r = secadd(s, s', k). */
-    addi a0, t2, 0 /* ptr_s */
-    addi a1, t1, 0
-    addi a2, sp, 0 /* ptr_sp */
-    addi a3, t1, 0
-    addi a5, t3, 0 /* ptr_r */
-    addi a6, t1, 0
-    addi a7, t0, 0 /* k */
-    jal  x1, secadd
+  /* Compute r = secadd(s, s', k). */
+  addi a0, t2, 0 /* ptr_s */
+  addi a1, t1, 0
+  addi a2, sp, 0 /* ptr_sp */
+  addi a3, t1, 0
+  addi a5, t3, 0 /* ptr_r */
+  addi a6, t1, 0
+  addi a7, t0, 0 /* k */
+  jal  x1, secadd
 
-    /* Restore sp and fp. */
-    addi sp, fp, 0
-    lw   fp, 0(sp)
-    addi sp, sp, 32
-    ret
+  /* Restore sp and fp. */
+  addi sp, fp, 0
+  lw   fp, 0(sp)
+  addi sp, sp, 32
+  ret
 
 /*
  * Name: seca2bmodq
@@ -987,52 +987,25 @@ seca2b:
 .globl seca2bmodq
 .type seca2bmodq, @function
 seca2bmodq:
-    /* Frame below sp:
-     *   sp +    0 : s' / a   (832 B)
-     *   sp +  832 : carry c  ( 64 B)
-     *   sp +  896 : s / u    (832 B)
-     *   sp + 1728 : saved s2 */
-    addi sp, sp, -1760
-    sw   s2, 1728(sp)
-    addi s2, a2, 0 /* output pointer */
+  /* Frame below sp:
+   *   sp +    0 : s' / a   (832 B)
+   *   sp +  832 : carry c  ( 64 B)
+   *   sp +  896 : s / u    (832 B)
+   *   sp + 1728 : saved s2 */
+  addi sp, sp, -1760
+  sw   s2, 1728(sp)
+  addi s2, a2, 0 /* output pointer */
 
-    /* Compute s = p + x[0], k + 1 bits (one share).
-     * p = 2**(k + 1) - q = 4863 = b1001011111111. */
-    addi t0, sp, 896 /* ptr_s */
-    /* a0 already points to x[0]. */
-    addi x4, x0, 1
-    /* cin = 0 */
-    bn.xor w2, w2, w2
+  /* Compute s = p + x[0], k + 1 bits (one share).
+   * p = 2**(k + 1) - q = 4863 = b1001011111111. */
+  addi t0, sp, 896 /* ptr_s */
+  /* a0 already points to x[0]. */
+  addi x4, x0, 1
+  /* cin = 0 */
+  bn.xor w2, w2, w2
 
-    /* Bit 0 -- 7: 1. */
-    loopi 8, 9
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        bn.xor w1, w1, w1
-        /* Compute r = x ^ p ^ cin. */
-        bn.lid x0, 0(a0++)
-        bn.not w3, w0 /* a = x ^ p */
-        bn.xor w1, w3, w2 /* r = a ^ cin */
-        bn.sid x4, 0(t0++) /* Save r. */
-        /* Compute cout = x ^ ((x ^ p) & (x ^ cin)) = x ^ (a & (x ^ cin)). */
-        bn.xor w2, w0, w2 /* cout = x ^ cin */
-        bn.and w2, w3, w2 /* cout &= a */
-        bn.xor w2, w2, w0 /* cout ^= x */
-    endloop
-
-    /* Bit 8: 0. */
-    /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
-    /* Compute r = x ^ 0 ^ cin = x ^ cin. */
-    bn.lid x0, 0(a0++)
-    bn.xor w1, w0, w2 /* r = x ^ cin */
-    bn.sid x4, 0(t0++) /* Save r. */
-    /* Compute cout = x ^ ((x ^ p) & (x ^ cin)) = x ^ (x & r). */
-    bn.and w2, w0, w1 /* cout = x & r */
-    bn.xor w2, w2, w0 /* cout ^= x */
-
-    /* Bit 9: 1. */
+  /* Bit 0 -- 7: 1. */
+  loopi 8, 9
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
@@ -1045,152 +1018,179 @@ seca2bmodq:
     bn.xor w2, w0, w2 /* cout = x ^ cin */
     bn.and w2, w3, w2 /* cout &= a */
     bn.xor w2, w2, w0 /* cout ^= x */
+  endloop
 
-    /* Bit 10 -- 11: 0. */
-    loopi 2, 7
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        bn.xor w1, w1, w1
-        /* Compute r = x ^ 0 ^ cin = x ^ cin. */
-        bn.lid x0, 0(a0++)
-        bn.xor w1, w0, w2 /* r = x ^ cin */
-        bn.sid x4, 0(t0++) /* Save r. */
-        /* Compute cout = x ^ ((x ^ p) & (x ^ cin)) = x ^ (x & r). */
-        bn.and w2, w0, w1 /* cout = x & r */
-        bn.xor w2, w2, w0 /* cout ^= x */
-    endloop
+  /* Bit 8: 0. */
+  /* Whitening. */
+  bn.xor w0, w0, w0
+  bn.xor w1, w1, w1
+  /* Compute r = x ^ 0 ^ cin = x ^ cin. */
+  bn.lid x0, 0(a0++)
+  bn.xor w1, w0, w2 /* r = x ^ cin */
+  bn.sid x4, 0(t0++) /* Save r. */
+  /* Compute cout = x ^ ((x ^ p) & (x ^ cin)) = x ^ (x & r). */
+  bn.and w2, w0, w1 /* cout = x & r */
+  bn.xor w2, w2, w0 /* cout ^= x */
 
-    /* Bit 12: 1. */
+  /* Bit 9: 1. */
+  /* Whitening. */
+  bn.xor w0, w0, w0
+  bn.xor w1, w1, w1
+  /* Compute r = x ^ p ^ cin. */
+  bn.lid x0, 0(a0++)
+  bn.not w3, w0 /* a = x ^ p */
+  bn.xor w1, w3, w2 /* r = a ^ cin */
+  bn.sid x4, 0(t0++) /* Save r. */
+  /* Compute cout = x ^ ((x ^ p) & (x ^ cin)) = x ^ (a & (x ^ cin)). */
+  bn.xor w2, w0, w2 /* cout = x ^ cin */
+  bn.and w2, w3, w2 /* cout &= a */
+  bn.xor w2, w2, w0 /* cout ^= x */
+
+  /* Bit 10 -- 11: 0. */
+  loopi 2, 7
     /* Whitening. */
+    bn.xor w0, w0, w0
     bn.xor w1, w1, w1
-    /* Compute r = x ^ p ^ cin = p ^ cin. (x only has k bits, while p has k + 1 bits). */
-    bn.not w1, w2 /* r = p ^ cin */
+    /* Compute r = x ^ 0 ^ cin = x ^ cin. */
+    bn.lid x0, 0(a0++)
+    bn.xor w1, w0, w2 /* r = x ^ cin */
     bn.sid x4, 0(t0++) /* Save r. */
+    /* Compute cout = x ^ ((x ^ p) & (x ^ cin)) = x ^ (x & r). */
+    bn.and w2, w0, w1 /* cout = x & r */
+    bn.xor w2, w2, w0 /* cout ^= x */
+  endloop
 
-    /* Extend s to 2 shares, i.e., clear next share of s. */
-    bn.xor w0, w0, w0
-    loopi 13, 1
-        bn.sid x0, 0(t0++)
-    endloop
+  /* Bit 12: 1. */
+  /* Whitening. */
+  bn.xor w1, w1, w1
+  /* Compute r = x ^ p ^ cin = p ^ cin. (x only has k bits, while p has k + 1 bits). */
+  bn.not w1, w2 /* r = p ^ cin */
+  bn.sid x4, 0(t0++) /* Save r. */
 
-    /* Clear first share of sprime and copy x[1] to second share of sprime with
-     * share stride = 416. */
-    addi t0, sp, 0 /* ptr_sprime */
-    loopi 13, 1
-        bn.sid x0, 0(t0++)
-    endloop
-    loopi 12, 3
-        bn.lid x0, 0(a0++) /* a0 already points to x[1]. */
-        bn.sid x0, 0(t0++)
-        /* Whitening. */
-        bn.xor w0, w0, w0
-    endloop
+  /* Extend s to 2 shares, i.e., clear next share of s. */
+  bn.xor w0, w0, w0
+  loopi 13, 1
     bn.sid x0, 0(t0++)
+  endloop
 
-    /* Compute u = secadd(s, sprime, k + 1). */
-    /* Initialize c = 0. */
-    addi  t0, sp, 832 /* ptr_c */
+  /* Clear first share of sprime and copy x[1] to second share of sprime with
+   * share stride = 416. */
+  addi t0, sp, 0 /* ptr_sprime */
+  loopi 13, 1
+    bn.sid x0, 0(t0++)
+  endloop
+  loopi 12, 3
+    bn.lid x0, 0(a0++) /* a0 already points to x[1]. */
+    bn.sid x0, 0(t0++)
+    /* Whitening. */
     bn.xor w0, w0, w0
-    loopi 2, 1
-        bn.sid x0, 0(t0++)
-    endloop
+  endloop
+  bn.sid x0, 0(t0++)
 
-    addi a0, sp, 896 /* ptr_s */
-    addi a1, x0, 416
-    addi a2, sp, 0 /* ptr_sprime */
-    addi a3, x0, 416
-    addi a5, sp, 896 /* ptr_u */
-    addi a6, x0, 416
-    addi a7, sp, 832 /* ptr_c */
-    addi t4, x0, 32
-    addi t5, sp, 832 /* ptr_c */
-    addi t6, x0, 32
-    loopi 12, 2
-        jal x1, secfulladder
-        nop
-    endloop
-    /* Handle bit 12. */
-    /* Compute r[12] = x[12] ^ y[12] ^ c. */
-    addi x4, x0, 1
-    addi t1, x0, 2
-    addi t2, x0, 3
-    loopi 2, 14
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        bn.xor w1, w1, w1
-        bn.xor w2, w2, w2
-        bn.xor w3, w3, w3
-        /* Computation. */
-        bn.lid x0, 0(a0)
-        bn.lid x4, 0(a2)
-        bn.lid t1, 0(a7)
-        bn.xor w3, w0, w1
-        bn.xor w3, w3, w2
-        bn.sid t2, 0(a5)
-        /* Adjust addresses. */
-        add    a0, a0, a1
-        add    a2, a2, a3
-        add    a7, a7, t4
-        add    a5, a5, a6
-    endloop
+  /* Compute u = secadd(s, sprime, k + 1). */
+  /* Initialize c = 0. */
+  addi  t0, sp, 832 /* ptr_c */
+  bn.xor w0, w0, w0
+  loopi 2, 1
+    bn.sid x0, 0(t0++)
+  endloop
 
-    /* Compute a = bitcopymask(u[k], (k + 1) * 32). */
-    addi a0, sp, 1280 /* ptr_u[k] */
-    addi a1, x0, 416
-    addi a3, sp, 0 /* ptr_a */
-    jal  x1, bitcopymask
-
-    /* Compute u = secadd(a, u, k). */
-    /* Initialize c = 0. */
-    addi  t0, sp, 832 /* ptr_c */
+  addi a0, sp, 896 /* ptr_s */
+  addi a1, x0, 416
+  addi a2, sp, 0 /* ptr_sprime */
+  addi a3, x0, 416
+  addi a5, sp, 896 /* ptr_u */
+  addi a6, x0, 416
+  addi a7, sp, 832 /* ptr_c */
+  addi t4, x0, 32
+  addi t5, sp, 832 /* ptr_c */
+  addi t6, x0, 32
+  loopi 12, 2
+    jal x1, secfulladder
+    nop
+  endloop
+  /* Handle bit 12. */
+  /* Compute r[12] = x[12] ^ y[12] ^ c. */
+  addi x4, x0, 1
+  addi t1, x0, 2
+  addi t2, x0, 3
+  loopi 2, 14
+    /* Whitening. */
     bn.xor w0, w0, w0
-    loopi 2, 1
-        bn.sid x0, 0(t0++)
-    endloop
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    /* Computation. */
+    bn.lid x0, 0(a0)
+    bn.lid x4, 0(a2)
+    bn.lid t1, 0(a7)
+    bn.xor w3, w0, w1
+    bn.xor w3, w3, w2
+    bn.sid t2, 0(a5)
+    /* Adjust addresses. */
+    add    a0, a0, a1
+    add    a2, a2, a3
+    add    a7, a7, t4
+    add    a5, a5, a6
+  endloop
 
-    addi a0, sp, 0 /* ptr_a */
-    addi a1, x0, 384
-    addi a2, sp, 896 /* ptr_u */
-    addi a3, x0, 416
-    addi a5, s2, 0 /* ptr_r */
-    addi a6, x0, 384
-    addi a7, sp, 832 /* ptr_c */
-    addi t4, x0, 32
-    addi t5, sp, 832 /* ptr_c */
-    addi t6, x0, 32
-    loopi 11, 2
-        jal x1, secfulladder
-        nop
-    endloop
-    /* Handle bit 11. */
-    /* Compute r[11] = x[11] ^ y[11] ^ c. */
-    addi x4, x0, 1
-    addi t1, x0, 2
-    addi t2, x0, 3
-    loopi 2, 14
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        bn.xor w1, w1, w1
-        bn.xor w2, w2, w2
-        bn.xor w3, w3, w3
-        /* Computation. */
-        bn.lid x0, 0(a0)
-        bn.lid x4, 0(a2)
-        bn.lid t1, 0(a7)
-        bn.xor w3, w0, w1
-        bn.xor w3, w3, w2
-        bn.sid t2, 0(a5)
-        /* Adjust addresses. */
-        add    a0, a0, a1
-        add    a2, a2, a3
-        add    a7, a7, t4
-        add    a5, a5, a6
-    endloop
+  /* Compute a = bitcopymask(u[k], (k + 1) * 32). */
+  addi a0, sp, 1280 /* ptr_u[k] */
+  addi a1, x0, 416
+  addi a3, sp, 0 /* ptr_a */
+  jal  x1, bitcopymask
 
-    /* Restore s2 and frame. */
-    lw   s2, 1728(sp)
-    addi sp, sp, 1760
-    ret
+  /* Compute u = secadd(a, u, k). */
+  /* Initialize c = 0. */
+  addi  t0, sp, 832 /* ptr_c */
+  bn.xor w0, w0, w0
+  loopi 2, 1
+    bn.sid x0, 0(t0++)
+  endloop
+
+  addi a0, sp, 0 /* ptr_a */
+  addi a1, x0, 384
+  addi a2, sp, 896 /* ptr_u */
+  addi a3, x0, 416
+  addi a5, s2, 0 /* ptr_r */
+  addi a6, x0, 384
+  addi a7, sp, 832 /* ptr_c */
+  addi t4, x0, 32
+  addi t5, sp, 832 /* ptr_c */
+  addi t6, x0, 32
+  loopi 11, 2
+    jal x1, secfulladder
+    nop
+  endloop
+  /* Handle bit 11. */
+  /* Compute r[11] = x[11] ^ y[11] ^ c. */
+  addi x4, x0, 1
+  addi t1, x0, 2
+  addi t2, x0, 3
+  loopi 2, 14
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    /* Computation. */
+    bn.lid x0, 0(a0)
+    bn.lid x4, 0(a2)
+    bn.lid t1, 0(a7)
+    bn.xor w3, w0, w1
+    bn.xor w3, w3, w2
+    bn.sid t2, 0(a5)
+    /* Adjust addresses. */
+    add    a0, a0, a1
+    add    a2, a2, a3
+    add    a7, a7, t4
+    add    a5, a5, a6
+  endloop
+
+  /* Restore s2 and frame. */
+  lw   s2, 1728(sp)
+  addi sp, sp, 1760
+  ret
 
 /*
  * Name: seconebitb2amodq
@@ -1216,81 +1216,81 @@ seca2bmodq:
 .globl seconebitb2amodq
 .type seconebitb2amodq, @function
 seconebitb2amodq:
-    /* Frame: v[0..1] at sp+0 (1024 B), saved s0/s2 above. */
-    addi sp, sp, -1056
-    sw   s0, 1024(sp)
-    sw   s2, 1028(sp)
-    addi s0, a0, 0 /* ptr_x */
-    addi s2, a2, 0 /* ptr_r */
+  /* Frame: v[0..1] at sp+0 (1024 B), saved s0/s2 above. */
+  addi sp, sp, -1056
+  sw   s0, 1024(sp)
+  sw   s2, 1028(sp)
+  addi s0, a0, 0 /* ptr_x */
+  addi s2, a2, 0 /* ptr_r */
 
-    /* Copy x[0] to v[0]. */
-    addi t0, sp, 0 /* ptr_v */
-    add  t1, a0, x0 /* ptr_x[0] */
-    loopi 16, 2
-        bn.lid x0, 0(t1++)
-        bn.sid x0, 0(t0++)
-    endloop
-    /* Zeroize v[1]. */
-    bn.xor w0, w0, w0
-    loopi 16, 1
-        bn.sid x0, 0(t0++)
-    endloop
+  /* Copy x[0] to v[0]. */
+  addi t0, sp, 0 /* ptr_v */
+  add  t1, a0, x0 /* ptr_x[0] */
+  loopi 16, 2
+    bn.lid x0, 0(t1++)
+    bn.sid x0, 0(t0++)
+  endloop
+  /* Zeroize v[1]. */
+  bn.xor w0, w0, w0
+  loopi 16, 1
+    bn.sid x0, 0(t0++)
+  endloop
 
-    /* Construct the vector of 1s. */
-    bn.subi    w30, w0, 1
-    bn.shv.16h w30, w30 >> 15
+  /* Construct the vector of 1s. */
+  bn.subi    w30, w0, 1
+  bn.shv.16h w30, w30 >> 15
 
-    /* Refresh v in place. */
-    addi a0, sp, 0 /* ptr_v */
-    addi a2, a0, 0 /* in-place */
-    jal  x1, refreshmodq
+  /* Refresh v in place. */
+  addi a0, sp, 0 /* ptr_v */
+  addi a2, a0, 0 /* in-place */
+  jal  x1, refreshmodq
 
-    /* To avoid use modular multiplication, we compute (1 - 2*x[1]) * v[j]
-     * as follows:
-     *  - t0 = x[1] - 1
-     *  - We have t0 = 0xFFFF if x[1] = 0 and t0 = 0 if x[1] = 1.
-     *  - t1 = v[j] & t0
-     *  - t1 <<= 1
-     *  - r = bn.subvm(t1, v[j]) with MOD = Q. This works because if x[1] = 0,
-     *    then t1 = 2*v[j] and r = 2*v[j] - v[j] = v[j]. Otherwise,
-     *    t1 = (0 - v[j]) mod Q.
-     * For v[0], we continue with v[0] = (v[0] + x[1]) mod Q before
-     * saving the result to memory.
-     */
-    addi t0, s0, 512 /* ptr_x[1] */
-    addi t1, sp, 0 /* ptr_v */
-    addi x4, x0, 1
-    loopi 16, 16
-        bn.lid         x0, 0(t0++) /* x[1] */
-        bn.subv.16h    w2, w0, w30
-        addi           t2, t1, 0
-        /* v[0]: also add x[1] before storing. */
-        bn.lid       x4, 0(t1) /* v[0] */
-        bn.and       w3, w1, w2
-        bn.shv.16h   w3, w3 << 1
-        bn.subvm.16h w1, w3, w1
-        bn.addvm.16h w1, w0, w1
-        bn.sid       x4, 0(t1)
-        addi         t1, t1, 512 /* Point to v[1]. */
-        /* v[1]. */
-        bn.lid       x4, 0(t1) /* v[1] */
-        bn.and       w3, w1, w2
-        bn.shv.16h   w3, w3 << 1
-        bn.subvm.16h w1, w3, w1
-        bn.sid       x4, 0(t1)
-        addi t1, t2, 32
-    endloop
+  /* To avoid use modular multiplication, we compute (1 - 2*x[1]) * v[j]
+   * as follows:
+   *  - t0 = x[1] - 1
+   *  - We have t0 = 0xFFFF if x[1] = 0 and t0 = 0 if x[1] = 1.
+   *  - t1 = v[j] & t0
+   *  - t1 <<= 1
+   *  - r = bn.subvm(t1, v[j]) with MOD = Q. This works because if x[1] = 0,
+   *    then t1 = 2*v[j] and r = 2*v[j] - v[j] = v[j]. Otherwise,
+   *    t1 = (0 - v[j]) mod Q.
+   * For v[0], we continue with v[0] = (v[0] + x[1]) mod Q before
+   * saving the result to memory.
+   */
+  addi t0, s0, 512 /* ptr_x[1] */
+  addi t1, sp, 0 /* ptr_v */
+  addi x4, x0, 1
+  loopi 16, 16
+    bn.lid         x0, 0(t0++) /* x[1] */
+    bn.subv.16h    w2, w0, w30
+    addi           t2, t1, 0
+    /* v[0]: also add x[1] before storing. */
+    bn.lid       x4, 0(t1) /* v[0] */
+    bn.and       w3, w1, w2
+    bn.shv.16h   w3, w3 << 1
+    bn.subvm.16h w1, w3, w1
+    bn.addvm.16h w1, w0, w1
+    bn.sid       x4, 0(t1)
+    addi         t1, t1, 512 /* Point to v[1]. */
+    /* v[1]. */
+    bn.lid       x4, 0(t1) /* v[1] */
+    bn.and       w3, w1, w2
+    bn.shv.16h   w3, w3 << 1
+    bn.subvm.16h w1, w3, w1
+    bn.sid       x4, 0(t1)
+    addi t1, t2, 32
+  endloop
 
-    /* Final refresh: r = refreshmodq(v). */
-    addi a0, sp, 0 /* ptr_v */
-    addi a2, s2, 0 /* ptr_r */
-    jal  x1, refreshmodq
+  /* Final refresh: r = refreshmodq(v). */
+  addi a0, sp, 0 /* ptr_v */
+  addi a2, s2, 0 /* ptr_r */
+  jal  x1, refreshmodq
 
-    /* Restore registers and frame. */
-    lw   s0, 1024(sp)
-    lw   s2, 1028(sp)
-    addi sp, sp, 1056
-    ret
+  /* Restore registers and frame. */
+  lw   s0, 1024(sp)
+  lw   s2, 1028(sp)
+  addi sp, sp, 1056
+  ret
 
 /*
  * Name: secb2amodq
@@ -1317,232 +1317,232 @@ seconebitb2amodq:
 .globl secb2amodq
 .type secb2amodq, @function
 secb2amodq:
-    /* Frame (2656 B, 2 shares):
-     *   sp +    0 : saved s0, s2, s3, s4, s5
-     *   sp +   32 : ptr_zp / scratch (1024 B)
-     *   sp + 1056 : ptr_s            ( 832 B)
-     *   sp + 1888 : ptr_a, ptr_b, ptr_c (bitsliced, 768 B) */
-    addi sp, sp, -2048
-    addi sp, sp, -608
-    sw s0, 0(sp)
-    sw s2, 4(sp)
-    sw s3, 8(sp)
-    sw s4, 12(sp)
-    sw s5, 16(sp)
+  /* Frame (2656 B, 2 shares):
+   *   sp +    0 : saved s0, s2, s3, s4, s5
+   *   sp +   32 : ptr_zp / scratch (1024 B)
+   *   sp + 1056 : ptr_s            ( 832 B)
+   *   sp + 1888 : ptr_a, ptr_b, ptr_c (bitsliced, 768 B) */
+  addi sp, sp, -2048
+  addi sp, sp, -608
+  sw s0, 0(sp)
+  sw s2, 4(sp)
+  sw s3, 8(sp)
+  sw s4, 12(sp)
+  sw s5, 16(sp)
 
-    /* Save input/output addresses and buffer bases. */
-    addi s0, a0, 0 /* ptr_x */
-    addi s2, a2, 0 /* ptr_r */
-    addi s3, sp, 1888 /* ptr_a, ptr_b, ptr_c (bitsliced) */
-    addi s4, sp, 1056 /* ptr_s */
-    /* ptr_zp = sp + 32 */
+  /* Save input/output addresses and buffer bases. */
+  addi s0, a0, 0 /* ptr_x */
+  addi s2, a2, 0 /* ptr_r */
+  addi s3, sp, 1888 /* ptr_a, ptr_b, ptr_c (bitsliced) */
+  addi s4, sp, 1056 /* ptr_s */
+  /* ptr_zp = sp + 32 */
 
-    /* Sample rand, then compute zp = q - rand. */
-    addi    x4, x0, 30
-    la      t0, modulus_bn
-    bn.lid  x4, 0(t0)
-    addi    a0, a2, 0 /* ptr_r */
-    addi    t2, sp, 32 /* ptr_zp */
-    bn.wsrr w16, mod
-    jal x1, poly_rej_samp
-    loopi 16, 3
-        bn.lid      x0, 0(a2++)
-        bn.subv.16h w0, w30, w0 /* Since inputs are < q, we need to only use bn.subv. */
-        bn.sid      x0, 0(t2++)
-    endloop
+  /* Sample rand, then compute zp = q - rand. */
+  addi    x4, x0, 30
+  la      t0, modulus_bn
+  bn.lid  x4, 0(t0)
+  addi    a0, a2, 0 /* ptr_r */
+  addi    t2, sp, 32 /* ptr_zp */
+  bn.wsrr w16, mod
+  jal x1, poly_rej_samp
+  loopi 16, 3
+    bn.lid      x0, 0(a2++)
+    bn.subv.16h w0, w30, w0 /* Since inputs are < q, we need to only use bn.subv. */
+    bn.sid      x0, 0(t2++)
+  endloop
 
-    /* Bitslice share 0 of zp; the last share (bitsliced) is cleared below. */
-    addi a0, sp, 32 /* ptr_zp */
-    addi a1, s3, 0 /* ptr_zp (bitsliced) */
-    jal  x1, poly_to_bitsliced
-    addi a1, a1, 384
-    /* Clear the last share of zp (bitsliced). */
-    bn.xor w0, w0, w0
-    loopi 12, 1
-        bn.sid x0, 0(a1++)
-    endloop
+  /* Bitslice share 0 of zp; the last share (bitsliced) is cleared below. */
+  addi a0, sp, 32 /* ptr_zp */
+  addi a1, s3, 0 /* ptr_zp (bitsliced) */
+  jal  x1, poly_to_bitsliced
+  addi a1, a1, 384
+  /* Clear the last share of zp (bitsliced). */
+  bn.xor w0, w0, w0
+  loopi 12, 1
+    bn.sid x0, 0(a1++)
+  endloop
 
-    /* Compute a = seca2bmodq(zp). */
-    addi a0, s3, 0 /* ptr_zp (bitsliced) */
-    addi a2, s3, 0 /* ptr_a */
-    jal  x1, seca2bmodq
+  /* Compute a = seca2bmodq(zp). */
+  addi a0, s3, 0 /* ptr_zp (bitsliced) */
+  addi a2, s3, 0 /* ptr_a */
+  jal  x1, seca2bmodq
 
-    /* Compute b = secaddmodq(a, x). */
-    /* Inline secaddmodq. */
-    /* Compute s = secadd(a, x, k + 1). */
-    /* Initialize c = 0. */
-    bn.xor w0, w0, w0
-    addi   t0, s4, 384 /* ptr_c */
-    loopi 2, 2
-        bn.sid x0, 0(t0)
-        addi   t0, t0, 416
-    endloop
+  /* Compute b = secaddmodq(a, x). */
+  /* Inline secaddmodq. */
+  /* Compute s = secadd(a, x, k + 1). */
+  /* Initialize c = 0. */
+  bn.xor w0, w0, w0
+  addi   t0, s4, 384 /* ptr_c */
+  loopi 2, 2
+    bn.sid x0, 0(t0)
+    addi   t0, t0, 416
+  endloop
 
-    /* Ripple-carry adder. */
-    addi a0, s3, 0 /* ptr_a */
-    addi a1, x0, 384
-    addi a2, s0, 0 /* ptr_x */
-    addi a3, x0, 384
-    addi a5, s4, 0 /* ptr_s */
-    addi a6, x0, 416
-    addi a7, s4, 384 /* ptr_c = cin */
-    addi t4, x0, 416
-    addi t5, s4, 384 /* ptr_c = cout */
-    addi t6, x0, 416
-    /* Loop over i=1,...,k-1. */
-    loopi 12, 2
-        /* a0 already points to x[i] */
-        /* a1 is already share stride of x. */
-        /* a2 already points to y[i] */
-        /* a3 is already share stride of y. */
-        /* a5 already points to r. */
-        /* a6 is already share stride of r. */
-        /* a7 already points to ptr_c = cin. */
-        /* t4 is already share stride of cin. */
-        /* t5 already points to ptr_c = cout. */
-        /* t6 is already share stride of cout. */
-        jal  x1, secfulladder
-        /* After secfulladder:
-         *  - a0 and a2 points to x[i + 1] and y[i + 1].
-         *  - a1 and a3 are still share stride of x and y.
-         *  - a5 points to r[i + 1].
-         *  - a6 is still share stride of r.
-         *  - a7 points to cin.
-         *  - t4 is still share stride of cin.
-         *  - t5 points to cout.
-         *  - t6 is still share stride of cout. */
-        nop
-    endloop
-    /* Bit i = k + 1 is already x[k + 1] ^ y[k + 1] ^ c = cout since x[k + 1] = y[k + 1] = 0. */
+  /* Ripple-carry adder. */
+  addi a0, s3, 0 /* ptr_a */
+  addi a1, x0, 384
+  addi a2, s0, 0 /* ptr_x */
+  addi a3, x0, 384
+  addi a5, s4, 0 /* ptr_s */
+  addi a6, x0, 416
+  addi a7, s4, 384 /* ptr_c = cin */
+  addi t4, x0, 416
+  addi t5, s4, 384 /* ptr_c = cout */
+  addi t6, x0, 416
+  /* Loop over i=1,...,k-1. */
+  loopi 12, 2
+    /* a0 already points to x[i] */
+    /* a1 is already share stride of x. */
+    /* a2 already points to y[i] */
+    /* a3 is already share stride of y. */
+    /* a5 already points to r. */
+    /* a6 is already share stride of r. */
+    /* a7 already points to ptr_c = cin. */
+    /* t4 is already share stride of cin. */
+    /* t5 already points to ptr_c = cout. */
+    /* t6 is already share stride of cout. */
+    jal  x1, secfulladder
+    /* After secfulladder:
+     *  - a0 and a2 points to x[i + 1] and y[i + 1].
+     *  - a1 and a3 are still share stride of x and y.
+     *  - a5 points to r[i + 1].
+     *  - a6 is still share stride of r.
+     *  - a7 points to cin.
+     *  - t4 is still share stride of cin.
+     *  - t5 points to cout.
+     *  - t6 is still share stride of cout. */
+    nop
+  endloop
+  /* Bit i = k + 1 is already x[k + 1] ^ y[k + 1] ^ c = cout since x[k + 1] = y[k + 1] = 0. */
 
-    /* Compute s = secadd(s, p, k + 1) where p = 2**(k + 1) - q = 4863 = b1001011111111. */
-    /* Initialize c = 0. */
-    addi   t0, sp, 32 /* ptr_c */
-    bn.xor w0, w0, w0
-    loopi 2, 1
-        bn.sid x0, 0(t0++)
-    endloop
-    addi s5, t0, 0 /* ptr_p */
+  /* Compute s = secadd(s, p, k + 1) where p = 2**(k + 1) - q = 4863 = b1001011111111. */
+  /* Initialize c = 0. */
+  addi   t0, sp, 32 /* ptr_c */
+  bn.xor w0, w0, w0
+  loopi 2, 1
+    bn.sid x0, 0(t0++)
+  endloop
+  addi s5, t0, 0 /* ptr_p */
 
-    addi    t0, s5, 0 /* ptr_p */
-    bn.subi w1, w0, 1
-    addi    x4, x0, 1
-    bn.sid  x4, 0(t0++)
-    bn.sid  x0, 0(t0++)
+  addi    t0, s5, 0 /* ptr_p */
+  bn.subi w1, w0, 1
+  addi    x4, x0, 1
+  bn.sid  x4, 0(t0++)
+  bn.sid  x0, 0(t0++)
 
-    addi a0, s5, 0 /* ptr_p */
-    addi a1, x0, 32
-    addi a2, s4, 0 /* ptr_s */
-    addi a3, x0, 416
-    addi a5, s4, 0 /* ptr_s */
-    addi a6, x0, 416
-    addi a7, sp, 32 /* cin */
-    addi t4, x0, 32
-    addi t5, sp, 32 /* cout */
-    addi t6, x0, 32
-    /* Bit 0 -- 7: p = 1. */
-    loopi 8, 2
-        jal  x1, secfulladder
-        addi a0, a0, -32 /* Reset a0 to ptr_p. */
-    endloop
+  addi a0, s5, 0 /* ptr_p */
+  addi a1, x0, 32
+  addi a2, s4, 0 /* ptr_s */
+  addi a3, x0, 416
+  addi a5, s4, 0 /* ptr_s */
+  addi a6, x0, 416
+  addi a7, sp, 32 /* cin */
+  addi t4, x0, 32
+  addi t5, sp, 32 /* cout */
+  addi t6, x0, 32
+  /* Bit 0 -- 7: p = 1. */
+  loopi 8, 2
+    jal  x1, secfulladder
+    addi a0, a0, -32 /* Reset a0 to ptr_p. */
+  endloop
 
-    /* Bit 8: p = 0. */
-    bn.xor w0, w0, w0
-    bn.sid x0, 0(a0)
-    addi   a0, s5, 0
-    jal    x1, secfulladder
-    /* Bit 9: p = 1. */
-    bn.xor  w0, w0, w0
-    bn.subi w0, w0, 1
-    addi    a0, s5, 0
-    bn.sid  x0, 0(a0)
-    jal     x1, secfulladder
-    /* Bit 10 -- 11: p = 0. */
-    bn.xor w0, w0, w0
-    addi   a0, s5, 0
-    bn.sid x0, 0(a0)
-    jal    x1, secfulladder
-    addi   a0, s5, 0
-    jal    x1, secfulladder
+  /* Bit 8: p = 0. */
+  bn.xor w0, w0, w0
+  bn.sid x0, 0(a0)
+  addi   a0, s5, 0
+  jal    x1, secfulladder
+  /* Bit 9: p = 1. */
+  bn.xor  w0, w0, w0
+  bn.subi w0, w0, 1
+  addi    a0, s5, 0
+  bn.sid  x0, 0(a0)
+  jal     x1, secfulladder
+  /* Bit 10 -- 11: p = 0. */
+  bn.xor w0, w0, w0
+  addi   a0, s5, 0
+  bn.sid x0, 0(a0)
+  jal    x1, secfulladder
+  addi   a0, s5, 0
+  jal    x1, secfulladder
 
-    /* Bit 12: p = 1. */
-    /* Compute r[12] = p[12] ^ s[12] ^ c = ~(s[12] ^ c) since p[12] = 1. */
-    addi x4, x0, 1
-    addi t1, x0, 2
-    /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
-    bn.xor w2, w2, w2
-    bn.xor w3, w3, w3
-    /* Computation. */
-    bn.lid x0, 0(a2)
-    bn.lid x4, 0(a7)
-    bn.xor w3, w0, w1
-    bn.not w2, w3
-    bn.sid t1, 0(a2)
-    add    a2, a2, a3
-    add    a7, a7, t4
+  /* Bit 12: p = 1. */
+  /* Compute r[12] = p[12] ^ s[12] ^ c = ~(s[12] ^ c) since p[12] = 1. */
+  addi x4, x0, 1
+  addi t1, x0, 2
+  /* Whitening. */
+  bn.xor w0, w0, w0
+  bn.xor w1, w1, w1
+  bn.xor w2, w2, w2
+  bn.xor w3, w3, w3
+  /* Computation. */
+  bn.lid x0, 0(a2)
+  bn.lid x4, 0(a7)
+  bn.xor w3, w0, w1
+  bn.not w2, w3
+  bn.sid t1, 0(a2)
+  add    a2, a2, a3
+  add    a7, a7, t4
 
-    /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
-    bn.xor w2, w2, w2
-    /* Computation. */
-    bn.lid x0, 0(a2)
-    bn.lid x4, 0(a7)
-    bn.xor w2, w0, w1
-    bn.sid t1, 0(a2)
+  /* Whitening. */
+  bn.xor w0, w0, w0
+  bn.xor w1, w1, w1
+  bn.xor w2, w2, w2
+  /* Computation. */
+  bn.lid x0, 0(a2)
+  bn.lid x4, 0(a7)
+  bn.xor w2, w0, w1
+  bn.sid t1, 0(a2)
 
-    /* Compute a = bitcopymask(s[k], (k + 1) * 32). */
-    addi a0, s4, 384 /* ptr_s[k] */
-    addi a1, x0, 416 /* share_str = (k + 1) * 32 */
-    addi a3, s3, 0 /* ptr_a */
-    jal  x1, bitcopymask
+  /* Compute a = bitcopymask(s[k], (k + 1) * 32). */
+  addi a0, s4, 384 /* ptr_s[k] */
+  addi a1, x0, 416 /* share_str = (k + 1) * 32 */
+  addi a3, s3, 0 /* ptr_a */
+  jal  x1, bitcopymask
 
-    /* Compute r = secadd(a, s, k). */
-    addi a0, s3, 0 /* ptr_a */
-    addi a1, x0, 384
-    addi a2, s4, 0 /* ptr_s */
-    addi a3, x0, 416
-    addi a5, s3, 0 /* ptr_b */
-    addi a6, x0, 384
-    addi a7, x0, 12 /* k */
-    jal  x1, secadd
-    /* End inlining secaddmodq. */
+  /* Compute r = secadd(a, s, k). */
+  addi a0, s3, 0 /* ptr_a */
+  addi a1, x0, 384
+  addi a2, s4, 0 /* ptr_s */
+  addi a3, x0, 416
+  addi a5, s3, 0 /* ptr_b */
+  addi a6, x0, 384
+  addi a7, x0, 12 /* k */
+  jal  x1, secadd
+  /* End inlining secaddmodq. */
 
-    /* Compute c = refreshios(b, k, k * 32). */
-    addi a0, s3, 0 /* ptr_b */
-    addi a1, x0, 12 /* k */
-    addi a2, x0, 384 /* k * 32 */
-    addi a4, s3, 0 /* ptr_c */
-    jal  x1, refreshios
+  /* Compute c = refreshios(b, k, k * 32). */
+  addi a0, s3, 0 /* ptr_b */
+  addi a1, x0, 12 /* k */
+  addi a2, x0, 384 /* k * 32 */
+  addi a4, s3, 0 /* ptr_c */
+  jal  x1, refreshios
 
-    /* Unmask c. */
-    addi t0, s3, 0 /* ptr_c */
-    addi x4, x0, 1
-    loopi 12, 5
-        addi   t1, t0, 384
-        bn.lid x0, 0(t0)
-        bn.lid x4, 0(t1)
-        bn.xor w0, w0, w1
-        bn.sid x0, 0(t0++)
-    endloop
+  /* Unmask c. */
+  addi t0, s3, 0 /* ptr_c */
+  addi x4, x0, 1
+  loopi 12, 5
+    addi   t1, t0, 384
+    bn.lid x0, 0(t0)
+    bn.lid x4, 0(t1)
+    bn.xor w0, w0, w1
+    bn.sid x0, 0(t0++)
+  endloop
 
-    /* Convert c from bitsliced to normal representation, into share 1. */
-    addi a0, s3, 0 /* ptr_c */
-    addi a1, s2, 0 /* ptr_r */
-    addi a1, a1, 512 /* r[1] */
-    jal x1, poly_from_bitsliced
+  /* Convert c from bitsliced to normal representation, into share 1. */
+  addi a0, s3, 0 /* ptr_c */
+  addi a1, s2, 0 /* ptr_r */
+  addi a1, a1, 512 /* r[1] */
+  jal x1, poly_from_bitsliced
 
-    /* Restore registers. */
-    lw s0, 0(sp)
-    lw s2, 4(sp)
-    lw s3, 8(sp)
-    lw s4, 12(sp)
-    lw s5, 16(sp)
-    addi sp, sp, 2047
-    addi sp, sp, 609
-    ret
+  /* Restore registers. */
+  lw s0, 0(sp)
+  lw s2, 4(sp)
+  lw s3, 8(sp)
+  lw s4, 12(sp)
+  lw s5, 16(sp)
+  addi sp, sp, 2047
+  addi sp, sp, 609
+  ret
 
 /*
  * Name: poly_hocompress
@@ -1575,179 +1575,179 @@ secb2amodq:
 .globl poly_hocompress
 .type poly_hocompress, @function
 poly_hocompress:
-    /* Allocate y[0], y[1] scratch and save callee-saved registers. */
-    addi sp, sp, -1024
-    add  t2, sp, x0
-    addi sp, sp, -1184
-    sw   s1, 1152(sp)
-    sw   s2, 1156(sp)
-    sw   s3, 1160(sp)
-    addi s1, a2, 0
+  /* Allocate y[0], y[1] scratch and save callee-saved registers. */
+  addi sp, sp, -1024
+  add  t2, sp, x0
+  addi sp, sp, -1184
+  sw   s1, 1152(sp)
+  sw   s2, 1156(sp)
+  sw   s3, 1160(sp)
+  addi s1, a2, 0
 
-    /* Load all constants. */
-    addi      x4, x0, 17
-    la        t0, const_m_dv
-    bn.lid    x4++, 0(t0)
-    la        t0, modulus_over_2
-    bn.lid    x4++, 0(t0)
-    bn.shv.8s w18, w18 >> 16
+  /* Load all constants. */
+  addi      x4, x0, 17
+  la        t0, const_m_dv
+  bn.lid    x4++, 0(t0)
+  la        t0, modulus_over_2
+  bn.lid    x4++, 0(t0)
+  bn.shv.8s w18, w18 >> 16
 
-    /* Create 1-bit mask and 2**(alpha - 1). */
-    bn.subi   w19, w31, 1
-    bn.shv.8s w19, w19 >> 31
-    bn.shv.8s w19, w19 << 12  /* alpha - 1 */
+  /* Create 1-bit mask and 2**(alpha - 1). */
+  bn.subi   w19, w31, 1
+  bn.shv.8s w19, w19 >> 31
+  bn.shv.8s w19, w19 << 12  /* alpha - 1 */
 
-    /* Select alpha-dependent parameters: w3 = 2**(alpha - 1), s2 = the
-     * extraction byte offset alpha * 32, s3 = dv. */
-    addi      x4, x0, 4
-    addi      s2, x0, 416  /* alpha * 32, alpha = 13 */
-    addi      s3, x0, 5
-    beq       a3, x4, _dv_params_done
-    bn.shv.8s w19, w19 << 1
-    addi      s2, x0, 448  /* alpha * 32, alpha = 14 (k != 4) */
-    addi      s3, x0, 4
+  /* Select alpha-dependent parameters: w3 = 2**(alpha - 1), s2 = the
+   * extraction byte offset alpha * 32, s3 = dv. */
+  addi      x4, x0, 4
+  addi      s2, x0, 416  /* alpha * 32, alpha = 13 */
+  addi      s3, x0, 5
+  beq       a3, x4, _dv_params_done
+  bn.shv.8s w19, w19 << 1
+  addi      s2, x0, 448  /* alpha * 32, alpha = 14 (k != 4) */
+  addi      s3, x0, 4
 _dv_params_done:
 
-    addi t1, sp, 0 /* ptr_z */
-    addi t3, t1, 512 /* Skip the first 16 bits. */
+  addi t1, sp, 0 /* ptr_z */
+  addi t3, t1, 512 /* Skip the first 16 bits. */
 
-    /* For DV in {4,5}, in order to avoid division by Q, we need to compute:
-     *  - x << (DV + ALPHA) --> x is maximum 20 bits.
-     *  - x += 1665
-     *  - x *=m where m = ((1 << 37) + Q // 2) // Q = 41285357 (m is 26 bits).
-     *  - x >>= k where k = 37.
-     *  - x &= ((1 << (DV + ALPHA)) - 1).
-     * where 37 is the smallest integer that makes this algorithm equivalent to
-     * the division by Q.
-     *
-     * Now for the first share, for performance reason after the step above, we
-     * want to also compute + 2**(ALPHA - 1) before saving the results to
-     * memory. This would result in two more bn.addv.8s instructions compared
-     * to the other shares. In order to reduce code size, we want the
-     * computation of the first share to be identical to subsequent shares. We
-     * realize that if k = 40, after the taking the high parts of the 64-bit
-     * products of x * m, we need to shift 8 bits more, instead of 5 bits.
-     * This shift of a multiple of 8 bits helps us to merge the final shift by
-     * 5 bits with the addition of 2**(alpha - 1) by using bn.add instead of
-     * bn.shv.8s and bn.addv.8s. Since alpha = 13 or 14, and (x * m) >> 40 is
-     * of size 19 bits, their sum is maximum 20 bits, which doesn't overflow
-     * 32-bit slot, ensuring that the addition with bn.add is equivalent to the
-     * vector addition with bn.addv.8s. This is for the first share.
-     *
-     * For subsequent shares, we only need to add (x * m) >> k with 0 with
-     * bn.add to make it a shift, thus reusing the same code for all the shares.
-     */
+  /* For DV in {4,5}, in order to avoid division by Q, we need to compute:
+   *  - x << (DV + ALPHA) --> x is maximum 20 bits.
+   *  - x += 1665
+   *  - x *=m where m = ((1 << 37) + Q // 2) // Q = 41285357 (m is 26 bits).
+   *  - x >>= k where k = 37.
+   *  - x &= ((1 << (DV + ALPHA)) - 1).
+   * where 37 is the smallest integer that makes this algorithm equivalent to
+   * the division by Q.
+   *
+   * Now for the first share, for performance reason after the step above, we
+   * want to also compute + 2**(ALPHA - 1) before saving the results to
+   * memory. This would result in two more bn.addv.8s instructions compared
+   * to the other shares. In order to reduce code size, we want the
+   * computation of the first share to be identical to subsequent shares. We
+   * realize that if k = 40, after the taking the high parts of the 64-bit
+   * products of x * m, we need to shift 8 bits more, instead of 5 bits.
+   * This shift of a multiple of 8 bits helps us to merge the final shift by
+   * 5 bits with the addition of 2**(alpha - 1) by using bn.add instead of
+   * bn.shv.8s and bn.addv.8s. Since alpha = 13 or 14, and (x * m) >> 40 is
+   * of size 19 bits, their sum is maximum 20 bits, which doesn't overflow
+   * 32-bit slot, ensuring that the addition with bn.add is equivalent to the
+   * vector addition with bn.addv.8s. This is for the first share.
+   *
+   * For subsequent shares, we only need to add (x * m) >> k with 0 with
+   * bn.add to make it a shift, thus reusing the same code for all the shares.
+   */
 
-    /* Compute z[0] = Compressq(x[0], dv + alpha) + 2**(alpha - 1). */
-    loopi 2, 58
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        bn.xor w1, w1, w1
-        bn.xor w2, w2, w2
-        bn.xor w3, w3, w3
-        bn.xor w4, w4, w4
-        bn.xor w5, w5, w5
-        bn.xor w6, w6, w6
-        bn.xor w7, w7, w7
-        bn.xor w8, w8, w8
-        bn.xor w9, w9, w9
-        bn.xor w10, w10, w10
-        bn.xor w11, w11, w11
-        bn.xor w12, w12, w12
-        bn.xor w13, w13, w13
-        bn.xor w14, w14, w14
-        bn.xor w15, w15, w15
-        bn.xor w20, w20, w20
-        bn.xor w21, w21, w21
-        bn.xor w28, w28, w28
-        bn.xor w29, w29, w29
+  /* Compute z[0] = Compressq(x[0], dv + alpha) + 2**(alpha - 1). */
+  loopi 2, 58
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    bn.xor w4, w4, w4
+    bn.xor w5, w5, w5
+    bn.xor w6, w6, w6
+    bn.xor w7, w7, w7
+    bn.xor w8, w8, w8
+    bn.xor w9, w9, w9
+    bn.xor w10, w10, w10
+    bn.xor w11, w11, w11
+    bn.xor w12, w12, w12
+    bn.xor w13, w13, w13
+    bn.xor w14, w14, w14
+    bn.xor w15, w15, w15
+    bn.xor w20, w20, w20
+    bn.xor w21, w21, w21
+    bn.xor w28, w28, w28
+    bn.xor w29, w29, w29
 
-        addi x4, x0, 15
-        loopi 16, 18  /* 16 WDRs hold the 256 coeffs */
-            bn.lid             x0, 0(a0++)
-            /* Handle even-positioned coeffs. */
-            bn.trn1.16h        w20, w0, w31
-            bn.shv.8s          w20, w20 << 18
-            bn.addv.8s         w20, w20, w18
-            bn.mulv.8s.even.hi w20, w20, w17
-            bn.mulv.8s.odd.hi  w20, w20, w17
-            bn.add             w21, w19, w20 >> 8
-            /* Handle odd-positioned coeffs. */
-            bn.trn2.16h        w20, w0, w31
-            bn.shv.8s          w20, w20 << 18
-            bn.addv.8s         w20, w20, w18
-            bn.mulv.8s.even.hi w20, w20, w17
-            bn.mulv.8s.odd.hi  w20, w20, w17
-            bn.add             w20, w19, w20 >> 8
-            /* Combine the results before bitslicing. */
-            bn.trn2.16h        w0, w21, w20
-            bn.sid             x0, 0(t2++)
-            bn.trn1.16h        w0, w21, w20
-            bn.movr            x4, x0
-            addi               x4, x4, -1
-        endloop
-
-        /* For the first share, w19 is 2**(alpha - 1). After that, we need to
-         * clear w19 so that bn.add acts as a shift. */
-        bn.xor w19, w19, w19
-
-        /* Bitslice the first 16 bits. */
-        jal x1, _bitslice_transpose
-
-        add x4, x0, x0
-        loopi 16, 2
-            bn.sid x4, 0(t1++)
-            addi   x4, x4, 1
-        endloop
-        addi t1, t1, 64 /* Skip the last 2 bits. */
-
-        /* Bitslice the last 2 bits. */
-        addi x4, x0, 15
-        addi t2, t2, -512
-        loopi 16, 2
-            bn.lid x4, 0(t2++)
-            addi   x4, x4, -1
-        endloop
-
-        jal x1, _bitslice_transpose
-
-        add x4, x0, x0
-        loopi 2, 2
-            bn.sid x4, 0(t3++)
-            addi   x4, x4, 1
-        endloop
-        addi t3, t3, 512 /* Skip the first 16 bits. */
+    addi x4, x0, 15
+    loopi 16, 18  /* 16 WDRs hold the 256 coeffs */
+      bn.lid             x0, 0(a0++)
+      /* Handle even-positioned coeffs. */
+      bn.trn1.16h        w20, w0, w31
+      bn.shv.8s          w20, w20 << 18
+      bn.addv.8s         w20, w20, w18
+      bn.mulv.8s.even.hi w20, w20, w17
+      bn.mulv.8s.odd.hi  w20, w20, w17
+      bn.add             w21, w19, w20 >> 8
+      /* Handle odd-positioned coeffs. */
+      bn.trn2.16h        w20, w0, w31
+      bn.shv.8s          w20, w20 << 18
+      bn.addv.8s         w20, w20, w18
+      bn.mulv.8s.even.hi w20, w20, w17
+      bn.mulv.8s.odd.hi  w20, w20, w17
+      bn.add             w20, w19, w20 >> 8
+      /* Combine the results before bitslicing. */
+      bn.trn2.16h        w0, w21, w20
+      bn.sid             x0, 0(t2++)
+      bn.trn1.16h        w0, w21, w20
+      bn.movr            x4, x0
+      addi               x4, x4, -1
     endloop
 
-    /* Compute c = seca2b(z), k = dv + alpha, share bytes = 576. */
-    addi a0, sp, 0 /* ptr_z */
-    addi a1, x0, 18 /* dv + alpha */
-    addi a2, x0, 576
-    addi a4, sp, 0 /* ptr_c */
-    jal  x1, seca2b
+    /* For the first share, w19 is 2**(alpha - 1). After that, we need to
+     * clear w19 so that bn.add acts as a shift. */
+    bn.xor w19, w19, w19
 
-    /* Compute r = c >> alpha: keep the bits c[alpha]...c[alpha + dv]. */
-    addi t0, sp, 0 /* ptr_c */
-    add  t0, t0, s2
-    addi t1, s1, 0 /* ptr_r */
-    loopi 2, 5
-        loop s3, 3
-            /* Whitening. */
-            bn.xor w0, w0, w0
-            bn.lid x0, 0(t0++)
-            bn.sid x0, 0(t1++)
-        endloop
-        /* After copy DV bits of z to r, we need to adjust address of z again. */
-        add t0, t0, s2
+    /* Bitslice the first 16 bits. */
+    jal x1, _bitslice_transpose
+
+    add x4, x0, x0
+    loopi 16, 2
+      bn.sid x4, 0(t1++)
+      addi   x4, x4, 1
+    endloop
+    addi t1, t1, 64 /* Skip the last 2 bits. */
+
+    /* Bitslice the last 2 bits. */
+    addi x4, x0, 15
+    addi t2, t2, -512
+    loopi 16, 2
+      bn.lid x4, 0(t2++)
+      addi   x4, x4, -1
     endloop
 
-    /* Restore registers. */
-    lw   s1, 1152(sp)
-    lw   s2, 1156(sp)
-    lw   s3, 1160(sp)
-    addi sp, sp, 1184
-    addi sp, sp, 1024
-    ret
+    jal x1, _bitslice_transpose
+
+    add x4, x0, x0
+    loopi 2, 2
+      bn.sid x4, 0(t3++)
+      addi   x4, x4, 1
+    endloop
+    addi t3, t3, 512 /* Skip the first 16 bits. */
+  endloop
+
+  /* Compute c = seca2b(z), k = dv + alpha, share bytes = 576. */
+  addi a0, sp, 0 /* ptr_z */
+  addi a1, x0, 18 /* dv + alpha */
+  addi a2, x0, 576
+  addi a4, sp, 0 /* ptr_c */
+  jal  x1, seca2b
+
+  /* Compute r = c >> alpha: keep the bits c[alpha]...c[alpha + dv]. */
+  addi t0, sp, 0 /* ptr_c */
+  add  t0, t0, s2
+  addi t1, s1, 0 /* ptr_r */
+  loopi 2, 5
+    loop s3, 3
+      /* Whitening. */
+      bn.xor w0, w0, w0
+      bn.lid x0, 0(t0++)
+      bn.sid x0, 0(t1++)
+    endloop
+    /* After copy DV bits of z to r, we need to adjust address of z again. */
+    add t0, t0, s2
+  endloop
+
+  /* Restore registers. */
+  lw   s1, 1152(sp)
+  lw   s2, 1156(sp)
+  lw   s3, 1160(sp)
+  addi sp, sp, 1184
+  addi sp, sp, 1024
+  ret
 
 /*
  * Name: polyvec_hocompress
@@ -1778,191 +1778,191 @@ _dv_params_done:
 .globl polyvec_hocompress
 .type polyvec_hocompress, @function
 polyvec_hocompress:
-    /* Allocate y[0], y[1] scratch and save callee-saved registers. */
-    addi sp, sp, -1024
-    add  t2, sp, x0
-    addi sp, sp, -1568
-    sw   s1, 1536(sp)
-    sw   s2, 1540(sp)
-    sw   s3, 1544(sp)
-    addi s1, a2, 0
+  /* Allocate y[0], y[1] scratch and save callee-saved registers. */
+  addi sp, sp, -1024
+  add  t2, sp, x0
+  addi sp, sp, -1568
+  sw   s1, 1536(sp)
+  sw   s2, 1540(sp)
+  sw   s3, 1544(sp)
+  addi s1, a2, 0
 
-    /* Create 2**(alpha - 1). */
-    bn.subi   w30, w31, 1
-    bn.shv.8s w30, w30 >> 31
-    bn.shv.8s w30, w30 << 12  /* alpha - 1 */
+  /* Create 2**(alpha - 1). */
+  bn.subi   w30, w31, 1
+  bn.shv.8s w30, w30 >> 31
+  bn.shv.8s w30, w30 << 12  /* alpha - 1 */
 
-    /* Select alpha-dependent parameters: s2 = the extraction byte offset
-     * alpha * 32, s3 = du. The in-loop computation of 2**(alpha - 1)
-     * branches on a3 (k) directly. */
-    addi      x4, x0, 4
-    addi      s2, x0, 416  /* alpha * 32, alpha = 13 */
-    addi      s3, x0, 11
-    beq       a3, x4, _du_params_done
-    bn.shv.8s w30, w30 << 1
-    addi      s2, x0, 448  /* alpha * 32, alpha = 14 (k != 4) */
-    addi      s3, x0, 10
+  /* Select alpha-dependent parameters: s2 = the extraction byte offset
+   * alpha * 32, s3 = du. The in-loop computation of 2**(alpha - 1)
+   * branches on a3 (k) directly. */
+  addi      x4, x0, 4
+  addi      s2, x0, 416  /* alpha * 32, alpha = 13 */
+  addi      s3, x0, 11
+  beq       a3, x4, _du_params_done
+  bn.shv.8s w30, w30 << 1
+  addi      s2, x0, 448  /* alpha * 32, alpha = 14 (k != 4) */
+  addi      s3, x0, 10
 _du_params_done:
 
-    /* Load all constants. */
-    addi       x4, x0, 17
-    la         t0, const_m_du
-    bn.lid     x4++, 0(t0)
+  /* Load all constants. */
+  addi       x4, x0, 17
+  la         t0, const_m_du
+  bn.lid     x4++, 0(t0)
 
-    la         t0, const_1664
-    bn.lid     x4, 0(t0)
+  la         t0, const_1664
+  bn.lid     x4, 0(t0)
 
-    /* Adjust space for temporary variable y. */
-    addi t0, x0, 21
-    addi t1, sp, 0 /* ptr_z */
-    addi t3, t1, 512 /* Skip the first 16 bits. */
+  /* Adjust space for temporary variable y. */
+  addi t0, x0, 21
+  addi t1, sp, 0 /* ptr_z */
+  addi t3, t1, 512 /* Skip the first 16 bits. */
 
-    loopi 2, 85
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        bn.xor w1, w1, w1
-        bn.xor w2, w2, w2
-        bn.xor w3, w3, w3
-        bn.xor w4, w4, w4
-        bn.xor w5, w5, w5
-        bn.xor w6, w6, w6
-        bn.xor w7, w7, w7
-        bn.xor w8, w8, w8
-        bn.xor w9, w9, w9
-        bn.xor w10, w10, w10
-        bn.xor w11, w11, w11
-        bn.xor w12, w12, w12
-        bn.xor w13, w13, w13
-        bn.xor w14, w14, w14
-        bn.xor w15, w15, w15
-        bn.xor w19, w19, w19
-        bn.xor w20, w20, w20
-        bn.xor w21, w21, w21
-        bn.xor w28, w28, w28
-        bn.xor w29, w29, w29
+  loopi 2, 85
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    bn.xor w4, w4, w4
+    bn.xor w5, w5, w5
+    bn.xor w6, w6, w6
+    bn.xor w7, w7, w7
+    bn.xor w8, w8, w8
+    bn.xor w9, w9, w9
+    bn.xor w10, w10, w10
+    bn.xor w11, w11, w11
+    bn.xor w12, w12, w12
+    bn.xor w13, w13, w13
+    bn.xor w14, w14, w14
+    bn.xor w15, w15, w15
+    bn.xor w19, w19, w19
+    bn.xor w20, w20, w20
+    bn.xor w21, w21, w21
+    bn.xor w28, w28, w28
+    bn.xor w29, w29, w29
 
-        addi x4, x0, 15
-        loopi 16, 44  /* 16 WDRs hold the 256 coeffs */
-            bn.lid           x0, 0(a0++)
-            /* Handle even-positioned coeffs. */
-            bn.trn1.16h      w19, w0, w31
-            /* Handle coeff[0] - coeff[4] - coeff[8] - coeff[12]. */
-            bn.trn1.8s      w20, w19, w31
-            bn.rshi         w20, w20, w31 >> 232
-            bn.add          w20, w20, w18
-            bn.mulqacc.so.z w21.l, w20.0, w17.0, 0
-            bn.mulqacc.so.z w21.u, w20.2, w17.0, 0
-            bn.mulqacc.so.z w20.l, w20.1, w17.0, 0
-            bn.mulqacc.so.z w20.u, w20.3, w17.0, 0
-            bn.trn2.4d      w20, w21, w20
-            /* Handle coeff[2] - coeff[6] - coeff[10] - coeff[14]. */
-            bn.trn2.8s      w19, w19, w31
-            bn.rshi         w19, w19, w31 >> 232
-            bn.add          w19, w19, w18
-            bn.mulqacc.so.z w21.l, w19.0, w17.0, 0
-            bn.mulqacc.so.z w21.u, w19.2, w17.0, 0
-            bn.mulqacc.so.z w19.l, w19.1, w17.0, 0
-            bn.mulqacc.so.z w19.u, w19.3, w17.0, 0
-            bn.trn2.4d      w19, w21, w19
-            /* Combine the result. */
-            bn.trn1.8s      w19, w20, w19
+    addi x4, x0, 15
+    loopi 16, 44  /* 16 WDRs hold the 256 coeffs */
+      bn.lid           x0, 0(a0++)
+      /* Handle even-positioned coeffs. */
+      bn.trn1.16h      w19, w0, w31
+      /* Handle coeff[0] - coeff[4] - coeff[8] - coeff[12]. */
+      bn.trn1.8s      w20, w19, w31
+      bn.rshi         w20, w20, w31 >> 232
+      bn.add          w20, w20, w18
+      bn.mulqacc.so.z w21.l, w20.0, w17.0, 0
+      bn.mulqacc.so.z w21.u, w20.2, w17.0, 0
+      bn.mulqacc.so.z w20.l, w20.1, w17.0, 0
+      bn.mulqacc.so.z w20.u, w20.3, w17.0, 0
+      bn.trn2.4d      w20, w21, w20
+      /* Handle coeff[2] - coeff[6] - coeff[10] - coeff[14]. */
+      bn.trn2.8s      w19, w19, w31
+      bn.rshi         w19, w19, w31 >> 232
+      bn.add          w19, w19, w18
+      bn.mulqacc.so.z w21.l, w19.0, w17.0, 0
+      bn.mulqacc.so.z w21.u, w19.2, w17.0, 0
+      bn.mulqacc.so.z w19.l, w19.1, w17.0, 0
+      bn.mulqacc.so.z w19.u, w19.3, w17.0, 0
+      bn.trn2.4d      w19, w21, w19
+      /* Combine the result. */
+      bn.trn1.8s      w19, w20, w19
 
-            /* Handle odd-positioned coeffs. */
-            bn.trn2.16h     w0, w0, w31
-            /* Handle coeff[1] - coeff[5] - coeff[9] - coeff[13]. */
-            bn.trn1.8s      w20, w0, w31
-            bn.rshi         w20, w20, w31 >> 232
-            bn.add          w20, w20, w18
-            bn.mulqacc.so.z w21.l, w20.0, w17.0, 0
-            bn.mulqacc.so.z w21.u, w20.2, w17.0, 0
-            bn.mulqacc.so.z w20.l, w20.1, w17.0, 0
-            bn.mulqacc.so.z w20.u, w20.3, w17.0, 0
-            bn.trn2.4d      w20, w21, w20
-            /* Handle coeff[3] - coeff[7] - coeff[11] - coeff[15]. */
-            bn.trn2.8s      w0, w0, w31
-            bn.rshi         w0, w0, w31 >> 232
-            bn.add          w0, w0, w18
-            bn.mulqacc.so.z w21.l, w0.0, w17.0, 0
-            bn.mulqacc.so.z w21.u, w0.2, w17.0, 0
-            bn.mulqacc.so.z w0.l, w0.1, w17.0, 0
-            bn.mulqacc.so.z w0.u, w0.3, w17.0, 0
-            bn.trn2.4d      w0, w21, w0
-            /* Combine the result. */
-            bn.trn1.8s      w20, w20, w0
-            /* Compute + 2**(alpha - 1) mod 2**(du + alpha); w30 holds
-            * 2**(alpha - 1) for the alpha selected per K. Then turn w31 into
-            * the per-lane bit mask for the bitslice helper below; it is zeroed
-            * again at the end of the loop body. */
-            bn.addv.8s      w19, w19, w30
-            bn.addv.8s      w20, w20, w30
-            /* Combine the results before bitslicing. */
-            bn.trn1.16h     w21, w19, w20
-            bn.movr         x4, t0
-            addi            x4, x4, -1
-            bn.trn2.16h     w21, w19, w20
-            bn.sid          t0, 0(t2++)
-        endloop
-
-        /* Clear w30. */
-        bn.xor w30, w30, w30
-
-        /* Bitslice the first 16 bits. */
-        jal x1, _bitslice_transpose
-
-        add x4, x0, x0
-        loopi 16, 2
-            bn.sid x4, 0(t1++)
-            addi   x4, x4, 1
-        endloop
-        addi t1, t1, 256 /* Skip the last 8 bits. */
-
-        /* Bitslice the last 8 bits. */
-        addi x4, x0, 15
-        addi t2, t2, -512
-        loopi 16, 2
-            bn.lid x4, 0(t2++)
-            addi   x4, x4, -1
-        endloop
-
-        jal x1, _bitslice_transpose
-
-        add x4, x0, x0
-        loopi 8, 2
-            bn.sid x4, 0(t3++)
-            addi   x4, x4, 1
-        endloop
-        addi t3, t3, 512 /* Skip the first 16 bits. */
+      /* Handle odd-positioned coeffs. */
+      bn.trn2.16h     w0, w0, w31
+      /* Handle coeff[1] - coeff[5] - coeff[9] - coeff[13]. */
+      bn.trn1.8s      w20, w0, w31
+      bn.rshi         w20, w20, w31 >> 232
+      bn.add          w20, w20, w18
+      bn.mulqacc.so.z w21.l, w20.0, w17.0, 0
+      bn.mulqacc.so.z w21.u, w20.2, w17.0, 0
+      bn.mulqacc.so.z w20.l, w20.1, w17.0, 0
+      bn.mulqacc.so.z w20.u, w20.3, w17.0, 0
+      bn.trn2.4d      w20, w21, w20
+      /* Handle coeff[3] - coeff[7] - coeff[11] - coeff[15]. */
+      bn.trn2.8s      w0, w0, w31
+      bn.rshi         w0, w0, w31 >> 232
+      bn.add          w0, w0, w18
+      bn.mulqacc.so.z w21.l, w0.0, w17.0, 0
+      bn.mulqacc.so.z w21.u, w0.2, w17.0, 0
+      bn.mulqacc.so.z w0.l, w0.1, w17.0, 0
+      bn.mulqacc.so.z w0.u, w0.3, w17.0, 0
+      bn.trn2.4d      w0, w21, w0
+      /* Combine the result. */
+      bn.trn1.8s      w20, w20, w0
+      /* Compute + 2**(alpha - 1) mod 2**(du + alpha); w30 holds
+      * 2**(alpha - 1) for the alpha selected per K. Then turn w31 into
+      * the per-lane bit mask for the bitslice helper below; it is zeroed
+      * again at the end of the loop body. */
+      bn.addv.8s      w19, w19, w30
+      bn.addv.8s      w20, w20, w30
+      /* Combine the results before bitslicing. */
+      bn.trn1.16h     w21, w19, w20
+      bn.movr         x4, t0
+      addi            x4, x4, -1
+      bn.trn2.16h     w21, w19, w20
+      bn.sid          t0, 0(t2++)
     endloop
 
-    /* Compute c = seca2b(z), k = du + alpha, share bytes = 768. */
-    addi a0, sp, 0 /* ptr_z */
-    addi a1, x0, 24 /* du + alpha */
-    addi a2, x0, 768
-    addi a4, sp, 0 /* ptr_c */
-    jal  x1, seca2b
+    /* Clear w30. */
+    bn.xor w30, w30, w30
 
-    /* Compute r = c >> alpha: keep the bits c[alpha]...c[alpha + du]. */
-    addi t0, sp, 0 /* ptr_c */
-    add  t0, t0, s2
-    addi t1, s1, 0 /* ptr_r */
-    loopi 2, 5
-        loop s3, 3
-            /* Whitening. */
-            bn.xor w0, w0, w0
-            bn.lid x0, 0(t0++)
-            bn.sid x0, 0(t1++)
-        endloop
-        /* After copy DV bits of z to r, we need to adjust address of z again. */
-        add t0, t0, s2
+    /* Bitslice the first 16 bits. */
+    jal x1, _bitslice_transpose
+
+    add x4, x0, x0
+    loopi 16, 2
+      bn.sid x4, 0(t1++)
+      addi   x4, x4, 1
+    endloop
+    addi t1, t1, 256 /* Skip the last 8 bits. */
+
+    /* Bitslice the last 8 bits. */
+    addi x4, x0, 15
+    addi t2, t2, -512
+    loopi 16, 2
+      bn.lid x4, 0(t2++)
+      addi   x4, x4, -1
     endloop
 
-    /* Restore registers. */
-    lw   s1, 1536(sp)
-    lw   s2, 1540(sp)
-    lw   s3, 1544(sp)
-    addi sp, sp, 1568
-    addi sp, sp, 1024
-    ret
+    jal x1, _bitslice_transpose
+
+    add x4, x0, x0
+    loopi 8, 2
+      bn.sid x4, 0(t3++)
+      addi   x4, x4, 1
+    endloop
+    addi t3, t3, 512 /* Skip the first 16 bits. */
+  endloop
+
+  /* Compute c = seca2b(z), k = du + alpha, share bytes = 768. */
+  addi a0, sp, 0 /* ptr_z */
+  addi a1, x0, 24 /* du + alpha */
+  addi a2, x0, 768
+  addi a4, sp, 0 /* ptr_c */
+  jal  x1, seca2b
+
+  /* Compute r = c >> alpha: keep the bits c[alpha]...c[alpha + du]. */
+  addi t0, sp, 0 /* ptr_c */
+  add  t0, t0, s2
+  addi t1, s1, 0 /* ptr_r */
+  loopi 2, 5
+    loop s3, 3
+      /* Whitening. */
+      bn.xor w0, w0, w0
+      bn.lid x0, 0(t0++)
+      bn.sid x0, 0(t1++)
+    endloop
+    /* After copy DV bits of z to r, we need to adjust address of z again. */
+    add t0, t0, s2
+  endloop
+
+  /* Restore registers. */
+  lw   s1, 1536(sp)
+  lw   s2, 1540(sp)
+  lw   s3, 1544(sp)
+  addi sp, sp, 1568
+  addi sp, sp, 1024
+  ret
 
 /*
  * Name: onebitdecompress
@@ -1988,52 +1988,52 @@ _du_params_done:
 .globl onebitdecompress
 .type onebitdecompress, @function
 onebitdecompress:
-    /* Save the output base pointer; reused as scratch across the call. */
-    addi sp, sp, -32
-    sw   s0, 0(sp)
-    addi s0, a2, 0
+  /* Save the output base pointer; reused as scratch across the call. */
+  addi sp, sp, -32
+  sw   s0, 0(sp)
+  addi s0, a2, 0
 
-    /* Unpack m, matching the bitslice layout from masked_poly_tomsg. */
-    addi x4, x0, 1
-    loopi 2, 7
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        bn.lid x0, 0(a0++)
-        loopi 16, 3
-            bn.shv.16h w1, w0 >> 15
-            bn.shv.16h w0, w0 << 1
-            bn.sid     x4, 0(a2++)
-        endloop
-        nop
+  /* Unpack m, matching the bitslice layout from masked_poly_tomsg. */
+  addi x4, x0, 1
+  loopi 2, 7
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    bn.lid x0, 0(a0++)
+    loopi 16, 3
+      bn.shv.16h w1, w0 >> 15
+      bn.shv.16h w0, w0 << 1
+      bn.sid     x4, 0(a2++)
     endloop
+    nop
+  endloop
 
-    /* mp = seconebitb2amodq(m), with w16 = R | Q. */
-    addi a0, s0, 0 /* ptr_m */
-    addi a2, s0, 0 /* ptr_r */
-    jal  x1, seconebitb2amodq
+  /* mp = seconebitb2amodq(m), with w16 = R | Q. */
+  addi a0, s0, 0 /* ptr_m */
+  addi a2, s0, 0 /* ptr_r */
+  jal  x1, seconebitb2amodq
 
-    /* mp *= (q + 1) / 2 mod q, coefficient-wise (Montgomery). */
-    la      t0, modulus_over_2_m2_16 /* ((Q + 1) / 2) * (2^16) % Q. */
-    addi    x4, x0, 1
-    bn.lid  x4, 0(t0)
-    loopi 2, 9
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        loopi 16, 6
-            bn.lid               x0, 0(s0)
-            bn.mulv.16h.acc.z.lo w0, w0, w1
-            bn.mulv.l.16h.lo     w0, w0, sw0.2
-            bn.mulv.l.16h.acc.hi w0, w0, sw0.0
-            bn.addvm.16h         w0, w0, w31
-            bn.sid               x0, 0(s0++)
-        endloop
-        nop
+  /* mp *= (q + 1) / 2 mod q, coefficient-wise (Montgomery). */
+  la      t0, modulus_over_2_m2_16 /* ((Q + 1) / 2) * (2^16) % Q. */
+  addi    x4, x0, 1
+  bn.lid  x4, 0(t0)
+  loopi 2, 9
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    loopi 16, 6
+      bn.lid               x0, 0(s0)
+      bn.mulv.16h.acc.z.lo w0, w0, w1
+      bn.mulv.l.16h.lo     w0, w0, sw0.2
+      bn.mulv.l.16h.acc.hi w0, w0, sw0.0
+      bn.addvm.16h         w0, w0, w31
+      bn.sid               x0, 0(s0++)
     endloop
+    nop
+  endloop
 
-    /* Restore the output base pointer and stack. */
-    lw   s0, 0(sp)
-    addi sp, sp, 32
-    ret
+  /* Restore the output base pointer and stack. */
+  lw   s0, 0(sp)
+  addi sp, sp, 32
+  ret
 
 /*
  * Name: masked_cbd
@@ -2059,162 +2059,85 @@ onebitdecompress:
 .globl masked_cbd
 .type masked_cbd, @function
 masked_cbd:
-    /* Frame: tmp at 0 (768 B), sum at 768 (64 B), s at 832 (384 B, sized for
-     * the worst case eta = 3), saved registers at 1216. */
-    addi sp, sp, -1248
-    sw s0, 1216(sp)
-    sw s1, 1220(sp)
-    sw s2, 1224(sp)
-    sw s4, 1228(sp)
-    sw s5, 1232(sp)
-    sw s6, 1236(sp)
+  /* Frame: tmp at 0 (768 B), sum at 768 (64 B), s at 832 (384 B, sized for
+   * the worst case eta = 3), saved registers at 1216. */
+  addi sp, sp, -1248
+  sw s0, 1216(sp)
+  sw s1, 1220(sp)
+  sw s2, 1224(sp)
+  sw s4, 1228(sp)
+  sw s5, 1232(sp)
+  sw s6, 1236(sp)
 
-    /* Save input/output addresses and set the scratch pointers. */
-    addi s0, a0, 0
-    addi s1, a1, 0
-    addi s2, a2, 0
-    addi s4, a4, 0
-    addi s5, sp, 832 /* ptr_s */
-    addi s6, sp, 768 /* ptr_sum */
+  /* Save input/output addresses and set the scratch pointers. */
+  addi s0, a0, 0
+  addi s1, a1, 0
+  addi s2, a2, 0
+  addi s4, a4, 0
+  addi s5, sp, 832 /* ptr_s */
+  addi s6, sp, 768 /* ptr_sum */
 
-    /* Copy x to s[1,..,eta] and ~y to s[eta + 1,..,2 * eta]. */
-    addi t0, s5, 0 /* ptr_s */
-    slli x4, a2, 5 /* eta * 32 */
-    add  t1, s5, x4 /* ptr_s[eta + 1] */
-    /* Share 0: copy x[0] and ~y[0]. */
-    loop a2, 7
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        /* Copy x[0]. */
-        bn.lid x0, 0(a0++)
-        bn.sid x0, 0(t0++)
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        /* Copy ~y[0]. */
-        bn.lid x0, 0(a1++)
-        bn.not w0, w0
-        bn.sid x0, 0(t1++)
-    endloop
-    add t0, t0, x4
-    add t1, t1, x4
-    /* Share 1: copy x[1] and y[1]. */
-    loop a2, 6
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        /* Copy x[1]. */
-        bn.lid x0, 0(a0++)
-        bn.sid x0, 0(t0++)
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        /* Copy y[1]. */
-        bn.lid x0, 0(a1++)
-        bn.sid x0, 0(t1++)
-    endloop
-
-    /* We need to loop over i = 1,...,k where k = ceil(log2(l + 1)) = 3 for both
-     * eta = 2 and eta = 3. Then the inner loop is over j = 1,...,l where
-     * l >>= i, so j is in {eta, eta/2, eta/4}, i.e., {2, 1, 0} for eta = 2 and
-     * {3, 1, 0} for eta = 3. Thus, in the third iteration i = k, the inner loop
-     * is not executed at all. */
-    /*----------------------- Iteration i = 1, l = 2 * eta -----------------------*/
-    /* Since l mod 2 = 0, we clear the carry sum. */
-    addi   t0, s6, 0 /* ptr_sum */
+  /* Copy x to s[1,..,eta] and ~y to s[eta + 1,..,2 * eta]. */
+  addi t0, s5, 0 /* ptr_s */
+  slli x4, a2, 5 /* eta * 32 */
+  add  t1, s5, x4 /* ptr_s[eta + 1] */
+  /* Share 0: copy x[0] and ~y[0]. */
+  loop a2, 7
+    /* Whitening. */
     bn.xor w0, w0, w0
-    loopi 2, 1
-        bn.sid x0, 0(t0++)
-    endloop
-
-    /* l >>= 1: loop j = 1,..., l = 1,...,eta. */
-    /* Inputs to secfulladder. */
-    slli t0, a2, 6 /* (2 * eta) * 32 */
-    addi a0, s5, 0 /* s[0] */
-    addi a1, t0, 0
-    addi a2, s5, 32 /* s[1] */
-    addi a3, t0, 0
-    addi a5, s6, 0 /* ptr_sum = r */
-    addi a6, x0, 32
-    addi a7, s6, 0 /* ptr_sum = cin */
-    addi t4, x0, 32
-    addi t5, s5, 0 /* s[0] = cout */
-    addi t6, t0, 0
-    loop s2, 5
-        /* Compute c, s[j] = secfulladder(s[2j], s[2j + 1], c). */
-        /* a0 already points to s[2j] */
-        /* a1 is already share stride of s. */
-        /* a2 already points to s[2j + 1] */
-        /* a3 is already share stride of s. */
-        /* a5 already points to sum = r. */
-        /* a6 is already share stride of sum = r. */
-        /* a7 already points to sum = cin. */
-        /* t4 is already share stride of sum = cin. */
-        /* t5 already points to s[j] = cout. */
-        /* t6 is already share stride of s = cout. */
-        jal  x1, secfulladder
-        /* After secfulladder:
-        *  - a0 and a2 points to s[2j + 1] and s[2j + 2] --> need to be adjusted.
-        *  - a1 and a3 are still share stride of s.
-        *  - a5 points to sum + 32 (output) --> need to be adjusted to sum.
-        *  - a6 is still share stride of sum.
-        *  - a7 points to sum (cin).
-        *  - t4 is still share stride of sum.
-        *  - t5 points to s[j] (cout) --> need to be adjusted to s[j + 1].
-        *  - t6 is still share stride of s. */
-        /* Adjust addresses. */
-        addi a0, a0, 32 /* s[2 * (j + 1)] */
-        addi a2, a2, 32 /* s[2 * (j + 1) + 1] */
-        addi a5, a5, -32 /* sum */
-        addi t5, t5, 32 /* s[j + 1] */
-    endloop
-
-    /* Copy sum to ptr_tmp[1]. */
-    addi t0, sp, 0 /* ptr_tmp[1] */
-    loopi 2, 4
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        bn.lid x0, 0(a5++) /* a5 still points to sum. */
-        bn.sid x0, 0(t0)
-        addi   t0, t0, 384
-    endloop
-
-    /*----------------------- Iteration i = 2, l = eta -----------------------*/
-    addi t0, x0, 2
-    beq  s2, t0, _cbd_eta_2
-    /* Since l mod 2 = 1 if eta = 3, we compute sum = s[l] = s[3]. */
-    addi t0, s6, 0 /* ptr_sum */
-    addi t1, s5, 0 /* ptr_s */
-    addi t1, t1, 64 /* 2 * 32 */
-    slli x4, s2, 6 /* (2 * eta) * 32 */
-    loopi 2, 4
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        bn.lid x0, 0(t1)
-        bn.sid x0, 0(t0++)
-        add    t1, t1, x4
-    endloop
-    beq x0, x0, _continue_1
-
-_cbd_eta_2:
-    /* Since l mod 2 = 0 if eta = 2, we clear the carry sum. */
-    addi   t0, s6, 0 /* ptr_sum */
+    /* Copy x[0]. */
+    bn.lid x0, 0(a0++)
+    bn.sid x0, 0(t0++)
+    /* Whitening. */
     bn.xor w0, w0, w0
-    loopi 2, 1
-        bn.sid x0, 0(t0++)
-    endloop
+    /* Copy ~y[0]. */
+    bn.lid x0, 0(a1++)
+    bn.not w0, w0
+    bn.sid x0, 0(t1++)
+  endloop
+  add t0, t0, x4
+  add t1, t1, x4
+  /* Share 1: copy x[1] and y[1]. */
+  loop a2, 6
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    /* Copy x[1]. */
+    bn.lid x0, 0(a0++)
+    bn.sid x0, 0(t0++)
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    /* Copy y[1]. */
+    bn.lid x0, 0(a1++)
+    bn.sid x0, 0(t1++)
+  endloop
 
-_continue_1:
-    /* l >> 1: loop j = 1,...,l // 2 --> 1 iteration. */
-    /* Inputs to secfulladder. */
-    slli t0, s2, 6
-    addi a0, s5, 0 /* s[0] */
-    addi a1, t0, 0
-    addi a2, s5, 32 /* s[1] */
-    addi a3, t0, 0
-    addi a5, s6, 0 /* ptr_sum = r */
-    addi a6, x0, 32
-    addi a7, s6, 0 /* ptr_sum = cin */
-    addi t4, x0, 32
-    addi t5, s5, 0 /* s[0] = cout */
-    addi t6, t0, 0
+  /* We need to loop over i = 1,...,k where k = ceil(log2(l + 1)) = 3 for both
+   * eta = 2 and eta = 3. Then the inner loop is over j = 1,...,l where
+   * l >>= i, so j is in {eta, eta/2, eta/4}, i.e., {2, 1, 0} for eta = 2 and
+   * {3, 1, 0} for eta = 3. Thus, in the third iteration i = k, the inner loop
+   * is not executed at all. */
+  /*----------------------- Iteration i = 1, l = 2 * eta -----------------------*/
+  /* Since l mod 2 = 0, we clear the carry sum. */
+  addi   t0, s6, 0 /* ptr_sum */
+  bn.xor w0, w0, w0
+  loopi 2, 1
+    bn.sid x0, 0(t0++)
+  endloop
+
+  /* l >>= 1: loop j = 1,..., l = 1,...,eta. */
+  /* Inputs to secfulladder. */
+  slli t0, a2, 6 /* (2 * eta) * 32 */
+  addi a0, s5, 0 /* s[0] */
+  addi a1, t0, 0
+  addi a2, s5, 32 /* s[1] */
+  addi a3, t0, 0
+  addi a5, s6, 0 /* ptr_sum = r */
+  addi a6, x0, 32
+  addi a7, s6, 0 /* ptr_sum = cin */
+  addi t4, x0, 32
+  addi t5, s5, 0 /* s[0] = cout */
+  addi t6, t0, 0
+  loop s2, 5
     /* Compute c, s[j] = secfulladder(s[2j], s[2j + 1], c). */
     /* a0 already points to s[2j] */
     /* a1 is already share stride of s. */
@@ -2236,72 +2159,149 @@ _continue_1:
     *  - t4 is still share stride of sum.
     *  - t5 points to s[j] (cout) --> need to be adjusted to s[j + 1].
     *  - t6 is still share stride of s. */
+    /* Adjust addresses. */
+    addi a0, a0, 32 /* s[2 * (j + 1)] */
+    addi a2, a2, 32 /* s[2 * (j + 1) + 1] */
+    addi a5, a5, -32 /* sum */
+    addi t5, t5, 32 /* s[j + 1] */
+  endloop
 
-    /* Copy sum to ptr_tmp[2]. */
-    addi t0, sp, 32 /* ptr_tmp[2] */
-    loopi 2, 4
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        bn.lid x0, 0(a7++) /* a7 still points to sum. */
-        bn.sid x0, 0(t0)
-        addi   t0, t0, 384
-    endloop
-
-    /*----------------------- Iteration i = 3, l = eta / 2 -----------------------*/
-    /* Since l mod 2 = 1, we compute tmp[3] = s[l] = s[1]. */
-    addi t0, sp, 0 /* ptr_tmp */
-    addi t0, t0, 64
-    addi t1, s5, 0 /* ptr_s */
-    slli t2, s2, 6
-
-    loopi 2, 5
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        bn.lid x0, 0(t1)
-        bn.sid x0, 0(t0)
-        add    t1, t1, t2
-        addi   t0, t0, 384
-    endloop
-
-    /* Clear bit k --> 12 of tmp. */
-    addi   t0, sp, 0 /* ptr_tmp */
-    addi   t0, t0, 96
+  /* Copy sum to ptr_tmp[1]. */
+  addi t0, sp, 0 /* ptr_tmp[1] */
+  loopi 2, 4
+    /* Whitening. */
     bn.xor w0, w0, w0
-    loopi 2, 3
-        loopi 9, 1
-            bn.sid x0, 0(t0++)
-        endloop
-        addi t0, t0, 96 /* point to next share. */
-    endloop
+    bn.lid x0, 0(a5++) /* a5 still points to sum. */
+    bn.sid x0, 0(t0)
+    addi   t0, t0, 384
+  endloop
 
-    /* Compute r = secb2amodq(tmp). */
-    addi a0, sp, 0 /* ptr_tmp */
-    addi a2, s4, 0 /* ptr_r */
-    jal  x1, secb2amodq
-
-    /* Compute r[0] = r[0] - eta mod q. */
-    addi   t0, s4, 0 /* ptr_r */
-    addi   t1, s5, 0 /* ptr_s */
-    sw     s2, 0(t1)
+  /*----------------------- Iteration i = 2, l = eta -----------------------*/
+  addi t0, x0, 2
+  beq  s2, t0, _cbd_eta_2
+  /* Since l mod 2 = 1 if eta = 3, we compute sum = s[l] = s[3]. */
+  addi t0, s6, 0 /* ptr_sum */
+  addi t1, s5, 0 /* ptr_s */
+  addi t1, t1, 64 /* 2 * 32 */
+  slli x4, s2, 6 /* (2 * eta) * 32 */
+  loopi 2, 4
+    /* Whitening. */
+    bn.xor w0, w0, w0
     bn.lid x0, 0(t1)
-    loopi 16, 1
-        bn.rshi w1, w0, w1 >> 16
-    endloop
-    loopi 16, 3
-        bn.lid       x0, 0(t0)
-        bn.subvm.16h w0, w0, w1
-        bn.sid       x0, 0(t0++)
-    endloop
+    bn.sid x0, 0(t0++)
+    add    t1, t1, x4
+  endloop
+  beq x0, x0, _continue_1
 
-    /* Restore registers and stack. */
-    lw s0, 1216(sp)
-    lw s1, 1220(sp)
-    lw s2, 1224(sp)
-    lw s4, 1228(sp)
-    lw s5, 1232(sp)
-    lw s6, 1236(sp)
-    addi sp, sp, 1248
-    ret
+_cbd_eta_2:
+  /* Since l mod 2 = 0 if eta = 2, we clear the carry sum. */
+  addi   t0, s6, 0 /* ptr_sum */
+  bn.xor w0, w0, w0
+  loopi 2, 1
+    bn.sid x0, 0(t0++)
+  endloop
+
+_continue_1:
+  /* l >> 1: loop j = 1,...,l // 2 --> 1 iteration. */
+  /* Inputs to secfulladder. */
+  slli t0, s2, 6
+  addi a0, s5, 0 /* s[0] */
+  addi a1, t0, 0
+  addi a2, s5, 32 /* s[1] */
+  addi a3, t0, 0
+  addi a5, s6, 0 /* ptr_sum = r */
+  addi a6, x0, 32
+  addi a7, s6, 0 /* ptr_sum = cin */
+  addi t4, x0, 32
+  addi t5, s5, 0 /* s[0] = cout */
+  addi t6, t0, 0
+  /* Compute c, s[j] = secfulladder(s[2j], s[2j + 1], c). */
+  /* a0 already points to s[2j] */
+  /* a1 is already share stride of s. */
+  /* a2 already points to s[2j + 1] */
+  /* a3 is already share stride of s. */
+  /* a5 already points to sum = r. */
+  /* a6 is already share stride of sum = r. */
+  /* a7 already points to sum = cin. */
+  /* t4 is already share stride of sum = cin. */
+  /* t5 already points to s[j] = cout. */
+  /* t6 is already share stride of s = cout. */
+  jal  x1, secfulladder
+  /* After secfulladder:
+  *  - a0 and a2 points to s[2j + 1] and s[2j + 2] --> need to be adjusted.
+  *  - a1 and a3 are still share stride of s.
+  *  - a5 points to sum + 32 (output) --> need to be adjusted to sum.
+  *  - a6 is still share stride of sum.
+  *  - a7 points to sum (cin).
+  *  - t4 is still share stride of sum.
+  *  - t5 points to s[j] (cout) --> need to be adjusted to s[j + 1].
+  *  - t6 is still share stride of s. */
+
+  /* Copy sum to ptr_tmp[2]. */
+  addi t0, sp, 32 /* ptr_tmp[2] */
+  loopi 2, 4
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    bn.lid x0, 0(a7++) /* a7 still points to sum. */
+    bn.sid x0, 0(t0)
+    addi   t0, t0, 384
+  endloop
+
+  /*----------------------- Iteration i = 3, l = eta / 2 -----------------------*/
+  /* Since l mod 2 = 1, we compute tmp[3] = s[l] = s[1]. */
+  addi t0, sp, 0 /* ptr_tmp */
+  addi t0, t0, 64
+  addi t1, s5, 0 /* ptr_s */
+  slli t2, s2, 6
+
+  loopi 2, 5
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    bn.lid x0, 0(t1)
+    bn.sid x0, 0(t0)
+    add    t1, t1, t2
+    addi   t0, t0, 384
+  endloop
+
+  /* Clear bit k --> 12 of tmp. */
+  addi   t0, sp, 0 /* ptr_tmp */
+  addi   t0, t0, 96
+  bn.xor w0, w0, w0
+  loopi 2, 3
+    loopi 9, 1
+      bn.sid x0, 0(t0++)
+    endloop
+    addi t0, t0, 96 /* point to next share. */
+  endloop
+
+  /* Compute r = secb2amodq(tmp). */
+  addi a0, sp, 0 /* ptr_tmp */
+  addi a2, s4, 0 /* ptr_r */
+  jal  x1, secb2amodq
+
+  /* Compute r[0] = r[0] - eta mod q. */
+  addi   t0, s4, 0 /* ptr_r */
+  addi   t1, s5, 0 /* ptr_s */
+  sw     s2, 0(t1)
+  bn.lid x0, 0(t1)
+  loopi 16, 1
+    bn.rshi w1, w0, w1 >> 16
+  endloop
+  loopi 16, 3
+    bn.lid       x0, 0(t0)
+    bn.subvm.16h w0, w0, w1
+    bn.sid       x0, 0(t0++)
+  endloop
+
+  /* Restore registers and stack. */
+  lw s0, 1216(sp)
+  lw s1, 1220(sp)
+  lw s2, 1224(sp)
+  lw s4, 1228(sp)
+  lw s5, 1232(sp)
+  lw s6, 1236(sp)
+  addi sp, sp, 1248
+  ret
 
 
 /* Config to start a SHAKE-256 operation. */
@@ -2322,30 +2322,30 @@ _continue_1:
 .globl masked_poly_getnoise_eta_init
 .type masked_poly_getnoise_eta_init, @function
 masked_poly_getnoise_eta_init:
-    /* Initialize a SHAKE256 operation. */
-    addi  t0, x0, 33
-    slli  t0, t0, 5
-    addi  t0, t0, SHAKE256_CFG
-    addi  t1, x0, 1
-    slli  t1, t1, 20
-    add   t0, t0, t1
-    csrrw x0, kmac_cfg, t0
+  /* Initialize a SHAKE256 operation. */
+  addi  t0, x0, 33
+  slli  t0, t0, 5
+  addi  t0, t0, SHAKE256_CFG
+  addi  t1, x0, 1
+  slli  t1, t1, 20
+  add   t0, t0, t1
+  csrrw x0, kmac_cfg, t0
 
-    /* Send the message to the Keccak core. */
-    bn.xor  w0, w0, w0 /* Whitening. */
-    bn.lid  x0, 0(a0++)
-    bn.wsrw kmac_msg, w0
-    bn.xor  w0, w0, w0 /* Whitening. */
-    bn.lid  x0, 0(a0++)
-    bn.wsrw kmac_msg1, w0
-    li      t0, 1
-    csrrw   x0, kmac_partial_write, t0
-    bn.lid  x0, 0(a1)
-    bn.wsrw kmac_msg, w0
-    bn.xor  w0, w0, w0
-    bn.wsrw kmac_msg1, w0
+  /* Send the message to the Keccak core. */
+  bn.xor  w0, w0, w0 /* Whitening. */
+  bn.lid  x0, 0(a0++)
+  bn.wsrw kmac_msg, w0
+  bn.xor  w0, w0, w0 /* Whitening. */
+  bn.lid  x0, 0(a0++)
+  bn.wsrw kmac_msg1, w0
+  li      t0, 1
+  csrrw   x0, kmac_partial_write, t0
+  bn.lid  x0, 0(a1)
+  bn.wsrw kmac_msg, w0
+  bn.xor  w0, w0, w0
+  bn.wsrw kmac_msg1, w0
 
-    ret
+  ret
 
 /*
  * Name: masked_poly_getnoise_eta_2
@@ -2384,163 +2384,91 @@ masked_poly_getnoise_eta_2:
 .globl masked_poly_getnoise_eta_1
 .type masked_poly_getnoise_eta_1, @function
 masked_poly_getnoise_eta_1:
-    /* Frame: ptr_y at 0, ptr_x at 192 (each 2 * eta * 32, sized for the worst
-     * case eta = 3), saved registers at 384. */
-    addi sp, sp, -416
-    sw   s0, 384(sp)
-    sw   s1, 388(sp)
-    sw   s2, 392(sp)
-    sw   s3, 396(sp)
-    addi s0, a0, 0
-    addi s1, a1, 0
-    addi s2, sp, 192 /* ptr_x */
+  /* Frame: ptr_y at 0, ptr_x at 192 (each 2 * eta * 32, sized for the worst
+   * case eta = 3), saved registers at 384. */
+  addi sp, sp, -416
+  sw   s0, 384(sp)
+  sw   s1, 388(sp)
+  sw   s2, 392(sp)
+  sw   s3, 396(sp)
+  addi s0, a0, 0
+  addi s1, a1, 0
+  addi s2, sp, 192 /* ptr_x */
 
-    addi x4, x0, 3
-    bne  a0, x4, _getnoise_eta_2
+  addi x4, x0, 3
+  bne  a0, x4, _getnoise_eta_2
 
-    addi t0, sp, 0 /* ptr_y */
+  addi t0, sp, 0 /* ptr_y */
 
-    bn.wsrr w17, kmac_digest
-    bn.wsrr w23, kmac_digest1
-    bn.wsrr w18, kmac_digest
-    bn.wsrr w24, kmac_digest1
-    bn.wsrr w19, kmac_digest
-    bn.wsrr w25, kmac_digest1
+  bn.wsrr w17, kmac_digest
+  bn.wsrr w23, kmac_digest1
+  bn.wsrr w18, kmac_digest
+  bn.wsrr w24, kmac_digest1
+  bn.wsrr w19, kmac_digest
+  bn.wsrr w25, kmac_digest1
 
-    bn.wsrr w20, kmac_digest
-    bn.wsrr w26, kmac_digest1
-    bn.wsrr w21, kmac_digest
-    bn.wsrr w27, kmac_digest1
-    bn.wsrr w22, kmac_digest
-    bn.wsrr w30, kmac_digest1
+  bn.wsrr w20, kmac_digest
+  bn.wsrr w26, kmac_digest1
+  bn.wsrr w21, kmac_digest
+  bn.wsrr w27, kmac_digest1
+  bn.wsrr w22, kmac_digest
+  bn.wsrr w30, kmac_digest1
 
-    jal x1, _bitslice_eta_3
+  jal x1, _bitslice_eta_3
 
-    add x4, x0, x0
-    loopi 3, 2
-        bn.sid x4, 0(s2++)
-        addi   x4, x4, 1
-    endloop
-    loopi 3, 2
-        bn.sid x4, 0(t0++)
-        addi   x4, x4, 1
-    endloop
+  add x4, x0, x0
+  loopi 3, 2
+    bn.sid x4, 0(s2++)
+    addi   x4, x4, 1
+  endloop
+  loopi 3, 2
+    bn.sid x4, 0(t0++)
+    addi   x4, x4, 1
+  endloop
 
-    bn.xor w17, w17, w17
-    bn.mov w17, w23
-    bn.xor w18, w18, w18
-    bn.mov w18, w24
-    bn.xor w19, w19, w19
-    bn.mov w19, w25
-    bn.xor w20, w20, w20
-    bn.mov w20, w26
-    bn.xor w21, w21, w21
-    bn.mov w21, w27
-    bn.xor w22, w22, w22
-    bn.mov w22, w30
+  bn.xor w17, w17, w17
+  bn.mov w17, w23
+  bn.xor w18, w18, w18
+  bn.mov w18, w24
+  bn.xor w19, w19, w19
+  bn.mov w19, w25
+  bn.xor w20, w20, w20
+  bn.mov w20, w26
+  bn.xor w21, w21, w21
+  bn.mov w21, w27
+  bn.xor w22, w22, w22
+  bn.mov w22, w30
 
-    jal x1, _bitslice_eta_3
+  jal x1, _bitslice_eta_3
 
-    add x4, x0, x0
-    loopi 3, 2
-        bn.sid x4, 0(s2++)
-        addi   x4, x4, 1
-    endloop
-    loopi 3, 2
-        bn.sid x4, 0(t0++)
-        addi   x4, x4, 1
-    endloop
+  add x4, x0, x0
+  loopi 3, 2
+    bn.sid x4, 0(s2++)
+    addi   x4, x4, 1
+  endloop
+  loopi 3, 2
+    bn.sid x4, 0(t0++)
+    addi   x4, x4, 1
+  endloop
 
-    beq  x0, x0, _getnoise_common
+  beq  x0, x0, _getnoise_common
 
 _getnoise_eta_2:
 
-    bn.wsrr w17, kmac_digest
-    bn.wsrr w21, kmac_digest1
-    bn.wsrr w18, kmac_digest
-    bn.wsrr w22, kmac_digest1
-    bn.wsrr w19, kmac_digest
-    bn.wsrr w23, kmac_digest1
-    bn.wsrr w20, kmac_digest
-    bn.wsrr w24, kmac_digest1
+  bn.wsrr w17, kmac_digest
+  bn.wsrr w21, kmac_digest1
+  bn.wsrr w18, kmac_digest
+  bn.wsrr w22, kmac_digest1
+  bn.wsrr w19, kmac_digest
+  bn.wsrr w23, kmac_digest1
+  bn.wsrr w20, kmac_digest
+  bn.wsrr w24, kmac_digest1
 
-    addi t0, x0, 25
-    addi t1, x0, 17
-    addi t2, x0, 26
-    addi t3, sp, 0 /* ptr_y */
-    loopi 2, 38
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        bn.xor w1, w1, w1
-        bn.xor w2, w2, w2
-        bn.xor w3, w3, w3
-        bn.xor w4, w4, w4
-        bn.xor w5, w5, w5
-        bn.xor w6, w6, w6
-        bn.xor w7, w7, w7
-        bn.xor w8, w8, w8
-        bn.xor w9, w9, w9
-        bn.xor w10, w10, w10
-        bn.xor w11, w11, w11
-        bn.xor w12, w12, w12
-        bn.xor w13, w13, w13
-        bn.xor w14, w14, w14
-        bn.xor w15, w15, w15
-        bn.xor w25, w25, w25
-        bn.xor w26, w26, w26
-        bn.xor w28, w28, w28
-        bn.xor w29, w29, w29
-
-        addi x4, x0, 15
-        loopi 4, 8
-            bn.movr t0, t1
-            loopi 4, 5
-                loopi 16, 2
-                    bn.rshi w26, w25, w26 >> 16
-                    bn.rshi w25, w31, w25 >> 4
-                endloop
-                bn.movr x4, t2
-                addi    x4, x4, -1
-            endloop
-            addi t1, t1, 1
-        endloop
-
-        jal x1, _bitslice_transpose
-
-        bn.sid x0, 0(s2++)
-        addi   x4, x0, 1
-        bn.sid x4, 0(s2++)
-        addi   x4, x4, 1
-        bn.sid x4, 0(t3++)
-        addi   x4, x4, 1
-        bn.sid x4, 0(t3++)
-    endloop
-
-_getnoise_common:
-    /* Compute r = masked_cbd(x, y, eta). */
-    addi a0, sp, 192 /* ptr_x */
-    addi a1, sp, 0 /* ptr_y */
-    addi a2, s0, 0 /* eta */
-    addi a4, s1, 0 /* ptr_r */
-    jal  x1, masked_cbd
-
-    /* Restore inputs. */
-    addi a0, s0, 0
-    /* We want to point r to the next polynomial for next cbd. */
-    addi a1, s1, 512
-
-    /* Restore registers and stack. */
-    lw   s0, 384(sp)
-    lw   s1, 388(sp)
-    lw   s2, 392(sp)
-    lw   s3, 396(sp)
-    addi sp, sp, 416
-    ret
-
-/* Bitslice the SHAKE-256 digests in w17-w22 into the eta = 3 x and y
- * bit-planes for masked_cbd. Called by masked_poly_getnoise_eta_1 on the
- * KYBER_K == 2 path. */
-_bitslice_eta_3:
+  addi t0, x0, 25
+  addi t1, x0, 17
+  addi t2, x0, 26
+  addi t3, sp, 0 /* ptr_y */
+  loopi 2, 38
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
@@ -2558,119 +2486,191 @@ _bitslice_eta_3:
     bn.xor w13, w13, w13
     bn.xor w14, w14, w14
     bn.xor w15, w15, w15
+    bn.xor w25, w25, w25
+    bn.xor w26, w26, w26
     bn.xor w28, w28, w28
     bn.xor w29, w29, w29
 
-    loopi 16, 2
-        bn.rshi w15, w17, w15 >> 16
-        bn.rshi w17, w31, w17 >> 6
-    endloop
-
-    loopi 16, 2
-        bn.rshi w14, w17, w14 >> 16
-        bn.rshi w17, w31, w17 >> 6
-    endloop
-
-    loopi 10, 2
-        bn.rshi w13, w17, w13 >> 16
-        bn.rshi w17, w31, w17 >> 6
-    endloop
-    bn.rshi w13, w17, w13 >> 4
-    bn.rshi w13, w18, w13 >> 12
-    bn.rshi w18, w31, w18 >> 2
-    loopi 5, 2
-        bn.rshi w13, w18, w13 >> 16
-        bn.rshi w18, w31, w18 >> 6
-    endloop
-
-    loopi 16, 2
-        bn.rshi w12, w18, w12 >> 16
-        bn.rshi w18, w31, w18 >> 6
-    endloop
-
-    loopi 16, 2
-        bn.rshi w11, w18, w11 >> 16
-        bn.rshi w18, w31, w18 >> 6
-    endloop
-
-    loopi 5, 2
-        bn.rshi w10, w18, w10 >> 16
-        bn.rshi w18, w31, w18 >> 6
-    endloop
-    bn.rshi w10, w18, w10 >> 2
-    bn.rshi w10, w19, w10 >> 14
-    bn.rshi w19, w31, w19 >> 4
-    loopi 10, 2
-        bn.rshi w10, w19, w10 >> 16
-        bn.rshi w19, w31, w19 >> 6
-    endloop
-
-    loopi 16, 2
-        bn.rshi w9, w19, w9 >> 16
-        bn.rshi w19, w31, w19 >> 6
-    endloop
-
-    loopi 16, 2
-        bn.rshi w8, w19, w8 >> 16
-        bn.rshi w19, w31, w19 >> 6
-    endloop
-
-    loopi 16, 2
-        bn.rshi w7, w20, w7 >> 16
-        bn.rshi w20, w31, w20 >> 6
-    endloop
-
-    loopi 16, 2
-        bn.rshi w6, w20, w6 >> 16
-        bn.rshi w20, w31, w20 >> 6
-    endloop
-
-    loopi 10, 2
-        bn.rshi w5, w20, w5 >> 16
-        bn.rshi w20, w31, w20 >> 6
-    endloop
-    bn.rshi w5, w20, w5 >> 4
-    bn.rshi w5, w21, w5 >> 12
-    bn.rshi w21, w31, w21 >> 2
-    loopi 5, 2
-        bn.rshi w5, w21, w5 >> 16
-        bn.rshi w21, w31, w21 >> 6
-    endloop
-
-    loopi 16, 2
-        bn.rshi w4, w21, w4 >> 16
-        bn.rshi w21, w31, w21 >> 6
-    endloop
-
-    loopi 16, 2
-        bn.rshi w3, w21, w3 >> 16
-        bn.rshi w21, w31, w21 >> 6
-    endloop
-
-    loopi 5, 2
-        bn.rshi w2, w21, w2 >> 16
-        bn.rshi w21, w31, w21 >> 6
-    endloop
-    bn.rshi w2, w21, w2 >> 2
-    bn.rshi w2, w22, w2 >> 14
-    bn.rshi w22, w31, w22 >> 4
-    loopi 10, 2
-        bn.rshi w2, w22, w2 >> 16
-        bn.rshi w22, w31, w22 >> 6
-    endloop
-
-    loopi 16, 2
-        bn.rshi w1, w22, w1 >> 16
-        bn.rshi w22, w31, w22 >> 6
-    endloop
-
-    loopi 16, 2
-        bn.rshi w0, w22, w0 >> 16
-        bn.rshi w22, w31, w22 >> 6
+    addi x4, x0, 15
+    loopi 4, 8
+      bn.movr t0, t1
+      loopi 4, 5
+        loopi 16, 2
+          bn.rshi w26, w25, w26 >> 16
+          bn.rshi w25, w31, w25 >> 4
+        endloop
+        bn.movr x4, t2
+        addi    x4, x4, -1
+      endloop
+      addi t1, t1, 1
     endloop
 
     jal x1, _bitslice_transpose
-    ret
+
+    bn.sid x0, 0(s2++)
+    addi   x4, x0, 1
+    bn.sid x4, 0(s2++)
+    addi   x4, x4, 1
+    bn.sid x4, 0(t3++)
+    addi   x4, x4, 1
+    bn.sid x4, 0(t3++)
+  endloop
+
+_getnoise_common:
+  /* Compute r = masked_cbd(x, y, eta). */
+  addi a0, sp, 192 /* ptr_x */
+  addi a1, sp, 0 /* ptr_y */
+  addi a2, s0, 0 /* eta */
+  addi a4, s1, 0 /* ptr_r */
+  jal  x1, masked_cbd
+
+  /* Restore inputs. */
+  addi a0, s0, 0
+  /* We want to point r to the next polynomial for next cbd. */
+  addi a1, s1, 512
+
+  /* Restore registers and stack. */
+  lw   s0, 384(sp)
+  lw   s1, 388(sp)
+  lw   s2, 392(sp)
+  lw   s3, 396(sp)
+  addi sp, sp, 416
+  ret
+
+/* Bitslice the SHAKE-256 digests in w17-w22 into the eta = 3 x and y
+ * bit-planes for masked_cbd. Called by masked_poly_getnoise_eta_1 on the
+ * KYBER_K == 2 path. */
+_bitslice_eta_3:
+  /* Whitening. */
+  bn.xor w0, w0, w0
+  bn.xor w1, w1, w1
+  bn.xor w2, w2, w2
+  bn.xor w3, w3, w3
+  bn.xor w4, w4, w4
+  bn.xor w5, w5, w5
+  bn.xor w6, w6, w6
+  bn.xor w7, w7, w7
+  bn.xor w8, w8, w8
+  bn.xor w9, w9, w9
+  bn.xor w10, w10, w10
+  bn.xor w11, w11, w11
+  bn.xor w12, w12, w12
+  bn.xor w13, w13, w13
+  bn.xor w14, w14, w14
+  bn.xor w15, w15, w15
+  bn.xor w28, w28, w28
+  bn.xor w29, w29, w29
+
+  loopi 16, 2
+    bn.rshi w15, w17, w15 >> 16
+    bn.rshi w17, w31, w17 >> 6
+  endloop
+
+  loopi 16, 2
+    bn.rshi w14, w17, w14 >> 16
+    bn.rshi w17, w31, w17 >> 6
+  endloop
+
+  loopi 10, 2
+    bn.rshi w13, w17, w13 >> 16
+    bn.rshi w17, w31, w17 >> 6
+  endloop
+  bn.rshi w13, w17, w13 >> 4
+  bn.rshi w13, w18, w13 >> 12
+  bn.rshi w18, w31, w18 >> 2
+  loopi 5, 2
+    bn.rshi w13, w18, w13 >> 16
+    bn.rshi w18, w31, w18 >> 6
+  endloop
+
+  loopi 16, 2
+    bn.rshi w12, w18, w12 >> 16
+    bn.rshi w18, w31, w18 >> 6
+  endloop
+
+  loopi 16, 2
+    bn.rshi w11, w18, w11 >> 16
+    bn.rshi w18, w31, w18 >> 6
+  endloop
+
+  loopi 5, 2
+    bn.rshi w10, w18, w10 >> 16
+    bn.rshi w18, w31, w18 >> 6
+  endloop
+  bn.rshi w10, w18, w10 >> 2
+  bn.rshi w10, w19, w10 >> 14
+  bn.rshi w19, w31, w19 >> 4
+  loopi 10, 2
+    bn.rshi w10, w19, w10 >> 16
+    bn.rshi w19, w31, w19 >> 6
+  endloop
+
+  loopi 16, 2
+    bn.rshi w9, w19, w9 >> 16
+    bn.rshi w19, w31, w19 >> 6
+  endloop
+
+  loopi 16, 2
+    bn.rshi w8, w19, w8 >> 16
+    bn.rshi w19, w31, w19 >> 6
+  endloop
+
+  loopi 16, 2
+    bn.rshi w7, w20, w7 >> 16
+    bn.rshi w20, w31, w20 >> 6
+  endloop
+
+  loopi 16, 2
+    bn.rshi w6, w20, w6 >> 16
+    bn.rshi w20, w31, w20 >> 6
+  endloop
+
+  loopi 10, 2
+    bn.rshi w5, w20, w5 >> 16
+    bn.rshi w20, w31, w20 >> 6
+  endloop
+  bn.rshi w5, w20, w5 >> 4
+  bn.rshi w5, w21, w5 >> 12
+  bn.rshi w21, w31, w21 >> 2
+  loopi 5, 2
+    bn.rshi w5, w21, w5 >> 16
+    bn.rshi w21, w31, w21 >> 6
+  endloop
+
+  loopi 16, 2
+    bn.rshi w4, w21, w4 >> 16
+    bn.rshi w21, w31, w21 >> 6
+  endloop
+
+  loopi 16, 2
+    bn.rshi w3, w21, w3 >> 16
+    bn.rshi w21, w31, w21 >> 6
+  endloop
+
+  loopi 5, 2
+    bn.rshi w2, w21, w2 >> 16
+    bn.rshi w21, w31, w21 >> 6
+  endloop
+  bn.rshi w2, w21, w2 >> 2
+  bn.rshi w2, w22, w2 >> 14
+  bn.rshi w22, w31, w22 >> 4
+  loopi 10, 2
+    bn.rshi w2, w22, w2 >> 16
+    bn.rshi w22, w31, w22 >> 6
+  endloop
+
+  loopi 16, 2
+    bn.rshi w1, w22, w1 >> 16
+    bn.rshi w22, w31, w22 >> 6
+  endloop
+
+  loopi 16, 2
+    bn.rshi w0, w22, w0 >> 16
+    bn.rshi w22, w31, w22 >> 6
+  endloop
+
+  jal x1, _bitslice_transpose
+  ret
 
 /* Undefine gadget-local macros. */
 #undef SHAKE256_CFG
@@ -2703,117 +2703,117 @@ _bitslice_eta_3:
 .globl masked_poly_tomsg
 .type masked_poly_tomsg, @function
 masked_poly_tomsg:
-    /* Allocate y[0], y[1] scratch and save callee-saved registers. */
-    addi sp, sp, -1056
-    sw   s0, 1024(sp)
-    addi s0, a2, 0
+  /* Allocate y[0], y[1] scratch and save callee-saved registers. */
+  addi sp, sp, -1056
+  sw   s0, 1024(sp)
+  addi s0, a2, 0
 
-    /* Load all constants. */
-    addi      x4, x0, 17
-    la        t0, const_m_dv
-    bn.lid    x4++, 0(t0)
-    la        t0, modulus_over_2
-    bn.lid    x4++, 0(t0)
-    bn.shv.8s w18, w18 >> 16
+  /* Load all constants. */
+  addi      x4, x0, 17
+  la        t0, const_m_dv
+  bn.lid    x4++, 0(t0)
+  la        t0, modulus_over_2
+  bn.lid    x4++, 0(t0)
+  bn.shv.8s w18, w18 >> 16
 
-    /* Create 2**(alpha - 1), alpha = 15. */
-    bn.subi    w19, w31, 1
-    bn.shv.8s  w19, w19 >> 31
-    bn.shv.8s  w19, w19 << 14
+  /* Create 2**(alpha - 1), alpha = 15. */
+  bn.subi    w19, w31, 1
+  bn.shv.8s  w19, w19 >> 31
+  bn.shv.8s  w19, w19 << 14
 
 
-    /* In order to avoid division by Q, we need to compute:
-     *  - x << (1 + alpha) --> x is 28 bits.
-     *  - x += 1665
-     *  - x *=m where m = ((1 << 37) + Q // 2) // Q = 41285357 (m is 26 bits).
-     *  - x >>= k where k = 37. */
-    /* Compute y[i] = Compressq(x[i], 1 + alpha); share 0 also adds
-     * 2**(alpha - 1). */
-    addi t0, x0, 21
-    addi t1, sp, 0 /* ptr_y */
+  /* In order to avoid division by Q, we need to compute:
+   *  - x << (1 + alpha) --> x is 28 bits.
+   *  - x += 1665
+   *  - x *=m where m = ((1 << 37) + Q // 2) // Q = 41285357 (m is 26 bits).
+   *  - x >>= k where k = 37. */
+  /* Compute y[i] = Compressq(x[i], 1 + alpha); share 0 also adds
+   * 2**(alpha - 1). */
+  addi t0, x0, 21
+  addi t1, sp, 0 /* ptr_y */
 
-    loopi 2, 44
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        bn.xor w1, w1, w1
-        bn.xor w2, w2, w2
-        bn.xor w3, w3, w3
-        bn.xor w4, w4, w4
-        bn.xor w5, w5, w5
-        bn.xor w6, w6, w6
-        bn.xor w7, w7, w7
-        bn.xor w8, w8, w8
-        bn.xor w9, w9, w9
-        bn.xor w10, w10, w10
-        bn.xor w11, w11, w11
-        bn.xor w12, w12, w12
-        bn.xor w13, w13, w13
-        bn.xor w14, w14, w14
-        bn.xor w15, w15, w15
-        bn.xor w20, w20, w20
-        bn.xor w21, w21, w21
-        bn.xor w28, w28, w28
-        bn.xor w29, w29, w29
+  loopi 2, 44
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    bn.xor w4, w4, w4
+    bn.xor w5, w5, w5
+    bn.xor w6, w6, w6
+    bn.xor w7, w7, w7
+    bn.xor w8, w8, w8
+    bn.xor w9, w9, w9
+    bn.xor w10, w10, w10
+    bn.xor w11, w11, w11
+    bn.xor w12, w12, w12
+    bn.xor w13, w13, w13
+    bn.xor w14, w14, w14
+    bn.xor w15, w15, w15
+    bn.xor w20, w20, w20
+    bn.xor w21, w21, w21
+    bn.xor w28, w28, w28
+    bn.xor w29, w29, w29
 
-        addi x4, x0, 15
-        loopi 16, 16
-            bn.lid             x0, 0(a0++)
-            /* Handle even-positioned coeffs. */
-            bn.trn1.16h        w20, w0, w31
-            bn.shv.8s          w20, w20 << 16
-            bn.addv.8s         w20, w20, w18
-            bn.mulv.8s.even.hi w20, w20, w17
-            bn.mulv.8s.odd.hi  w20, w20, w17
-            bn.add             w21, w19, w20 >> 8
-            /* Handle odd-positioned coeffs. */
-            bn.trn2.16h        w20, w0, w31
-            bn.shv.8s          w20, w20 << 16
-            bn.addv.8s         w20, w20, w18
-            bn.mulv.8s.even.hi w20, w20, w17
-            bn.mulv.8s.odd.hi  w20, w20, w17
-            bn.add             w20, w19, w20 >> 8
-            /* Combine results. */
-            bn.trn1.16h        w21, w21, w20
-            bn.movr            x4, t0
-            addi               x4, x4, -1
-        endloop
-
-        jal x1, _bitslice_transpose
-
-        add x4, x0, x0
-        loopi 16, 2
-            bn.sid x4, 0(t1++)
-            addi   x4, x4, 1
-        endloop
-
-        /* Clear the offset; only share 0 carries 2**(alpha - 1). */
-        bn.xor w19, w19, w19
+    addi x4, x0, 15
+    loopi 16, 16
+      bn.lid             x0, 0(a0++)
+      /* Handle even-positioned coeffs. */
+      bn.trn1.16h        w20, w0, w31
+      bn.shv.8s          w20, w20 << 16
+      bn.addv.8s         w20, w20, w18
+      bn.mulv.8s.even.hi w20, w20, w17
+      bn.mulv.8s.odd.hi  w20, w20, w17
+      bn.add             w21, w19, w20 >> 8
+      /* Handle odd-positioned coeffs. */
+      bn.trn2.16h        w20, w0, w31
+      bn.shv.8s          w20, w20 << 16
+      bn.addv.8s         w20, w20, w18
+      bn.mulv.8s.even.hi w20, w20, w17
+      bn.mulv.8s.odd.hi  w20, w20, w17
+      bn.add             w20, w19, w20 >> 8
+      /* Combine results. */
+      bn.trn1.16h        w21, w21, w20
+      bn.movr            x4, t0
+      addi               x4, x4, -1
     endloop
 
-    /* Compute z = seca2b(y, k = 1 + alpha, share bytes = k * 32). */
-    addi a0, sp, 0 /* ptr_y */
-    addi a1, x0, 16 /* 1 + alpha */
-    addi a2, x0, 512
-    addi a4, sp, 0 /* ptr_z */
-    jal  x1, seca2b
+    jal x1, _bitslice_transpose
 
-    /* Compute z >>= alpha, i.e. keep only bit z[alpha], the message bit. */
-    addi t0, sp, 0 /* ptr_z */
-    addi t0, t0, 480 /* skip to bit-plane alpha = 15 */
-    addi t1, s0, 0 /* ptr_r */
-    loopi 2, 4
-        /* Whitening. */
-        bn.xor w0, w0, w0
-        bn.lid x0, 0(t0++)
-        bn.sid x0, 0(t1++)
-        /* Advance to bit-plane alpha of the next share. */
-        addi t0, t0, 480
+    add x4, x0, x0
+    loopi 16, 2
+      bn.sid x4, 0(t1++)
+      addi   x4, x4, 1
     endloop
 
-    /* Restore registers. */
-    lw   s0, 1024(sp)
-    addi sp, sp, 1056
-    ret
+    /* Clear the offset; only share 0 carries 2**(alpha - 1). */
+    bn.xor w19, w19, w19
+  endloop
+
+  /* Compute z = seca2b(y, k = 1 + alpha, share bytes = k * 32). */
+  addi a0, sp, 0 /* ptr_y */
+  addi a1, x0, 16 /* 1 + alpha */
+  addi a2, x0, 512
+  addi a4, sp, 0 /* ptr_z */
+  jal  x1, seca2b
+
+  /* Compute z >>= alpha, i.e. keep only bit z[alpha], the message bit. */
+  addi t0, sp, 0 /* ptr_z */
+  addi t0, t0, 480 /* skip to bit-plane alpha = 15 */
+  addi t1, s0, 0 /* ptr_r */
+  loopi 2, 4
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    bn.lid x0, 0(t0++)
+    bn.sid x0, 0(t1++)
+    /* Advance to bit-plane alpha of the next share. */
+    addi t0, t0, 480
+  endloop
+
+  /* Restore registers. */
+  lw   s0, 1024(sp)
+  addi sp, sp, 1056
+  ret
 
 #define N_COEFFS 16
 
@@ -2838,299 +2838,299 @@ masked_poly_tomsg:
 .globl poly_masked_compare_dv
 .type poly_masked_compare_dv, @function
 poly_masked_compare_dv:
-    /* Allocate t scratch (2 shares * 160 B, dv = 5 worst case) + saves. */
-    addi sp, sp, -352
-    sw   s0, 324(sp)
-    sw   s1, 328(sp)
-    sw   s2, 332(sp)
-    sw   s4, 340(sp)
-    sw   a5, 344(sp)
+  /* Allocate t scratch (2 shares * 160 B, dv = 5 worst case) + saves. */
+  addi sp, sp, -352
+  sw   s0, 324(sp)
+  sw   s1, 328(sp)
+  sw   s2, 332(sp)
+  sw   s4, 340(sp)
+  sw   a5, 344(sp)
 
-    /* Save input/output addresses. */
-    addi s0, a0, 0
-    addi s1, a1, 0
-    addi s2, a2, 0
-    addi s4, a4, 0
+  /* Save input/output addresses. */
+  addi s0, a0, 0
+  addi s1, a1, 0
+  addi s2, a2, 0
+  addi s4, a4, 0
 
-    /* Compute t = poly_hocompress(cprime). */
-    addi a0, s0, 0 /* ptr_cprime */
-    addi a2, sp, 0 /* ptr_t */
-    addi a3, a5, 0 /* k */
-    jal  x1, poly_hocompress
+  /* Compute t = poly_hocompress(cprime). */
+  addi a0, s0, 0 /* ptr_cprime */
+  addi a2, sp, 0 /* ptr_t */
+  addi a3, a5, 0 /* k */
+  jal  x1, poly_hocompress
 
-    /* Decode + bitslice c. */
-    addi a1, s1, 0 /* ptr_c */
+  /* Decode + bitslice c. */
+  addi a1, s1, 0 /* ptr_c */
 
-    addi x4, x0, 4
-    lw   a5, 344(sp)
-    bne  a5, x4, _handle_kn4_dv
+  addi x4, x0, 4
+  lw   a5, 344(sp)
+  bne  a5, x4, _handle_kn4_dv
 
 _handle_k4_dv:
-    addi   x4, x0, 17
-    bn.lid x4, 0(a1++)
-    /* group 0 -> w15 */
-    loopi 16, 2
-        bn.rshi w15, w17, w15 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    /* group 1 -> w14 */
-    loopi 16, 2
-        bn.rshi w14, w17, w14 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    /* group 2 -> w13 */
-    loopi 16, 2
-        bn.rshi w13, w17, w13 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    /* group 3 -> w12 */
-    loopi 3, 2
-        bn.rshi w12, w17, w12 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    bn.rshi w12, w17, w12 >> 1
-    bn.lid  x4, 0(a1++)
-    bn.rshi w12, w17, w12 >> 15
-    bn.rshi w17, w31, w17 >> 4
-    loopi 12, 2
-        bn.rshi w12, w17, w12 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    /* group 4 -> w11 */
-    loopi 16, 2
-        bn.rshi w11, w17, w11 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    /* group 5 -> w10 */
-    loopi 16, 2
-        bn.rshi w10, w17, w10 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    /* group 6 -> w9 */
-    loopi 6, 2
-        bn.rshi w9, w17, w9 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    bn.rshi w9, w17, w9 >> 2
-    bn.lid  x4, 0(a1++)
-    bn.rshi w9, w17, w9 >> 14
-    bn.rshi w17, w31, w17 >> 3
-    loopi 9, 2
-        bn.rshi w9, w17, w9 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    /* group 7 -> w8 */
-    loopi 16, 2
-        bn.rshi w8, w17, w8 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    /* group 8 -> w7 */
-    loopi 16, 2
-        bn.rshi w7, w17, w7 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    /* group 9 -> w6 */
-    loopi 9, 2
-        bn.rshi w6, w17, w6 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    bn.rshi w6, w17, w6 >> 3
-    bn.lid  x4, 0(a1++)
-    bn.rshi w6, w17, w6 >> 13
-    bn.rshi w17, w31, w17 >> 2
-    loopi 6, 2
-        bn.rshi w6, w17, w6 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    /* group 10 -> w5 */
-    loopi 16, 2
-        bn.rshi w5, w17, w5 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    /* group 11 -> w4 */
-    loopi 16, 2
-        bn.rshi w4, w17, w4 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    /* group 12 -> w3 */
-    loopi 12, 2
-        bn.rshi w3, w17, w3 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    bn.rshi w3, w17, w3 >> 4
-    bn.lid  x4, 0(a1++)
-    bn.rshi w3, w17, w3 >> 12
-    bn.rshi w17, w31, w17 >> 1
-    loopi 3, 2
-        bn.rshi w3, w17, w3 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    /* group 13 -> w2 */
-    loopi 16, 2
-        bn.rshi w2, w17, w2 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    /* group 14 -> w1 */
-    loopi 16, 2
-        bn.rshi w1, w17, w1 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    /* group 15 -> w0 */
-    loopi 16, 2
-        bn.rshi w0, w17, w0 >> 16
-        bn.rshi w17, w31, w17 >> 5
-    endloop
-    jal x1, _bitslice_transpose
+  addi   x4, x0, 17
+  bn.lid x4, 0(a1++)
+  /* group 0 -> w15 */
+  loopi 16, 2
+    bn.rshi w15, w17, w15 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  /* group 1 -> w14 */
+  loopi 16, 2
+    bn.rshi w14, w17, w14 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  /* group 2 -> w13 */
+  loopi 16, 2
+    bn.rshi w13, w17, w13 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  /* group 3 -> w12 */
+  loopi 3, 2
+    bn.rshi w12, w17, w12 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  bn.rshi w12, w17, w12 >> 1
+  bn.lid  x4, 0(a1++)
+  bn.rshi w12, w17, w12 >> 15
+  bn.rshi w17, w31, w17 >> 4
+  loopi 12, 2
+    bn.rshi w12, w17, w12 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  /* group 4 -> w11 */
+  loopi 16, 2
+    bn.rshi w11, w17, w11 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  /* group 5 -> w10 */
+  loopi 16, 2
+    bn.rshi w10, w17, w10 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  /* group 6 -> w9 */
+  loopi 6, 2
+    bn.rshi w9, w17, w9 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  bn.rshi w9, w17, w9 >> 2
+  bn.lid  x4, 0(a1++)
+  bn.rshi w9, w17, w9 >> 14
+  bn.rshi w17, w31, w17 >> 3
+  loopi 9, 2
+    bn.rshi w9, w17, w9 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  /* group 7 -> w8 */
+  loopi 16, 2
+    bn.rshi w8, w17, w8 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  /* group 8 -> w7 */
+  loopi 16, 2
+    bn.rshi w7, w17, w7 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  /* group 9 -> w6 */
+  loopi 9, 2
+    bn.rshi w6, w17, w6 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  bn.rshi w6, w17, w6 >> 3
+  bn.lid  x4, 0(a1++)
+  bn.rshi w6, w17, w6 >> 13
+  bn.rshi w17, w31, w17 >> 2
+  loopi 6, 2
+    bn.rshi w6, w17, w6 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  /* group 10 -> w5 */
+  loopi 16, 2
+    bn.rshi w5, w17, w5 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  /* group 11 -> w4 */
+  loopi 16, 2
+    bn.rshi w4, w17, w4 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  /* group 12 -> w3 */
+  loopi 12, 2
+    bn.rshi w3, w17, w3 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  bn.rshi w3, w17, w3 >> 4
+  bn.lid  x4, 0(a1++)
+  bn.rshi w3, w17, w3 >> 12
+  bn.rshi w17, w31, w17 >> 1
+  loopi 3, 2
+    bn.rshi w3, w17, w3 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  /* group 13 -> w2 */
+  loopi 16, 2
+    bn.rshi w2, w17, w2 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  /* group 14 -> w1 */
+  loopi 16, 2
+    bn.rshi w1, w17, w1 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  /* group 15 -> w0 */
+  loopi 16, 2
+    bn.rshi w0, w17, w0 >> 16
+    bn.rshi w17, w31, w17 >> 5
+  endloop
+  jal x1, _bitslice_transpose
 
-    addi    s1, x0, 5
-    beq     x0, x0, _handle_common_dv
+  addi    s1, x0, 5
+  beq     x0, x0, _handle_common_dv
 
 _handle_kn4_dv:
-    addi x4, x0, 17
-    bn.lid x4, 0(a1++)
-    /* group 0 -> w15 */
-    loopi 16, 2
-        bn.rshi w15, w17, w15 >> 16
-        bn.rshi w17, w31, w17 >> 4
-    endloop
-    /* group 1 -> w14 */
-    loopi 16, 2
-        bn.rshi w14, w17, w14 >> 16
-        bn.rshi w17, w31, w17 >> 4
-    endloop
-    /* group 2 -> w13 */
-    loopi 16, 2
-        bn.rshi w13, w17, w13 >> 16
-        bn.rshi w17, w31, w17 >> 4
-    endloop
-    /* group 3 -> w12 */
-    loopi 16, 2
-        bn.rshi w12, w17, w12 >> 16
-        bn.rshi w17, w31, w17 >> 4
-    endloop
-    bn.lid x4, 0(a1++)
-    /* group 4 -> w11 */
-    loopi 16, 2
-        bn.rshi w11, w17, w11 >> 16
-        bn.rshi w17, w31, w17 >> 4
-    endloop
-    /* group 5 -> w10 */
-    loopi 16, 2
-        bn.rshi w10, w17, w10 >> 16
-        bn.rshi w17, w31, w17 >> 4
-    endloop
-    /* group 6 -> w9 */
-    loopi 16, 2
-        bn.rshi w9, w17, w9 >> 16
-        bn.rshi w17, w31, w17 >> 4
-    endloop
-    /* group 7 -> w8 */
-    loopi 16, 2
-        bn.rshi w8, w17, w8 >> 16
-        bn.rshi w17, w31, w17 >> 4
-    endloop
-    bn.lid x4, 0(a1++)
-    /* group 8 -> w7 */
-    loopi 16, 2
-        bn.rshi w7, w17, w7 >> 16
-        bn.rshi w17, w31, w17 >> 4
-    endloop
-    /* group 9 -> w6 */
-    loopi 16, 2
-        bn.rshi w6, w17, w6 >> 16
-        bn.rshi w17, w31, w17 >> 4
-    endloop
-    /* group 10 -> w5 */
-    loopi 16, 2
-        bn.rshi w5, w17, w5 >> 16
-        bn.rshi w17, w31, w17 >> 4
-    endloop
-    /* group 11 -> w4 */
-    loopi 16, 2
-        bn.rshi w4, w17, w4 >> 16
-        bn.rshi w17, w31, w17 >> 4
-    endloop
-    bn.lid x4, 0(a1++)
-    /* group 12 -> w3 */
-    loopi 16, 2
-        bn.rshi w3, w17, w3 >> 16
-        bn.rshi w17, w31, w17 >> 4
-    endloop
-    /* group 13 -> w2 */
-    loopi 16, 2
-        bn.rshi w2, w17, w2 >> 16
-        bn.rshi w17, w31, w17 >> 4
-    endloop
-    /* group 14 -> w1 */
-    loopi 16, 2
-        bn.rshi w1, w17, w1 >> 16
-        bn.rshi w17, w31, w17 >> 4
-    endloop
-    /* group 15 -> w0 */
-    loopi 16, 2
-        bn.rshi w0, w17, w0 >> 16
-        bn.rshi w17, w31, w17 >> 4
-    endloop
-    jal x1, _bitslice_transpose
+  addi x4, x0, 17
+  bn.lid x4, 0(a1++)
+  /* group 0 -> w15 */
+  loopi 16, 2
+    bn.rshi w15, w17, w15 >> 16
+    bn.rshi w17, w31, w17 >> 4
+  endloop
+  /* group 1 -> w14 */
+  loopi 16, 2
+    bn.rshi w14, w17, w14 >> 16
+    bn.rshi w17, w31, w17 >> 4
+  endloop
+  /* group 2 -> w13 */
+  loopi 16, 2
+    bn.rshi w13, w17, w13 >> 16
+    bn.rshi w17, w31, w17 >> 4
+  endloop
+  /* group 3 -> w12 */
+  loopi 16, 2
+    bn.rshi w12, w17, w12 >> 16
+    bn.rshi w17, w31, w17 >> 4
+  endloop
+  bn.lid x4, 0(a1++)
+  /* group 4 -> w11 */
+  loopi 16, 2
+    bn.rshi w11, w17, w11 >> 16
+    bn.rshi w17, w31, w17 >> 4
+  endloop
+  /* group 5 -> w10 */
+  loopi 16, 2
+    bn.rshi w10, w17, w10 >> 16
+    bn.rshi w17, w31, w17 >> 4
+  endloop
+  /* group 6 -> w9 */
+  loopi 16, 2
+    bn.rshi w9, w17, w9 >> 16
+    bn.rshi w17, w31, w17 >> 4
+  endloop
+  /* group 7 -> w8 */
+  loopi 16, 2
+    bn.rshi w8, w17, w8 >> 16
+    bn.rshi w17, w31, w17 >> 4
+  endloop
+  bn.lid x4, 0(a1++)
+  /* group 8 -> w7 */
+  loopi 16, 2
+    bn.rshi w7, w17, w7 >> 16
+    bn.rshi w17, w31, w17 >> 4
+  endloop
+  /* group 9 -> w6 */
+  loopi 16, 2
+    bn.rshi w6, w17, w6 >> 16
+    bn.rshi w17, w31, w17 >> 4
+  endloop
+  /* group 10 -> w5 */
+  loopi 16, 2
+    bn.rshi w5, w17, w5 >> 16
+    bn.rshi w17, w31, w17 >> 4
+  endloop
+  /* group 11 -> w4 */
+  loopi 16, 2
+    bn.rshi w4, w17, w4 >> 16
+    bn.rshi w17, w31, w17 >> 4
+  endloop
+  bn.lid x4, 0(a1++)
+  /* group 12 -> w3 */
+  loopi 16, 2
+    bn.rshi w3, w17, w3 >> 16
+    bn.rshi w17, w31, w17 >> 4
+  endloop
+  /* group 13 -> w2 */
+  loopi 16, 2
+    bn.rshi w2, w17, w2 >> 16
+    bn.rshi w17, w31, w17 >> 4
+  endloop
+  /* group 14 -> w1 */
+  loopi 16, 2
+    bn.rshi w1, w17, w1 >> 16
+    bn.rshi w17, w31, w17 >> 4
+  endloop
+  /* group 15 -> w0 */
+  loopi 16, 2
+    bn.rshi w0, w17, w0 >> 16
+    bn.rshi w17, w31, w17 >> 4
+  endloop
+  jal x1, _bitslice_transpose
 
-    addi    s1, x0, 4
+  addi    s1, x0, 4
 
 _handle_common_dv:
-    /* t[0] ^= c ^ ((1 << N) - 1):  c-planes are now w0..w3 if s1 != 4 else w0..w4. */
-    bn.subi w15, w31, 1
-    addi    t0, sp, 0 /* ptr_t */
+  /* t[0] ^= c ^ ((1 << N) - 1):  c-planes are now w0..w3 if s1 != 4 else w0..w4. */
+  bn.subi w15, w31, 1
+  addi    t0, sp, 0 /* ptr_t */
 
-    bn.lid  x4, 0(t0)
-    bn.xor  w0, w0, w15
-    bn.xor  w17, w17, w0
-    bn.sid  x4, 0(t0++)
+  bn.lid  x4, 0(t0)
+  bn.xor  w0, w0, w15
+  bn.xor  w17, w17, w0
+  bn.sid  x4, 0(t0++)
 
-    bn.lid  x4, 0(t0)
-    bn.xor  w1, w1, w15
-    bn.xor  w17, w17, w1
-    bn.sid  x4, 0(t0++)
+  bn.lid  x4, 0(t0)
+  bn.xor  w1, w1, w15
+  bn.xor  w17, w17, w1
+  bn.sid  x4, 0(t0++)
 
-    bn.lid  x4, 0(t0)
-    bn.xor  w2, w2, w15
-    bn.xor  w17, w17, w2
-    bn.sid  x4, 0(t0++)
+  bn.lid  x4, 0(t0)
+  bn.xor  w2, w2, w15
+  bn.xor  w17, w17, w2
+  bn.sid  x4, 0(t0++)
 
-    bn.lid  x4, 0(t0)
-    bn.xor  w3, w3, w15
-    bn.xor  w17, w17, w3
-    bn.sid  x4, 0(t0++)
+  bn.lid  x4, 0(t0)
+  bn.xor  w3, w3, w15
+  bn.xor  w17, w17, w3
+  bn.sid  x4, 0(t0++)
 
-    addi    t1, x0, 4
-    beq     s1, t1, _skip_bit_4
+  addi    t1, x0, 4
+  beq     s1, t1, _skip_bit_4
 
-    bn.lid  x4, 0(t0)
-    bn.xor  w4, w4, w15
-    bn.xor  w17, w17, w4
-    bn.sid  x4, 0(t0++)
+  bn.lid  x4, 0(t0)
+  bn.xor  w4, w4, w15
+  bn.xor  w17, w17, w4
+  bn.sid  x4, 0(t0++)
 
 _skip_bit_4:
-    /* Compute r = secand(r, t). */
-    addi a1, x0, 32
-    addi a2, sp, 0 /* ptr_t */
-    addi a3, s2, 0 /* share_str */
-    addi a6, x0, 32 /* output share_str */
-    /* After the secand, the input and output pointers will point to
-     * next bit so we don't have to pass all the arguments above to secand again. */
-    loop s1, 4
-        addi a0, s4, 0 /* ptr_r */
-        addi a5, s4, 0 /* ptr_r */
-        jal  x1, secand
-        nop
-    endloop
+  /* Compute r = secand(r, t). */
+  addi a1, x0, 32
+  addi a2, sp, 0 /* ptr_t */
+  addi a3, s2, 0 /* share_str */
+  addi a6, x0, 32 /* output share_str */
+  /* After the secand, the input and output pointers will point to
+   * next bit so we don't have to pass all the arguments above to secand again. */
+  loop s1, 4
+    addi a0, s4, 0 /* ptr_r */
+    addi a5, s4, 0 /* ptr_r */
+    jal  x1, secand
+    nop
+  endloop
 
-    /* Restore registers. */
-    lw   s0, 324(sp)
-    lw   s1, 328(sp)
-    lw   s2, 332(sp)
-    lw   s4, 340(sp)
-    lw   a5, 344(sp)
-    addi sp, sp, 352
-    ret
+  /* Restore registers. */
+  lw   s0, 324(sp)
+  lw   s1, 328(sp)
+  lw   s2, 332(sp)
+  lw   s4, 340(sp)
+  lw   a5, 344(sp)
+  addi sp, sp, 352
+  ret
 
 
 /*
@@ -3154,404 +3154,404 @@ _skip_bit_4:
 .globl poly_masked_compare_du
 .type poly_masked_compare_du, @function
 poly_masked_compare_du:
-    /* Allocate t scratch (2 shares * 352 B, du = 11 worst case) + saves. */
-    addi sp, sp, -736
-    sw   s0, 708(sp)
-    sw   s1, 712(sp)
-    sw   s2, 716(sp)
-    sw   s4, 724(sp)
-    sw   a5, 728(sp)
+  /* Allocate t scratch (2 shares * 352 B, du = 11 worst case) + saves. */
+  addi sp, sp, -736
+  sw   s0, 708(sp)
+  sw   s1, 712(sp)
+  sw   s2, 716(sp)
+  sw   s4, 724(sp)
+  sw   a5, 728(sp)
 
-    /* Save input/output addresses. */
-    addi s0, a0, 0
-    addi s1, a1, 0
-    addi s2, a2, 0
-    addi s4, a4, 0
+  /* Save input/output addresses. */
+  addi s0, a0, 0
+  addi s1, a1, 0
+  addi s2, a2, 0
+  addi s4, a4, 0
 
-    /* Compute t = poly_hocompress(cprime). */
-    addi a0, s0, 0 /* ptr_cprime */
-    addi a2, sp, 0 /* ptr_t */
-    addi a3, a5, 0 /* k */
-    jal  x1, polyvec_hocompress
+  /* Compute t = poly_hocompress(cprime). */
+  addi a0, s0, 0 /* ptr_cprime */
+  addi a2, sp, 0 /* ptr_t */
+  addi a3, a5, 0 /* k */
+  jal  x1, polyvec_hocompress
 
-    /* Decode + bitslice c. */
-    addi a1, s1, 0 /* ptr_c */
+  /* Decode + bitslice c. */
+  addi a1, s1, 0 /* ptr_c */
 
-    addi x4, x0, 4
-    lw   a5, 728(sp)
-    bne  a5, x4, _handle_kn4_du
+  addi x4, x0, 4
+  lw   a5, 728(sp)
+  bne  a5, x4, _handle_kn4_du
 
 _handle_k4_du:
-    /* group 0 -> w15 */
-    addi   x4, x0, 17
-	bn.lid x4, 0(a1++)
-	loopi 16, 2
-		bn.rshi w15, w17, w15 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-
+  /* group 0 -> w15 */
+  addi   x4, x0, 17
+  bn.lid x4, 0(a1++)
+  loopi 16, 2
+    bn.rshi w15, w17, w15 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  
     /* group 1 -> w14 */
-	loopi 7, 2
-		bn.rshi w14, w17, w14 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-	bn.rshi w14, w17, w14 >> 3
-	bn.lid  x4, 0(a1++)
-	bn.rshi w14, w17, w14 >> 13
-	bn.rshi w17, w31, w17 >> 8
-	loopi 8, 2
-		bn.rshi w14, w17, w14 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-
-    /* group 2 -> w13 */
-	loopi 14, 2
-		bn.rshi w13, w17, w13 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-	bn.rshi w13, w17, w13 >> 6
-	bn.lid  x4, 0(a1++)
-	bn.rshi w13, w17, w13 >> 10
-	bn.rshi w17, w31, w17 >> 5
-	bn.rshi w13, w17, w13 >> 16
-	bn.rshi w17, w31, w17 >> 11
-
-    /* group 3 -> w12 */
-	loopi 16, 2
-		bn.rshi w12, w17, w12 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-
-    /* group 4 -> w11 */
-	loopi 5, 2
-		bn.rshi w11, w17, w11 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-	bn.rshi w11, w17, w11 >> 9
-	bn.lid  x4, 0(a1++)
-	bn.rshi w11, w17, w11 >> 7
-	bn.rshi w17, w31, w17 >> 2
-	loopi 10, 2
-		bn.rshi w11, w17, w11 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-
-    /* group 5 -> w10 */
-	loopi 13, 2
-		bn.rshi w10, w17, w10 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-	bn.rshi w10, w17, w10 >> 1
-	bn.lid  x4, 0(a1++)
-	bn.rshi w10, w17, w10 >> 15
-	bn.rshi w17, w31, w17 >> 10
-	loopi 2, 2
-		bn.rshi w10, w17, w10 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-
-    /* group 6 -> w9 */
-	loopi 16, 2
-		bn.rshi w9, w17, w9 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-
-    /* group 7 -> w8 */
-	loopi 4, 2
-		bn.rshi w8, w17, w8 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-	bn.rshi w8, w17, w8 >> 4
-	bn.lid  x4, 0(a1++)
-	bn.rshi w8, w17, w8 >> 12
-	bn.rshi w17, w31, w17 >> 7
-	loopi 11, 2
-		bn.rshi w8, w17, w8 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-
-    /* group 8 -> w7 */
-	loopi 11, 2
-		bn.rshi w7, w17, w7 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-	bn.rshi w7, w17, w7 >> 7
-	bn.lid  x4, 0(a1++)
-	bn.rshi w7, w17, w7 >> 9
-	bn.rshi w17, w31, w17 >> 4
-	loopi 4, 2
-		bn.rshi w7, w17, w7 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-
-    /* group 9 -> w6 */
-	loopi 16, 2
-		bn.rshi w6, w17, w6 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-
-    /* group 10 -> w5 */
-	loopi 2, 2
-		bn.rshi w5, w17, w5 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-	bn.rshi w5, w17, w5 >> 10
-	bn.lid  x4, 0(a1++)
-	bn.rshi w5, w17, w5 >> 6
-	bn.rshi w17, w31, w17 >> 1
-	loopi 13, 2
-		bn.rshi w5, w17, w5 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-
-    /* group 11 -> w4 */
-	loopi 10, 2
-		bn.rshi w4, w17, w4 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-	bn.rshi w4, w17, w4 >> 2
-	bn.lid  x4, 0(a1++)
-	bn.rshi w4, w17, w4 >> 14
-	bn.rshi w17, w31, w17 >> 9
-	loopi 5, 2
-		bn.rshi w4, w17, w4 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-
-    /* group 12 -> w3 */
-	loopi 16, 2
-		bn.rshi w3, w17, w3 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-
-    /* group 13 -> w2 */
-	bn.rshi w2, w17, w2 >> 16
-	bn.rshi w17, w31, w17 >> 11
-	bn.rshi w2, w17, w2 >> 5
-	bn.lid  x4, 0(a1++)
-	bn.rshi w2, w17, w2 >> 11
-	bn.rshi w17, w31, w17 >> 6
-	loopi 14, 2
-		bn.rshi w2, w17, w2 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-
-    /* group 14 -> w1 */
-	loopi 8, 2
-		bn.rshi w1, w17, w1 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-	bn.rshi w1, w17, w1 >> 8
-	bn.lid  x4, 0(a1++)
-	bn.rshi w1, w17, w1 >> 8
-	bn.rshi w17, w31, w17 >> 3
-	loopi 7, 2
-		bn.rshi w1, w17, w1 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-
-    /* group 15 -> w0 */
-	loopi 16, 2
-		bn.rshi w0, w17, w0 >> 16
-		bn.rshi w17, w31, w17 >> 11
-	endloop
-    jal x1, _bitslice_transpose
-
-    addi s1, x0, 11 /* du */
-    beq  x0, x0, _handle_common_du
+  loopi 7, 2
+    bn.rshi w14, w17, w14 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  bn.rshi w14, w17, w14 >> 3
+  bn.lid  x4, 0(a1++)
+  bn.rshi w14, w17, w14 >> 13
+  bn.rshi w17, w31, w17 >> 8
+  loopi 8, 2
+    bn.rshi w14, w17, w14 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  
+  /* group 2 -> w13 */
+  loopi 14, 2
+    bn.rshi w13, w17, w13 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  bn.rshi w13, w17, w13 >> 6
+  bn.lid  x4, 0(a1++)
+  bn.rshi w13, w17, w13 >> 10
+  bn.rshi w17, w31, w17 >> 5
+  bn.rshi w13, w17, w13 >> 16
+  bn.rshi w17, w31, w17 >> 11
+  
+  /* group 3 -> w12 */
+  loopi 16, 2
+    bn.rshi w12, w17, w12 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  
+  /* group 4 -> w11 */
+  loopi 5, 2
+    bn.rshi w11, w17, w11 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  bn.rshi w11, w17, w11 >> 9
+  bn.lid  x4, 0(a1++)
+  bn.rshi w11, w17, w11 >> 7
+  bn.rshi w17, w31, w17 >> 2
+  loopi 10, 2
+    bn.rshi w11, w17, w11 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  
+  /* group 5 -> w10 */
+  loopi 13, 2
+    bn.rshi w10, w17, w10 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  bn.rshi w10, w17, w10 >> 1
+  bn.lid  x4, 0(a1++)
+  bn.rshi w10, w17, w10 >> 15
+  bn.rshi w17, w31, w17 >> 10
+  loopi 2, 2
+    bn.rshi w10, w17, w10 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  
+  /* group 6 -> w9 */
+  loopi 16, 2
+    bn.rshi w9, w17, w9 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  
+  /* group 7 -> w8 */
+  loopi 4, 2
+    bn.rshi w8, w17, w8 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  bn.rshi w8, w17, w8 >> 4
+  bn.lid  x4, 0(a1++)
+  bn.rshi w8, w17, w8 >> 12
+  bn.rshi w17, w31, w17 >> 7
+  loopi 11, 2
+    bn.rshi w8, w17, w8 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  
+  /* group 8 -> w7 */
+  loopi 11, 2
+    bn.rshi w7, w17, w7 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  bn.rshi w7, w17, w7 >> 7
+  bn.lid  x4, 0(a1++)
+  bn.rshi w7, w17, w7 >> 9
+  bn.rshi w17, w31, w17 >> 4
+  loopi 4, 2
+    bn.rshi w7, w17, w7 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  
+  /* group 9 -> w6 */
+  loopi 16, 2
+    bn.rshi w6, w17, w6 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  
+  /* group 10 -> w5 */
+  loopi 2, 2
+    bn.rshi w5, w17, w5 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  bn.rshi w5, w17, w5 >> 10
+  bn.lid  x4, 0(a1++)
+  bn.rshi w5, w17, w5 >> 6
+  bn.rshi w17, w31, w17 >> 1
+  loopi 13, 2
+    bn.rshi w5, w17, w5 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  
+  /* group 11 -> w4 */
+  loopi 10, 2
+    bn.rshi w4, w17, w4 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  bn.rshi w4, w17, w4 >> 2
+  bn.lid  x4, 0(a1++)
+  bn.rshi w4, w17, w4 >> 14
+  bn.rshi w17, w31, w17 >> 9
+  loopi 5, 2
+    bn.rshi w4, w17, w4 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  
+  /* group 12 -> w3 */
+  loopi 16, 2
+    bn.rshi w3, w17, w3 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  
+  /* group 13 -> w2 */
+  bn.rshi w2, w17, w2 >> 16
+  bn.rshi w17, w31, w17 >> 11
+  bn.rshi w2, w17, w2 >> 5
+  bn.lid  x4, 0(a1++)
+  bn.rshi w2, w17, w2 >> 11
+  bn.rshi w17, w31, w17 >> 6
+  loopi 14, 2
+    bn.rshi w2, w17, w2 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  
+  /* group 14 -> w1 */
+  loopi 8, 2
+    bn.rshi w1, w17, w1 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  bn.rshi w1, w17, w1 >> 8
+  bn.lid  x4, 0(a1++)
+  bn.rshi w1, w17, w1 >> 8
+  bn.rshi w17, w31, w17 >> 3
+  loopi 7, 2
+    bn.rshi w1, w17, w1 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  
+  /* group 15 -> w0 */
+  loopi 16, 2
+    bn.rshi w0, w17, w0 >> 16
+    bn.rshi w17, w31, w17 >> 11
+  endloop
+  jal x1, _bitslice_transpose
+  
+  addi s1, x0, 11 /* du */
+  beq  x0, x0, _handle_common_du
 
 _handle_kn4_du:
-    addi x4, x0, 17
-    addi t0, x0, 15
-    addi t1, x0, 18
-    loopi 2, 69
-        /* group i + 0 */
-		bn.lid x4, 0(a1++)
-		loopi 16, 2
-			bn.rshi w18, w17, w18 >> 16
-			bn.rshi w17, w31, w17 >> 10
-		endloop
-        bn.movr t0, t1
-        addi    t0, t0, -1
-
-        /* group i + 1 */
-		loopi 9, 2
-			bn.rshi w18, w17, w18 >> 16
-			bn.rshi w17, w31, w17 >> 10
-		endloop
-		bn.rshi w18, w17, w18 >> 6
-		bn.lid  x4, 0(a1++)
-		bn.rshi w18, w17, w18 >> 10
-		bn.rshi w17, w31, w17 >> 4
-		loopi 6, 2
-			bn.rshi w18, w17, w18 >> 16
-			bn.rshi w17, w31, w17 >> 10
-		endloop
-        bn.movr t0, t1
-        addi    t0, t0, -1
-
-        /* group i + 2 */
-		loopi 16, 2
-			bn.rshi w18, w17, w18 >> 16
-			bn.rshi w17, w31, w17 >> 10
-		endloop
-        bn.movr t0, t1
-        addi    t0, t0, -1
-
-        /* group i + 3 */
-		loopi 3, 2
-			bn.rshi w18, w17, w18 >> 16
-			bn.rshi w17, w31, w17 >> 10
-		endloop
-		bn.rshi w18, w17, w18 >> 2
-		bn.lid  x4, 0(a1++)
-		bn.rshi w18, w17, w18 >> 14
-		bn.rshi w17, w31, w17 >> 8
-		loopi 12, 2
-			bn.rshi w18, w17, w18 >> 16
-			bn.rshi w17, w31, w17 >> 10
-		endloop
-        bn.movr t0, t1
-        addi    t0, t0, -1
-
-        /* group i + 4 */
-		loopi 12, 2
-			bn.rshi w18, w17, w18 >> 16
-			bn.rshi w17, w31, w17 >> 10
-		endloop
-		bn.rshi w18, w17, w18 >> 8
-		bn.lid  x4, 0(a1++)
-		bn.rshi w18, w17, w18 >> 8
-		bn.rshi w17, w31, w17 >> 2
-		loopi 3, 2
-			bn.rshi w18, w17, w18 >> 16
-			bn.rshi w17, w31, w17 >> 10
-		endloop
-        bn.movr t0, t1
-        addi    t0, t0, -1
-
-        /* group i + 5 */
-		loopi 16, 2
-			bn.rshi w18, w17, w18 >> 16
-			bn.rshi w17, w31, w17 >> 10
-		endloop
-        bn.movr t0, t1
-        addi    t0, t0, -1
-
-        /* group i + 6 */
-		loopi 6, 2
-			bn.rshi w18, w17, w18 >> 16
-			bn.rshi w17, w31, w17 >> 10
-		endloop
-		bn.rshi w18, w17, w18 >> 4
-		bn.lid  x4, 0(a1++)
-		bn.rshi w18, w17, w18 >> 12
-		bn.rshi w17, w31, w17 >> 6
-		loopi 9, 2
-			bn.rshi w18, w17, w18 >> 16
-			bn.rshi w17, w31, w17 >> 10
-		endloop
-        bn.movr t0, t1
-        addi    t0, t0, -1
-
-        /* group i + 7 */
-		loopi 16, 2
-			bn.rshi w18, w17, w18 >> 16
-			bn.rshi w17, w31, w17 >> 10
-		endloop
-        bn.movr t0, t1
-        addi    t0, t0, -1
+  addi x4, x0, 17
+  addi t0, x0, 15
+  addi t1, x0, 18
+  loopi 2, 69
+    /* group i + 0 */
+    bn.lid x4, 0(a1++)
+    loopi 16, 2
+      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w17, w31, w17 >> 10
     endloop
-    jal x1, _bitslice_transpose
-
-    addi s1, x0, 10 /* du */
+    bn.movr t0, t1
+    addi    t0, t0, -1
+    
+    /* group i + 1 */
+    loopi 9, 2
+      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w17, w31, w17 >> 10
+    endloop
+    bn.rshi w18, w17, w18 >> 6
+    bn.lid  x4, 0(a1++)
+    bn.rshi w18, w17, w18 >> 10
+    bn.rshi w17, w31, w17 >> 4
+    loopi 6, 2
+      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w17, w31, w17 >> 10
+    endloop
+    bn.movr t0, t1
+    addi    t0, t0, -1
+    
+    /* group i + 2 */
+    loopi 16, 2
+      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w17, w31, w17 >> 10
+    endloop
+    bn.movr t0, t1
+    addi    t0, t0, -1
+    
+    /* group i + 3 */
+    loopi 3, 2
+      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w17, w31, w17 >> 10
+    endloop
+    bn.rshi w18, w17, w18 >> 2
+    bn.lid  x4, 0(a1++)
+    bn.rshi w18, w17, w18 >> 14
+    bn.rshi w17, w31, w17 >> 8
+    loopi 12, 2
+      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w17, w31, w17 >> 10
+    endloop
+    bn.movr t0, t1
+    addi    t0, t0, -1
+    
+    /* group i + 4 */
+    loopi 12, 2
+      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w17, w31, w17 >> 10
+    endloop
+    bn.rshi w18, w17, w18 >> 8
+    bn.lid  x4, 0(a1++)
+    bn.rshi w18, w17, w18 >> 8
+    bn.rshi w17, w31, w17 >> 2
+    loopi 3, 2
+      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w17, w31, w17 >> 10
+    endloop
+    bn.movr t0, t1
+    addi    t0, t0, -1
+    
+    /* group i + 5 */
+    loopi 16, 2
+      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w17, w31, w17 >> 10
+    endloop
+    bn.movr t0, t1
+    addi    t0, t0, -1
+    
+    /* group i + 6 */
+    loopi 6, 2
+      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w17, w31, w17 >> 10
+    endloop
+    bn.rshi w18, w17, w18 >> 4
+    bn.lid  x4, 0(a1++)
+    bn.rshi w18, w17, w18 >> 12
+    bn.rshi w17, w31, w17 >> 6
+    loopi 9, 2
+      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w17, w31, w17 >> 10
+    endloop
+    bn.movr t0, t1
+    addi    t0, t0, -1
+    
+    /* group i + 7 */
+    loopi 16, 2
+      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w17, w31, w17 >> 10
+    endloop
+    bn.movr t0, t1
+    addi    t0, t0, -1
+  endloop
+  jal x1, _bitslice_transpose
+    
+  addi s1, x0, 10 /* du */
 
 _handle_common_du:
-    /* t[0] ^= c ^ ((1 << N) - 1):  c-planes are now w0..w9. */
-    bn.subi w15, w31, 1
-    addi    t0, sp, 0 /* ptr_t */
+  /* t[0] ^= c ^ ((1 << N) - 1):  c-planes are now w0..w9. */
+  bn.subi w15, w31, 1
+  addi    t0, sp, 0 /* ptr_t */
 
-    bn.lid x4, 0(t0)
-    bn.xor w0, w0, w15
-    bn.xor w17, w17, w0
-    bn.sid x4, 0(t0++)
+  bn.lid x4, 0(t0)
+  bn.xor w0, w0, w15
+  bn.xor w17, w17, w0
+  bn.sid x4, 0(t0++)
 
-    bn.lid x4, 0(t0)
-    bn.xor w1, w1, w15
-    bn.xor w17, w17, w1
-    bn.sid x4, 0(t0++)
+  bn.lid x4, 0(t0)
+  bn.xor w1, w1, w15
+  bn.xor w17, w17, w1
+  bn.sid x4, 0(t0++)
 
-    bn.lid x4, 0(t0)
-    bn.xor w2, w2, w15
-    bn.xor w17, w17, w2
-    bn.sid x4, 0(t0++)
+  bn.lid x4, 0(t0)
+  bn.xor w2, w2, w15
+  bn.xor w17, w17, w2
+  bn.sid x4, 0(t0++)
 
-    bn.lid x4, 0(t0)
-    bn.xor w3, w3, w15
-    bn.xor w17, w17, w3
-    bn.sid x4, 0(t0++)
+  bn.lid x4, 0(t0)
+  bn.xor w3, w3, w15
+  bn.xor w17, w17, w3
+  bn.sid x4, 0(t0++)
 
-    bn.lid x4, 0(t0)
-    bn.xor w4, w4, w15
-    bn.xor w17, w17, w4
-    bn.sid x4, 0(t0++)
+  bn.lid x4, 0(t0)
+  bn.xor w4, w4, w15
+  bn.xor w17, w17, w4
+  bn.sid x4, 0(t0++)
 
-    bn.lid x4, 0(t0)
-    bn.xor w5, w5, w15
-    bn.xor w17, w17, w5
-    bn.sid x4, 0(t0++)
+  bn.lid x4, 0(t0)
+  bn.xor w5, w5, w15
+  bn.xor w17, w17, w5
+  bn.sid x4, 0(t0++)
 
-    bn.lid x4, 0(t0)
-    bn.xor w6, w6, w15
-    bn.xor w17, w17, w6
-    bn.sid x4, 0(t0++)
+  bn.lid x4, 0(t0)
+  bn.xor w6, w6, w15
+  bn.xor w17, w17, w6
+  bn.sid x4, 0(t0++)
 
-    bn.lid x4, 0(t0)
-    bn.xor w7, w7, w15
-    bn.xor w17, w17, w7
-    bn.sid x4, 0(t0++)
+  bn.lid x4, 0(t0)
+  bn.xor w7, w7, w15
+  bn.xor w17, w17, w7
+  bn.sid x4, 0(t0++)
 
-    bn.lid x4, 0(t0)
-    bn.xor w8, w8, w15
-    bn.xor w17, w17, w8
-    bn.sid x4, 0(t0++)
+  bn.lid x4, 0(t0)
+  bn.xor w8, w8, w15
+  bn.xor w17, w17, w8
+  bn.sid x4, 0(t0++)
 
-    bn.lid x4, 0(t0)
-    bn.xor w9, w9, w15
-    bn.xor w17, w17, w9
-    bn.sid x4, 0(t0++)
+  bn.lid x4, 0(t0)
+  bn.xor w9, w9, w15
+  bn.xor w17, w17, w9
+  bn.sid x4, 0(t0++)
 
-    addi   t1, x0, 10
-    beq    s1, t1, _skip_bit_10
+  addi   t1, x0, 10
+  beq    s1, t1, _skip_bit_10
 
-    bn.lid x4, 0(t0)
-    bn.xor w10, w10, w15
-    bn.xor w17, w17, w10
-    bn.sid x4, 0(t0++)
+  bn.lid x4, 0(t0)
+  bn.xor w10, w10, w15
+  bn.xor w17, w17, w10
+  bn.sid x4, 0(t0++)
 
 _skip_bit_10:
-    /* Compute r = secand(r, t). */
-    addi a1, x0, 32
-    addi a2, sp, 0 /* ptr_t */
-    addi a3, s2, 0 /* share_str */
-    addi a6, x0, 32 /* output share_str */
-    /* After the secand, the input and output pointers will point to
-     * next bit so we don't have to pass all the arguments above to secand again. */
-    loop s1, 4
-        addi a0, s4, 0 /* ptr_r */
-        addi a5, s4, 0 /* ptr_r */
-        jal  x1, secand
-        nop
-    endloop
+  /* Compute r = secand(r, t). */
+  addi a1, x0, 32
+  addi a2, sp, 0 /* ptr_t */
+  addi a3, s2, 0 /* share_str */
+  addi a6, x0, 32 /* output share_str */
+  /* After the secand, the input and output pointers will point to
+   * next bit so we don't have to pass all the arguments above to secand again. */
+  loop s1, 4
+    addi a0, s4, 0 /* ptr_r */
+    addi a5, s4, 0 /* ptr_r */
+    jal  x1, secand
+    nop
+  endloop
 
-    /* Restore registers. */
-    lw   s0, 708(sp)
-    lw   s1, 712(sp)
-    lw   s2, 716(sp)
-    lw   s4, 724(sp)
-    lw   a5, 728(sp)
-    addi sp, sp, 736
-    ret
+  /* Restore registers. */
+  lw   s0, 708(sp)
+  lw   s1, 712(sp)
+  lw   s2, 716(sp)
+  lw   s4, 724(sp)
+  lw   a5, 728(sp)
+  addi sp, sp, 736
+  ret
 
 /*
  * Name: finalize_cmp
@@ -3570,190 +3570,190 @@ _skip_bit_10:
 .globl finalize_cmp
 .type finalize_cmp, @function
 finalize_cmp:
-    /* Allocate t scratch (2 shares * 32 B) and save s0. */
-    addi sp, sp, -96
-    sw s0, 68(sp)
+  /* Allocate t scratch (2 shares * 32 B) and save s0. */
+  addi sp, sp, -96
+  sw s0, 68(sp)
 
-    /* Save the in/out address. */
-    addi s0, a0, 0
+  /* Save the in/out address. */
+  addi s0, a0, 0
 
-    /* Compute x &= (x >> 128). */
-    /* Compute t = x >> 128. */
-    addi x4, x0, 1
-    addi t0, sp, 0 /* ptr_t */
-    loopi 2, 5
-        /* Whitening. */
-        bn.xor  w0, w0, w0
-        bn.xor  w1, w1, w1
-        bn.lid  x0, 0(a0++)
-        bn.rshi w1, w31, w0 >> 128
-        bn.sid  x4, 0(t0++)
-    endloop
-    /* Compute x &= t. */
-    addi a0, s0, 0
-    addi a1, x0, 32
-    addi a2, sp, 0
-    addi a3, x0, 32
-    addi a5, s0, 0
-    addi a6, x0, 32
-    jal  x1, secand
+  /* Compute x &= (x >> 128). */
+  /* Compute t = x >> 128. */
+  addi x4, x0, 1
+  addi t0, sp, 0 /* ptr_t */
+  loopi 2, 5
+    /* Whitening. */
+    bn.xor  w0, w0, w0
+    bn.xor  w1, w1, w1
+    bn.lid  x0, 0(a0++)
+    bn.rshi w1, w31, w0 >> 128
+    bn.sid  x4, 0(t0++)
+  endloop
+  /* Compute x &= t. */
+  addi a0, s0, 0
+  addi a1, x0, 32
+  addi a2, sp, 0
+  addi a3, x0, 32
+  addi a5, s0, 0
+  addi a6, x0, 32
+  jal  x1, secand
 
-    /* Compute x &= (x >> 64). */
-    /* Compute t = x >> 64. */
-    addi x4, x0, 1
-    addi a0, s0, 0
-    addi t0, sp, 0 /* ptr_t */
-    loopi 2, 5
-        /* Whitening. */
-        bn.xor  w0, w0, w0
-        bn.xor  w1, w1, w1
-        bn.lid  x0, 0(a0++)
-        bn.rshi w1, w31, w0 >> 64
-        bn.sid  x4, 0(t0++)
-    endloop
-    /* Compute x &= t. */
-    addi a0, s0, 0
-    /* a1 is still 32. */
-    addi a2, sp, 0
-    /* a3 is still 32. */
-    addi a5, s0, 0
-    /* a6 is still 32. */
-    jal  x1, secand
+  /* Compute x &= (x >> 64). */
+  /* Compute t = x >> 64. */
+  addi x4, x0, 1
+  addi a0, s0, 0
+  addi t0, sp, 0 /* ptr_t */
+  loopi 2, 5
+    /* Whitening. */
+    bn.xor  w0, w0, w0
+    bn.xor  w1, w1, w1
+    bn.lid  x0, 0(a0++)
+    bn.rshi w1, w31, w0 >> 64
+    bn.sid  x4, 0(t0++)
+  endloop
+  /* Compute x &= t. */
+  addi a0, s0, 0
+  /* a1 is still 32. */
+  addi a2, sp, 0
+  /* a3 is still 32. */
+  addi a5, s0, 0
+  /* a6 is still 32. */
+  jal  x1, secand
 
-    /* Compute x &= (x >> 32). */
-    /* Compute t = x >> 32. */
-    addi x4, x0, 1
-    addi a0, s0, 0
-    addi t0, sp, 0 /* ptr_t */
-    loopi 2, 5
-        /* Whitening. */
-        bn.xor  w0, w0, w0
-        bn.xor  w1, w1, w1
-        bn.lid  x0, 0(a0++)
-        bn.rshi w1, w31, w0 >> 32
-        bn.sid  x4, 0(t0++)
-    endloop
-    /* Compute x &= t. */
-    addi a0, s0, 0
-    /* a1 is still 32. */
-    addi a2, sp, 0
-    /* a3 is still 32. */
-    addi a5, s0, 0
-    /* a6 is still 32. */
-    jal  x1, secand
+  /* Compute x &= (x >> 32). */
+  /* Compute t = x >> 32. */
+  addi x4, x0, 1
+  addi a0, s0, 0
+  addi t0, sp, 0 /* ptr_t */
+  loopi 2, 5
+    /* Whitening. */
+    bn.xor  w0, w0, w0
+    bn.xor  w1, w1, w1
+    bn.lid  x0, 0(a0++)
+    bn.rshi w1, w31, w0 >> 32
+    bn.sid  x4, 0(t0++)
+  endloop
+  /* Compute x &= t. */
+  addi a0, s0, 0
+  /* a1 is still 32. */
+  addi a2, sp, 0
+  /* a3 is still 32. */
+  addi a5, s0, 0
+  /* a6 is still 32. */
+  jal  x1, secand
 
-    /* Compute x &= (x >> 16). */
-    /* Compute t = x >> 16. */
-    addi x4, x0, 1
-    addi a0, s0, 0
-    addi t0, sp, 0 /* ptr_t */
-    loopi 2, 5
-        /* Whitening. */
-        bn.xor  w0, w0, w0
-        bn.xor  w1, w1, w1
-        bn.lid  x0, 0(a0++)
-        bn.rshi w1, w31, w0 >> 16
-        bn.sid  x4, 0(t0++)
-    endloop
-    /* Compute x &= t. */
-    addi a0, s0, 0
-    /* a1 is still 32. */
-    addi a2, sp, 0
-    /* a3 is still 32. */
-    addi a5, s0, 0
-    /* a6 is still 32. */
-    jal  x1, secand
+  /* Compute x &= (x >> 16). */
+  /* Compute t = x >> 16. */
+  addi x4, x0, 1
+  addi a0, s0, 0
+  addi t0, sp, 0 /* ptr_t */
+  loopi 2, 5
+    /* Whitening. */
+    bn.xor  w0, w0, w0
+    bn.xor  w1, w1, w1
+    bn.lid  x0, 0(a0++)
+    bn.rshi w1, w31, w0 >> 16
+    bn.sid  x4, 0(t0++)
+  endloop
+  /* Compute x &= t. */
+  addi a0, s0, 0
+  /* a1 is still 32. */
+  addi a2, sp, 0
+  /* a3 is still 32. */
+  addi a5, s0, 0
+  /* a6 is still 32. */
+  jal  x1, secand
 
-    /* Compute x &= (x >> 8). */
-    /* Compute t = x >> 8. */
-    addi x4, x0, 1
-    addi a0, s0, 0
-    addi t0, sp, 0 /* ptr_t */
-    loopi 2, 5
-        /* Whitening. */
-        bn.xor  w0, w0, w0
-        bn.xor  w1, w1, w1
-        bn.lid  x0, 0(a0++)
-        bn.rshi w1, w31, w0 >> 8
-        bn.sid  x4, 0(t0++)
-    endloop
-    /* Compute x &= t. */
-    addi a0, s0, 0
-    /* a1 is still 32. */
-    addi a2, sp, 0
-    /* a3 is still 32. */
-    addi a5, s0, 0
-    /* a6 is still 32. */
-    jal  x1, secand
+  /* Compute x &= (x >> 8). */
+  /* Compute t = x >> 8. */
+  addi x4, x0, 1
+  addi a0, s0, 0
+  addi t0, sp, 0 /* ptr_t */
+  loopi 2, 5
+    /* Whitening. */
+    bn.xor  w0, w0, w0
+    bn.xor  w1, w1, w1
+    bn.lid  x0, 0(a0++)
+    bn.rshi w1, w31, w0 >> 8
+    bn.sid  x4, 0(t0++)
+  endloop
+  /* Compute x &= t. */
+  addi a0, s0, 0
+  /* a1 is still 32. */
+  addi a2, sp, 0
+  /* a3 is still 32. */
+  addi a5, s0, 0
+  /* a6 is still 32. */
+  jal  x1, secand
 
-    /* Compute x &= (x >> 4). */
-    /* Compute t = x >> 4. */
-    addi x4, x0, 1
-    addi a0, s0, 0
-    addi t0, sp, 0 /* ptr_t */
-    loopi 2, 5
-        /* Whitening. */
-        bn.xor  w0, w0, w0
-        bn.xor  w1, w1, w1
-        bn.lid  x0, 0(a0++)
-        bn.rshi w1, w31, w0 >> 4
-        bn.sid  x4, 0(t0++)
-    endloop
-    /* Compute x &= t. */
-    addi a0, s0, 0
-    /* a1 is still 32. */
-    addi a2, sp, 0
-    /* a3 is still 32. */
-    addi a5, s0, 0
-    /* a6 is still 32. */
-    jal  x1, secand
+  /* Compute x &= (x >> 4). */
+  /* Compute t = x >> 4. */
+  addi x4, x0, 1
+  addi a0, s0, 0
+  addi t0, sp, 0 /* ptr_t */
+  loopi 2, 5
+    /* Whitening. */
+    bn.xor  w0, w0, w0
+    bn.xor  w1, w1, w1
+    bn.lid  x0, 0(a0++)
+    bn.rshi w1, w31, w0 >> 4
+    bn.sid  x4, 0(t0++)
+  endloop
+  /* Compute x &= t. */
+  addi a0, s0, 0
+  /* a1 is still 32. */
+  addi a2, sp, 0
+  /* a3 is still 32. */
+  addi a5, s0, 0
+  /* a6 is still 32. */
+  jal  x1, secand
 
-    /* Compute x &= (x >> 2). */
-    /* Compute t = x >> 2. */
-    addi x4, x0, 1
-    addi a0, s0, 0
-    addi t0, sp, 0 /* ptr_t */
-    loopi 2, 5
-        /* Whitening. */
-        bn.xor  w0, w0, w0
-        bn.xor  w1, w1, w1
-        bn.lid  x0, 0(a0++)
-        bn.rshi w1, w31, w0 >> 2
-        bn.sid  x4, 0(t0++)
-    endloop
-    /* Compute x &= t. */
-    addi a0, s0, 0
-    /* a1 is still 32. */
-    addi a2, sp, 0
-    /* a3 is still 32. */
-    addi a5, s0, 0
-    /* a6 is still 32. */
-    jal  x1, secand
+  /* Compute x &= (x >> 2). */
+  /* Compute t = x >> 2. */
+  addi x4, x0, 1
+  addi a0, s0, 0
+  addi t0, sp, 0 /* ptr_t */
+  loopi 2, 5
+    /* Whitening. */
+    bn.xor  w0, w0, w0
+    bn.xor  w1, w1, w1
+    bn.lid  x0, 0(a0++)
+    bn.rshi w1, w31, w0 >> 2
+    bn.sid  x4, 0(t0++)
+  endloop
+  /* Compute x &= t. */
+  addi a0, s0, 0
+  /* a1 is still 32. */
+  addi a2, sp, 0
+  /* a3 is still 32. */
+  addi a5, s0, 0
+  /* a6 is still 32. */
+  jal  x1, secand
 
-    /* Compute x &= (x >> 1). */
-    /* Compute t = x >> 1. */
-    addi x4, x0, 1
-    addi a0, s0, 0
-    addi t0, sp, 0 /* ptr_t */
-    loopi 2, 5
-        /* Whitening. */
-        bn.xor  w0, w0, w0
-        bn.xor  w1, w1, w1
-        bn.lid  x0, 0(a0++)
-        bn.rshi w1, w31, w0 >> 1
-        bn.sid  x4, 0(t0++)
-    endloop
-    /* Compute x &= t. */
-    addi a0, s0, 0
-    /* a1 is still 32. */
-    addi a2, sp, 0
-    /* a3 is still 32. */
-    addi a5, s0, 0
-    /* a6 is still 32. */
-    jal  x1, secand
+  /* Compute x &= (x >> 1). */
+  /* Compute t = x >> 1. */
+  addi x4, x0, 1
+  addi a0, s0, 0
+  addi t0, sp, 0 /* ptr_t */
+  loopi 2, 5
+    /* Whitening. */
+    bn.xor  w0, w0, w0
+    bn.xor  w1, w1, w1
+    bn.lid  x0, 0(a0++)
+    bn.rshi w1, w31, w0 >> 1
+    bn.sid  x4, 0(t0++)
+  endloop
+  /* Compute x &= t. */
+  addi a0, s0, 0
+  /* a1 is still 32. */
+  addi a2, sp, 0
+  /* a3 is still 32. */
+  addi a5, s0, 0
+  /* a6 is still 32. */
+  jal  x1, secand
 
-    /* Restore s0. */
-    lw s0, 68(sp)
+  /* Restore s0. */
+  lw s0, 68(sp)
 
-    addi sp, sp, 96
-    ret
+  addi sp, sp, 96
+  ret

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -456,18 +456,18 @@ poly_rej_samp:
   la        x6, modulus_times_19_minus_1
   bn.lid    x5++, 0(x6)
   bn.shv.8s w1, w1 >> 16
-  
+
   /* Load mont = 2^16 % q. */
   la     x6, mont
   bn.lid x5, 0(x6)
-  
+
   /* x10 + 512 is the last valid address. */
   addi x5, x10, 512
 
 #if defined(MLKEM_REJ_SAMPLE_TEST)
   addi x30, x0, 3
 #endif
-  
+
   /* Loop until 256 coefficients have been written to the output. */
 _rej_sample_loop:
   /* Get 16 randoms. */
@@ -486,11 +486,11 @@ _rej_sample_loop:
   bn.xor      w4, w4, w31, FG0
   csrrs       x6, fg0, x0 /* Read flag fg0. */
   srli        x6, x6, 3   /* Extract fg0.z */
-  
+
   /* If fg0.z == 0, there is at least one bad coeff. We throw away this
    * vector and sample again. */
   beq x6, x0, _rej_sample_loop
-  
+
   /* Once the whole vector is accepted, reduce the accepted candidates mod Q
    * using Montgomery. */
   bn.mulv.16h.acc.z.lo w0, w3, w2
@@ -498,7 +498,7 @@ _rej_sample_loop:
   bn.mulv.l.16h.acc.hi w0, w0, sw0.0
   bn.addvm.16h         w0, w0, w31
   bn.sid               x0, 0(x10++)
-  
+
   /* If we reach the last valid address, we've filled up a polynomial.
    * Otherwise, continue to sample. */
   beq x10, x5, _end_rej_sample_loop
@@ -3192,7 +3192,7 @@ _handle_k4_du:
     bn.rshi w15, w17, w15 >> 16
     bn.rshi w17, w31, w17 >> 11
   endloop
-  
+
     /* group 1 -> w14 */
   loopi 7, 2
     bn.rshi w14, w17, w14 >> 16
@@ -3206,7 +3206,7 @@ _handle_k4_du:
     bn.rshi w14, w17, w14 >> 16
     bn.rshi w17, w31, w17 >> 11
   endloop
-  
+
   /* group 2 -> w13 */
   loopi 14, 2
     bn.rshi w13, w17, w13 >> 16
@@ -3218,13 +3218,13 @@ _handle_k4_du:
   bn.rshi w17, w31, w17 >> 5
   bn.rshi w13, w17, w13 >> 16
   bn.rshi w17, w31, w17 >> 11
-  
+
   /* group 3 -> w12 */
   loopi 16, 2
     bn.rshi w12, w17, w12 >> 16
     bn.rshi w17, w31, w17 >> 11
   endloop
-  
+
   /* group 4 -> w11 */
   loopi 5, 2
     bn.rshi w11, w17, w11 >> 16
@@ -3238,7 +3238,7 @@ _handle_k4_du:
     bn.rshi w11, w17, w11 >> 16
     bn.rshi w17, w31, w17 >> 11
   endloop
-  
+
   /* group 5 -> w10 */
   loopi 13, 2
     bn.rshi w10, w17, w10 >> 16
@@ -3252,13 +3252,13 @@ _handle_k4_du:
     bn.rshi w10, w17, w10 >> 16
     bn.rshi w17, w31, w17 >> 11
   endloop
-  
+
   /* group 6 -> w9 */
   loopi 16, 2
     bn.rshi w9, w17, w9 >> 16
     bn.rshi w17, w31, w17 >> 11
   endloop
-  
+
   /* group 7 -> w8 */
   loopi 4, 2
     bn.rshi w8, w17, w8 >> 16
@@ -3272,7 +3272,7 @@ _handle_k4_du:
     bn.rshi w8, w17, w8 >> 16
     bn.rshi w17, w31, w17 >> 11
   endloop
-  
+
   /* group 8 -> w7 */
   loopi 11, 2
     bn.rshi w7, w17, w7 >> 16
@@ -3286,13 +3286,13 @@ _handle_k4_du:
     bn.rshi w7, w17, w7 >> 16
     bn.rshi w17, w31, w17 >> 11
   endloop
-  
+
   /* group 9 -> w6 */
   loopi 16, 2
     bn.rshi w6, w17, w6 >> 16
     bn.rshi w17, w31, w17 >> 11
   endloop
-  
+
   /* group 10 -> w5 */
   loopi 2, 2
     bn.rshi w5, w17, w5 >> 16
@@ -3306,7 +3306,7 @@ _handle_k4_du:
     bn.rshi w5, w17, w5 >> 16
     bn.rshi w17, w31, w17 >> 11
   endloop
-  
+
   /* group 11 -> w4 */
   loopi 10, 2
     bn.rshi w4, w17, w4 >> 16
@@ -3320,13 +3320,13 @@ _handle_k4_du:
     bn.rshi w4, w17, w4 >> 16
     bn.rshi w17, w31, w17 >> 11
   endloop
-  
+
   /* group 12 -> w3 */
   loopi 16, 2
     bn.rshi w3, w17, w3 >> 16
     bn.rshi w17, w31, w17 >> 11
   endloop
-  
+
   /* group 13 -> w2 */
   bn.rshi w2, w17, w2 >> 16
   bn.rshi w17, w31, w17 >> 11
@@ -3338,7 +3338,7 @@ _handle_k4_du:
     bn.rshi w2, w17, w2 >> 16
     bn.rshi w17, w31, w17 >> 11
   endloop
-  
+
   /* group 14 -> w1 */
   loopi 8, 2
     bn.rshi w1, w17, w1 >> 16
@@ -3352,14 +3352,14 @@ _handle_k4_du:
     bn.rshi w1, w17, w1 >> 16
     bn.rshi w17, w31, w17 >> 11
   endloop
-  
+
   /* group 15 -> w0 */
   loopi 16, 2
     bn.rshi w0, w17, w0 >> 16
     bn.rshi w17, w31, w17 >> 11
   endloop
   jal x1, _bitslice_transpose
-  
+
   addi x9, x0, 11
   beq  x0, x0, _handle_common_du
 
@@ -3376,7 +3376,7 @@ _handle_kn4_du:
     endloop
     bn.movr x5, x6
     addi    x5, x5, -1
-    
+
     /* group i + 1 */
     loopi 9, 2
       bn.rshi w18, w17, w18 >> 16
@@ -3392,7 +3392,7 @@ _handle_kn4_du:
     endloop
     bn.movr x5, x6
     addi    x5, x5, -1
-    
+
     /* group i + 2 */
     loopi 16, 2
       bn.rshi w18, w17, w18 >> 16
@@ -3400,7 +3400,7 @@ _handle_kn4_du:
     endloop
     bn.movr x5, x6
     addi    x5, x5, -1
-    
+
     /* group i + 3 */
     loopi 3, 2
       bn.rshi w18, w17, w18 >> 16
@@ -3416,7 +3416,7 @@ _handle_kn4_du:
     endloop
     bn.movr x5, x6
     addi    x5, x5, -1
-    
+
     /* group i + 4 */
     loopi 12, 2
       bn.rshi w18, w17, w18 >> 16
@@ -3432,7 +3432,7 @@ _handle_kn4_du:
     endloop
     bn.movr x5, x6
     addi    x5, x5, -1
-    
+
     /* group i + 5 */
     loopi 16, 2
       bn.rshi w18, w17, w18 >> 16
@@ -3440,7 +3440,7 @@ _handle_kn4_du:
     endloop
     bn.movr x5, x6
     addi    x5, x5, -1
-    
+
     /* group i + 6 */
     loopi 6, 2
       bn.rshi w18, w17, w18 >> 16
@@ -3456,7 +3456,7 @@ _handle_kn4_du:
     endloop
     bn.movr x5, x6
     addi    x5, x5, -1
-    
+
     /* group i + 7 */
     loopi 16, 2
       bn.rshi w18, w17, w18 >> 16
@@ -3466,7 +3466,7 @@ _handle_kn4_du:
     addi    x5, x5, -1
   endloop
   jal x1, _bitslice_transpose
-    
+
   addi x9, x0, 10
 
 _handle_common_du:

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -3442,190 +3442,184 @@ _skip_bit_10:
 .globl finalize_cmp
 .type finalize_cmp, @function
 finalize_cmp:
-  /* Allocate t scratch (2 shares * 32 B) and save x8. */
-  addi x2, x2, -96
-  sw x8, 68(x2)
-
-  /* Save the in/out address. */
-  add  x8, x10, x0
+  /* Allocate t scratch (2 shares * 32 B). */
+  addi x2, x2, -64
 
   /* Compute r &= (r >> 128). */
   /* Compute t = r >> 128. */
-  addi x4, x0, 1
   add  x5, x2, x0
-  loopi 2, 5
+  add  x6, x10, x0
+  loopi 2, 4
     /* Whitening. */
     bn.xor  w0, w0, w0
-    bn.xor  w1, w1, w1
-    bn.lid  x0, 0(x10++)
-    bn.rshi w1, w31, w0 >> 128
-    bn.sid  x4, 0(x5++)
+    bn.lid  x0, 0(x6++)
+    bn.rshi w0, w31, w0 >> 128
+    bn.sid  x0, 0(x5++)
   endloop
   /* Compute r &= t. */
-  add  x10, x8, x0
+  /* x10 already points to r. */
   addi x11, x0, 32
   add  x12, x2, x0
   addi x13, x0, 32
-  add  x15, x8, x0
+  add  x15, x10, x0
   addi x16, x0, 32
   jal  x1, secand
+  addi x10, x10, -32
+  addi x15, x15, -32
 
   /* Compute r &= (r >> 64). */
   /* Compute t = r >> 64. */
-  addi x4, x0, 1
-  add  x10, x8, x0
   add  x5, x2, x0
-  loopi 2, 5
+  add  x6, x10, x0
+  loopi 2, 4
     /* Whitening. */
     bn.xor  w0, w0, w0
-    bn.xor  w1, w1, w1
-    bn.lid  x0, 0(x10++)
-    bn.rshi w1, w31, w0 >> 64
-    bn.sid  x4, 0(x5++)
+    bn.lid  x0, 0(x6++)
+    bn.rshi w0, w31, w0 >> 64
+    bn.sid  x0, 0(x5++)
   endloop
   /* Compute r &= t. */
-  add  x10, x8, x0
+  /* x10 already points to r. */
   /* x11 is still 32. */
   add  x12, x2, x0
   /* x13 is still 32. */
-  add  x15, x8, x0
+  /* x15 already points to r. */
   /* x16 is still 32. */
   jal  x1, secand
+  addi x10, x10, -32
+  addi x15, x15, -32
 
   /* Compute r &= (r >> 32). */
   /* Compute t = r >> 32. */
-  addi x4, x0, 1
-  add  x10, x8, x0
   add  x5, x2, x0
-  loopi 2, 5
+  add  x6, x10, x0
+  loopi 2, 4
     /* Whitening. */
     bn.xor  w0, w0, w0
-    bn.xor  w1, w1, w1
-    bn.lid  x0, 0(x10++)
-    bn.rshi w1, w31, w0 >> 32
-    bn.sid  x4, 0(x5++)
+    bn.lid  x0, 0(x6++)
+    bn.rshi w0, w31, w0 >> 32
+    bn.sid  x0, 0(x5++)
   endloop
   /* Compute r &= t. */
-  add  x10, x8, x0
+  /* x10 already points to r. */
   /* x11 is still 32. */
   add  x12, x2, x0
   /* x13 is still 32. */
-  add  x15, x8, x0
+  /* x15 already points to r. */
   /* x16 is still 32. */
   jal  x1, secand
+  addi x10, x10, -32
+  addi x15, x15, -32
 
   /* Compute r &= (r >> 16). */
   /* Compute t = r >> 16. */
-  addi x4, x0, 1
-  add  x10, x8, x0
   add  x5, x2, x0
-  loopi 2, 5
+  add  x6, x10, x0
+  loopi 2, 4
     /* Whitening. */
     bn.xor  w0, w0, w0
-    bn.xor  w1, w1, w1
-    bn.lid  x0, 0(x10++)
-    bn.rshi w1, w31, w0 >> 16
-    bn.sid  x4, 0(x5++)
+    bn.lid  x0, 0(x6++)
+    bn.rshi w0, w31, w0 >> 16
+    bn.sid  x0, 0(x5++)
   endloop
   /* Compute r &= t. */
-  add  x10, x8, x0
+  /* x10 already points to r. */
   /* x11 is still 32. */
   add  x12, x2, x0
   /* x13 is still 32. */
-  add  x15, x8, x0
+  /* x15 already points to r. */
   /* x16 is still 32. */
   jal  x1, secand
+  addi x10, x10, -32
+  addi x15, x15, -32
 
   /* Compute r &= (r >> 8). */
   /* Compute t = r >> 8. */
-  addi x4, x0, 1
-  add  x10, x8, x0
   add  x5, x2, x0
-  loopi 2, 5
+  add  x6, x10, x0
+  loopi 2, 4
     /* Whitening. */
     bn.xor  w0, w0, w0
-    bn.xor  w1, w1, w1
-    bn.lid  x0, 0(x10++)
-    bn.rshi w1, w31, w0 >> 8
-    bn.sid  x4, 0(x5++)
+    bn.lid  x0, 0(x6++)
+    bn.rshi w0, w31, w0 >> 8
+    bn.sid  x0, 0(x5++)
   endloop
   /* Compute r &= t. */
-  add  x10, x8, x0
+  /* x10 already points to r. */
   /* x11 is still 32. */
   add  x12, x2, x0
   /* x13 is still 32. */
-  add  x15, x8, x0
+  /* x15 already points to r. */
   /* x16 is still 32. */
   jal  x1, secand
+  addi x10, x10, -32
+  addi x15, x15, -32
 
   /* Compute r &= (r >> 4). */
   /* Compute t = r >> 4. */
-  addi x4, x0, 1
-  add  x10, x8, x0
   add  x5, x2, x0
-  loopi 2, 5
+  add  x6, x10, x0
+  loopi 2, 4
     /* Whitening. */
     bn.xor  w0, w0, w0
-    bn.xor  w1, w1, w1
-    bn.lid  x0, 0(x10++)
-    bn.rshi w1, w31, w0 >> 4
-    bn.sid  x4, 0(x5++)
+    bn.lid  x0, 0(x6++)
+    bn.rshi w0, w31, w0 >> 4
+    bn.sid  x0, 0(x5++)
   endloop
   /* Compute r &= t. */
-  add  x10, x8, x0
+  /* x10 already points to r. */
   /* x11 is still 32. */
   add  x12, x2, x0
   /* x13 is still 32. */
-  add  x15, x8, x0
+  /* x15 already points to r. */
   /* x16 is still 32. */
   jal  x1, secand
+  addi x10, x10, -32
+  addi x15, x15, -32
 
   /* Compute r &= (r >> 2). */
   /* Compute t = r >> 2. */
-  addi x4, x0, 1
-  add  x10, x8, x0
   add  x5, x2, x0
-  loopi 2, 5
+  add  x6, x10, x0
+  loopi 2, 4
     /* Whitening. */
     bn.xor  w0, w0, w0
-    bn.xor  w1, w1, w1
-    bn.lid  x0, 0(x10++)
-    bn.rshi w1, w31, w0 >> 2
-    bn.sid  x4, 0(x5++)
+    bn.lid  x0, 0(x6++)
+    bn.rshi w0, w31, w0 >> 2
+    bn.sid  x0, 0(x5++)
   endloop
   /* Compute r &= t. */
-  add  x10, x8, x0
+  /* x10 already points to r. */
   /* x11 is still 32. */
   add  x12, x2, x0
   /* x13 is still 32. */
-  add  x15, x8, x0
+  /* x15 already points to r. */
   /* x16 is still 32. */
   jal  x1, secand
+  addi x10, x10, -32
+  addi x15, x15, -32
 
   /* Compute r &= (r >> 1). */
   /* Compute t = r >> 1. */
-  addi x4, x0, 1
-  add  x10, x8, x0
   add  x5, x2, x0
-  loopi 2, 5
+  add  x6, x10, x0
+  loopi 2, 4
     /* Whitening. */
     bn.xor  w0, w0, w0
-    bn.xor  w1, w1, w1
-    bn.lid  x0, 0(x10++)
-    bn.rshi w1, w31, w0 >> 1
-    bn.sid  x4, 0(x5++)
+    bn.lid  x0, 0(x6++)
+    bn.rshi w0, w31, w0 >> 1
+    bn.sid  x0, 0(x5++)
   endloop
   /* Compute r &= t. */
-  add  x10, x8, x0
+  /* x10 already points to r. */
   /* x11 is still 32. */
   add  x12, x2, x0
   /* x13 is still 32. */
-  add  x15, x8, x0
+  /* x15 already points to r. */
   /* x16 is still 32. */
   jal  x1, secand
+  addi x10, x10, -32
+  addi x15, x15, -32
 
-  /* Restore x8. */
-  lw x8, 68(x2)
-
-  addi x2, x2, 96
+  addi x2, x2, 64
   ret

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -67,25 +67,21 @@
 .globl secand
 .type secand, @function
 secand:
-  /* Save addresses. */
-  add x5, x10, x0
-  add x6, x12, x0
-  add x7, x15, x0
+  add x4, x0, x0
 
   /* Load x. */
   bn.xor w0, w0, w0   /* Whitening. */
-  bn.lid x0, 0(x5)    /* w0 = x_0 */
+  bn.lid x4++, 0(x10) /* w0 = x_0 */
   bn.xor w1, w1, w1   /* Whitening. */
-  add    x5, x5, x11
-  addi   x4, x0, 1
+  add    x5, x10, x11
   bn.lid x4++, 0(x5)  /* w1 = x_1 */
 
   /* Load y. */
   bn.xor w2, w2, w2   /* Whitening. */
-  bn.lid x4++, 0(x6)  /* w2 = y_0 */
+  bn.lid x4++, 0(x12) /* w2 = y_0 */
   bn.xor w3, w3, w3   /* Whitening. */
-  add    x6, x6, x13
-  bn.lid x4, 0(x6)    /* w3 = y_1 */
+  add    x5, x12, x13
+  bn.lid x4, 0(x5)    /* w3 = y_1 */
 
   /* Refresh with one fresh random. */
   bn.wsrr w5, urnd    /* w5 = s */
@@ -102,8 +98,7 @@ secand:
   bn.xor  w7, w7, w8  /* w7 ^= w8 */
   bn.xor  w6, w6, w7  /* r_0 = (w6 ^ w7) */
   addi    x4, x0, 6
-  bn.sid  x4, 0(x7)
-  add     x7, x7, x16
+  bn.sid  x4, 0(x15)
 
   /* Pair (i, j) = (1, 0). */
   bn.xor  w6, w6, w6  /* Whitening. */
@@ -116,7 +111,8 @@ secand:
   bn.and  w8, w8, w5  /* w8 &= s */
   bn.xor  w7, w7, w8  /* w7 ^= w8 */
   bn.xor  w6, w6, w7  /* r_1 = (w6 ^ w7) */
-  bn.sid  x4, 0(x7)
+  add     x5, x15, x16
+  bn.sid  x4, 0(x5)
 
   /* Advance x10, x12, x15 to the next bit. */
   addi x10, x10, 32

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -1168,18 +1168,15 @@ seca2bmodq:
 .globl seconebitb2amodq
 .type seconebitb2amodq, @function
 seconebitb2amodq:
-  /* Frame: v_0..1 at x2+0 (1024 B), saved x8/x18 above. */
+  /* Frame: v_0..1 at x2+0 (1024 B), saved x10/x12 above. */
   addi x2, x2, -1056
-  sw   x8, 1024(x2)
-  sw   x18, 1028(x2)
-  add  x8, x10, x0
-  add  x18, x12, x0
+  sw   x10, 1024(x2)
+  sw   x12, 1028(x2)
 
   /* Build v = (x_0, 0). */
   add x5, x2, x0
-  add x6, x10, x0
   loopi 16, 2
-    bn.lid x0, 0(x6++)
+    bn.lid x0, 0(x10++)
     bn.sid x0, 0(x5++)
   endloop
 
@@ -1188,13 +1185,9 @@ seconebitb2amodq:
     bn.sid x0, 0(x5++)
   endloop
 
-  /* Construct the vector of 1s. */
-  bn.subi    w30, w0, 1
-  bn.shv.16h w30, w30 >> 15
-
   /* Compute v = refreshmodq(v). */
   add x10, x2, x0
-  add x12, x10, x0
+  add x12, x2, x0
   jal x1, refreshmodq
 
   /* We need to compute r = (1 - 2 * x_1) * v_j for j = 0..1.
@@ -1215,13 +1208,18 @@ seconebitb2amodq:
    *  - if x_1 = 1, then t1 = 0.
    *    Then (t1 - v_j) mod q = (-v_j) mod q.
    */
-  addi x5, x8, 512 /* x_1 */
-  add  x6, x2, x0  /* v */
+
+  /* Generate 1 in each of the 16 16-bit lanes. */
+  bn.subi    w4, w31, 1
+  bn.shv.16h w4, w4 >> 15
+
   addi x4, x0, 1
-  loopi 16, 16
-    bn.lid         x0, 0(x5++)
-    bn.subv.16h    w2, w0, w30
-    add            x7, x6, x0
+  lw   x5, 1024(x2)
+  addi x5, x5, 512 /* x_1 */
+  add  x6, x2, x0  /* v */
+  loopi 16, 14
+    bn.lid       x0, 0(x5++)
+    bn.subv.16h  w2, w0, w4
     /* Handle v_0. */
     bn.lid       x4, 0(x6)
     bn.and       w3, w1, w2
@@ -1229,24 +1227,21 @@ seconebitb2amodq:
     bn.subvm.16h w1, w3, w1
     bn.addvm.16h w1, w0, w1
     bn.sid       x4, 0(x6)
-    addi         x6, x6, 512
     /* Handle v_1. */
-    bn.lid       x4, 0(x6)
+    bn.lid       x4, 512(x6)
     bn.and       w3, w1, w2
     bn.shv.16h   w3, w3 << 1
     bn.subvm.16h w1, w3, w1
-    bn.sid       x4, 0(x6)
-    addi x6, x7, 32
+    bn.sid       x4, 512(x6)
+    addi         x6, x6, 32
   endloop
 
   /* Compute r = refreshmodq(v). */
   add x10, x2, x0
-  add x12, x18, x0
+  lw  x12, 1028(x2)
   jal x1, refreshmodq
 
-  /* Restore registers and frame. */
-  lw   x8, 1024(x2)
-  lw   x18, 1028(x2)
+  /* Restore frame. */
   addi x2, x2, 1056
   ret
 

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -2735,9 +2735,9 @@ masked_poly_tomsg:
  * clobbered flag groups: FG0
  */
 
-.globl poly_masked_compare_dv
-.type poly_masked_compare_dv, @function
-poly_masked_compare_dv:
+.globl masked_poly_compare_dv
+.type masked_poly_compare_dv, @function
+masked_poly_compare_dv:
   /* Allocate t scratch (2 shares * 160 B, dv = 5 worst case) + saves. */
   addi x2, x2, -352
   sw   x11, 320(x2)
@@ -3039,9 +3039,9 @@ _skip_bit_4:
  * clobbered flag groups: FG0
  */
 
-.globl poly_masked_compare_du
-.type poly_masked_compare_du, @function
-poly_masked_compare_du:
+.globl masked_poly_compare_du
+.type masked_poly_compare_du, @function
+masked_poly_compare_du:
   /* Allocate t scratch (2 shares * 352 B, du = 11 worst case) + saves. */
   addi x2, x2, -736
   sw   x11, 708(x2)

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -62,7 +62,7 @@
  * @param[out] x15: dmem pointer to Boolean shares of r
  * @param[in]  x16: share stride of r
  *
- * clobbered registers: x4 to x7, x10, x12, x15, w0 to w3, w5 to w8
+ * clobbered registers: x4 to x5, w0 to w3, w5 to w8
  * clobbered flag groups: FG0
  */
 
@@ -143,7 +143,7 @@ secand:
  * @param[out] x30: dmem pointer to Boolean shares of cout
  * @param[in]  x31: share stride of cout
  *
- * clobbered registers: x4 to x7, x10, x12, x15, x28, w0 to w9
+ * clobbered registers: x4 to x5, w0 to w9
  * clobbered flag groups: FG0
  */
 
@@ -260,7 +260,8 @@ secfulladder:
  * @param[in]  x16: share stride of r
  * @param[in]  x17: k, bitsize of x and y
  *
- * clobbered registers: x2, x4 to x8, x10, x12, x15, x17, x28 to x31, w0 to w9
+ * clobbered registers: x2, x4 to x5, x8, x10, x12, x15, x17, x29 to x31,
+ *                      w0 to w9
  * clobbered flag groups: FG0
  */
 
@@ -380,7 +381,7 @@ bitcopymask:
  * @param[in]  x12: share stride of x and r
  * @param[out] x14: dmem pointer to Boolean shares of r
  *
- * clobbered registers: x4 to x6, x10, x14, w0 to w2
+ * clobbered registers: x5 to x6, x10, x14, w0 to w1
  * clobbered flag groups: FG0
  */
 
@@ -421,7 +422,7 @@ refreshios:
  * @param[in]  w31: all-zero register
  * @param[in]  mod: q = 3329
  *
- * clobbered registers: x5 to x6, x10, w0 to w5, acch, acc
+ * clobbered registers: x4 to x5, x10, w0 to w4, acch, acc
  * clobbered flag groups: FG0
  */
 
@@ -497,7 +498,7 @@ _end_rej_sample_loop:
  *                        sw0.2 = -q^-1 mod 2^16 = 3327 (3rd 16-bit lane)
  * @param[in]  mod: q = 3329
  *
- * clobbered registers: x2, x4 to x7, x10, x12, x28, w0 to w5, acch, acc
+ * clobbered registers: x2, x4 to x7, x10, x12, w0 to w4, acch, acc
  * clobbered flag groups: FG0
  */
 
@@ -859,7 +860,7 @@ _bitslice_transpose:
  * @param[in]  x12: share stride of x and r
  * @param[out] x14: dmem pointer to Boolean shares of r
  *
- * clobbered registers: x2 to x8, x10 to x13, x15 to x17, x28 to x31, w0 to w9
+ * clobbered registers: x2 to x8, x10 to x13, x15 to x17, x29 to x31, w0 to w9
  * clobbered flag groups: FG0
  */
 
@@ -942,7 +943,8 @@ seca2b:
  * @param[out] x12: dmem pointer to Boolean shares of r
  * @param[in]  w31: all-zero register
  *
- * clobbered registers: x2, x4 to x7, x10 to x13, x15 to x18, x28 to x31, w0 to w9
+ * clobbered registers: x2, x4 to x5, x10 to x13, x15 to x17, x29 to x31,
+ *                      w0 to w9
  * clobbered flag groups: FG0
  */
 
@@ -1163,7 +1165,7 @@ seca2bmodq:
  *                        sw0.2 = -q^-1 mod 2^16 = 3327 (3rd 16-bit lane)
  * @param[in]  mod: q = 3329
  *
- * clobbered registers: x2, x4 to x8, x10, x12, x18, x28, w0 to w5, w30, acch, acc
+ * clobbered registers: x2, x4 to x7, x10, x12, w0 to w4, acch, acc
  * clobbered flag groups: FG0
  */
 
@@ -1270,7 +1272,8 @@ seconebitb2amodq:
  * @param[in]  w31: all-zero register
  * @param[in]  mod: q = 3329
  *
- * clobbered registers: x2, x4 to x8, x10 to x21, x28 to x31, w0 to w16, w28 to w30, acch, acc
+ * clobbered registers: x2, x4 to x6, x8 to x17, x29 to x31,
+ *                      w0 to w15, w28 to w29, acch, acc
  * clobbered flag groups: FG0
  */
 
@@ -1495,7 +1498,8 @@ secb2amodq:
  * @param[in]  x13: k, the security level
  * @param[in]  w31: all-zero register
  *
- * clobbered registers: x2 to x19, x28 to x31, w0 to w15, w17 to w21, w28 to w29
+ * clobbered registers: x2 to x17, x29 to x31,
+ *                      w0 to w15, w17 to w21, w28 to w29
  * clobbered flag groups: FG0
  */
 
@@ -1677,7 +1681,8 @@ _dv_params_done:
  * @param[in]  x13: k, the security level
  * @param[in]  w31: all-zero register
  *
- * clobbered registers: x2 to x19, x28 to x31, w0 to w15, w17 to w21, w28 to w30, acc
+ * clobbered registers: x2 to x17, x29 to x31,
+ *                      w0 to w15, w17 to w21, w28 to w30, acc
  * clobbered flag groups: FG0
  */
 
@@ -1892,7 +1897,7 @@ _du_params_done:
  * @param[in]  w31: all-zero register
  * @param[in]  mod: q = 3329
  *
- * clobbered registers: x2, x4 to x8, x10, x12, x18, x28, w0 to w5, w30, acch, acc
+ * clobbered registers: x2, x4 to x8, x10, x12, w0 to w4, acch, acc
  * clobbered flag groups: FG0
  */
 
@@ -1969,7 +1974,8 @@ masked_poly_frommsg:
  * @param[in]  w31: all-zero register
  * @param[in]  mod: q = 3329
  *
- * clobbered registers: x2, x4 to x22, x28 to x31, w0 to w16, w28 to w30, acch, acc
+ * clobbered registers: x2, x4 to x18, x29 to x31,
+ *                      w0 to w15, w28 to w29, acch, acc
  * clobbered flag groups: FG0
  */
 
@@ -2188,7 +2194,7 @@ _continue_1:
  * @param[in]  x11: dmem pointer to the nonce
  * @param[in]  w31: all-zero register
  *
- * clobbered registers: x5 to x6, x10, w0
+ * clobbered registers: x4 to x5, x10, w0
  * clobbered flag groups: FG0
  */
 
@@ -2243,7 +2249,8 @@ masked_poly_getnoise_eta_init:
  * @param[in]  w31: all-zero register
  * @param[in]  mod: q = 3329
  *
- * clobbered registers: x2, x4 to x22, x28 to x31, w0 to w30, acch, acc
+ * clobbered registers: x2, x4 to x18, x29 to x31,
+ *                      w0 to w15, w17 to w30, acch, acc
  * clobbered flag groups: FG0
  */
 
@@ -2271,7 +2278,8 @@ masked_poly_getnoise_eta_2:
  * @param[in]  w31: all-zero register
  * @param[in]  mod: q = 3329
  *
- * clobbered registers: x2, x4 to x22, x28 to x31, w0 to w30, acch, acc
+ * clobbered registers: x2, x4 to x18, x29 to x31,
+ *                      w0 to w15, w17 to w30, acch, acc
  * clobbered flag groups: FG0
  */
 
@@ -2435,7 +2443,7 @@ _getnoise_common:
  * @param[in]     w17 to w22: the six digest words to bitslice
  * @param[in]     w31: all-zero register
  *
- * clobbered registers: x4, x10 to x11, w0 to w15, w17 to w22, w28 to w29
+ * clobbered registers: w0 to w15, w17 to w22, w28 to w29
  * clobbered flag groups: FG0
  */
 
@@ -2596,7 +2604,8 @@ _bitslice_eta_3:
  * @param[out] x12: dmem pointer to bitsliced compressed output r
  * @param[in]  w31: all-zero register
  *
- * clobbered registers: x2 to x8, x10 to x17, x28 to x31, w0 to w15, w17 to w21, w28 to w29
+ * clobbered registers: x2 to x8, x10 to x17, x29 to x31,
+ *                      w0 to w15, w17 to w21, w28 to w29
  * clobbered flag groups: FG0
  */
 
@@ -2733,7 +2742,8 @@ masked_poly_tomsg:
  * @param[in]     x15: k, the security level
  * @param[in]     w31: all-zero register
  *
- * clobbered registers: x2 to x20, x28 to x31, w0 to w15, w17 to w21, w28 to w29
+ * clobbered registers: x2 to x17, x29 to x31,
+ *                      w0 to w15, w17 to w21, w28 to w29
  * clobbered flag groups: FG0
  */
 
@@ -3037,7 +3047,8 @@ _skip_bit_4:
  * @param[in]     x15: k, the security level
  * @param[in]     w31: all-zero register
  *
- * clobbered registers: x2 to x20, x28 to x31, w0 to w15, w17 to w21, w28 to w30, acc
+ * clobbered registers: x2 to x17, x29 to x31,
+ *                      w0 to w15, w17 to w21, w28 to w30, acc
  * clobbered flag groups: FG0
  */
 
@@ -3441,7 +3452,8 @@ _skip_bit_10:
  *                     of masked_poly_compare_{du, dv}
  * @param[in]     w31: all-zero register
  *
- * clobbered registers: x2, x4 to x8, x10 to x13, x15 to x16, w0 to w3, w5 to w8
+ * clobbered registers: x2, x4 to x6, x11 to x13, x15 to x16,
+ *                      w0 to w3, w5 to w8
  * clobbered flag groups: FG0
  */
 

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -1712,8 +1712,10 @@ _du_params_done:
   addi       x4, x0, 17
   la         x5, const_m_du
   bn.lid     x4++, 0(x5)
-  la         x5, const_1664
+  la         x5, modulus_bn
   bn.lid     x4, 0(x5)
+  bn.shv.8s  w18, w18 >> 17 /* 0x680 in 8 32-bit lanes. */
+  bn.trn1.8s w18, w18, w31  /* 0x680 in 4 64-bit lanes. */
 
   add x6, x2, x0 /* z */
 

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -254,6 +254,7 @@ secfulladder:
  * @param[out] x15: dmem pointer to Boolean shares of r
  * @param[in]  x16: share stride of r
  * @param[in]  x17: k, bitsize of x and y
+ * @param[in]  w31: all-zero register
  *
  * clobbered registers: x2, x4 to x5, x8, x10, x12, x15, x17, x29 to x31,
  *                      w0 to w9
@@ -268,7 +269,7 @@ secadd:
   sw   x8, 64(x2)
 
   /* Initialize c = 0. */
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
   bn.sid x0, 0(x2)
   bn.sid x0, 32(x2)
 
@@ -300,8 +301,8 @@ secadd:
     bn.sid x0, 0(x15)
     add    x15, x15, x16
     /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
+    bn.xor w0, w31, w31
+    bn.xor w1, w31, w31
   endloop
 
   /* Restore x17. */
@@ -326,6 +327,7 @@ secadd:
  * @param[in]  x10: dmem pointer to Boolean shares of x
  * @param[in]  x11: share stride of x
  * @param[out] x13: dmem pointer to Boolean shares of r
+ * @param[in]  w31: all-zero register
  *
  * clobbered registers: x4, x10, x13, w0
  * clobbered flag groups: FG0
@@ -354,7 +356,7 @@ bitcopymask:
     bn.sid x0, 0(x13++)
     bn.sid x0, 0(x13++)
     /* Whitening. */
-    bn.xor w0, w0, w0
+    bn.xor w0, w31, w31
   endloop
   ret
 
@@ -375,6 +377,7 @@ bitcopymask:
  * @param[in]  x11: k, bitsize of x
  * @param[in]  x12: share stride of x and r
  * @param[out] x14: dmem pointer to Boolean shares of r
+ * @param[in]  w31: all-zero register
  *
  * clobbered registers: x5 to x6, x10, x14, w0 to w1
  * clobbered flag groups: FG0
@@ -393,13 +396,13 @@ refreshios:
     bn.xor  w0, w0, w1
     bn.sid  x0, 0(x14++)
     /* Whitening. */
-    bn.xor  w0, w0, w0
+    bn.xor  w0, w31, w31
     /* r_1 = x_1 ^ s. */
     bn.lid  x0, 0(x5++)
     bn.xor  w0, w0, w1
     bn.sid  x0, 0(x6++)
     /* Whitening. */
-    bn.xor  w0, w0, w0
+    bn.xor  w0, w31, w31
   endloop
   ret
 
@@ -474,9 +477,9 @@ _rej_sample_loop:
 
 _end_rej_sample_loop:
   /* Whitening. */
-  bn.xor w0, w0, w0
-  bn.xor w3, w3, w3
-  bn.xor w4, w4, w4
+  bn.xor w0, w31, w31
+  bn.xor w3, w31, w31
+  bn.xor w4, w31, w31
   ret
 
 /**
@@ -495,6 +498,7 @@ _end_rej_sample_loop:
  * @param[out] x12: dmem pointer to arithmetic shares of r
  * @param[in]  w16 (sw0): sw0.0 = q = 3329 (1st 16-bit lane),
  *                        sw0.2 = -q^-1 mod 2^16 = 3327 (3rd 16-bit lane)
+ * @param[in]  w31: all-zero register
  * @param[in]  mod: q = 3329
  *
  * clobbered registers: x2, x4 to x7, x10, x12, w0 to w4, acch, acc
@@ -527,16 +531,16 @@ refreshmodq:
     bn.addvm.16h w0, w0, w1
     bn.sid       x0, 0(x12++)
     /* Whitening. */
-    bn.xor       w0, w0, w0
+    bn.xor       w0, w31, w31
     /* r_1 = x_1 - rand. */
     bn.lid       x0, 0(x6++)
     bn.subvm.16h w0, w0, w1
     bn.sid       x0, 0(x7++)
     /* Whitening. */
-    bn.xor       w0, w0, w0
+    bn.xor       w0, w31, w31
   endloop
   /* Whitening. */
-  bn.xor w1, w1, w1
+  bn.xor w1, w31, w31
 
   /* Restore stack. */
   addi x2, x2, 544
@@ -581,24 +585,24 @@ poly_to_bitsliced:
   endloop
 
   /* Whitening. */
-  bn.xor w0, w0, w0
-  bn.xor w1, w1, w1
-  bn.xor w2, w2, w2
-  bn.xor w3, w3, w3
-  bn.xor w4, w4, w4
-  bn.xor w5, w5, w5
-  bn.xor w6, w6, w6
-  bn.xor w7, w7, w7
-  bn.xor w8, w8, w8
-  bn.xor w9, w9, w9
-  bn.xor w10, w10, w10
-  bn.xor w11, w11, w11
-  bn.xor w12, w12, w12
-  bn.xor w13, w13, w13
-  bn.xor w14, w14, w14
-  bn.xor w15, w15, w15
-  bn.xor w28, w28, w28
-  bn.xor w29, w29, w29
+  bn.xor w0, w31, w31
+  bn.xor w1, w31, w31
+  bn.xor w2, w31, w31
+  bn.xor w3, w31, w31
+  bn.xor w4, w31, w31
+  bn.xor w5, w31, w31
+  bn.xor w6, w31, w31
+  bn.xor w7, w31, w31
+  bn.xor w8, w31, w31
+  bn.xor w9, w31, w31
+  bn.xor w10, w31, w31
+  bn.xor w11, w31, w31
+  bn.xor w12, w31, w31
+  bn.xor w13, w31, w31
+  bn.xor w14, w31, w31
+  bn.xor w15, w31, w31
+  bn.xor w28, w31, w31
+  bn.xor w29, w31, w31
   ret
 
 /**
@@ -629,10 +633,10 @@ poly_from_bitsliced:
     bn.lid x4, 0(x10++)
     addi   x4, x4, 1
   endloop
-  bn.xor w12, w12, w12
-  bn.xor w13, w13, w13
-  bn.xor w14, w14, w14
-  bn.xor w15, w15, w15
+  bn.xor w12, w31, w31
+  bn.xor w13, w31, w31
+  bn.xor w14, w31, w31
+  bn.xor w15, w31, w31
 
   jal x1, _bitslice_transpose
 
@@ -644,24 +648,24 @@ poly_from_bitsliced:
   endloop
 
   /* Whitening. */
-  bn.xor w0, w0, w0
-  bn.xor w1, w1, w1
-  bn.xor w2, w2, w2
-  bn.xor w3, w3, w3
-  bn.xor w4, w4, w4
-  bn.xor w5, w5, w5
-  bn.xor w6, w6, w6
-  bn.xor w7, w7, w7
-  bn.xor w8, w8, w8
-  bn.xor w9, w9, w9
-  bn.xor w10, w10, w10
-  bn.xor w11, w11, w11
-  bn.xor w12, w12, w12
-  bn.xor w13, w13, w13
-  bn.xor w14, w14, w14
-  bn.xor w15, w15, w15
-  bn.xor w28, w28, w28
-  bn.xor w29, w29, w29
+  bn.xor w0, w31, w31
+  bn.xor w1, w31, w31
+  bn.xor w2, w31, w31
+  bn.xor w3, w31, w31
+  bn.xor w4, w31, w31
+  bn.xor w5, w31, w31
+  bn.xor w6, w31, w31
+  bn.xor w7, w31, w31
+  bn.xor w8, w31, w31
+  bn.xor w9, w31, w31
+  bn.xor w10, w31, w31
+  bn.xor w11, w31, w31
+  bn.xor w12, w31, w31
+  bn.xor w13, w31, w31
+  bn.xor w14, w31, w31
+  bn.xor w15, w31, w31
+  bn.xor w28, w31, w31
+  bn.xor w29, w31, w31
   ret
 
 /**
@@ -900,6 +904,7 @@ _bitslice_transpose:
  * @param[in]  x11: k, bitsize of x
  * @param[in]  x12: share stride of x and r
  * @param[out] x14: dmem pointer to Boolean shares of r
+ * @param[in]  w31: all-zero register
  *
  * clobbered registers: x2 to x8, x10 to x13, x15 to x17, x29 to x31, w0 to w9
  * clobbered flag groups: FG0
@@ -925,7 +930,7 @@ seca2b:
     bn.lid x0, 0(x10++)
     bn.sid x0, 0(x6++)
   endloop
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
   loop x11, 1
     bn.sid x0, 0(x6++)
   endloop
@@ -940,7 +945,7 @@ seca2b:
     bn.sid x0, 0(x5++)
   endloop
   /* Whitening. */
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
 
   /* Save registers. */
   add x4, x11, x0
@@ -1017,7 +1022,7 @@ seca2bmodq:
   addi x5, x2, 896 /* s */
   addi x4, x0, 1
   /* Initialize cin = 0. */
-  bn.xor w2, w2, w2
+  bn.xor w2, w31, w31
 
   /* Bits 0..7: p[i] = 1. */
   loopi 8, 7
@@ -1060,10 +1065,10 @@ seca2bmodq:
   bn.sid x4, 0(x5++)
 
   /* Whitening. */
-  bn.xor w0, w0, w0
-  bn.xor w1, w1, w1
-  bn.xor w2, w2, w2
-  bn.xor w3, w3, w3
+  bn.xor w0, w31, w31
+  bn.xor w1, w31, w31
+  bn.xor w2, w31, w31
+  bn.xor w3, w31, w31
   /********** End inline s = secadd(p, x_0, k + 1). **********/
 
   /* Build s = (s, 0) for (k + 1) bits. */
@@ -1080,7 +1085,7 @@ seca2bmodq:
     bn.lid x0, 0(x10++)
     bn.sid x0, 0(x5++)
   endloop
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
   bn.sid x0, 0(x5++)
 
   /********** Start inline u = secadd(s, s', k + 1). **********/
@@ -1118,8 +1123,8 @@ seca2bmodq:
     bn.sid x0, 0(x15)
     add    x15, x15, x16
     /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
+    bn.xor w0, w31, w31
+    bn.xor w1, w31, w31
   endloop
   /********** End inline u = secadd(s, s', k + 1). **********/
 
@@ -1131,7 +1136,7 @@ seca2bmodq:
 
   /********** Start inline r = secadd(a, u, k). **********/
   /* Initialize c = 0. */
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
   bn.sid x0, 832(x2)
   bn.sid x0, 864(x2)
 
@@ -1165,8 +1170,8 @@ seca2bmodq:
     bn.sid x0, 0(x15)
     add    x15, x15, x16
     /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
+    bn.xor w0, w31, w31
+    bn.xor w1, w31, w31
   endloop
   /********** End inline r = secadd(a, u, k). **********/
 
@@ -1192,6 +1197,7 @@ seca2bmodq:
  * @param[out] x12: dmem pointer to arithmetic shares of r
  * @param[in]  w16 (sw0): sw0.0 = q = 3329 (1st 16-bit lane),
  *                        sw0.2 = -q^-1 mod 2^16 = 3327 (3rd 16-bit lane)
+ * @param[in]  w31: all-zero register
  * @param[in]  mod: q = 3329
  *
  * clobbered registers: x2, x4 to x7, x10, x12, w0 to w4, acch, acc
@@ -1213,7 +1219,7 @@ seconebitb2amodq:
     bn.sid x0, 0(x5++)
   endloop
 
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
   loopi 16, 1
     bn.sid x0, 0(x5++)
   endloop
@@ -1261,8 +1267,8 @@ seconebitb2amodq:
     bn.addvm.16h w1, w0, w1
     bn.sid       x4, 0(x6)
     /* Whitening. */
-    bn.xor       w1, w1, w1
-    bn.xor       w3, w3, w3
+    bn.xor       w1, w31, w31
+    bn.xor       w3, w31, w31
     /* Handle v_1. */
     bn.lid       x4, 512(x6)
     bn.and       w3, w1, w2
@@ -1271,12 +1277,12 @@ seconebitb2amodq:
     bn.sid       x4, 512(x6)
     addi         x6, x6, 32
     /* Whitening. */
-    bn.xor       w1, w1, w1
-    bn.xor       w3, w3, w3
+    bn.xor       w1, w31, w31
+    bn.xor       w3, w31, w31
   endloop
   /* Whitening. */
-  bn.xor w0, w0, w0
-  bn.xor w2, w2, w2
+  bn.xor w0, w31, w31
+  bn.xor w2, w31, w31
 
   /* Compute r = refreshmodq(v). */
   add x10, x2, x0
@@ -1348,14 +1354,14 @@ secb2amodq:
     bn.sid      x0, 0(x5++)
   endloop
   /* Whitening. */
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
 
   /* Bitslice zp_0 and clear zp_1 (bitsliced). */
   addi   x10, x2, 32
   add    x11, x8, x0  /* zp (bitsliced) */
   jal    x1, poly_to_bitsliced
   addi   x11, x11, 384
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
   loopi 12, 1
     bn.sid x0, 0(x11++)
   endloop
@@ -1369,7 +1375,7 @@ secb2amodq:
   /********** Start inline b = secaddmodq(a, x). **********/
   /********** Start inline s = secadd(a, x, k + 1). **********/
   /* Initialize c = 0. */
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
   bn.sid x0, 384(x9)
   bn.sid x0, 800(x9)
 
@@ -1395,7 +1401,7 @@ secb2amodq:
 
   /********** Start inline s = secadd(s, p = 2^(k + 1) - q, k + 1). **********/
   /* Initialize c = 0. */
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
   bn.sid x0, 32(x2)
   bn.sid x0, 64(x2)
 
@@ -1453,8 +1459,8 @@ secb2amodq:
   bn.sid x0, 0(x12)
   add    x12, x12, x13
   /* Whitening. */
-  bn.xor w0, w0, w0
-  bn.xor w1, w1, w1
+  bn.xor w0, w31, w31
+  bn.xor w1, w31, w31
 
   /* s_1 */
   bn.lid x0, 0(x12)
@@ -1462,8 +1468,8 @@ secb2amodq:
   bn.xor w0, w0, w1
   bn.sid x0, 0(x12)
   /* Whitening. */
-  bn.xor w0, w0, w0
-  bn.xor w1, w1, w1
+  bn.xor w0, w31, w31
+  bn.xor w1, w31, w31
   /********** End inline s = secadd(s, p = 2^(k + 1) - q, k + 1). **********/
 
   /* Compute a = bitcopymask(s[k], (k + 1) * 32). */
@@ -1644,29 +1650,29 @@ _dv_params_done:
 
     /* For the first share, w19 holds 2^(alpha - 1).
      * After that, we clear w19 so that bn.add acts as a shift. */
-    bn.xor w19, w19, w19
+    bn.xor w19, w31, w31
 
     /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
-    bn.xor w2, w2, w2
-    bn.xor w3, w3, w3
-    bn.xor w4, w4, w4
-    bn.xor w5, w5, w5
-    bn.xor w6, w6, w6
-    bn.xor w7, w7, w7
-    bn.xor w8, w8, w8
-    bn.xor w9, w9, w9
-    bn.xor w10, w10, w10
-    bn.xor w11, w11, w11
-    bn.xor w12, w12, w12
-    bn.xor w13, w13, w13
-    bn.xor w14, w14, w14
-    bn.xor w15, w15, w15
-    bn.xor w20, w20, w20
-    bn.xor w21, w21, w21
-    bn.xor w28, w28, w28
-    bn.xor w29, w29, w29
+    bn.xor w0, w31, w31
+    bn.xor w1, w31, w31
+    bn.xor w2, w31, w31
+    bn.xor w3, w31, w31
+    bn.xor w4, w31, w31
+    bn.xor w5, w31, w31
+    bn.xor w6, w31, w31
+    bn.xor w7, w31, w31
+    bn.xor w8, w31, w31
+    bn.xor w9, w31, w31
+    bn.xor w10, w31, w31
+    bn.xor w11, w31, w31
+    bn.xor w12, w31, w31
+    bn.xor w13, w31, w31
+    bn.xor w14, w31, w31
+    bn.xor w15, w31, w31
+    bn.xor w20, w31, w31
+    bn.xor w21, w31, w31
+    bn.xor w28, w31, w31
+    bn.xor w29, w31, w31
   endloop
 
   /* Compute c = seca2b(z), k = dv + alpha = 18, share bytes = 576. */
@@ -1686,7 +1692,7 @@ _dv_params_done:
     endloop
     add x5, x5, x8
     /* Whitening. */
-    bn.xor w0, w0, w0
+    bn.xor w0, w31, w31
   endloop
 
   /* Restore registers. */
@@ -1863,30 +1869,30 @@ _du_params_done:
 
     /* For the first share, w30 holds 2^(alpha - 1).
      * After that, we clear w30 for the 2nd share. */
-    bn.xor w30, w30, w30
+    bn.xor w30, w31, w31
 
     /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
-    bn.xor w2, w2, w2
-    bn.xor w3, w3, w3
-    bn.xor w4, w4, w4
-    bn.xor w5, w5, w5
-    bn.xor w6, w6, w6
-    bn.xor w7, w7, w7
-    bn.xor w8, w8, w8
-    bn.xor w9, w9, w9
-    bn.xor w10, w10, w10
-    bn.xor w11, w11, w11
-    bn.xor w12, w12, w12
-    bn.xor w13, w13, w13
-    bn.xor w14, w14, w14
-    bn.xor w15, w15, w15
-    bn.xor w19, w19, w19
-    bn.xor w20, w20, w20
-    bn.xor w21, w21, w21
-    bn.xor w28, w28, w28
-    bn.xor w29, w29, w29
+    bn.xor w0, w31, w31
+    bn.xor w1, w31, w31
+    bn.xor w2, w31, w31
+    bn.xor w3, w31, w31
+    bn.xor w4, w31, w31
+    bn.xor w5, w31, w31
+    bn.xor w6, w31, w31
+    bn.xor w7, w31, w31
+    bn.xor w8, w31, w31
+    bn.xor w9, w31, w31
+    bn.xor w10, w31, w31
+    bn.xor w11, w31, w31
+    bn.xor w12, w31, w31
+    bn.xor w13, w31, w31
+    bn.xor w14, w31, w31
+    bn.xor w15, w31, w31
+    bn.xor w19, w31, w31
+    bn.xor w20, w31, w31
+    bn.xor w21, w31, w31
+    bn.xor w28, w31, w31
+    bn.xor w29, w31, w31
   endloop
 
   /* Compute c = seca2b(z), k = du + alpha = 24, share bytes = 768. */
@@ -1906,7 +1912,7 @@ _du_params_done:
     endloop
     add x5, x5, x8
     /* Whitening. */
-    bn.xor w0, w0, w0
+    bn.xor w0, w31, w31
   endloop
 
   /* Restore registers. */
@@ -1959,8 +1965,8 @@ masked_poly_frommsg:
       bn.sid     x4, 0(x12++)
     endloop
     /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
+    bn.xor w0, w31, w31
+    bn.xor w1, w31, w31
   endloop
 
   /* Compute mp = seconebitb2amodq(m). */
@@ -1982,7 +1988,7 @@ masked_poly_frommsg:
       bn.sid               x0, 0(x8++)
     endloop
     /* Whitening. */
-    bn.xor w0, w0, w0
+    bn.xor w0, w31, w31
   endloop
 
   /* Restore the output base pointer and stack. */
@@ -2052,7 +2058,7 @@ masked_cbd:
     bn.sid x0, 0(x6++)
   endloop
   /* Whitening. */
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
   /* Share 1. */
   add x5, x5, x4
   add x6, x6, x4
@@ -2065,7 +2071,7 @@ masked_cbd:
     bn.sid x0, 0(x6++)
   endloop
   /* Whitening. */
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
 
   /* The block below does as follows:
    *  - ell <- 2 * eta
@@ -2079,7 +2085,7 @@ masked_cbd:
    */
   /********** Iteration i = 0, ell = 2 * eta. **********/
   /* Since ell mod 2 = 0, we clear a. */
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
   bn.sid x0, 0(x9)
   bn.sid x0, 32(x9)
 
@@ -2110,7 +2116,7 @@ masked_cbd:
     bn.sid x0, 0(x5)
     addi   x5, x5, 384
     /* Whitening. */
-    bn.xor w0, w0, w0
+    bn.xor w0, w31, w31
   endloop
 
   /********** Iteration i = 1, ell = eta. **********/
@@ -2125,13 +2131,13 @@ masked_cbd:
     add    x6, x6, x4
     bn.sid x0, 0(x5++)
     /* Whitening. */
-    bn.xor w0, w0, w0
+    bn.xor w0, w31, w31
   endloop
   beq x0, x0, _continue_1
 
 _cbd_eta_2:
   /* Since ell mod 2 = 0 if eta = 2, we clear a. */
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
   bn.sid x0, 0(x9)
   bn.sid x0, 32(x9)
 
@@ -2158,7 +2164,7 @@ _continue_1:
     bn.sid x0, 0(x5)
     addi   x5, x5, 384
     /* Whitening. */
-    bn.xor w0, w0, w0
+    bn.xor w0, w31, w31
   endloop
 
   /********** Iteration i = 2, ell = eta // 2 = 1. **********/
@@ -2172,11 +2178,11 @@ _continue_1:
     bn.sid x0, 0(x5)
     addi   x5, x5, 384
     /* Whitening. */
-    bn.xor w0, w0, w0
+    bn.xor w0, w31, w31
   endloop
 
   /* Clear bits b[3..k - 1]. */
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
   addi   x5, x2, 96
   loopi 2, 3
     loopi 9, 1
@@ -2205,7 +2211,7 @@ _continue_1:
     bn.sid       x0, 0(x5++)
   endloop
   /* Whitening. */
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
 
   /* Restore registers and stack. */
   lw   x8, 1220(x2)
@@ -2250,17 +2256,17 @@ masked_poly_getnoise_eta_init:
   /* Send seed. */
   bn.lid  x0, 0(x10++)
   bn.wsrw kmac_msg, w0
-  bn.xor  w0, w0, w0 /* Whitening. */
+  bn.xor  w0, w31, w31 /* Whitening. */
   bn.lid  x0, 0(x10++)
   bn.wsrw kmac_msg1, w0
-  bn.xor  w0, w0, w0 /* Whitening. */
+  bn.xor  w0, w31, w31 /* Whitening. */
 
   /* Send nonce. */
   li      x5, 1
   csrrw   x0, kmac_partial_write, x5
   bn.lid  x0, 0(x11)
   bn.wsrw kmac_msg, w0
-  bn.xor  w0, w0, w0
+  bn.xor  w0, w31, w31
   bn.wsrw kmac_msg1, w0
 
   ret
@@ -2363,12 +2369,12 @@ masked_poly_getnoise_eta_1:
   jal x1, _bitslice_eta_3
 
   /* Whitening. */
-  bn.xor w23, w23, w23
-  bn.xor w24, w24, w24
-  bn.xor w25, w25, w25
-  bn.xor w26, w26, w26
-  bn.xor w27, w27, w27
-  bn.xor w30, w30, w30
+  bn.xor w23, w31, w31
+  bn.xor w24, w31, w31
+  bn.xor w25, w31, w31
+  bn.xor w26, w31, w31
+  bn.xor w27, w31, w31
+  bn.xor w30, w31, w31
 
   beq  x0, x0, _getnoise_common
 
@@ -2410,35 +2416,35 @@ _getnoise_eta_2:
     bn.sid x4, 0(x11++)
 
     /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
-    bn.xor w2, w2, w2
-    bn.xor w3, w3, w3
-    bn.xor w4, w4, w4
-    bn.xor w5, w5, w5
-    bn.xor w6, w6, w6
-    bn.xor w7, w7, w7
-    bn.xor w8, w8, w8
-    bn.xor w9, w9, w9
-    bn.xor w10, w10, w10
-    bn.xor w11, w11, w11
-    bn.xor w12, w12, w12
-    bn.xor w13, w13, w13
-    bn.xor w14, w14, w14
-    bn.xor w15, w15, w15
-    bn.xor w17, w17, w17
-    bn.xor w28, w28, w28
-    bn.xor w29, w29, w29
+    bn.xor w0, w31, w31
+    bn.xor w1, w31, w31
+    bn.xor w2, w31, w31
+    bn.xor w3, w31, w31
+    bn.xor w4, w31, w31
+    bn.xor w5, w31, w31
+    bn.xor w6, w31, w31
+    bn.xor w7, w31, w31
+    bn.xor w8, w31, w31
+    bn.xor w9, w31, w31
+    bn.xor w10, w31, w31
+    bn.xor w11, w31, w31
+    bn.xor w12, w31, w31
+    bn.xor w13, w31, w31
+    bn.xor w14, w31, w31
+    bn.xor w15, w31, w31
+    bn.xor w17, w31, w31
+    bn.xor w28, w31, w31
+    bn.xor w29, w31, w31
   endloop
 
   /* Whitening. */
-  bn.xor w18, w18, w18
-  bn.xor w19, w19, w19
-  bn.xor w20, w20, w20
-  bn.xor w21, w21, w21
-  bn.xor w22, w22, w22
-  bn.xor w23, w23, w23
-  bn.xor w24, w24, w24
+  bn.xor w18, w31, w31
+  bn.xor w19, w31, w31
+  bn.xor w20, w31, w31
+  bn.xor w21, w31, w31
+  bn.xor w22, w31, w31
+  bn.xor w23, w31, w31
+  bn.xor w24, w31, w31
 
 _getnoise_common:
   /* Compute r = masked_cbd(x, y, eta). */
@@ -2597,30 +2603,30 @@ _bitslice_eta_3:
   endloop
 
   /* Whitening. */
-  bn.xor w0, w0, w0
-  bn.xor w1, w1, w1
-  bn.xor w2, w2, w2
-  bn.xor w3, w3, w3
-  bn.xor w4, w4, w4
-  bn.xor w5, w5, w5
-  bn.xor w6, w6, w6
-  bn.xor w7, w7, w7
-  bn.xor w8, w8, w8
-  bn.xor w9, w9, w9
-  bn.xor w10, w10, w10
-  bn.xor w11, w11, w11
-  bn.xor w12, w12, w12
-  bn.xor w13, w13, w13
-  bn.xor w14, w14, w14
-  bn.xor w15, w15, w15
-  bn.xor w17, w17, w17
-  bn.xor w18, w18, w18
-  bn.xor w19, w19, w19
-  bn.xor w20, w20, w20
-  bn.xor w21, w21, w21
-  bn.xor w22, w22, w22
-  bn.xor w28, w28, w28
-  bn.xor w29, w29, w29
+  bn.xor w0, w31, w31
+  bn.xor w1, w31, w31
+  bn.xor w2, w31, w31
+  bn.xor w3, w31, w31
+  bn.xor w4, w31, w31
+  bn.xor w5, w31, w31
+  bn.xor w6, w31, w31
+  bn.xor w7, w31, w31
+  bn.xor w8, w31, w31
+  bn.xor w9, w31, w31
+  bn.xor w10, w31, w31
+  bn.xor w11, w31, w31
+  bn.xor w12, w31, w31
+  bn.xor w13, w31, w31
+  bn.xor w14, w31, w31
+  bn.xor w15, w31, w31
+  bn.xor w17, w31, w31
+  bn.xor w18, w31, w31
+  bn.xor w19, w31, w31
+  bn.xor w20, w31, w31
+  bn.xor w21, w31, w31
+  bn.xor w22, w31, w31
+  bn.xor w28, w31, w31
+  bn.xor w29, w31, w31
   ret
 
 /* Undefine gadget-local macros. */
@@ -2721,29 +2727,29 @@ masked_poly_tomsg:
 
     /* For the first share, w19 holds 2^(alpha - 1).
      * After that, we clear w19 so that bn.add acts as a shift. */
-    bn.xor w19, w19, w19
+    bn.xor w19, w31, w31
 
     /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
-    bn.xor w2, w2, w2
-    bn.xor w3, w3, w3
-    bn.xor w4, w4, w4
-    bn.xor w5, w5, w5
-    bn.xor w6, w6, w6
-    bn.xor w7, w7, w7
-    bn.xor w8, w8, w8
-    bn.xor w9, w9, w9
-    bn.xor w10, w10, w10
-    bn.xor w11, w11, w11
-    bn.xor w12, w12, w12
-    bn.xor w13, w13, w13
-    bn.xor w14, w14, w14
-    bn.xor w15, w15, w15
-    bn.xor w20, w20, w20
-    bn.xor w21, w21, w21
-    bn.xor w28, w28, w28
-    bn.xor w29, w29, w29
+    bn.xor w0, w31, w31
+    bn.xor w1, w31, w31
+    bn.xor w2, w31, w31
+    bn.xor w3, w31, w31
+    bn.xor w4, w31, w31
+    bn.xor w5, w31, w31
+    bn.xor w6, w31, w31
+    bn.xor w7, w31, w31
+    bn.xor w8, w31, w31
+    bn.xor w9, w31, w31
+    bn.xor w10, w31, w31
+    bn.xor w11, w31, w31
+    bn.xor w12, w31, w31
+    bn.xor w13, w31, w31
+    bn.xor w14, w31, w31
+    bn.xor w15, w31, w31
+    bn.xor w20, w31, w31
+    bn.xor w21, w31, w31
+    bn.xor w28, w31, w31
+    bn.xor w29, w31, w31
   endloop
 
   /* Compute c = seca2b(z), k = 1 + alpha = 16, share bytes = 512. */
@@ -2761,7 +2767,7 @@ masked_poly_tomsg:
     addi   x5, x5, 512
     bn.sid x0, 0(x6++)
     /* Whitening. */
-    bn.xor w0, w0, w0
+    bn.xor w0, w31, w31
   endloop
 
   /* Restore registers. */
@@ -3057,7 +3063,7 @@ _handle_common_dv:
 
 _skip_bit_4:
   /* Whitening. */
-  bn.xor w17, w17, w17
+  bn.xor w17, w31, w31
 
   /* Compute r = secand(r, t). */
   lw   x10, 328(x2)
@@ -3469,7 +3475,7 @@ _handle_common_du:
 
 _skip_bit_10:
   /* Whitening. */
-  bn.xor w17, w17, w17
+  bn.xor w17, w31, w31
 
   /* Compute r = secand(r, t). */
   lw   x10, 716(x2)
@@ -3522,7 +3528,7 @@ finalize_cmp:
     bn.rshi w0, w31, w0 >> 128
     bn.sid  x0, 0(x5++)
     /* Whitening. */
-    bn.xor  w0, w0, w0
+    bn.xor  w0, w31, w31
   endloop
   /* Compute r &= t. */
   /* x10 already points to r. */
@@ -3542,7 +3548,7 @@ finalize_cmp:
     bn.rshi w0, w31, w0 >> 64
     bn.sid  x0, 0(x5++)
     /* Whitening. */
-    bn.xor  w0, w0, w0
+    bn.xor  w0, w31, w31
   endloop
   /* Compute r &= t. */
   jal  x1, secand
@@ -3556,7 +3562,7 @@ finalize_cmp:
     bn.rshi w0, w31, w0 >> 32
     bn.sid  x0, 0(x5++)
     /* Whitening. */
-    bn.xor  w0, w0, w0
+    bn.xor  w0, w31, w31
   endloop
   /* Compute r &= t. */
   jal  x1, secand
@@ -3570,7 +3576,7 @@ finalize_cmp:
     bn.rshi w0, w31, w0 >> 16
     bn.sid  x0, 0(x5++)
     /* Whitening. */
-    bn.xor  w0, w0, w0
+    bn.xor  w0, w31, w31
   endloop
   /* Compute r &= t. */
   jal  x1, secand
@@ -3584,7 +3590,7 @@ finalize_cmp:
     bn.rshi w0, w31, w0 >> 8
     bn.sid  x0, 0(x5++)
     /* Whitening. */
-    bn.xor  w0, w0, w0
+    bn.xor  w0, w31, w31
   endloop
   /* Compute r &= t. */
   jal  x1, secand
@@ -3598,7 +3604,7 @@ finalize_cmp:
     bn.rshi w0, w31, w0 >> 4
     bn.sid  x0, 0(x5++)
     /* Whitening. */
-    bn.xor  w0, w0, w0
+    bn.xor  w0, w31, w31
   endloop
   /* Compute r &= t. */
   jal  x1, secand
@@ -3612,7 +3618,7 @@ finalize_cmp:
     bn.rshi w0, w31, w0 >> 2
     bn.sid  x0, 0(x5++)
     /* Whitening. */
-    bn.xor  w0, w0, w0
+    bn.xor  w0, w31, w31
   endloop
   /* Compute r &= t. */
   jal  x1, secand
@@ -3626,7 +3632,7 @@ finalize_cmp:
     bn.rshi w0, w31, w0 >> 1
     bn.sid  x0, 0(x5++)
     /* Whitening. */
-    bn.xor  w0, w0, w0
+    bn.xor  w0, w31, w31
   endloop
   /* Compute r &= t. */
   jal  x1, secand

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -1971,26 +1971,20 @@ masked_cbd:
    *   x2 +  832 : s ( 384 B)
    *   x2 + 1216 : save registers. */
   addi x2, x2, -1248
-  addi x2, x2, -1248
-  sw x8, 1216(x2)
-  sw x9, 1220(x2)
-  sw x18, 1224(x2)
-  sw x20, 1228(x2)
-  sw x21, 1232(x2)
-  sw x22, 1236(x2)
+  sw   x14, 1216(x2)
+  sw   x8, 1220(x2)
+  sw   x9, 1224(x2)
+  sw   x18, 1228(x2)
 
   /* Save input/output addresses and set the scratch pointers. */
-  add  x8, x10, x0
-  add  x9, x11, x0
+  addi x8, x2, 832 /* s */
+  addi x9, x2, 768 /* a */
   add  x18, x12, x0
-  add  x20, x14, x0
-  addi x21, x2, 832 /* s */
-  addi x22, x2, 768 /* a */
 
   /* Copy x to s[0..eta - 1] and ~y to s[eta..2 * eta - 1]. */
-  add  x5, x21, x0
-  slli x4, x12, 5 /* eta * 32 */
-  add  x6, x21, x4
+  add  x5, x8, x0
+  slli x4, x18, 5 /* eta * 32 */
+  add  x6, x8, x4
   /* Share 0. */
   loop x12, 7
     /* Whitening. */
@@ -2033,24 +2027,22 @@ masked_cbd:
    */
   /********** Iteration i = 0, ell = 2 * eta. **********/
   /* Since ell mod 2 = 0, we clear a. */
-  add    x5, x22, x0
   bn.xor w0, w0, w0
-  loopi 2, 1
-    bn.sid x0, 0(x5++)
-  endloop
+  bn.sid x0, 0(x9)
+  bn.sid x0, 32(x9)
 
   /* Loop j = 0..eta - 1. */
   /* Compute (a, s[j]) = secfulladder(s[2 * j], s[2 * j + 1], a). */
-  slli x5, x12, 6 /* (2 * eta) * 32 */
-  add  x10, x21, x0
+  slli x5, x18, 6 /* (2 * eta) * 32 */
+  add  x10, x8, x0
   add  x11, x5, x0
-  addi x12, x21, 32
+  addi x12, x8, 32
   add  x13, x5, x0
-  add  x15, x22, x0
+  add  x15, x9, x0
   addi x16, x0, 32
-  add  x17, x22, x0
+  add  x17, x9, x0
   addi x29, x0, 32
-  add  x30, x21, x0
+  add  x30, x8, x0
   add  x31, x5, x0
   loop x18, 5
     jal  x1, secfulladder
@@ -2065,7 +2057,7 @@ masked_cbd:
   loopi 2, 4
     /* Whitening. */
     bn.xor w0, w0, w0
-    bn.lid x0, 0(x15++)
+    bn.lid x0, 0(x17++)
     bn.sid x0, 0(x5)
     addi   x5, x5, 384
   endloop
@@ -2074,40 +2066,37 @@ masked_cbd:
   addi x5, x0, 2
   beq  x18, x5, _cbd_eta_2
   /* Since ell mod 2 = 1 if eta = 3, we compute a = s[ell - 1]. */
-  add  x5, x22, x0
-  add  x6, x21, x0
-  addi x6, x6, 64
+  add  x5, x9, x0
+  addi x6, x8, 64
   slli x4, x18, 6 /* (2 * eta) * 32 */
   loopi 2, 4
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.lid x0, 0(x6)
-    bn.sid x0, 0(x5++)
     add    x6, x6, x4
+    bn.sid x0, 0(x5++)
   endloop
   beq x0, x0, _continue_1
 
 _cbd_eta_2:
   /* Since ell mod 2 = 0 if eta = 2, we clear a. */
-  add    x5, x22, x0
   bn.xor w0, w0, w0
-  loopi 2, 1
-    bn.sid x0, 0(x5++)
-  endloop
+  bn.sid x0, 0(x9)
+  bn.sid x0, 32(x9)
 
 _continue_1:
   /* Loop j = 0. */
   /* Compute (a, s[0]) = secfulladder(s[0], s[1], a). */
   slli x5, x18, 6
-  add  x10, x21, x0
+  add  x10, x8, x0
   add  x11, x5, x0
-  addi x12, x21, 32
+  addi x12, x8, 32
   add  x13, x5, x0
-  add  x15, x22, x0
+  add  x15, x9, x0
   addi x16, x0, 32
-  add  x17, x22, x0
+  add  x17, x9, x0
   addi x29, x0, 32
-  add  x30, x21, x0
+  add  x30, x8, x0
   add  x31, x5, x0
   jal  x1, secfulladder
 
@@ -2123,24 +2112,21 @@ _continue_1:
 
   /********** Iteration i = 2, ell = eta // 2 = 1. **********/
   /* Since ell mod 2 = 1, we compute b[2] = s[ell - 1] = s[0] directly. */
-  add  x5, x2, x0
-  addi x5, x5, 64
-  add  x6, x21, x0
+  addi x5, x2, 64
+  add  x6, x8, x0
   slli x7, x18, 6
-
   loopi 2, 5
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.lid x0, 0(x6)
-    bn.sid x0, 0(x5)
     add    x6, x6, x7
+    bn.sid x0, 0(x5)
     addi   x5, x5, 384
   endloop
 
   /* Clear bits b[3..k - 1]. */
-  add    x5, x2, x0
-  addi   x5, x5, 96
   bn.xor w0, w0, w0
+  addi   x5, x2, 96
   loopi 2, 3
     loopi 9, 1
       bn.sid x0, 0(x5++)
@@ -2150,17 +2136,18 @@ _continue_1:
 
   /* Compute r = secb2amodq(b). */
   add x10, x2, x0
-  add x12, x20, x0
+  lw  x12, 1216(x2)
   jal x1, secb2amodq
 
-  /* Compute r_0 = (r_0 - eta) mod q. */
-  add    x5, x20, x0
-  add    x6, x21, x0
-  sw     x18, 0(x6)
-  bn.lid x0, 0(x6)
-  loopi 16, 1
-    bn.rshi w1, w0, w1 >> 16
+  /* Generate eta in 16 16-bit lanes. */
+  bn.subi    w0, w31, 1
+  bn.shv.16h w0, w0 >> 15
+  bn.xor     w1, w31, w31
+  loop x18, 1
+    bn.add w1, w1, w0
   endloop
+  /* Compute r_0 = (r_0 - eta) mod q. */
+  lw x5, 1216(x2)
   loopi 16, 3
     bn.lid       x0, 0(x5)
     bn.subvm.16h w0, w0, w1
@@ -2168,12 +2155,9 @@ _continue_1:
   endloop
 
   /* Restore registers and stack. */
-  lw x8, 1216(x2)
-  lw x9, 1220(x2)
-  lw x18, 1224(x2)
-  lw x20, 1228(x2)
-  lw x21, 1232(x2)
-  lw x22, 1236(x2)
+  lw   x8, 1220(x2)
+  lw   x9, 1224(x2)
+  lw   x18, 1228(x2)
   addi x2, x2, 1248
   ret
 

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -584,25 +584,7 @@ poly_to_bitsliced:
     addi   x4, x4, 1
   endloop
 
-  /* Whitening. */
-  bn.xor w0, w31, w31
-  bn.xor w1, w31, w31
-  bn.xor w2, w31, w31
-  bn.xor w3, w31, w31
-  bn.xor w4, w31, w31
-  bn.xor w5, w31, w31
-  bn.xor w6, w31, w31
-  bn.xor w7, w31, w31
-  bn.xor w8, w31, w31
-  bn.xor w9, w31, w31
-  bn.xor w10, w31, w31
-  bn.xor w11, w31, w31
-  bn.xor w12, w31, w31
-  bn.xor w13, w31, w31
-  bn.xor w14, w31, w31
-  bn.xor w15, w31, w31
-  bn.xor w28, w31, w31
-  bn.xor w29, w31, w31
+  jal x1, whitening_bitslice_transpose
   ret
 
 /**
@@ -647,25 +629,7 @@ poly_from_bitsliced:
     addi   x4, x4, -1
   endloop
 
-  /* Whitening. */
-  bn.xor w0, w31, w31
-  bn.xor w1, w31, w31
-  bn.xor w2, w31, w31
-  bn.xor w3, w31, w31
-  bn.xor w4, w31, w31
-  bn.xor w5, w31, w31
-  bn.xor w6, w31, w31
-  bn.xor w7, w31, w31
-  bn.xor w8, w31, w31
-  bn.xor w9, w31, w31
-  bn.xor w10, w31, w31
-  bn.xor w11, w31, w31
-  bn.xor w12, w31, w31
-  bn.xor w13, w31, w31
-  bn.xor w14, w31, w31
-  bn.xor w15, w31, w31
-  bn.xor w28, w31, w31
-  bn.xor w29, w31, w31
+  jal x1, whitening_bitslice_transpose
   ret
 
 /**
@@ -683,209 +647,209 @@ poly_from_bitsliced:
 
 _bitslice_transpose:
   /* Stage d=8. */
-  bn.not     w28, w31
-  bn.shv.16h w28, w28 >> 8      /* 0x00ff */
-  bn.shv.16h w29, w0 >> 8
-  bn.xor     w29, w29, w8
-  bn.and     w29, w29, w28
-  bn.xor     w8, w8, w29
-  bn.shv.16h w29, w29 << 8
-  bn.xor     w0, w0, w29
-  bn.shv.16h w29, w1 >> 8
-  bn.xor     w29, w29, w9
-  bn.and     w29, w29, w28
-  bn.xor     w9, w9, w29
-  bn.shv.16h w29, w29 << 8
-  bn.xor     w1, w1, w29
-  bn.shv.16h w29, w2 >> 8
-  bn.xor     w29, w29, w10
-  bn.and     w29, w29, w28
-  bn.xor     w10, w10, w29
-  bn.shv.16h w29, w29 << 8
-  bn.xor     w2, w2, w29
-  bn.shv.16h w29, w3 >> 8
-  bn.xor     w29, w29, w11
-  bn.and     w29, w29, w28
-  bn.xor     w11, w11, w29
-  bn.shv.16h w29, w29 << 8
-  bn.xor     w3, w3, w29
-  bn.shv.16h w29, w4 >> 8
-  bn.xor     w29, w29, w12
-  bn.and     w29, w29, w28
-  bn.xor     w12, w12, w29
-  bn.shv.16h w29, w29 << 8
-  bn.xor     w4, w4, w29
-  bn.shv.16h w29, w5 >> 8
-  bn.xor     w29, w29, w13
-  bn.and     w29, w29, w28
-  bn.xor     w13, w13, w29
-  bn.shv.16h w29, w29 << 8
-  bn.xor     w5, w5, w29
-  bn.shv.16h w29, w6 >> 8
-  bn.xor     w29, w29, w14
-  bn.and     w29, w29, w28
-  bn.xor     w14, w14, w29
-  bn.shv.16h w29, w29 << 8
-  bn.xor     w6, w6, w29
-  bn.shv.16h w29, w7 >> 8
-  bn.xor     w29, w29, w15
-  bn.and     w29, w29, w28
-  bn.xor     w15, w15, w29
-  bn.shv.16h w29, w29 << 8
-  bn.xor     w7, w7, w29
+  bn.not     w24, w31
+  bn.shv.16h w24, w24 >> 8      /* 0x00ff */
+  bn.shv.16h w25, w0 >> 8
+  bn.xor     w25, w25, w8
+  bn.and     w25, w25, w24
+  bn.xor     w8, w8, w25
+  bn.shv.16h w25, w25 << 8
+  bn.xor     w0, w0, w25
+  bn.shv.16h w25, w1 >> 8
+  bn.xor     w25, w25, w9
+  bn.and     w25, w25, w24
+  bn.xor     w9, w9, w25
+  bn.shv.16h w25, w25 << 8
+  bn.xor     w1, w1, w25
+  bn.shv.16h w25, w2 >> 8
+  bn.xor     w25, w25, w10
+  bn.and     w25, w25, w24
+  bn.xor     w10, w10, w25
+  bn.shv.16h w25, w25 << 8
+  bn.xor     w2, w2, w25
+  bn.shv.16h w25, w3 >> 8
+  bn.xor     w25, w25, w11
+  bn.and     w25, w25, w24
+  bn.xor     w11, w11, w25
+  bn.shv.16h w25, w25 << 8
+  bn.xor     w3, w3, w25
+  bn.shv.16h w25, w4 >> 8
+  bn.xor     w25, w25, w12
+  bn.and     w25, w25, w24
+  bn.xor     w12, w12, w25
+  bn.shv.16h w25, w25 << 8
+  bn.xor     w4, w4, w25
+  bn.shv.16h w25, w5 >> 8
+  bn.xor     w25, w25, w13
+  bn.and     w25, w25, w24
+  bn.xor     w13, w13, w25
+  bn.shv.16h w25, w25 << 8
+  bn.xor     w5, w5, w25
+  bn.shv.16h w25, w6 >> 8
+  bn.xor     w25, w25, w14
+  bn.and     w25, w25, w24
+  bn.xor     w14, w14, w25
+  bn.shv.16h w25, w25 << 8
+  bn.xor     w6, w6, w25
+  bn.shv.16h w25, w7 >> 8
+  bn.xor     w25, w25, w15
+  bn.and     w25, w25, w24
+  bn.xor     w15, w15, w25
+  bn.shv.16h w25, w25 << 8
+  bn.xor     w7, w7, w25
   /* Stage d=4. */
-  bn.shv.16h w29, w28 << 4
-  bn.xor     w28, w28, w29      /* 0x0f0f */
-  bn.shv.16h w29, w0 >> 4
-  bn.xor     w29, w29, w4
-  bn.and     w29, w29, w28
-  bn.xor     w4, w4, w29
-  bn.shv.16h w29, w29 << 4
-  bn.xor     w0, w0, w29
-  bn.shv.16h w29, w1 >> 4
-  bn.xor     w29, w29, w5
-  bn.and     w29, w29, w28
-  bn.xor     w5, w5, w29
-  bn.shv.16h w29, w29 << 4
-  bn.xor     w1, w1, w29
-  bn.shv.16h w29, w2 >> 4
-  bn.xor     w29, w29, w6
-  bn.and     w29, w29, w28
-  bn.xor     w6, w6, w29
-  bn.shv.16h w29, w29 << 4
-  bn.xor     w2, w2, w29
-  bn.shv.16h w29, w3 >> 4
-  bn.xor     w29, w29, w7
-  bn.and     w29, w29, w28
-  bn.xor     w7, w7, w29
-  bn.shv.16h w29, w29 << 4
-  bn.xor     w3, w3, w29
-  bn.shv.16h w29, w8 >> 4
-  bn.xor     w29, w29, w12
-  bn.and     w29, w29, w28
-  bn.xor     w12, w12, w29
-  bn.shv.16h w29, w29 << 4
-  bn.xor     w8, w8, w29
-  bn.shv.16h w29, w9 >> 4
-  bn.xor     w29, w29, w13
-  bn.and     w29, w29, w28
-  bn.xor     w13, w13, w29
-  bn.shv.16h w29, w29 << 4
-  bn.xor     w9, w9, w29
-  bn.shv.16h w29, w10 >> 4
-  bn.xor     w29, w29, w14
-  bn.and     w29, w29, w28
-  bn.xor     w14, w14, w29
-  bn.shv.16h w29, w29 << 4
-  bn.xor     w10, w10, w29
-  bn.shv.16h w29, w11 >> 4
-  bn.xor     w29, w29, w15
-  bn.and     w29, w29, w28
-  bn.xor     w15, w15, w29
-  bn.shv.16h w29, w29 << 4
-  bn.xor     w11, w11, w29
+  bn.shv.16h w25, w24 << 4
+  bn.xor     w24, w24, w25      /* 0x0f0f */
+  bn.shv.16h w25, w0 >> 4
+  bn.xor     w25, w25, w4
+  bn.and     w25, w25, w24
+  bn.xor     w4, w4, w25
+  bn.shv.16h w25, w25 << 4
+  bn.xor     w0, w0, w25
+  bn.shv.16h w25, w1 >> 4
+  bn.xor     w25, w25, w5
+  bn.and     w25, w25, w24
+  bn.xor     w5, w5, w25
+  bn.shv.16h w25, w25 << 4
+  bn.xor     w1, w1, w25
+  bn.shv.16h w25, w2 >> 4
+  bn.xor     w25, w25, w6
+  bn.and     w25, w25, w24
+  bn.xor     w6, w6, w25
+  bn.shv.16h w25, w25 << 4
+  bn.xor     w2, w2, w25
+  bn.shv.16h w25, w3 >> 4
+  bn.xor     w25, w25, w7
+  bn.and     w25, w25, w24
+  bn.xor     w7, w7, w25
+  bn.shv.16h w25, w25 << 4
+  bn.xor     w3, w3, w25
+  bn.shv.16h w25, w8 >> 4
+  bn.xor     w25, w25, w12
+  bn.and     w25, w25, w24
+  bn.xor     w12, w12, w25
+  bn.shv.16h w25, w25 << 4
+  bn.xor     w8, w8, w25
+  bn.shv.16h w25, w9 >> 4
+  bn.xor     w25, w25, w13
+  bn.and     w25, w25, w24
+  bn.xor     w13, w13, w25
+  bn.shv.16h w25, w25 << 4
+  bn.xor     w9, w9, w25
+  bn.shv.16h w25, w10 >> 4
+  bn.xor     w25, w25, w14
+  bn.and     w25, w25, w24
+  bn.xor     w14, w14, w25
+  bn.shv.16h w25, w25 << 4
+  bn.xor     w10, w10, w25
+  bn.shv.16h w25, w11 >> 4
+  bn.xor     w25, w25, w15
+  bn.and     w25, w25, w24
+  bn.xor     w15, w15, w25
+  bn.shv.16h w25, w25 << 4
+  bn.xor     w11, w11, w25
   /* Stage d=2. */
-  bn.shv.16h w29, w28 << 2
-  bn.xor     w28, w28, w29      /* 0x3333 */
-  bn.shv.16h w29, w0 >> 2
-  bn.xor     w29, w29, w2
-  bn.and     w29, w29, w28
-  bn.xor     w2, w2, w29
-  bn.shv.16h w29, w29 << 2
-  bn.xor     w0, w0, w29
-  bn.shv.16h w29, w1 >> 2
-  bn.xor     w29, w29, w3
-  bn.and     w29, w29, w28
-  bn.xor     w3, w3, w29
-  bn.shv.16h w29, w29 << 2
-  bn.xor     w1, w1, w29
-  bn.shv.16h w29, w4 >> 2
-  bn.xor     w29, w29, w6
-  bn.and     w29, w29, w28
-  bn.xor     w6, w6, w29
-  bn.shv.16h w29, w29 << 2
-  bn.xor     w4, w4, w29
-  bn.shv.16h w29, w5 >> 2
-  bn.xor     w29, w29, w7
-  bn.and     w29, w29, w28
-  bn.xor     w7, w7, w29
-  bn.shv.16h w29, w29 << 2
-  bn.xor     w5, w5, w29
-  bn.shv.16h w29, w8 >> 2
-  bn.xor     w29, w29, w10
-  bn.and     w29, w29, w28
-  bn.xor     w10, w10, w29
-  bn.shv.16h w29, w29 << 2
-  bn.xor     w8, w8, w29
-  bn.shv.16h w29, w9 >> 2
-  bn.xor     w29, w29, w11
-  bn.and     w29, w29, w28
-  bn.xor     w11, w11, w29
-  bn.shv.16h w29, w29 << 2
-  bn.xor     w9, w9, w29
-  bn.shv.16h w29, w12 >> 2
-  bn.xor     w29, w29, w14
-  bn.and     w29, w29, w28
-  bn.xor     w14, w14, w29
-  bn.shv.16h w29, w29 << 2
-  bn.xor     w12, w12, w29
-  bn.shv.16h w29, w13 >> 2
-  bn.xor     w29, w29, w15
-  bn.and     w29, w29, w28
-  bn.xor     w15, w15, w29
-  bn.shv.16h w29, w29 << 2
-  bn.xor     w13, w13, w29
+  bn.shv.16h w25, w24 << 2
+  bn.xor     w24, w24, w25      /* 0x3333 */
+  bn.shv.16h w25, w0 >> 2
+  bn.xor     w25, w25, w2
+  bn.and     w25, w25, w24
+  bn.xor     w2, w2, w25
+  bn.shv.16h w25, w25 << 2
+  bn.xor     w0, w0, w25
+  bn.shv.16h w25, w1 >> 2
+  bn.xor     w25, w25, w3
+  bn.and     w25, w25, w24
+  bn.xor     w3, w3, w25
+  bn.shv.16h w25, w25 << 2
+  bn.xor     w1, w1, w25
+  bn.shv.16h w25, w4 >> 2
+  bn.xor     w25, w25, w6
+  bn.and     w25, w25, w24
+  bn.xor     w6, w6, w25
+  bn.shv.16h w25, w25 << 2
+  bn.xor     w4, w4, w25
+  bn.shv.16h w25, w5 >> 2
+  bn.xor     w25, w25, w7
+  bn.and     w25, w25, w24
+  bn.xor     w7, w7, w25
+  bn.shv.16h w25, w25 << 2
+  bn.xor     w5, w5, w25
+  bn.shv.16h w25, w8 >> 2
+  bn.xor     w25, w25, w10
+  bn.and     w25, w25, w24
+  bn.xor     w10, w10, w25
+  bn.shv.16h w25, w25 << 2
+  bn.xor     w8, w8, w25
+  bn.shv.16h w25, w9 >> 2
+  bn.xor     w25, w25, w11
+  bn.and     w25, w25, w24
+  bn.xor     w11, w11, w25
+  bn.shv.16h w25, w25 << 2
+  bn.xor     w9, w9, w25
+  bn.shv.16h w25, w12 >> 2
+  bn.xor     w25, w25, w14
+  bn.and     w25, w25, w24
+  bn.xor     w14, w14, w25
+  bn.shv.16h w25, w25 << 2
+  bn.xor     w12, w12, w25
+  bn.shv.16h w25, w13 >> 2
+  bn.xor     w25, w25, w15
+  bn.and     w25, w25, w24
+  bn.xor     w15, w15, w25
+  bn.shv.16h w25, w25 << 2
+  bn.xor     w13, w13, w25
   /* Stage d=1. */
-  bn.shv.16h w29, w28 << 1
-  bn.xor     w28, w28, w29      /* 0x5555 */
-  bn.shv.16h w29, w0 >> 1
-  bn.xor     w29, w29, w1
-  bn.and     w29, w29, w28
-  bn.xor     w1, w1, w29
-  bn.shv.16h w29, w29 << 1
-  bn.xor     w0, w0, w29
-  bn.shv.16h w29, w2 >> 1
-  bn.xor     w29, w29, w3
-  bn.and     w29, w29, w28
-  bn.xor     w3, w3, w29
-  bn.shv.16h w29, w29 << 1
-  bn.xor     w2, w2, w29
-  bn.shv.16h w29, w4 >> 1
-  bn.xor     w29, w29, w5
-  bn.and     w29, w29, w28
-  bn.xor     w5, w5, w29
-  bn.shv.16h w29, w29 << 1
-  bn.xor     w4, w4, w29
-  bn.shv.16h w29, w6 >> 1
-  bn.xor     w29, w29, w7
-  bn.and     w29, w29, w28
-  bn.xor     w7, w7, w29
-  bn.shv.16h w29, w29 << 1
-  bn.xor     w6, w6, w29
-  bn.shv.16h w29, w8 >> 1
-  bn.xor     w29, w29, w9
-  bn.and     w29, w29, w28
-  bn.xor     w9, w9, w29
-  bn.shv.16h w29, w29 << 1
-  bn.xor     w8, w8, w29
-  bn.shv.16h w29, w10 >> 1
-  bn.xor     w29, w29, w11
-  bn.and     w29, w29, w28
-  bn.xor     w11, w11, w29
-  bn.shv.16h w29, w29 << 1
-  bn.xor     w10, w10, w29
-  bn.shv.16h w29, w12 >> 1
-  bn.xor     w29, w29, w13
-  bn.and     w29, w29, w28
-  bn.xor     w13, w13, w29
-  bn.shv.16h w29, w29 << 1
-  bn.xor     w12, w12, w29
-  bn.shv.16h w29, w14 >> 1
-  bn.xor     w29, w29, w15
-  bn.and     w29, w29, w28
-  bn.xor     w15, w15, w29
-  bn.shv.16h w29, w29 << 1
-  bn.xor     w14, w14, w29
+  bn.shv.16h w25, w24 << 1
+  bn.xor     w24, w24, w25      /* 0x5555 */
+  bn.shv.16h w25, w0 >> 1
+  bn.xor     w25, w25, w1
+  bn.and     w25, w25, w24
+  bn.xor     w1, w1, w25
+  bn.shv.16h w25, w25 << 1
+  bn.xor     w0, w0, w25
+  bn.shv.16h w25, w2 >> 1
+  bn.xor     w25, w25, w3
+  bn.and     w25, w25, w24
+  bn.xor     w3, w3, w25
+  bn.shv.16h w25, w25 << 1
+  bn.xor     w2, w2, w25
+  bn.shv.16h w25, w4 >> 1
+  bn.xor     w25, w25, w5
+  bn.and     w25, w25, w24
+  bn.xor     w5, w5, w25
+  bn.shv.16h w25, w25 << 1
+  bn.xor     w4, w4, w25
+  bn.shv.16h w25, w6 >> 1
+  bn.xor     w25, w25, w7
+  bn.and     w25, w25, w24
+  bn.xor     w7, w7, w25
+  bn.shv.16h w25, w25 << 1
+  bn.xor     w6, w6, w25
+  bn.shv.16h w25, w8 >> 1
+  bn.xor     w25, w25, w9
+  bn.and     w25, w25, w24
+  bn.xor     w9, w9, w25
+  bn.shv.16h w25, w25 << 1
+  bn.xor     w8, w8, w25
+  bn.shv.16h w25, w10 >> 1
+  bn.xor     w25, w25, w11
+  bn.and     w25, w25, w24
+  bn.xor     w11, w11, w25
+  bn.shv.16h w25, w25 << 1
+  bn.xor     w10, w10, w25
+  bn.shv.16h w25, w12 >> 1
+  bn.xor     w25, w25, w13
+  bn.and     w25, w25, w24
+  bn.xor     w13, w13, w25
+  bn.shv.16h w25, w25 << 1
+  bn.xor     w12, w12, w25
+  bn.shv.16h w25, w14 >> 1
+  bn.xor     w25, w25, w15
+  bn.and     w25, w25, w24
+  bn.xor     w15, w15, w25
+  bn.shv.16h w25, w25 << 1
+  bn.xor     w14, w14, w25
   ret
 
 /**
@@ -1561,25 +1525,25 @@ poly_hocompress_dv:
   sw   x9, 1160(x2)
 
   /* Load all constants. */
-  addi      x4, x0, 17
+  addi      x4, x0, 20
   la        x5, const_m_dv
   bn.lid    x4++, 0(x5)
   la        x5, const_qp1_half
   bn.lid    x4++, 0(x5)
-  bn.shv.8s w18, w18 >> 16
+  bn.shv.8s w21, w21 >> 16
 
   /* Create 2^(alpha - 1). */
-  bn.subi   w19, w31, 1
-  bn.shv.8s w19, w19 >> 31
-  bn.shv.8s w19, w19 << 12
+  bn.subi   w22, w31, 1
+  bn.shv.8s w22, w22 >> 31
+  bn.shv.8s w22, w22 << 12
 
-  /* Select alpha-dependent parameters: w19 = 2^(alpha - 1), x8 = the
+  /* Select alpha-dependent parameters: w22 = 2^(alpha - 1), x8 = the
    * extraction byte offset alpha * 32, x9 = dv. */
   addi      x4, x0, 4
   addi      x8, x0, 416  /* alpha * 32, alpha = 13 */
   addi      x9, x0, 5
   beq       x13, x4, _dv_params_done
-  bn.shv.8s w19, w19 << 1
+  bn.shv.8s w22, w22 << 1
   addi      x8, x0, 448  /* alpha * 32, alpha = 14 (k != 4) */
   addi      x9, x0, 4
 
@@ -1597,28 +1561,28 @@ _dv_params_done:
    *  - x >>= s
    *  - x &= ((1 << (dv + alpha)) - 1).
    */
-  loopi 2, 56
+  loopi 2, 37
     addi x4, x0, 15
     loopi 16, 18
       bn.lid             x0, 0(x10++)
       /* Handle even-positioned coeffs. */
-      bn.trn1.16h        w20, w0, w31
-      bn.shv.8s          w20, w20 << 18
-      bn.addv.8s         w20, w20, w18
-      bn.mulv.8s.even.hi w20, w20, w17
-      bn.mulv.8s.odd.hi  w20, w20, w17
-      bn.add             w21, w19, w20 >> 8
+      bn.trn1.16h        w17, w0, w31
+      bn.shv.8s          w17, w17 << 18
+      bn.addv.8s         w17, w17, w21
+      bn.mulv.8s.even.hi w17, w17, w20
+      bn.mulv.8s.odd.hi  w17, w17, w20
+      bn.add             w18, w22, w17 >> 8
       /* Handle odd-positioned coeffs. */
-      bn.trn2.16h        w20, w0, w31
-      bn.shv.8s          w20, w20 << 18
-      bn.addv.8s         w20, w20, w18
-      bn.mulv.8s.even.hi w20, w20, w17
-      bn.mulv.8s.odd.hi  w20, w20, w17
-      bn.add             w20, w19, w20 >> 8
+      bn.trn2.16h        w17, w0, w31
+      bn.shv.8s          w17, w17 << 18
+      bn.addv.8s         w17, w17, w21
+      bn.mulv.8s.even.hi w17, w17, w20
+      bn.mulv.8s.odd.hi  w17, w17, w20
+      bn.add             w17, w22, w17 >> 8
       /* Combine the results before bitslicing. */
-      bn.trn2.16h        w0, w21, w20
+      bn.trn2.16h        w0, w18, w17
       bn.sid             x0, 0(x7++)
-      bn.trn1.16h        w0, w21, w20
+      bn.trn1.16h        w0, w18, w17
       bn.movr            x4, x0
       addi               x4, x4, -1
     endloop
@@ -1648,31 +1612,11 @@ _dv_params_done:
       addi   x4, x4, 1
     endloop
 
-    /* For the first share, w19 holds 2^(alpha - 1).
-     * After that, we clear w19 so that bn.add acts as a shift. */
-    bn.xor w19, w31, w31
+    jal x1, whitening_dv
 
-    /* Whitening. */
-    bn.xor w0, w31, w31
-    bn.xor w1, w31, w31
-    bn.xor w2, w31, w31
-    bn.xor w3, w31, w31
-    bn.xor w4, w31, w31
-    bn.xor w5, w31, w31
-    bn.xor w6, w31, w31
-    bn.xor w7, w31, w31
-    bn.xor w8, w31, w31
-    bn.xor w9, w31, w31
-    bn.xor w10, w31, w31
-    bn.xor w11, w31, w31
-    bn.xor w12, w31, w31
-    bn.xor w13, w31, w31
-    bn.xor w14, w31, w31
-    bn.xor w15, w31, w31
-    bn.xor w20, w31, w31
-    bn.xor w21, w31, w31
-    bn.xor w28, w31, w31
-    bn.xor w29, w31, w31
+    /* For the first share, w22 holds 2^(alpha - 1).
+     * After that, we clear w22 so that bn.add acts as a shift. */
+    bn.xor w22, w31, w31
   endloop
 
   /* Compute c = seca2b(z), k = dv + alpha = 18, share bytes = 576. */
@@ -1744,29 +1688,29 @@ poly_hocompress_du:
   sw   x9, 1544(x2)
 
   /* Create 2^(alpha - 1). */
-  bn.subi   w30, w31, 1
-  bn.shv.8s w30, w30 >> 31
-  bn.shv.8s w30, w30 << 12
+  bn.subi   w22, w31, 1
+  bn.shv.8s w22, w22 >> 31
+  bn.shv.8s w22, w22 << 12
 
-  /* Select alpha-dependent parameters: w30 = 2^(alpha - 1), x8 = the
-   * extraction byte offset alpha * 32, x9 = dv. */
+  /* Select alpha-dependent parameters: w22 = 2^(alpha - 1), x8 = the
+   * extraction byte offset alpha * 32, x9 = du. */
   addi      x4, x0, 4
   addi      x8, x0, 416  /* alpha * 32, alpha = 13 */
   addi      x9, x0, 11
   beq       x13, x4, _du_params_done
-  bn.shv.8s w30, w30 << 1
+  bn.shv.8s w22, w22 << 1
   addi      x8, x0, 448  /* alpha * 32, alpha = 14 (k != 4) */
   addi      x9, x0, 10
 
 _du_params_done:
   /* Load all constants. */
-  addi       x4, x0, 17
+  addi       x4, x0, 20
   la         x5, const_m_du
   bn.lid     x4++, 0(x5)
   la         x5, const_q
   bn.lid     x4, 0(x5)
-  bn.shv.8s  w18, w18 >> 17 /* 0x680 in 8 32-bit lanes. */
-  bn.trn1.8s w18, w18, w31  /* 0x680 in 4 64-bit lanes. */
+  bn.shv.8s  w21, w21 >> 17 /* 0x680 in 8 32-bit lanes. */
+  bn.trn1.8s w21, w21, w31  /* 0x680 in 4 64-bit lanes. */
 
   add x6, x2, x0 /* z */
 
@@ -1781,63 +1725,63 @@ _du_params_done:
    *  - x >>= s
    *  - x &= ((1 << (du + alpha)) - 1).
    */
-  loopi 2, 83
+  loopi 2, 63
     addi x4, x0, 15
     loopi 16, 44
       bn.lid          x0, 0(x10++)
       /* Handle even-positioned coeffs. */
-      bn.trn1.16h      w19, w0, w31
+      bn.trn1.16h     w17, w0, w31
       /* Handle coeff[0] - coeff[4] - coeff[8] - coeff[12]. */
-      bn.trn1.8s      w20, w19, w31
-      bn.rshi         w20, w20, w31 >> 232
-      bn.add          w20, w20, w18
-      bn.mulqacc.so.z w21.l, w20.0, w17.0, 0
-      bn.mulqacc.so.z w21.u, w20.2, w17.0, 0
-      bn.mulqacc.so.z w20.l, w20.1, w17.0, 0
-      bn.mulqacc.so.z w20.u, w20.3, w17.0, 0
-      bn.trn2.4d      w20, w21, w20
+      bn.trn1.8s      w18, w17, w31
+      bn.rshi         w18, w18, w31 >> 232
+      bn.add          w18, w18, w21
+      bn.mulqacc.so.z w19.l, w18.0, w20.0, 0
+      bn.mulqacc.so.z w19.u, w18.2, w20.0, 0
+      bn.mulqacc.so.z w18.l, w18.1, w20.0, 0
+      bn.mulqacc.so.z w18.u, w18.3, w20.0, 0
+      bn.trn2.4d      w18, w19, w18
       /* Handle coeff[2] - coeff[6] - coeff[10] - coeff[14]. */
-      bn.trn2.8s      w19, w19, w31
-      bn.rshi         w19, w19, w31 >> 232
-      bn.add          w19, w19, w18
-      bn.mulqacc.so.z w21.l, w19.0, w17.0, 0
-      bn.mulqacc.so.z w21.u, w19.2, w17.0, 0
-      bn.mulqacc.so.z w19.l, w19.1, w17.0, 0
-      bn.mulqacc.so.z w19.u, w19.3, w17.0, 0
-      bn.trn2.4d      w19, w21, w19
+      bn.trn2.8s      w17, w17, w31
+      bn.rshi         w17, w17, w31 >> 232
+      bn.add          w17, w17, w21
+      bn.mulqacc.so.z w19.l, w17.0, w20.0, 0
+      bn.mulqacc.so.z w19.u, w17.2, w20.0, 0
+      bn.mulqacc.so.z w17.l, w17.1, w20.0, 0
+      bn.mulqacc.so.z w17.u, w17.3, w20.0, 0
+      bn.trn2.4d      w17, w19, w17
       /* Combine the result. */
-      bn.trn1.8s      w19, w20, w19
+      bn.trn1.8s      w17, w18, w17
 
       /* Handle odd-positioned coeffs. */
       bn.trn2.16h     w0, w0, w31
       /* Handle coeff[1] - coeff[5] - coeff[9] - coeff[13]. */
-      bn.trn1.8s      w20, w0, w31
-      bn.rshi         w20, w20, w31 >> 232
-      bn.add          w20, w20, w18
-      bn.mulqacc.so.z w21.l, w20.0, w17.0, 0
-      bn.mulqacc.so.z w21.u, w20.2, w17.0, 0
-      bn.mulqacc.so.z w20.l, w20.1, w17.0, 0
-      bn.mulqacc.so.z w20.u, w20.3, w17.0, 0
-      bn.trn2.4d      w20, w21, w20
+      bn.trn1.8s      w18, w0, w31
+      bn.rshi         w18, w18, w31 >> 232
+      bn.add          w18, w18, w21
+      bn.mulqacc.so.z w19.l, w18.0, w20.0, 0
+      bn.mulqacc.so.z w19.u, w18.2, w20.0, 0
+      bn.mulqacc.so.z w18.l, w18.1, w20.0, 0
+      bn.mulqacc.so.z w18.u, w18.3, w20.0, 0
+      bn.trn2.4d      w18, w19, w18
       /* Handle coeff[3] - coeff[7] - coeff[11] - coeff[15]. */
       bn.trn2.8s      w0, w0, w31
       bn.rshi         w0, w0, w31 >> 232
-      bn.add          w0, w0, w18
-      bn.mulqacc.so.z w21.l, w0.0, w17.0, 0
-      bn.mulqacc.so.z w21.u, w0.2, w17.0, 0
-      bn.mulqacc.so.z w0.l, w0.1, w17.0, 0
-      bn.mulqacc.so.z w0.u, w0.3, w17.0, 0
-      bn.trn2.4d      w0, w21, w0
+      bn.add          w0, w0, w21
+      bn.mulqacc.so.z w19.l, w0.0, w20.0, 0
+      bn.mulqacc.so.z w19.u, w0.2, w20.0, 0
+      bn.mulqacc.so.z w0.l, w0.1, w20.0, 0
+      bn.mulqacc.so.z w0.u, w0.3, w20.0, 0
+      bn.trn2.4d      w0, w19, w0
       /* Combine the result. */
-      bn.trn1.8s      w20, w20, w0
+      bn.trn1.8s      w18, w18, w0
 
       /* Compute + 2^(alpha - 1) for the 1st share or 0 for the 2nd share. */
-      bn.addv.8s      w19, w19, w30
-      bn.addv.8s      w20, w20, w30
+      bn.addv.8s      w17, w17, w22
+      bn.addv.8s      w18, w18, w22
       /* Combine the results before bitslicing. */
-      bn.trn2.16h     w0, w19, w20
+      bn.trn2.16h     w0, w17, w18
       bn.sid          x0, 0(x7++)
-      bn.trn1.16h     w0, w19, w20
+      bn.trn1.16h     w0, w17, w18
       bn.movr         x4, x0
       addi            x4, x4, -1
     endloop
@@ -1867,32 +1811,11 @@ _du_params_done:
       addi   x4, x4, 1
     endloop
 
-    /* For the first share, w30 holds 2^(alpha - 1).
-     * After that, we clear w30 for the 2nd share. */
-    bn.xor w30, w31, w31
+    jal x1, whitening_du
 
-    /* Whitening. */
-    bn.xor w0, w31, w31
-    bn.xor w1, w31, w31
-    bn.xor w2, w31, w31
-    bn.xor w3, w31, w31
-    bn.xor w4, w31, w31
-    bn.xor w5, w31, w31
-    bn.xor w6, w31, w31
-    bn.xor w7, w31, w31
-    bn.xor w8, w31, w31
-    bn.xor w9, w31, w31
-    bn.xor w10, w31, w31
-    bn.xor w11, w31, w31
-    bn.xor w12, w31, w31
-    bn.xor w13, w31, w31
-    bn.xor w14, w31, w31
-    bn.xor w15, w31, w31
-    bn.xor w19, w31, w31
-    bn.xor w20, w31, w31
-    bn.xor w21, w31, w31
-    bn.xor w28, w31, w31
-    bn.xor w29, w31, w31
+    /* For the first share, w22 holds 2^(alpha - 1).
+     * After that, we clear w22 for the 2nd share. */
+    bn.xor w22, w31, w31
   endloop
 
   /* Compute c = seca2b(z), k = du + alpha = 24, share bytes = 768. */
@@ -2346,63 +2269,63 @@ masked_poly_getnoise_eta_1:
   bn.wsrr w17, kmac_digest
   bn.wsrr w23, kmac_digest1
   bn.wsrr w18, kmac_digest
-  bn.wsrr w24, kmac_digest1
+  bn.wsrr w26, kmac_digest1
   bn.wsrr w19, kmac_digest
-  bn.wsrr w25, kmac_digest1
+  bn.wsrr w27, kmac_digest1
 
   bn.wsrr w20, kmac_digest
-  bn.wsrr w26, kmac_digest1
+  bn.wsrr w28, kmac_digest1
   bn.wsrr w21, kmac_digest
-  bn.wsrr w27, kmac_digest1
+  bn.wsrr w29, kmac_digest1
   bn.wsrr w22, kmac_digest
   bn.wsrr w30, kmac_digest1
 
   jal x1, _bitslice_eta_3
 
   bn.mov w17, w23
-  bn.mov w18, w24
-  bn.mov w19, w25
-  bn.mov w20, w26
-  bn.mov w21, w27
+  bn.mov w18, w26
+  bn.mov w19, w27
+  bn.mov w20, w28
+  bn.mov w21, w29
   bn.mov w22, w30
 
   jal x1, _bitslice_eta_3
 
   /* Whitening. */
   bn.xor w23, w31, w31
-  bn.xor w24, w31, w31
-  bn.xor w25, w31, w31
   bn.xor w26, w31, w31
   bn.xor w27, w31, w31
+  bn.xor w28, w31, w31
+  bn.xor w29, w31, w31
   bn.xor w30, w31, w31
 
   beq  x0, x0, _getnoise_common
 
 _getnoise_eta_2:
-  bn.wsrr w17, kmac_digest
-  bn.wsrr w21, kmac_digest1
-  bn.wsrr w18, kmac_digest
-  bn.wsrr w22, kmac_digest1
-  bn.wsrr w19, kmac_digest
-  bn.wsrr w23, kmac_digest1
-  bn.wsrr w20, kmac_digest
-  bn.wsrr w24, kmac_digest1
+  bn.wsrr w24, kmac_digest
+  bn.wsrr w20, kmac_digest1
+  bn.wsrr w23, kmac_digest
+  bn.wsrr w19, kmac_digest1
+  bn.wsrr w22, kmac_digest
+  bn.wsrr w18, kmac_digest1
+  bn.wsrr w21, kmac_digest
+  bn.wsrr w17, kmac_digest1
 
-  addi x5, x0, 17
-  addi x6, x0, 17
-  loopi 2, 37
+  addi x5, x0, 24
+  addi x6, x0, 24
+  loopi 2, 20
     addi x4, x0, 15
     loopi 4, 8
       bn.movr x5, x6
       loopi 4, 5
         loopi 16, 2
-          bn.rshi w0, w17, w0 >> 16
-          bn.rshi w17, w31, w17 >> 4
+          bn.rshi w0, w24, w0 >> 16
+          bn.rshi w24, w31, w24 >> 4
         endloop
         bn.movr x4, x0
         addi    x4, x4, -1
       endloop
-      addi x6, x6, 1
+      addi x6, x6, -1
     endloop
 
     jal x1, _bitslice_transpose
@@ -2415,36 +2338,18 @@ _getnoise_eta_2:
     addi   x4, x4, 1
     bn.sid x4, 0(x11++)
 
-    /* Whitening. */
-    bn.xor w0, w31, w31
-    bn.xor w1, w31, w31
-    bn.xor w2, w31, w31
-    bn.xor w3, w31, w31
-    bn.xor w4, w31, w31
-    bn.xor w5, w31, w31
-    bn.xor w6, w31, w31
-    bn.xor w7, w31, w31
-    bn.xor w8, w31, w31
-    bn.xor w9, w31, w31
-    bn.xor w10, w31, w31
-    bn.xor w11, w31, w31
-    bn.xor w12, w31, w31
-    bn.xor w13, w31, w31
-    bn.xor w14, w31, w31
-    bn.xor w15, w31, w31
-    bn.xor w17, w31, w31
-    bn.xor w28, w31, w31
-    bn.xor w29, w31, w31
+    jal x1, whitening_getnoise_eta_e2
+    nop
   endloop
 
   /* Whitening. */
+  bn.xor w17, w31, w31
   bn.xor w18, w31, w31
   bn.xor w19, w31, w31
   bn.xor w20, w31, w31
   bn.xor w21, w31, w31
   bn.xor w22, w31, w31
   bn.xor w23, w31, w31
-  bn.xor w24, w31, w31
 
 _getnoise_common:
   /* Compute r = masked_cbd(x, y, eta). */
@@ -2602,31 +2507,7 @@ _bitslice_eta_3:
     addi   x4, x4, 1
   endloop
 
-  /* Whitening. */
-  bn.xor w0, w31, w31
-  bn.xor w1, w31, w31
-  bn.xor w2, w31, w31
-  bn.xor w3, w31, w31
-  bn.xor w4, w31, w31
-  bn.xor w5, w31, w31
-  bn.xor w6, w31, w31
-  bn.xor w7, w31, w31
-  bn.xor w8, w31, w31
-  bn.xor w9, w31, w31
-  bn.xor w10, w31, w31
-  bn.xor w11, w31, w31
-  bn.xor w12, w31, w31
-  bn.xor w13, w31, w31
-  bn.xor w14, w31, w31
-  bn.xor w15, w31, w31
-  bn.xor w17, w31, w31
-  bn.xor w18, w31, w31
-  bn.xor w19, w31, w31
-  bn.xor w20, w31, w31
-  bn.xor w21, w31, w31
-  bn.xor w22, w31, w31
-  bn.xor w28, w31, w31
-  bn.xor w29, w31, w31
+  jal x1, whitening_getnoise_eta_e3
   ret
 
 /* Undefine gadget-local macros. */
@@ -2668,17 +2549,17 @@ masked_poly_tomsg:
   sw   x12, 1028(x2)
 
   /* Load all constants. */
-  addi      x4, x0, 17
+  addi      x4, x0, 20
   la        x5, const_m_dv
   bn.lid    x4++, 0(x5)
   la        x5, const_qp1_half
   bn.lid    x4++, 0(x5)
-  bn.shv.8s w18, w18 >> 16
+  bn.shv.8s w21, w21 >> 16
 
   /* Create 2^(alpha - 1), alpha = 15. */
-  bn.subi    w19, w31, 1
-  bn.shv.8s  w19, w19 >> 31
-  bn.shv.8s  w19, w19 << 14
+  bn.subi    w22, w31, 1
+  bn.shv.8s  w22, w22 >> 31
+  bn.shv.8s  w22, w22 << 14
 
   /* Compute z_0 = Compressq(x_0, 1 + alpha) + 2^(alpha - 1),
    *         z_1 = Compressq(x_1, 1 + alpha).
@@ -2693,26 +2574,26 @@ masked_poly_tomsg:
    */
   add  x6, x2, x0 /* z */
 
-  loopi 2, 44
+  loopi 2, 25
     addi x4, x0, 15
     loopi 16, 16
       bn.lid             x0, 0(x10++)
       /* Handle even-positioned coeffs. */
-      bn.trn1.16h        w20, w0, w31
-      bn.shv.8s          w20, w20 << 16
-      bn.addv.8s         w20, w20, w18
-      bn.mulv.8s.even.hi w20, w20, w17
-      bn.mulv.8s.odd.hi  w20, w20, w17
-      bn.add             w21, w19, w20 >> 8
+      bn.trn1.16h        w17, w0, w31
+      bn.shv.8s          w17, w17 << 16
+      bn.addv.8s         w17, w17, w21
+      bn.mulv.8s.even.hi w17, w17, w20
+      bn.mulv.8s.odd.hi  w17, w17, w20
+      bn.add             w18, w22, w17 >> 8
       /* Handle odd-positioned coeffs. */
-      bn.trn2.16h        w20, w0, w31
-      bn.shv.8s          w20, w20 << 16
-      bn.addv.8s         w20, w20, w18
-      bn.mulv.8s.even.hi w20, w20, w17
-      bn.mulv.8s.odd.hi  w20, w20, w17
-      bn.add             w20, w19, w20 >> 8
+      bn.trn2.16h        w17, w0, w31
+      bn.shv.8s          w17, w17 << 16
+      bn.addv.8s         w17, w17, w21
+      bn.mulv.8s.even.hi w17, w17, w20
+      bn.mulv.8s.odd.hi  w17, w17, w20
+      bn.add             w17, w22, w17 >> 8
       /* Combine results. */
-      bn.trn1.16h        w0, w21, w20
+      bn.trn1.16h        w0, w18, w17
       bn.movr            x4, x0
       addi               x4, x4, -1
     endloop
@@ -2725,31 +2606,11 @@ masked_poly_tomsg:
       addi   x4, x4, 1
     endloop
 
-    /* For the first share, w19 holds 2^(alpha - 1).
-     * After that, we clear w19 so that bn.add acts as a shift. */
-    bn.xor w19, w31, w31
+    jal x1, whitening_dv
 
-    /* Whitening. */
-    bn.xor w0, w31, w31
-    bn.xor w1, w31, w31
-    bn.xor w2, w31, w31
-    bn.xor w3, w31, w31
-    bn.xor w4, w31, w31
-    bn.xor w5, w31, w31
-    bn.xor w6, w31, w31
-    bn.xor w7, w31, w31
-    bn.xor w8, w31, w31
-    bn.xor w9, w31, w31
-    bn.xor w10, w31, w31
-    bn.xor w11, w31, w31
-    bn.xor w12, w31, w31
-    bn.xor w13, w31, w31
-    bn.xor w14, w31, w31
-    bn.xor w15, w31, w31
-    bn.xor w20, w31, w31
-    bn.xor w21, w31, w31
-    bn.xor w28, w31, w31
-    bn.xor w29, w31, w31
+    /* For the first share, w22 holds 2^(alpha - 1).
+     * After that, we clear w22 so that bn.add acts as a shift. */
+    bn.xor w22, w31, w31
   endloop
 
   /* Compute c = seca2b(z), k = 1 + alpha = 16, share bytes = 512. */

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -1499,9 +1499,9 @@ secb2amodq:
  * clobbered flag groups: FG0
  */
 
-.globl poly_hocompress
-.type poly_hocompress, @function
-poly_hocompress:
+.globl poly_hocompress_dv
+.type poly_hocompress_dv, @function
+poly_hocompress_dv:
   /* Allocate the t, z scratch, save x8, x9 and spill the output pointer. */
   addi x2, x2, -1024
   add  x7, x2, x0 /* t */
@@ -1681,9 +1681,9 @@ _dv_params_done:
  * clobbered flag groups: FG0
  */
 
-.globl polyvec_hocompress
-.type polyvec_hocompress, @function
-polyvec_hocompress:
+.globl poly_hocompress_du
+.type poly_hocompress_du, @function
+poly_hocompress_du:
   /* Allocate the t, z scratch, save x8, x9 and spill the output pointer. */
   addi x2, x2, -1024
   add  x7, x2, x0 /* t */
@@ -2746,11 +2746,11 @@ poly_masked_compare_dv:
   sw   x15, 332(x2)
   sw   x8, 336(x2)
 
-  /* Compute t = poly_hocompress(c'). */
+  /* Compute t = poly_hocompress_dv(c'). */
   /* x10 already points to c'. */
   add x12, x2, x0
   add x13, x15, x0
-  jal x1, poly_hocompress
+  jal x1, poly_hocompress_dv
 
   /* Decode + bitslice c. */
   lw     x11, 320(x2)
@@ -3050,11 +3050,11 @@ poly_masked_compare_du:
   sw   x15, 720(x2)
   sw   x8, 724(x2)
 
-  /* Compute t = polyvec_hocompress(c'). */
+  /* Compute t = poly_hocompress_du(c'). */
   /* x10 already points to c'. */
   add x12, x2, x0
   add x13, x15, x0
-  jal x1, polyvec_hocompress
+  jal x1, poly_hocompress_du
 
   /* Decode + bitslice c. */
   lw   x11, 708(x2)

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -73,47 +73,50 @@ secand:
   addi x7, x15, 0
 
   /* Load x. */
-  bn.xor w0, w0, w0
-  bn.lid x0, 0(x5) /* x[0] */
-  bn.xor w1, w1, w1
+  bn.xor w0, w0, w0   /* Whitening. */
+  bn.lid x0, 0(x5)    /* w0 = x_0 */
+  bn.xor w1, w1, w1   /* Whitening. */
   add    x5, x5, x11
   addi   x4, x0, 1
-  bn.lid x4++, 0(x5) /* x[1] */
+  bn.lid x4++, 0(x5)  /* w1 = x_1 */
 
   /* Load y. */
-  bn.xor w2, w2, w2
-  bn.lid x4++, 0(x6) /* y[0] */
-  bn.xor w3, w3, w3
+  bn.xor w2, w2, w2   /* Whitening. */
+  bn.lid x4++, 0(x6)  /* w2 = y_0 */
+  bn.xor w3, w3, w3   /* Whitening. */
   add    x6, x6, x13
-  bn.lid x4, 0(x6) /* y[1] */
+  bn.lid x4, 0(x6)    /* w3 = y_1 */
 
+  /* Refresh with one fresh random. */
+  bn.wsrr w5, urnd    /* w5 = s */
+
+  /* Pair (i, j) = (0, 1). */
+  bn.xor  w6, w6, w6  /* Whitening. */
+  bn.and  w6, w0, w2  /* w6 = x_0 & y_0 */
+  bn.xor  w7, w7, w7  /* Whitening. */
+  bn.xor  w7, w3, w5  /* w7 = y_1 ^ s */
+  bn.and  w7, w0, w7  /* w7 &= x_0 */
+  bn.xor  w8, w8, w8  /* Whitening. */
+  bn.not  w8, w0      /* w8 = x_0 ^ 1 */
+  bn.and  w8, w8, w5  /* w8 &= s */
+  bn.xor  w7, w7, w8  /* w7 ^= w8 */
+  bn.xor  w6, w6, w7  /* r_0 = (w6 ^ w7) */
   addi    x4, x0, 6
-  bn.wsrr w5, urnd
-  /* Handle z_01. */
-  bn.xor  w6, w6, w6
-  bn.and  w6, w0, w2 /* x[0] & y[0] */
-  bn.xor  w7, w7, w7
-  bn.xor  w7, w3, w5 /* y[1] ^ r */
-  bn.and  w7, w0, w7 /* &= x[0] */
-  bn.xor  w8, w8, w8
-  bn.not  w8, w0 /* x[0] ^ 1 */
-  bn.and  w8, w8, w5 /* &= r */
-  bn.xor  w7, w7, w8 /* w7 ^= w8 */
-  bn.xor  w6, w6, w7
-  bn.sid  x4, 0(x7) /* Save r[0]. */
+  bn.sid  x4, 0(x7)
   add     x7, x7, x16
-  /* Handle z_10. */
-  bn.xor  w6, w6, w6
-  bn.and  w6, w1, w3 /* x[1] & y[1] */
-  bn.xor  w7, w7, w7
-  bn.xor  w7, w2, w5 /* y[0] ^ r */
-  bn.and  w7, w1, w7 /* &= x[1] */
-  bn.xor  w8, w8, w8
-  bn.not  w8, w1 /* x[1] ^ 1 */
-  bn.and  w8, w8, w5 /* &= r */
-  bn.xor  w7, w7, w8 /* w7 ^= w8 */
-  bn.xor  w6, w6, w7
-  bn.sid  x4, 0(x7) /* Save r[1]. */
+
+  /* Pair (i, j) = (1, 0). */
+  bn.xor  w6, w6, w6  /* Whitening. */
+  bn.and  w6, w1, w3  /* w6 = x_1 & y_1 */
+  bn.xor  w7, w7, w7  /* Whitening. */
+  bn.xor  w7, w2, w5  /* w7 = y_0 ^ s */
+  bn.and  w7, w1, w7  /* w7 &= x_1 */
+  bn.xor  w8, w8, w8  /* Whitening. */
+  bn.not  w8, w1      /* w8 = x_1 ^ 1 */
+  bn.and  w8, w8, w5  /* w8 &= s */
+  bn.xor  w7, w7, w8  /* w7 ^= w8 */
+  bn.xor  w6, w6, w7  /* r_1 = (w6 ^ w7) */
+  bn.sid  x4, 0(x7)
 
   /* Advance x10, x12, x15 to the next bit. */
   addi x10, x10, 32
@@ -158,88 +161,93 @@ secfulladder:
   add x28, x17, x0
 
   /* Load x. */
-  bn.xor w0, w0, w0
-  bn.lid x0, 0(x5) /* x[0] */
+  bn.xor w0, w0, w0   /* Whitening. */
+  bn.lid x0, 0(x5)    /* w0 = x_0 */
   add    x5, x5, x11
   addi   x4, x0, 1
-  bn.xor w1, w1, w1
-  bn.lid x4++, 0(x5) /* x[1] */
+  bn.xor w1, w1, w1   /* Whitening. */
+  bn.lid x4++, 0(x5)  /* w1 = x_1 */
+
   /* Load y. */
-  bn.xor w2, w2, w2
-  bn.lid x4++, 0(x6) /* y[0] */
+  bn.xor w2, w2, w2   /* Whitening. */
+  bn.lid x4++, 0(x6)  /* w2 = y_0 */
   add    x6, x6, x13
-  bn.xor w3, w3, w3
-  bn.lid x4, 0(x6) /* y[1] */
+  bn.xor w3, w3, w3   /* Whitening. */
+  bn.lid x4, 0(x6)    /* w3 = y_1 */
 
   /* Compute sharewise a = x ^ y. */
-  bn.xor w4, w4, w4
+  bn.xor w4, w4, w4   /* Whitening. */
   bn.xor w4, w0, w2
-  bn.xor w5, w5, w5
+  bn.xor w5, w5, w5   /* Whitening. */
   bn.xor w5, w1, w3
 
-  /* Compute r = cin ^ a. */
-  bn.xor w2, w2, w2
+  /* Load cin. */
+  bn.xor w2, w2, w2   /* Whitening. */
   addi   x4, x0, 2
-  bn.lid x4++, 0(x28)
+  bn.lid x4++, 0(x28) /* w2 = cin_0 */
   add    x28, x28, x29
-  bn.xor w3, w3, w3
-  bn.lid x4++, 0(x28)
+  bn.xor w3, w3, w3   /* Whitening. */
+  bn.lid x4++, 0(x28) /* w3 = cin_1 */
 
-  bn.xor w6, w6, w6
+  /* Compute r = cin ^ a. */
+  bn.xor w6, w6, w6   /* Whitening. */
   bn.xor w6, w4, w2
   addi   x4, x0, 6
   bn.sid x4, 0(x7)
   add    x7, x7, x16
-  bn.xor w6, w6, w6
+  bn.xor w6, w6, w6   /* Whitening. */
   bn.xor w6, w5, w3
   bn.sid x4, 0(x7)
 
   /* Compute cout = x ^ secand(a, x ^ cin). */
-  /* a: w4 -- w5
-   * x: w0 -- w1
-   * cin: w2 -- w3 */
-  bn.xor w6, w6, w6
-  bn.xor w6, w0, w2
-  bn.xor w7, w7, w7
-  bn.xor w7, w1, w3
+  /* Inline t = secand(a, x ^ cin) = secand(a, t).
+   *  - (a_0, a_1)     -> (w4, w5)
+   *  - (x_0, x_1)     -> (w0, w1)
+   *  - (cin_0, cin_1) -> (w2, w3) */
 
-  /* a: w4 -- w5
-   * x ^ cin: w6 -- w7
-   * x: w0 -- w1.  */
-  bn.wsrr w8, urnd
-  /* Handle cout_01. */
-  bn.xor  w2, w2, w2
-  bn.and  w2, w4, w6
-  bn.xor  w3, w3, w3
-  bn.xor  w3, w7, w8
-  bn.and  w3, w4, w3
-  bn.xor  w9, w9, w9
-  bn.not  w9, w4
-  bn.and  w9, w9, w8
-  bn.xor  w3, w3, w9
-  bn.xor  w2, w2, w3
-  bn.xor  w3, w3, w3
-  bn.xor  w3, w2, w0
+  /* Compute t = x ^ cin. */
+  bn.xor w6, w6, w6    /* Whitening. */
+  bn.xor w6, w0, w2    /* w6 = t_0 */
+  bn.xor w7, w7, w7    /* Whitening. */
+  bn.xor w7, w1, w3    /* w7 = t_1 */
+
+  /* Refresh with one fresh random. */
+  bn.wsrr w8, urnd     /* w8 = s */
+
+  /* Pair (i, j) = (0, 1). */
+  bn.xor  w2, w2, w2   /* Whitening. */
+  bn.and  w2, w4, w6   /* w2 = a_0 &  t_0 */
+  bn.xor  w3, w3, w3   /* Whitening. */
+  bn.xor  w3, w7, w8   /* w3 = t_1 ^ s */
+  bn.and  w3, w4, w3   /* w3 &= a_0 */
+  bn.xor  w9, w9, w9   /* Whitening. */
+  bn.not  w9, w4       /* w9 = a_0 ^ 1 */
+  bn.and  w9, w9, w8   /* w9 &= s */
+  bn.xor  w3, w3, w9   /* w3 ^= w9 */
+  bn.xor  w2, w2, w3   /* w2 ^= w3 */
+  bn.xor  w3, w3, w3   /* Whitening. */
+  bn.xor  w3, w2, w0   /* cout_0 = x_0 ^ w2 */
   add     x7, x30, x0
   addi    x4, x0, 3
   bn.sid  x4, 0(x7)
   add     x7, x7, x31
-  /* Handle cout_10. */
-  bn.xor  w2, w2, w2
-  bn.and  w2, w5, w7
-  bn.xor  w3, w3, w3
-  bn.xor  w3, w6, w8
-  bn.and  w3, w5, w3
-  bn.xor  w9, w9, w9
-  bn.not  w9, w5
-  bn.and  w9, w9, w8
-  bn.xor  w3, w3, w9
-  bn.xor  w2, w2, w3
-  bn.xor  w3, w3, w3
-  bn.xor  w3, w2, w1
+
+  /* Pair (i, j) = (1, 0). */
+  bn.xor  w2, w2, w2   /* Whitening. */
+  bn.and  w2, w5, w7   /* w2 = a_1 &  t_1 */
+  bn.xor  w3, w3, w3   /* Whitening. */
+  bn.xor  w3, w6, w8   /* w3 = t_0 ^ s */
+  bn.and  w3, w5, w3   /* w3 &= a_1 */
+  bn.xor  w9, w9, w9   /* Whitening. */
+  bn.not  w9, w5       /* w9 = a_1 ^ 1 */
+  bn.and  w9, w9, w8   /* w9 &= s */
+  bn.xor  w3, w3, w9   /* w3 ^= w9 */
+  bn.xor  w2, w2, w3   /* w2 ^= w3 */
+  bn.xor  w3, w3, w3   /* Whitening. */
+  bn.xor  w3, w2, w1   /* cout_0 = x_1 ^ w2 */
   bn.sid  x4, 0(x7)
 
-  /* Point to next bit. */
+  /* Advance x10, x12, x15 to the next bit. */
   addi x10, x10, 32
   addi x12, x12, 32
   addi x15, x15, 32
@@ -280,45 +288,25 @@ secadd:
 
   /* Initialize c = 0. */
   bn.xor w0, w0, w0
-  addi   x5, x2, 0 /* ptr_c */
+  addi   x5, x2, 0
   loopi 2, 1
     bn.sid x0, 0(x5++)
   endloop
 
   /* Ripple-carry adder. */
   addi x8, x17, -1
-  addi x17, x2, 0 /* ptr_c = cin */
+  addi x17, x2, 0
   addi x29, x0, 32
-  addi x30, x2, 0 /* ptr_c = cout */
+  addi x30, x2, 0
   addi x31, x0, 32
-  /* Loop over i=0,...,k-2. */
+  /* Handle bit i = 0..k - 2. */
   loop x8, 2
-    /* x10 already points to x[i] */
-    /* x11 is already share stride of x. */
-    /* x12 already points to y[i] */
-    /* x13 is already share stride of y. */
-    /* x15 already points to r. */
-    /* x16 is already share stride of r. */
-    /* x17 already points to ptr_c = cin. */
-    /* x29 is already share stride of cin. */
-    /* x30 already points to ptr_c = cout. */
-    /* x31 is already share stride of cout. */
     jal  x1, secfulladder
-    /* After secfulladder:
-     *  - x10 and x12 points to x[i + 1] and y[i + 1].
-     *  - x11 and x13 are still share stride of x and y.
-     *  - x15 points to r[i + 1].
-     *  - x16 is still share stride of r.
-     *  - x17 points to cin.
-     *  - x29 is still share stride of cin.
-     *  - x30 points to cout.
-     *  - x31 is still share stride of cout. */
     nop
   endloop
 
-  /* Handle bit i = k-1. */
-  /* Compute r[k-1] = x[k-1] ^ y[k-1] ^ c. */
-  addi x5, x2, 0 /* ptr_c */
+  /* Handle bit k - 1. */
+  addi x5, x2, 0
   addi x4, x0, 1
   addi x6, x0, 2
   addi x7, x0, 3
@@ -328,7 +316,7 @@ secadd:
     bn.xor w1, w1, w1
     bn.xor w2, w2, w2
     bn.xor w3, w3, w3
-    /* Computation. */
+    /* r[k - 1] = x[k - 1] ^ y[k - 1] ^ c. */
     bn.lid x0, 0(x10)
     bn.lid x4, 0(x12)
     bn.lid x6, 0(x5)
@@ -370,8 +358,8 @@ secadd:
 .globl bitcopymask
 .type bitcopymask, @function
 bitcopymask:
-  /* Since q = 3329 = b110100000001, we copy x to the 1st, 9th, 11th and 12th
-   * bit of r and zeroize the rest of r. */
+  /* Since q = 3329 = 0b110100000001, we copy x to bits 0, 8, 10 and 11 of r
+   * and zeroize the remaining bits. */
   addi   x4, x0, 31
   loopi 2, 10
     /* Whitening. */
@@ -380,7 +368,7 @@ bitcopymask:
     add    x10, x10, x11
     /* Copy x to bit 0. */
     bn.sid x0, 0(x13++)
-    /* Clear bit 1 -- 7. */
+    /* Clear bit 1..7. */
     loopi 7, 1
       bn.sid x4, 0(x13++)
     endloop
@@ -388,7 +376,7 @@ bitcopymask:
     bn.sid x0, 0(x13++)
     /* Clear bit 9. */
     bn.sid x4, 0(x13++)
-    /* Copy x to bit 10 -- 11. */
+    /* Copy x to bit 10..11. */
     bn.sid x0, 0(x13++)
     bn.sid x0, 0(x13++)
   endloop
@@ -419,20 +407,23 @@ bitcopymask:
 .globl refreshios
 .type refreshios, @function
 refreshios:
-  add  x5, x10, x12 /* 2nd share of x */
-  add  x6, x14, x12 /* 2nd share of r */
+  add  x5, x10, x12 /* x_1 */
+  add  x6, x14, x12 /* r_1 */
   addi x4, x0, 1
   loop x11, 11
+    /* s <- urnd. */
     bn.wsrr w2, urnd
     /* Whitening. */
     bn.xor  w0, w0, w0
     bn.xor  w1, w1, w1
+    /* r_0 = x_0 ^ s. */
     bn.lid  x0, 0(x10++)
     bn.xor  w1, w0, w2
     bn.sid  x4, 0(x14++)
     /* Whitening. */
     bn.xor  w0, w0, w0
     bn.xor  w1, w1, w1
+    /* r_1 = x_1 ^ s. */
     bn.lid  x0, 0(x5++)
     bn.xor  w1, w0, w2
     bn.sid  x4, 0(x6++)
@@ -460,13 +451,13 @@ refreshios:
 .globl poly_rej_samp
 .type poly_rej_samp, @function
 poly_rej_samp:
-  /* Load 19*Q - 1 into w1. */
+  /* Load 19 * q - 1. */
   addi      x5, x0, 1
   la        x6, modulus_times_19_minus_1
   bn.lid    x5++, 0(x6)
   bn.shv.8s w1, w1 >> 16
   
-  /* Load mont = 2**16 % Q into w2. */
+  /* Load mont = 2^16 % q. */
   la     x6, mont
   bn.lid x5, 0(x6)
   
@@ -477,7 +468,7 @@ poly_rej_samp:
   addi x30, x0, 3
 #endif
   
-  /* Loop until 256 coefficients have been written to the output */
+  /* Loop until 256 coefficients have been written to the output. */
 _rej_sample_loop:
   /* Get 16 randoms. */
 #if defined(MLKEM_REJ_SAMPLE_TEST)
@@ -494,9 +485,9 @@ _rej_sample_loop:
   bn.trn1.16h w4, w4, w5
   bn.xor      w4, w4, w31, FG0
   csrrs       x6, fg0, x0 /* Read flag fg0. */
-  srli        x6, x6, 3 /* Extract FG0.z */
+  srli        x6, x6, 3   /* Extract fg0.z */
   
-  /* If FG0.z == 0, there is at least one bad coeff. We throw away this
+  /* If fg0.z == 0, there is at least one bad coeff. We throw away this
    * vector and sample again. */
   beq x6, x0, _rej_sample_loop
   
@@ -508,7 +499,8 @@ _rej_sample_loop:
   bn.addvm.16h         w0, w0, w31
   bn.sid               x0, 0(x10++)
   
-  /* If x10 == x5, we've filled up a polynomial. Otherwise, continue to sample. */
+  /* If we reach the last valid address, we've filled up a polynomial.
+   * Otherwise, continue to sample. */
   beq x10, x5, _end_rej_sample_loop
   beq x0, x0, _rej_sample_loop
 
@@ -549,22 +541,23 @@ refreshmodq:
   add x10, x2, x0
   jal x1, poly_rej_samp
 
-  /* r[0] = x[0] + rand. */
-  /* r[1] = x[1] - rand. */
-  add  x5, x2, 0 /* rand */
+  add  x5, x2, 0    /* rand */
   lw   x10, 512(x2)
-  addi x6, x10, 512 /* x[1] */
+  addi x6, x10, 512 /* x_1 */
   lw   x12, 516(x2)
-  addi x7, x12, 512 /* r[1] */
+  addi x7, x12, 512 /* r_1 */
   addi x4, x0, 1
   addi x28, x0, 2
   loopi 16, 9
+    /* r_0 = x_0 + rand. */
     bn.lid       x0, 0(x5++)
     bn.lid       x4, 0(x10++)
     bn.addvm.16h w2, w1, w0
     bn.sid       x28, 0(x12++)
+    /* Whitening. */
     bn.xor       w1, w1, w1
     bn.xor       w2, w2, w2
+    /* r_1 = x_1 - rand. */
     bn.lid       x4, 0(x6++)
     bn.subvm.16h w2, w1, w0
     bn.sid       x28, 0(x7++)
@@ -595,7 +588,6 @@ refreshmodq:
 .globl poly_to_bitsliced
 .type poly_to_bitsliced, @function
 poly_to_bitsliced:
-
   /* Reverse-load the 16 input WDRs: coefficient WDR i -> w[15 - i]. */
   addi x4, x0, 15
   loopi 16, 2
@@ -605,7 +597,7 @@ poly_to_bitsliced:
 
   jal x1, _bitslice_transpose
 
-  /* Store the 12 bitsliced words bs[0..11] via x10 so x11 is left unchanged. */
+  /* Store the 12 bitsliced words r[0..11] via x10 so x11 is left unchanged. */
   addi   x4, x0, 0
   addi   x10, x11, 0
   loopi 12, 2
@@ -636,8 +628,7 @@ poly_to_bitsliced:
 .globl poly_from_bitsliced
 .type poly_from_bitsliced, @function
 poly_from_bitsliced:
-
-  /* Load bs[0..11] into w0..w11; zero the upper bit positions w12..w15. */
+  /* Load x[0..11] into w0..w11; zero the upper bit positions w12..w15. */
   addi x4, x0, 0
   loopi 12, 2
     bn.lid x4, 0(x10++)
@@ -909,13 +900,14 @@ seca2b:
 
   /* Adjust stack for temp variables. */
   slli x5, x12, 1
-  sub  x2, x2, x5 /* ptr_s */
-  add  x6, x2, x0
-  sub  x2, x2, x5 /* ptr_sp */
+  sub  x2, x2, x5
+  add  x6, x2, x0 /* s */
+  sub  x2, x2, x5 /* s' */
 
-  /* Build s = (x[0], 0). */
-  add x7, x6, x0 /* Save ptr_s. */
+  /* Build s = (x_0, 0). */
+  add x7, x6, x0
   loop x11, 3
+    /* Whitening. */
     bn.xor w0, w0, w0
     bn.lid x0, 0(x10++)
     bn.sid x0, 0(x6++)
@@ -925,7 +917,7 @@ seca2b:
     bn.sid x0, 0(x6++)
   endloop
 
-  /* Build s' = (0, x[1]). */
+  /* Build s' = (0, x_1). */
   add x5, x2, x0
   loop x11, 1
     bn.sid x0, 0(x5++)
@@ -933,6 +925,7 @@ seca2b:
   loop x11, 3
     bn.lid x0, 0(x10++)
     bn.sid x0, 0(x5++)
+    /* Whitening. */
     bn.xor w0, w0, w0
   endloop
 
@@ -942,13 +935,13 @@ seca2b:
   add x28, x14, x0
 
   /* Compute r = secadd(s, s', k). */
-  addi x10, x7, 0 /* ptr_s */
+  addi x10, x7, 0
   addi x11, x6, 0
-  addi x12, x2, 0 /* ptr_sp */
+  addi x12, x2, 0
   addi x13, x6, 0
-  addi x15, x28, 0 /* ptr_r */
+  addi x15, x28, 0
   addi x16, x6, 0
-  addi x17, x5, 0 /* k */
+  addi x17, x5, 0
   jal  x1, secadd
 
   /* Restore x2 and x3. */
@@ -990,123 +983,126 @@ seca2bmodq:
    *   x2 + 1728 : saved x18 */
   addi x2, x2, -1760
   sw   x18, 1728(x2)
-  addi x18, x12, 0 /* output pointer */
+  addi x18, x12, 0
 
-  /* Compute s = p + x[0], k + 1 bits (one share).
-   * p = 2**(k + 1) - q = 4863 = b1001011111111. */
-  addi x5, x2, 896 /* ptr_s */
-  /* x10 already points to x[0]. */
+  /* Compute s = p + x_0, k + 1 bits (one share).
+   * p = 2^(k + 1) - q = 4863 = 0b1001011111111.
+   *
+   * For i = 0..11:
+   *   If p[i] = 1:
+   *    - r[i] = x_0[i] ^ p[i] ^ cin = a[i] ^ cin
+   *    - cout = x_0[i] ^ (a[i] & (x_0[i] ^ cin))
+   *   If p[i] = 0:
+   *    - r[i] = x_0[i] ^ 0 ^ cin = x_0[i] ^ cin
+   *    - cout = x_0[i] ^ ((x_0[i] ^ p[i]) & (x_0[i] ^ cin))
+   *           = x_0[i] ^ ((x_0[i] ^ p[i]) & r[i]
+   *
+   * For i = 12, as x_0[12] = 0 and p[12] = 1:
+   *  - r[i] = o[i] ^ cin = ~cin
+   */
+  /********** Start inline s = secadd(p, x_0, k + 1). **********/
+  addi x5, x2, 896 /* s */
   addi x4, x0, 1
-  /* cin = 0 */
+  /* Initialize cin = 0. */
   bn.xor w2, w2, w2
 
-  /* Bit 0 -- 7: 1. */
+  /* Bits 0..7: p[i] = 1. */
   loopi 8, 9
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
-    /* Compute r = x ^ p ^ cin. */
     bn.lid x0, 0(x10++)
-    bn.not w3, w0 /* a = x ^ p */
-    bn.xor w1, w3, w2 /* r = a ^ cin */
-    bn.sid x4, 0(x5++) /* Save r. */
-    /* Compute cout = x ^ ((x ^ p) & (x ^ cin)) = x ^ (a & (x ^ cin)). */
-    bn.xor w2, w0, w2 /* cout = x ^ cin */
-    bn.and w2, w3, w2 /* cout &= a */
-    bn.xor w2, w2, w0 /* cout ^= x */
+    bn.not w3, w0
+    bn.xor w1, w3, w2
+    bn.sid x4, 0(x5++)
+    bn.xor w2, w0, w2
+    bn.and w2, w3, w2
+    bn.xor w2, w2, w0
   endloop
 
-  /* Bit 8: 0. */
+  /* Bit 8: p[i] = 0. */
   /* Whitening. */
   bn.xor w0, w0, w0
   bn.xor w1, w1, w1
-  /* Compute r = x ^ 0 ^ cin = x ^ cin. */
   bn.lid x0, 0(x10++)
-  bn.xor w1, w0, w2 /* r = x ^ cin */
-  bn.sid x4, 0(x5++) /* Save r. */
-  /* Compute cout = x ^ ((x ^ p) & (x ^ cin)) = x ^ (x & r). */
-  bn.and w2, w0, w1 /* cout = x & r */
-  bn.xor w2, w2, w0 /* cout ^= x */
+  bn.xor w1, w0, w2
+  bn.sid x4, 0(x5++)
+  bn.and w2, w0, w1
+  bn.xor w2, w2, w0
 
-  /* Bit 9: 1. */
+  /* Bit 9: p[i] = 1. */
   /* Whitening. */
   bn.xor w0, w0, w0
   bn.xor w1, w1, w1
-  /* Compute r = x ^ p ^ cin. */
   bn.lid x0, 0(x10++)
-  bn.not w3, w0 /* a = x ^ p */
-  bn.xor w1, w3, w2 /* r = a ^ cin */
-  bn.sid x4, 0(x5++) /* Save r. */
-  /* Compute cout = x ^ ((x ^ p) & (x ^ cin)) = x ^ (a & (x ^ cin)). */
-  bn.xor w2, w0, w2 /* cout = x ^ cin */
-  bn.and w2, w3, w2 /* cout &= a */
-  bn.xor w2, w2, w0 /* cout ^= x */
+  bn.not w3, w0
+  bn.xor w1, w3, w2
+  bn.sid x4, 0(x5++)
+  bn.xor w2, w0, w2
+  bn.and w2, w3, w2
+  bn.xor w2, w2, w0
 
-  /* Bit 10 -- 11: 0. */
+  /* Bits 10..11: p[i] = 0. */
   loopi 2, 7
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
-    /* Compute r = x ^ 0 ^ cin = x ^ cin. */
     bn.lid x0, 0(x10++)
-    bn.xor w1, w0, w2 /* r = x ^ cin */
-    bn.sid x4, 0(x5++) /* Save r. */
-    /* Compute cout = x ^ ((x ^ p) & (x ^ cin)) = x ^ (x & r). */
-    bn.and w2, w0, w1 /* cout = x & r */
-    bn.xor w2, w2, w0 /* cout ^= x */
+    bn.xor w1, w0, w2
+    bn.sid x4, 0(x5++)
+    bn.and w2, w0, w1
+    bn.xor w2, w2, w0
   endloop
 
-  /* Bit 12: 1. */
+  /* Bit 12: p[i] = 1 and x_0[i] = 0. */
   /* Whitening. */
   bn.xor w1, w1, w1
-  /* Compute r = x ^ p ^ cin = p ^ cin. (x only has k bits, while p has k + 1 bits). */
-  bn.not w1, w2 /* r = p ^ cin */
-  bn.sid x4, 0(x5++) /* Save r. */
+  bn.not w1, w2
+  bn.sid x4, 0(x5++)
+  /********** End inline s = secadd(p, x_0, k + 1). **********/
 
-  /* Extend s to 2 shares, i.e., clear next share of s. */
+  /* Build s = (s, 0) for (k + 1) bits. */
   bn.xor w0, w0, w0
   loopi 13, 1
     bn.sid x0, 0(x5++)
   endloop
 
-  /* Clear first share of sprime and copy x[1] to second share of sprime with
-   * share stride = 416. */
-  addi x5, x2, 0 /* ptr_sprime */
+  /* Build s' = (0, x_1) for (k + 1) bits. */
+  addi x5, x2, 0 /* s' */
   loopi 13, 1
     bn.sid x0, 0(x5++)
   endloop
   loopi 12, 3
-    bn.lid x0, 0(x10++) /* x10 already points to x[1]. */
+    bn.lid x0, 0(x10++)
     bn.sid x0, 0(x5++)
     /* Whitening. */
     bn.xor w0, w0, w0
   endloop
   bn.sid x0, 0(x5++)
 
-  /* Compute u = secadd(s, sprime, k + 1). */
+  /********** Start inline u = secadd(s, s', k + 1). **********/
   /* Initialize c = 0. */
-  addi  x5, x2, 832 /* ptr_c */
+  addi  x5, x2, 832
   bn.xor w0, w0, w0
   loopi 2, 1
     bn.sid x0, 0(x5++)
   endloop
 
-  addi x10, x2, 896 /* ptr_s */
+  addi x10, x2, 896
   addi x11, x0, 416
-  addi x12, x2, 0 /* ptr_sprime */
+  addi x12, x2, 0
   addi x13, x0, 416
-  addi x15, x2, 896 /* ptr_u */
+  addi x15, x2, 896
   addi x16, x0, 416
-  addi x17, x2, 832 /* ptr_c */
+  addi x17, x2, 832
   addi x29, x0, 32
-  addi x30, x2, 832 /* ptr_c */
+  addi x30, x2, 832
   addi x31, x0, 32
   loopi 12, 2
     jal x1, secfulladder
     nop
   endloop
-  /* Handle bit 12. */
-  /* Compute r[12] = x[12] ^ y[12] ^ c. */
+
   addi x4, x0, 1
   addi x6, x0, 2
   addi x7, x0, 3
@@ -1116,7 +1112,7 @@ seca2bmodq:
     bn.xor w1, w1, w1
     bn.xor w2, w2, w2
     bn.xor w3, w3, w3
-    /* Computation. */
+    /* u[12] = s[12] ^ s'[12] ^ c. */
     bn.lid x0, 0(x10)
     bn.lid x4, 0(x12)
     bn.lid x6, 0(x17)
@@ -1129,37 +1125,37 @@ seca2bmodq:
     add    x17, x17, x29
     add    x15, x15, x16
   endloop
+  /********** End inline u = secadd(s, s', k + 1). **********/
 
   /* Compute a = bitcopymask(u[k], (k + 1) * 32). */
-  addi x10, x2, 1280 /* ptr_u[k] */
+  addi x10, x2, 1280
   addi x11, x0, 416
-  addi x13, x2, 0 /* ptr_a */
+  addi x13, x2, 0
   jal  x1, bitcopymask
 
-  /* Compute u = secadd(a, u, k). */
+  /********** Start inline r = secadd(a, u, k). **********/
   /* Initialize c = 0. */
-  addi  x5, x2, 832 /* ptr_c */
+  addi  x5, x2, 832
   bn.xor w0, w0, w0
   loopi 2, 1
     bn.sid x0, 0(x5++)
   endloop
 
-  addi x10, x2, 0 /* ptr_a */
+  addi x10, x2, 0
   addi x11, x0, 384
-  addi x12, x2, 896 /* ptr_u */
+  addi x12, x2, 896
   addi x13, x0, 416
-  addi x15, x18, 0 /* ptr_r */
+  addi x15, x18, 0
   addi x16, x0, 384
-  addi x17, x2, 832 /* ptr_c */
+  addi x17, x2, 832
   addi x29, x0, 32
-  addi x30, x2, 832 /* ptr_c */
+  addi x30, x2, 832
   addi x31, x0, 32
   loopi 11, 2
     jal x1, secfulladder
     nop
   endloop
-  /* Handle bit 11. */
-  /* Compute r[11] = x[11] ^ y[11] ^ c. */
+
   addi x4, x0, 1
   addi x6, x0, 2
   addi x7, x0, 3
@@ -1169,7 +1165,7 @@ seca2bmodq:
     bn.xor w1, w1, w1
     bn.xor w2, w2, w2
     bn.xor w3, w3, w3
-    /* Computation. */
+    /* r[11] = a[11] ^ u[11] ^ c. */
     bn.lid x0, 0(x10)
     bn.lid x4, 0(x12)
     bn.lid x6, 0(x17)
@@ -1182,6 +1178,7 @@ seca2bmodq:
     add    x17, x17, x29
     add    x15, x15, x16
   endloop
+  /********** End inline r = secadd(a, u, k). **********/
 
   /* Restore x18 and frame. */
   lw   x18, 1728(x2)
@@ -1215,21 +1212,21 @@ seca2bmodq:
 .globl seconebitb2amodq
 .type seconebitb2amodq, @function
 seconebitb2amodq:
-  /* Frame: v[0..1] at x2+0 (1024 B), saved x8/x18 above. */
+  /* Frame: v_0..1 at x2+0 (1024 B), saved x8/x18 above. */
   addi x2, x2, -1056
   sw   x8, 1024(x2)
   sw   x18, 1028(x2)
-  addi x8, x10, 0 /* ptr_x */
-  addi x18, x12, 0 /* ptr_r */
+  addi x8, x10, 0
+  addi x18, x12, 0
 
-  /* Copy x[0] to v[0]. */
-  addi x5, x2, 0 /* ptr_v */
-  add  x6, x10, x0 /* ptr_x[0] */
+  /* Build v = (x_0, 0). */
+  addi x5, x2, 0
+  add  x6, x10, x0
   loopi 16, 2
     bn.lid x0, 0(x6++)
     bn.sid x0, 0(x5++)
   endloop
-  /* Zeroize v[1]. */
+
   bn.xor w0, w0, w0
   loopi 16, 1
     bn.sid x0, 0(x5++)
@@ -1239,40 +1236,46 @@ seconebitb2amodq:
   bn.subi    w30, w0, 1
   bn.shv.16h w30, w30 >> 15
 
-  /* Refresh v in place. */
-  addi x10, x2, 0 /* ptr_v */
-  addi x12, x10, 0 /* in-place */
+  /* Compute v = refreshmodq(v). */
+  addi x10, x2, 0
+  addi x12, x10, 0
   jal  x1, refreshmodq
 
-  /* To avoid use modular multiplication, we compute (1 - 2*x[1]) * v[j]
-   * as follows:
-   *  - x5 = x[1] - 1
-   *  - We have x5 = 0xFFFF if x[1] = 0 and x5 = 0 if x[1] = 1.
-   *  - x6 = v[j] & x5
-   *  - x6 <<= 1
-   *  - r = bn.subvm(x6, v[j]) with MOD = Q. This works because if x[1] = 0,
-   *    then x6 = 2*v[j] and r = 2*v[j] - v[j] = v[j]. Otherwise,
-   *    x6 = (0 - v[j]) mod Q.
-   * For v[0], we continue with v[0] = (v[0] + x[1]) mod Q before
-   * saving the result to memory.
+  /* We need to compute r = (1 - 2 * x_1) * v_j for j = 0..1.
+   * Since x_1 is either 0 or 1, this translates to:
+   *  - r = v_j if x_1 = 0
+   *  - r = (-v_j) mod q if x_1 = 1
+   *
+   * To avoid using modular multiplication, we proceed as follows:
+   * (note that all the operations below are vectorized):
+   *  (1) t0    = x_1 - 1 (t0 = 0xffff if x_1 = 0 else t0 = 0)
+   *  (2) t1    = (v_j & t0) << 1
+   *  (3) v_j  = (t1 - v_j) mod q
+   *  (4) v_0 += x_1 mod q
+   *
+   * This works because:
+   *  - if x_1 = 0, then t1 = v_j << 1 = 2 * v_j.
+   *    Then (t1 - v_j) mod q = v_j.
+   *  - if x_1 = 1, then t1 = 0.
+   *    Then (t1 - v_j) mod q = (-v_j) mod q.
    */
-  addi x5, x8, 512 /* ptr_x[1] */
-  addi x6, x2, 0 /* ptr_v */
+  addi x5, x8, 512 /* x_1 */
+  addi x6, x2, 0   /* v */
   addi x4, x0, 1
   loopi 16, 16
-    bn.lid         x0, 0(x5++) /* x[1] */
+    bn.lid         x0, 0(x5++)
     bn.subv.16h    w2, w0, w30
     addi           x7, x6, 0
-    /* v[0]: also add x[1] before storing. */
-    bn.lid       x4, 0(x6) /* v[0] */
+    /* Handle v_0. */
+    bn.lid       x4, 0(x6)
     bn.and       w3, w1, w2
     bn.shv.16h   w3, w3 << 1
     bn.subvm.16h w1, w3, w1
     bn.addvm.16h w1, w0, w1
     bn.sid       x4, 0(x6)
-    addi         x6, x6, 512 /* Point to v[1]. */
-    /* v[1]. */
-    bn.lid       x4, 0(x6) /* v[1] */
+    addi         x6, x6, 512
+    /* Handle v_1. */
+    bn.lid       x4, 0(x6)
     bn.and       w3, w1, w2
     bn.shv.16h   w3, w3 << 1
     bn.subvm.16h w1, w3, w1
@@ -1280,9 +1283,9 @@ seconebitb2amodq:
     addi x6, x7, 32
   endloop
 
-  /* Final refresh: r = refreshmodq(v). */
-  addi x10, x2, 0 /* ptr_v */
-  addi x12, x18, 0 /* ptr_r */
+  /* Compute r = refreshmodq(v). */
+  addi x10, x2, 0
+  addi x12, x18, 0
   jal  x1, refreshmodq
 
   /* Restore registers and frame. */
@@ -1323,9 +1326,9 @@ seconebitb2amodq:
 secb2amodq:
   /* Frame (2656 B, 2 shares):
    *   x2 +    0 : saved x8, x18, x19, x20, x21
-   *   x2 +   32 : ptr_zp / scratch (1024 B)
-   *   x2 + 1056 : ptr_s            ( 832 B)
-   *   x2 + 1888 : ptr_a, ptr_b, ptr_c (bitsliced, 768 B) */
+   *   x2 +   32 : zp / scratch (1024 B)
+   *   x2 + 1056 : s            ( 832 B)
+   *   x2 + 1888 : a, b, c, zp  (bitsliced, 768 B) */
   addi x2, x2, -2048
   addi x2, x2, -608
   sw x8, 0(x2)
@@ -1335,133 +1338,113 @@ secb2amodq:
   sw x21, 16(x2)
 
   /* Save input/output addresses and buffer bases. */
-  addi x8, x10, 0 /* ptr_x */
-  addi x18, x12, 0 /* ptr_r */
-  addi x19, x2, 1888 /* ptr_a, ptr_b, ptr_c (bitsliced) */
-  addi x20, x2, 1056 /* ptr_s */
-  /* ptr_zp = x2 + 32 */
+  addi x8, x10, 0
+  addi x18, x12, 0
+  addi x19, x2, 1888 /* a, b, c, zp (bitsliced) */
+  addi x20, x2, 1056 /* s */
+  /* zp = x2 + 32 */
 
-  /* Sample rand, then compute zp = q - rand. */
+  /* Sample r_0 = rand, then compute zp = q - rand. */
   addi    x4, x0, 30
   la      x5, modulus_bn
   bn.lid  x4, 0(x5)
-  addi    x10, x12, 0 /* ptr_r */
-  addi    x7, x2, 32 /* ptr_zp */
+  addi    x10, x12, 0
+  addi    x7, x2, 32
   bn.wsrr w16, mod
   jal x1, poly_rej_samp
   loopi 16, 3
     bn.lid      x0, 0(x12++)
-    bn.subv.16h w0, w30, w0 /* Since inputs are < q, we need to only use bn.subv. */
+    bn.subv.16h w0, w30, w0
     bn.sid      x0, 0(x7++)
   endloop
 
-  /* Bitslice share 0 of zp; the last share (bitsliced) is cleared below. */
-  addi x10, x2, 32 /* ptr_zp */
-  addi x11, x19, 0 /* ptr_zp (bitsliced) */
+  /* Bitslice zp_0 and clear zp_1 (bitsliced). */
+  addi x10, x2, 32
+  addi x11, x19, 0
   jal  x1, poly_to_bitsliced
   addi x11, x11, 384
-  /* Clear the last share of zp (bitsliced). */
   bn.xor w0, w0, w0
   loopi 12, 1
     bn.sid x0, 0(x11++)
   endloop
 
   /* Compute a = seca2bmodq(zp). */
-  addi x10, x19, 0 /* ptr_zp (bitsliced) */
-  addi x12, x19, 0 /* ptr_a */
+  addi x10, x19, 0
+  addi x12, x19, 0
   jal  x1, seca2bmodq
 
   /* Compute b = secaddmodq(a, x). */
-  /* Inline secaddmodq. */
-  /* Compute s = secadd(a, x, k + 1). */
+  /********** Start inline b = secaddmodq(a, x). **********/
+  /********** Start inline s = secadd(a, x, k + 1). **********/
   /* Initialize c = 0. */
   bn.xor w0, w0, w0
-  addi   x5, x20, 384 /* ptr_c */
+  addi   x5, x20, 384
   loopi 2, 2
     bn.sid x0, 0(x5)
     addi   x5, x5, 416
   endloop
 
-  /* Ripple-carry adder. */
-  addi x10, x19, 0 /* ptr_a */
+  addi x10, x19, 0
   addi x11, x0, 384
-  addi x12, x8, 0 /* ptr_x */
+  addi x12, x8, 0
   addi x13, x0, 384
-  addi x15, x20, 0 /* ptr_s */
+  addi x15, x20, 0
   addi x16, x0, 416
-  addi x17, x20, 384 /* ptr_c = cin */
+  addi x17, x20, 384
   addi x29, x0, 416
-  addi x30, x20, 384 /* ptr_c = cout */
+  addi x30, x20, 384
   addi x31, x0, 416
-  /* Loop over i=1,...,k-1. */
   loopi 12, 2
-    /* x10 already points to x[i] */
-    /* x11 is already share stride of x. */
-    /* x12 already points to y[i] */
-    /* x13 is already share stride of y. */
-    /* x15 already points to r. */
-    /* x16 is already share stride of r. */
-    /* x17 already points to ptr_c = cin. */
-    /* x29 is already share stride of cin. */
-    /* x30 already points to ptr_c = cout. */
-    /* x31 is already share stride of cout. */
     jal  x1, secfulladder
-    /* After secfulladder:
-     *  - x10 and x12 points to x[i + 1] and y[i + 1].
-     *  - x11 and x13 are still share stride of x and y.
-     *  - x15 points to r[i + 1].
-     *  - x16 is still share stride of r.
-     *  - x17 points to cin.
-     *  - x29 is still share stride of cin.
-     *  - x30 points to cout.
-     *  - x31 is still share stride of cout. */
     nop
   endloop
-  /* Bit i = k + 1 is already x[k + 1] ^ y[k + 1] ^ c = cout since x[k + 1] = y[k + 1] = 0. */
+  /* Bit i = k is already a[k] ^ x[k] ^ cout = cout
+   * since a[k] = x[k] = 0. */
+  /********** End inline s = secadd(a, x, k + 1). **********/
 
-  /* Compute s = secadd(s, p, k + 1) where p = 2**(k + 1) - q = 4863 = b1001011111111. */
+  /********** Start inline s = secadd(s, p = 2^(k + 1) - q, k + 1). **********/
   /* Initialize c = 0. */
-  addi   x5, x2, 32 /* ptr_c */
+  addi   x5, x2, 32
   bn.xor w0, w0, w0
   loopi 2, 1
     bn.sid x0, 0(x5++)
   endloop
-  addi x21, x5, 0 /* ptr_p */
+  addi x21, x5, 0 /* p */
 
-  addi    x5, x21, 0 /* ptr_p */
+  addi    x5, x21, 0
   bn.subi w1, w0, 1
   addi    x4, x0, 1
   bn.sid  x4, 0(x5++)
   bn.sid  x0, 0(x5++)
 
-  addi x10, x21, 0 /* ptr_p */
+  addi x10, x21, 0
   addi x11, x0, 32
-  addi x12, x20, 0 /* ptr_s */
+  addi x12, x20, 0
   addi x13, x0, 416
-  addi x15, x20, 0 /* ptr_s */
+  addi x15, x20, 0
   addi x16, x0, 416
-  addi x17, x2, 32 /* cin */
+  addi x17, x2, 32
   addi x29, x0, 32
-  addi x30, x2, 32 /* cout */
+  addi x30, x2, 32
   addi x31, x0, 32
-  /* Bit 0 -- 7: p = 1. */
+  /* Bits 0..7: p[i] = 1. */
   loopi 8, 2
     jal  x1, secfulladder
-    addi x10, x10, -32 /* Reset x10 to ptr_p. */
+    addi x10, x10, -32
   endloop
 
-  /* Bit 8: p = 0. */
+  /* Bit 8: p[i] = 0. */
   bn.xor w0, w0, w0
   bn.sid x0, 0(x10)
   addi   x10, x21, 0
   jal    x1, secfulladder
-  /* Bit 9: p = 1. */
+  /* Bit 9: p[i] = 1. */
   bn.xor  w0, w0, w0
   bn.subi w0, w0, 1
   addi    x10, x21, 0
   bn.sid  x0, 0(x10)
   jal     x1, secfulladder
-  /* Bit 10 -- 11: p = 0. */
+  /* Bits 10..11: p[i] = 0. */
   bn.xor w0, w0, w0
   addi   x10, x21, 0
   bn.sid x0, 0(x10)
@@ -1469,16 +1452,16 @@ secb2amodq:
   addi   x10, x21, 0
   jal    x1, secfulladder
 
-  /* Bit 12: p = 1. */
-  /* Compute r[12] = p[12] ^ s[12] ^ c = ~(s[12] ^ c) since p[12] = 1. */
+  /* Bit 12: p[i] = 1. */
   addi x4, x0, 1
   addi x6, x0, 2
+  /* s[12] = p[12] ^ s[12] ^ c = ~(s[12] ^ c) since p[12] = 1. */
   /* Whitening. */
   bn.xor w0, w0, w0
   bn.xor w1, w1, w1
   bn.xor w2, w2, w2
   bn.xor w3, w3, w3
-  /* Computation. */
+  /* s_0 */
   bn.lid x0, 0(x12)
   bn.lid x4, 0(x17)
   bn.xor w3, w0, w1
@@ -1491,38 +1474,39 @@ secb2amodq:
   bn.xor w0, w0, w0
   bn.xor w1, w1, w1
   bn.xor w2, w2, w2
-  /* Computation. */
+  /* s_1 */
   bn.lid x0, 0(x12)
   bn.lid x4, 0(x17)
   bn.xor w2, w0, w1
   bn.sid x6, 0(x12)
+  /********** End inline s = secadd(s, p = 2^(k + 1) - q, k + 1). **********/
 
   /* Compute a = bitcopymask(s[k], (k + 1) * 32). */
-  addi x10, x20, 384 /* ptr_s[k] */
-  addi x11, x0, 416 /* share_str = (k + 1) * 32 */
-  addi x13, x19, 0 /* ptr_a */
+  addi x10, x20, 384
+  addi x11, x0, 416
+  addi x13, x19, 0
   jal  x1, bitcopymask
 
   /* Compute r = secadd(a, s, k). */
-  addi x10, x19, 0 /* ptr_a */
+  addi x10, x19, 0
   addi x11, x0, 384
-  addi x12, x20, 0 /* ptr_s */
+  addi x12, x20, 0
   addi x13, x0, 416
-  addi x15, x19, 0 /* ptr_b */
+  addi x15, x19, 0
   addi x16, x0, 384
-  addi x17, x0, 12 /* k */
+  addi x17, x0, 12
   jal  x1, secadd
-  /* End inlining secaddmodq. */
+  /********** End inline b = secaddmodq(a, x). **********/
 
   /* Compute c = refreshios(b, k, k * 32). */
-  addi x10, x19, 0 /* ptr_b */
-  addi x11, x0, 12 /* k */
-  addi x12, x0, 384 /* k * 32 */
-  addi x14, x19, 0 /* ptr_c */
+  addi x10, x19, 0
+  addi x11, x0, 12
+  addi x12, x0, 384
+  addi x14, x19, 0
   jal  x1, refreshios
 
   /* Unmask c. */
-  addi x5, x19, 0 /* ptr_c */
+  addi x5, x19, 0
   addi x4, x0, 1
   loopi 12, 5
     addi   x6, x5, 384
@@ -1532,10 +1516,10 @@ secb2amodq:
     bn.sid x0, 0(x5++)
   endloop
 
-  /* Convert c from bitsliced to normal representation, into share 1. */
-  addi x10, x19, 0 /* ptr_c */
-  addi x11, x18, 0 /* ptr_r */
-  addi x11, x11, 512 /* r[1] */
+  /* Convert c from bitsliced to normal representation, into r_1. */
+  addi x10, x19, 0
+  addi x11, x18, 0
+  addi x11, x11, 512
   jal x1, poly_from_bitsliced
 
   /* Restore registers. */
@@ -1580,9 +1564,9 @@ secb2amodq:
 .globl poly_hocompress
 .type poly_hocompress, @function
 poly_hocompress:
-  /* Allocate y[0], y[1] scratch and save callee-saved registers. */
+  /* Allocate t_0..1, z scratch and save callee-saved registers. */
   addi x2, x2, -1024
-  add  x7, x2, x0
+  add  x7, x2, x0 /* t */
   addi x2, x2, -1184
   sw   x9, 1152(x2)
   sw   x18, 1156(x2)
@@ -1597,12 +1581,12 @@ poly_hocompress:
   bn.lid    x4++, 0(x5)
   bn.shv.8s w18, w18 >> 16
 
-  /* Create 1-bit mask and 2**(alpha - 1). */
+  /* Create 2^(alpha - 1). */
   bn.subi   w19, w31, 1
   bn.shv.8s w19, w19 >> 31
-  bn.shv.8s w19, w19 << 12  /* alpha - 1 */
+  bn.shv.8s w19, w19 << 12
 
-  /* Select alpha-dependent parameters: w3 = 2**(alpha - 1), x18 = the
+  /* Select alpha-dependent parameters: w19 = 2^(alpha - 1), x18 = the
    * extraction byte offset alpha * 32, x19 = dv. */
   addi      x4, x0, 4
   addi      x18, x0, 416  /* alpha * 32, alpha = 13 */
@@ -1613,37 +1597,20 @@ poly_hocompress:
   addi      x19, x0, 4
 _dv_params_done:
 
-  addi x6, x2, 0 /* ptr_z */
-  addi x28, x6, 512 /* Skip the first 16 bits. */
+  addi x6, x2, 0 /* z */
+  addi x28, x6, 512
 
-  /* For DV in {4,5}, in order to avoid division by Q, we need to compute:
-   *  - x << (DV + ALPHA) --> x is maximum 20 bits.
-   *  - x += 1665
-   *  - x *=m where m = ((1 << 37) + Q // 2) // Q = 41285357 (m is 26 bits).
-   *  - x >>= k where k = 37.
-   *  - x &= ((1 << (DV + ALPHA)) - 1).
-   * where 37 is the smallest integer that makes this algorithm equivalent to
-   * the division by Q.
+  /* Compute z_0 = Compressq(x_0, dv + alpha) + 2^(alpha - 1),
+   *         z_1 = Compressq(x_1, dv + alpha).
    *
-   * Now for the first share, for performance reason after the step above, we
-   * want to also compute + 2**(ALPHA - 1) before saving the results to
-   * memory. This would result in two more bn.addv.8s instructions compared
-   * to the other shares. In order to reduce code size, we want the
-   * computation of the first share to be identical to subsequent shares. We
-   * realize that if k = 40, after the taking the high parts of the 64-bit
-   * products of x * m, we need to shift 8 bits more, instead of 5 bits.
-   * This shift of a multiple of 8 bits helps us to merge the final shift by
-   * 5 bits with the addition of 2**(alpha - 1) by using bn.add instead of
-   * bn.shv.8s and bn.addv.8s. Since alpha = 13 or 14, and (x * m) >> 40 is
-   * of size 19 bits, their sum is maximum 20 bits, which doesn't overflow
-   * 32-bit slot, ensuring that the addition with bn.add is equivalent to the
-   * vector addition with bn.addv.8s. This is for the first share.
-   *
-   * For subsequent shares, we only need to add (x * m) >> k with 0 with
-   * bn.add to make it a shift, thus reusing the same code for all the shares.
+   * For dv in {4, 5}, in order to avoid division by q, let s = 40 and
+   * m = ((1 << s) + q // 2) // q = 0x13afb768 and do as follows:
+   *  - x << (dv + alpha)
+   *  - x += (q + 1) / 2 = 1665
+   *  - x *= m
+   *  - x >>= s
+   *  - x &= ((1 << (dv + alpha)) - 1).
    */
-
-  /* Compute z[0] = Compressq(x[0], dv + alpha) + 2**(alpha - 1). */
   loopi 2, 58
     /* Whitening. */
     bn.xor w0, w0, w0
@@ -1668,7 +1635,7 @@ _dv_params_done:
     bn.xor w29, w29, w29
 
     addi x4, x0, 15
-    loopi 16, 18  /* 16 WDRs hold the 256 coeffs */
+    loopi 16, 18
       bn.lid             x0, 0(x10++)
       /* Handle even-positioned coeffs. */
       bn.trn1.16h        w20, w0, w31
@@ -1692,8 +1659,8 @@ _dv_params_done:
       addi               x4, x4, -1
     endloop
 
-    /* For the first share, w19 is 2**(alpha - 1). After that, we need to
-     * clear w19 so that bn.add acts as a shift. */
+    /* For the first share, w19 holds 2^(alpha - 1).
+     * After that, we clear w19 so that bn.add acts as a shift. */
     bn.xor w19, w19, w19
 
     /* Bitslice the first 16 bits. */
@@ -1724,17 +1691,17 @@ _dv_params_done:
     addi x28, x28, 512 /* Skip the first 16 bits. */
   endloop
 
-  /* Compute c = seca2b(z), k = dv + alpha, share bytes = 576. */
-  addi x10, x2, 0 /* ptr_z */
-  addi x11, x0, 18 /* dv + alpha */
+  /* Compute c = seca2b(z), k = dv + alpha = 18, share bytes = 576. */
+  addi x10, x2, 0
+  addi x11, x0, 18
   addi x12, x0, 576
-  addi x14, x2, 0 /* ptr_c */
+  addi x14, x2, 0
   jal  x1, seca2b
 
-  /* Compute r = c >> alpha: keep the bits c[alpha]...c[alpha + dv]. */
-  addi x5, x2, 0 /* ptr_c */
+  /* Compute r = c >> alpha: keep the bits c[alpha]...c[dv + alpha]. */
+  addi x5, x2, 0
   add  x5, x5, x18
-  addi x6, x9, 0 /* ptr_r */
+  addi x6, x9, 0
   loopi 2, 5
     loop x19, 3
       /* Whitening. */
@@ -1742,7 +1709,6 @@ _dv_params_done:
       bn.lid x0, 0(x5++)
       bn.sid x0, 0(x6++)
     endloop
-    /* After copy DV bits of z to r, we need to adjust address of z again. */
     add x5, x5, x18
   endloop
 
@@ -1786,23 +1752,22 @@ _dv_params_done:
 .globl polyvec_hocompress
 .type polyvec_hocompress, @function
 polyvec_hocompress:
-  /* Allocate y[0], y[1] scratch and save callee-saved registers. */
+  /* Allocate t_0..1, z scratch and save callee-saved registers. */
   addi x2, x2, -1024
-  add  x7, x2, x0
+  add  x7, x2, x0 /* t */
   addi x2, x2, -1568
   sw   x9, 1536(x2)
   sw   x18, 1540(x2)
   sw   x19, 1544(x2)
   addi x9, x12, 0
 
-  /* Create 2**(alpha - 1). */
+  /* Create 2^(alpha - 1). */
   bn.subi   w30, w31, 1
   bn.shv.8s w30, w30 >> 31
-  bn.shv.8s w30, w30 << 12  /* alpha - 1 */
+  bn.shv.8s w30, w30 << 12
 
-  /* Select alpha-dependent parameters: x18 = the extraction byte offset
-   * alpha * 32, x19 = du. The in-loop computation of 2**(alpha - 1)
-   * branches on x13 (k) directly. */
+  /* Select alpha-dependent parameters: w30 = 2^(alpha - 1), x18 = the
+   * extraction byte offset alpha * 32, x19 = dv. */
   addi      x4, x0, 4
   addi      x18, x0, 416  /* alpha * 32, alpha = 13 */
   addi      x19, x0, 11
@@ -1816,15 +1781,24 @@ _du_params_done:
   addi       x4, x0, 17
   la         x5, const_m_du
   bn.lid     x4++, 0(x5)
-
   la         x5, const_1664
   bn.lid     x4, 0(x5)
 
-  /* Adjust space for temporary variable y. */
   addi x5, x0, 21
-  addi x6, x2, 0 /* ptr_z */
+  addi x6, x2, 0    /* z */
   addi x28, x6, 512 /* Skip the first 16 bits. */
 
+  /* Compute z_0 = Compressq(x_0, du + alpha) + 2^(alpha - 1),
+   *         z_1 = Compressq(x_1, du + alpha).
+   *
+   * For du in {10, 11}, in order to avoid division by q, let s = 64 and
+   * m = ((1 << s) + q // 2) // q = 0x13afb7680bb055 and do as follows:
+   *  - x << (du + alpha)
+   *  - x += 1664
+   *  - x *= m
+   *  - x >>= s
+   *  - x &= ((1 << (du + alpha)) - 1).
+   */
   loopi 2, 85
     /* Whitening. */
     bn.xor w0, w0, w0
@@ -1850,7 +1824,7 @@ _du_params_done:
     bn.xor w29, w29, w29
 
     addi x4, x0, 15
-    loopi 16, 44  /* 16 WDRs hold the 256 coeffs */
+    loopi 16, 44
       bn.lid           x0, 0(x10++)
       /* Handle even-positioned coeffs. */
       bn.trn1.16h      w19, w0, w31
@@ -1897,10 +1871,8 @@ _du_params_done:
       bn.trn2.4d      w0, w21, w0
       /* Combine the result. */
       bn.trn1.8s      w20, w20, w0
-      /* Compute + 2**(alpha - 1) mod 2**(du + alpha); w30 holds
-      * 2**(alpha - 1) for the alpha selected per K. Then turn w31 into
-      * the per-lane bit mask for the bitslice helper below; it is zeroed
-      * again at the end of the loop body. */
+
+      /* Compute + 2^(alpha - 1) for the 1st share or 0 for the 2nd share. */
       bn.addv.8s      w19, w19, w30
       bn.addv.8s      w20, w20, w30
       /* Combine the results before bitslicing. */
@@ -1911,7 +1883,8 @@ _du_params_done:
       bn.sid          x5, 0(x7++)
     endloop
 
-    /* Clear w30. */
+    /* For the first share, w30 holds 2^(alpha - 1).
+     * After that, we clear w30 for the 2nd share. */
     bn.xor w30, w30, w30
 
     /* Bitslice the first 16 bits. */
@@ -1942,17 +1915,17 @@ _du_params_done:
     addi x28, x28, 512 /* Skip the first 16 bits. */
   endloop
 
-  /* Compute c = seca2b(z), k = du + alpha, share bytes = 768. */
-  addi x10, x2, 0 /* ptr_z */
-  addi x11, x0, 24 /* du + alpha */
+  /* Compute c = seca2b(z), k = du + alpha = 24, share bytes = 768. */
+  addi x10, x2, 0
+  addi x11, x0, 24
   addi x12, x0, 768
-  addi x14, x2, 0 /* ptr_c */
+  addi x14, x2, 0
   jal  x1, seca2b
 
-  /* Compute r = c >> alpha: keep the bits c[alpha]...c[alpha + du]. */
-  addi x5, x2, 0 /* ptr_c */
+  /* Compute r = c >> alpha: keep the bits c[alpha]...c[du + alpha]. */
+  addi x5, x2, 0
   add  x5, x5, x18
-  addi x6, x9, 0 /* ptr_r */
+  addi x6, x9, 0
   loopi 2, 5
     loop x19, 3
       /* Whitening. */
@@ -1960,7 +1933,6 @@ _du_params_done:
       bn.lid x0, 0(x5++)
       bn.sid x0, 0(x6++)
     endloop
-    /* After copy DV bits of z to r, we need to adjust address of z again. */
     add x5, x5, x18
   endloop
 
@@ -2019,13 +1991,13 @@ onebitdecompress:
     nop
   endloop
 
-  /* mp = seconebitb2amodq(m), with w16 = R | Q. */
-  addi x10, x8, 0 /* ptr_m */
-  addi x12, x8, 0 /* ptr_r */
+  /* Compute mp = seconebitb2amodq(m). */
+  addi x10, x8, 0
+  addi x12, x8, 0
   jal  x1, seconebitb2amodq
 
   /* mp *= (q + 1) / 2 mod q, coefficient-wise (Montgomery). */
-  la      x5, modulus_over_2_m2_16 /* ((Q + 1) / 2) * (2^16) % Q. */
+  la      x5, modulus_over_2_m2_16  /* ((q + 1) / 2) * (2^16) mod q. */
   addi    x4, x0, 1
   bn.lid  x4, 0(x5)
   loopi 2, 9
@@ -2077,8 +2049,12 @@ onebitdecompress:
 .globl masked_cbd
 .type masked_cbd, @function
 masked_cbd:
-  /* Frame: tmp at 0 (768 B), sum at 768 (64 B), s at 832 (384 B, sized for
-   * the worst case eta = 3), saved registers at 1216. */
+  /* Frame:
+   *   x2 +    0 : b ( 768 B)
+   *   x2 +  768 : a (  64 B)
+   *   x2 +  832 : s ( 384 B)
+   *   x2 + 1216 : save registers. */
+  addi x2, x2, -1248
   addi x2, x2, -1248
   sw x8, 1216(x2)
   sw x9, 1220(x2)
@@ -2092,115 +2068,99 @@ masked_cbd:
   addi x9, x11, 0
   addi x18, x12, 0
   addi x20, x14, 0
-  addi x21, x2, 832 /* ptr_s */
-  addi x22, x2, 768 /* ptr_sum */
+  addi x21, x2, 832 /* s */
+  addi x22, x2, 768 /* a */
 
-  /* Copy x to s[1,..,eta] and ~y to s[eta + 1,..,2 * eta]. */
-  addi x5, x21, 0 /* ptr_s */
+  /* Copy x to s[0..eta - 1] and ~y to s[eta..2 * eta - 1]. */
+  addi x5, x21, 0
   slli x4, x12, 5 /* eta * 32 */
-  add  x6, x21, x4 /* ptr_s[eta + 1] */
-  /* Share 0: copy x[0] and ~y[0]. */
+  add  x6, x21, x4
+  /* Share 0. */
   loop x12, 7
     /* Whitening. */
     bn.xor w0, w0, w0
-    /* Copy x[0]. */
+    /* Copy x_0. */
     bn.lid x0, 0(x10++)
     bn.sid x0, 0(x5++)
     /* Whitening. */
     bn.xor w0, w0, w0
-    /* Copy ~y[0]. */
+    /* Copy ~y_0. */
     bn.lid x0, 0(x11++)
     bn.not w0, w0
     bn.sid x0, 0(x6++)
   endloop
+  /* Share 1. */
   add x5, x5, x4
   add x6, x6, x4
-  /* Share 1: copy x[1] and y[1]. */
   loop x12, 6
     /* Whitening. */
     bn.xor w0, w0, w0
-    /* Copy x[1]. */
+    /* Copy x_1. */
     bn.lid x0, 0(x10++)
     bn.sid x0, 0(x5++)
     /* Whitening. */
     bn.xor w0, w0, w0
-    /* Copy y[1]. */
+    /* Copy y_1. */
     bn.lid x0, 0(x11++)
     bn.sid x0, 0(x6++)
   endloop
 
-  /* We need to loop over i = 1,...,k where k = ceil(log2(l + 1)) = 3 for both
-   * eta = 2 and eta = 3. Then the inner loop is over j = 1,...,l where
-   * l >>= i, so j is in {eta, eta/2, eta/4}, i.e., {2, 1, 0} for eta = 2 and
-   * {3, 1, 0} for eta = 3. Thus, in the third iteration i = k, the inner loop
-   * is not executed at all. */
-  /*----------------------- Iteration i = 1, l = 2 * eta -----------------------*/
-  /* Since l mod 2 = 0, we clear the carry sum. */
-  addi   x5, x22, 0 /* ptr_sum */
+  /* The block below does as follows:
+   *  - ell <- 2 * eta
+   *  - c = ceil(log2(ell + 1)) = 3
+   *  - for i = 0..c - 1:
+   *      a <- s[ell - 1] if ell mod 2 = 1 else a <- 0
+   *      ell <- ell >> 1
+   *      for j = 0..ell - 1:
+   *        (a, s[j]) <- secfulladder(s[2 * j], s[2 * j + 1], a)  ; sum, carry
+   *      b[i] <- a
+   */
+  /********** Iteration i = 0, ell = 2 * eta. **********/
+  /* Since ell mod 2 = 0, we clear a. */
+  addi   x5, x22, 0
   bn.xor w0, w0, w0
   loopi 2, 1
     bn.sid x0, 0(x5++)
   endloop
 
-  /* l >>= 1: loop j = 1,..., l = 1,...,eta. */
-  /* Inputs to secfulladder. */
+  /* Loop j = 0..eta - 1. */
+  /* Compute (a, s[j]) = secfulladder(s[2 * j], s[2 * j + 1], a). */
   slli x5, x12, 6 /* (2 * eta) * 32 */
-  addi x10, x21, 0 /* s[0] */
+  addi x10, x21, 0
   addi x11, x5, 0
-  addi x12, x21, 32 /* s[1] */
+  addi x12, x21, 32
   addi x13, x5, 0
-  addi x15, x22, 0 /* ptr_sum = r */
+  addi x15, x22, 0
   addi x16, x0, 32
-  addi x17, x22, 0 /* ptr_sum = cin */
+  addi x17, x22, 0
   addi x29, x0, 32
-  addi x30, x21, 0 /* s[0] = cout */
+  addi x30, x21, 0
   addi x31, x5, 0
   loop x18, 5
-    /* Compute c, s[j] = secfulladder(s[2j], s[2j + 1], c). */
-    /* x10 already points to s[2j] */
-    /* x11 is already share stride of s. */
-    /* x12 already points to s[2j + 1] */
-    /* x13 is already share stride of s. */
-    /* x15 already points to sum = r. */
-    /* x16 is already share stride of sum = r. */
-    /* x17 already points to sum = cin. */
-    /* x29 is already share stride of sum = cin. */
-    /* x30 already points to s[j] = cout. */
-    /* x31 is already share stride of s = cout. */
     jal  x1, secfulladder
-    /* After secfulladder:
-    *  - x10 and x12 points to s[2j + 1] and s[2j + 2] --> need to be adjusted.
-    *  - x11 and x13 are still share stride of s.
-    *  - x15 points to sum + 32 (output) --> need to be adjusted to sum.
-    *  - x16 is still share stride of sum.
-    *  - x17 points to sum (cin).
-    *  - x29 is still share stride of sum.
-    *  - x30 points to s[j] (cout) --> need to be adjusted to s[j + 1].
-    *  - x31 is still share stride of s. */
-    /* Adjust addresses. */
-    addi x10, x10, 32 /* s[2 * (j + 1)] */
-    addi x12, x12, 32 /* s[2 * (j + 1) + 1] */
-    addi x15, x15, -32 /* sum */
-    addi x30, x30, 32 /* s[j + 1] */
+    addi x10, x10, 32  /* s[2 * (j + 1)] */
+    addi x12, x12, 32  /* s[2 * (j + 1) + 1] */
+    addi x15, x15, -32 /* a */
+    addi x30, x30, 32  /* s[j + 1] */
   endloop
 
-  /* Copy sum to ptr_tmp[1]. */
-  addi x5, x2, 0 /* ptr_tmp[1] */
+  /* b[0] <- a. */
+  addi x5, x2, 0
   loopi 2, 4
     /* Whitening. */
     bn.xor w0, w0, w0
-    bn.lid x0, 0(x15++) /* x15 still points to sum. */
+    bn.lid x0, 0(x15++)
     bn.sid x0, 0(x5)
     addi   x5, x5, 384
   endloop
 
-  /*----------------------- Iteration i = 2, l = eta -----------------------*/
+  /********** Iteration i = 1, ell = eta. **********/
   addi x5, x0, 2
   beq  x18, x5, _cbd_eta_2
-  /* Since l mod 2 = 1 if eta = 3, we compute sum = s[l] = s[3]. */
-  addi x5, x22, 0 /* ptr_sum */
-  addi x6, x21, 0 /* ptr_s */
-  addi x6, x6, 64 /* 2 * 32 */
+  /* Since ell mod 2 = 1 if eta = 3, we compute a = s[ell - 1]. */
+  addi x5, x22, 0
+  addi x6, x21, 0
+  addi x6, x6, 64
   slli x4, x18, 6 /* (2 * eta) * 32 */
   loopi 2, 4
     /* Whitening. */
@@ -2212,64 +2172,44 @@ masked_cbd:
   beq x0, x0, _continue_1
 
 _cbd_eta_2:
-  /* Since l mod 2 = 0 if eta = 2, we clear the carry sum. */
-  addi   x5, x22, 0 /* ptr_sum */
+  /* Since ell mod 2 = 0 if eta = 2, we clear a. */
+  addi   x5, x22, 0
   bn.xor w0, w0, w0
   loopi 2, 1
     bn.sid x0, 0(x5++)
   endloop
 
 _continue_1:
-  /* l >> 1: loop j = 1,...,l // 2 --> 1 iteration. */
-  /* Inputs to secfulladder. */
+  /* Loop j = 0. */
+  /* Compute (a, s[0]) = secfulladder(s[0], s[1], a). */
   slli x5, x18, 6
-  addi x10, x21, 0 /* s[0] */
+  addi x10, x21, 0
   addi x11, x5, 0
-  addi x12, x21, 32 /* s[1] */
+  addi x12, x21, 32
   addi x13, x5, 0
-  addi x15, x22, 0 /* ptr_sum = r */
+  addi x15, x22, 0
   addi x16, x0, 32
-  addi x17, x22, 0 /* ptr_sum = cin */
+  addi x17, x22, 0
   addi x29, x0, 32
-  addi x30, x21, 0 /* s[0] = cout */
+  addi x30, x21, 0
   addi x31, x5, 0
-  /* Compute c, s[j] = secfulladder(s[2j], s[2j + 1], c). */
-  /* x10 already points to s[2j] */
-  /* x11 is already share stride of s. */
-  /* x12 already points to s[2j + 1] */
-  /* x13 is already share stride of s. */
-  /* x15 already points to sum = r. */
-  /* x16 is already share stride of sum = r. */
-  /* x17 already points to sum = cin. */
-  /* x29 is already share stride of sum = cin. */
-  /* x30 already points to s[j] = cout. */
-  /* x31 is already share stride of s = cout. */
   jal  x1, secfulladder
-  /* After secfulladder:
-  *  - x10 and x12 points to s[2j + 1] and s[2j + 2] --> need to be adjusted.
-  *  - x11 and x13 are still share stride of s.
-  *  - x15 points to sum + 32 (output) --> need to be adjusted to sum.
-  *  - x16 is still share stride of sum.
-  *  - x17 points to sum (cin).
-  *  - x29 is still share stride of sum.
-  *  - x30 points to s[j] (cout) --> need to be adjusted to s[j + 1].
-  *  - x31 is still share stride of s. */
 
-  /* Copy sum to ptr_tmp[2]. */
-  addi x5, x2, 32 /* ptr_tmp[2] */
+  /* b[1] <- a. */
+  addi x5, x2, 32
   loopi 2, 4
     /* Whitening. */
     bn.xor w0, w0, w0
-    bn.lid x0, 0(x17++) /* x17 still points to sum. */
+    bn.lid x0, 0(x17++)
     bn.sid x0, 0(x5)
     addi   x5, x5, 384
   endloop
 
-  /*----------------------- Iteration i = 3, l = eta / 2 -----------------------*/
-  /* Since l mod 2 = 1, we compute tmp[3] = s[l] = s[1]. */
-  addi x5, x2, 0 /* ptr_tmp */
+  /********** Iteration i = 2, ell = eta // 2 = 1. **********/
+  /* Since ell mod 2 = 1, we compute b[2] = s[ell - 1] = s[0] directly. */
+  addi x5, x2, 0
   addi x5, x5, 64
-  addi x6, x21, 0 /* ptr_s */
+  addi x6, x21, 0
   slli x7, x18, 6
 
   loopi 2, 5
@@ -2281,25 +2221,25 @@ _continue_1:
     addi   x5, x5, 384
   endloop
 
-  /* Clear bit k --> 12 of tmp. */
-  addi   x5, x2, 0 /* ptr_tmp */
+  /* Clear bits b[3..k - 1]. */
+  addi   x5, x2, 0
   addi   x5, x5, 96
   bn.xor w0, w0, w0
   loopi 2, 3
     loopi 9, 1
       bn.sid x0, 0(x5++)
     endloop
-    addi x5, x5, 96 /* point to next share. */
+    addi x5, x5, 96
   endloop
 
-  /* Compute r = secb2amodq(tmp). */
-  addi x10, x2, 0 /* ptr_tmp */
-  addi x12, x20, 0 /* ptr_r */
+  /* Compute r = secb2amodq(b). */
+  addi x10, x2, 0
+  addi x12, x20, 0
   jal  x1, secb2amodq
 
-  /* Compute r[0] = r[0] - eta mod q. */
-  addi   x5, x20, 0 /* ptr_r */
-  addi   x6, x21, 0 /* ptr_s */
+  /* Compute r_0 = (r_0 - eta) mod q. */
+  addi   x5, x20, 0
+  addi   x6, x21, 0
   sw     x18, 0(x6)
   bn.lid x0, 0(x6)
   loopi 16, 1
@@ -2354,13 +2294,15 @@ masked_poly_getnoise_eta_init:
   add   x5, x5, x6
   csrrw x0, kmac_cfg, x5
 
-  /* Send the message to the Keccak core. */
+  /* Send seed. */
   bn.xor  w0, w0, w0 /* Whitening. */
   bn.lid  x0, 0(x10++)
   bn.wsrw kmac_msg, w0
   bn.xor  w0, w0, w0 /* Whitening. */
   bn.lid  x0, 0(x10++)
   bn.wsrw kmac_msg1, w0
+
+  /* Send nonce. */
   li      x5, 1
   csrrw   x0, kmac_partial_write, x5
   bn.lid  x0, 0(x11)
@@ -2426,7 +2368,7 @@ masked_poly_getnoise_eta_2:
 .globl masked_poly_getnoise_eta_1
 .type masked_poly_getnoise_eta_1, @function
 masked_poly_getnoise_eta_1:
-  /* Frame: ptr_y at 0, ptr_x at 192 (each 2 * eta * 32, sized for the worst
+  /* Frame: y at 0, x at 192 (each 2 * eta * 32, sized for the worst
    * case eta = 3), saved registers at 384. */
   addi x2, x2, -416
   sw   x8, 384(x2)
@@ -2435,12 +2377,12 @@ masked_poly_getnoise_eta_1:
   sw   x19, 396(x2)
   addi x8, x10, 0
   addi x9, x11, 0
-  addi x18, x2, 192 /* ptr_x */
+  addi x18, x2, 192
 
   addi x4, x0, 3
   bne  x10, x4, _getnoise_eta_2
 
-  addi x5, x2, 0 /* ptr_y */
+  addi x5, x2, 0
 
   bn.wsrr w17, kmac_digest
   bn.wsrr w23, kmac_digest1
@@ -2509,7 +2451,7 @@ _getnoise_eta_2:
   addi x5, x0, 25
   addi x6, x0, 17
   addi x7, x0, 26
-  addi x28, x2, 0 /* ptr_y */
+  addi x28, x2, 0
   loopi 2, 38
     /* Whitening. */
     bn.xor w0, w0, w0
@@ -2560,10 +2502,10 @@ _getnoise_eta_2:
 
 _getnoise_common:
   /* Compute r = masked_cbd(x, y, eta). */
-  addi x10, x2, 192 /* ptr_x */
-  addi x11, x2, 0 /* ptr_y */
-  addi x12, x8, 0 /* eta */
-  addi x14, x9, 0 /* ptr_r */
+  addi x10, x2, 192
+  addi x11, x2, 0
+  addi x12, x8, 0
+  addi x14, x9, 0
   jal  x1, masked_cbd
 
   /* Restore inputs. */
@@ -2586,9 +2528,6 @@ _getnoise_common:
  * that masked_cbd consumes, one share per call. Called by
  * masked_poly_getnoise_eta_1 on the KYBER_K = 2 path.
  *
- * @param[in]     x7: dmem pointer to const_zero
- * @param[in,out] x10: dmem pointer to the x bit-planes
- * @param[in,out] x11: dmem pointer to the y bit-planes
  * @param[in]     w17 to w22: the six digest words to bitslice
  * @param[in]     w31: all-zero register
  *
@@ -2760,7 +2699,7 @@ _bitslice_eta_3:
 .globl masked_poly_tomsg
 .type masked_poly_tomsg, @function
 masked_poly_tomsg:
-  /* Allocate y[0], y[1] scratch and save callee-saved registers. */
+  /* Allocate the z scratch and save callee-saved registers. */
   addi x2, x2, -1056
   sw   x8, 1024(x2)
   addi x8, x12, 0
@@ -2773,21 +2712,24 @@ masked_poly_tomsg:
   bn.lid    x4++, 0(x5)
   bn.shv.8s w18, w18 >> 16
 
-  /* Create 2**(alpha - 1), alpha = 15. */
+  /* Create 2^(alpha - 1), alpha = 15. */
   bn.subi    w19, w31, 1
   bn.shv.8s  w19, w19 >> 31
   bn.shv.8s  w19, w19 << 14
 
-
-  /* In order to avoid division by Q, we need to compute:
-   *  - x << (1 + alpha) --> x is 28 bits.
-   *  - x += 1665
-   *  - x *=m where m = ((1 << 37) + Q // 2) // Q = 41285357 (m is 26 bits).
-   *  - x >>= k where k = 37. */
-  /* Compute y[i] = Compressq(x[i], 1 + alpha); share 0 also adds
-   * 2**(alpha - 1). */
+  /* Compute z_0 = Compressq(x_0, 1 + alpha) + 2^(alpha - 1),
+   *         z_1 = Compressq(x_1, 1 + alpha).
+   *
+   * For d = 1, in order to avoid division by q, let s = 40 and
+   * m = ((1 << s) + q // 2) // q = 0x13afb768 and do as follows:
+   *  - x << (1 + alpha)
+   *  - x += (q + 1) / 2 = 1665
+   *  - x *= m
+   *  - x >>= s
+   *  - x &= ((1 << (1 + alpha)) - 1).
+   */
   addi x5, x0, 21
-  addi x6, x2, 0 /* ptr_y */
+  addi x6, x2, 0 /* z */
 
   loopi 2, 44
     /* Whitening. */
@@ -2843,36 +2785,34 @@ masked_poly_tomsg:
       addi   x4, x4, 1
     endloop
 
-    /* Clear the offset; only share 0 carries 2**(alpha - 1). */
+    /* For the first share, w19 holds 2^(alpha - 1).
+     * After that, we clear w19 so that bn.add acts as a shift. */
     bn.xor w19, w19, w19
   endloop
 
-  /* Compute z = seca2b(y, k = 1 + alpha, share bytes = k * 32). */
-  addi x10, x2, 0 /* ptr_y */
-  addi x11, x0, 16 /* 1 + alpha */
+  /* Compute c = seca2b(z), k = 1 + alpha = 16, share bytes = 512. */
+  addi x10, x2, 0
+  addi x11, x0, 16
   addi x12, x0, 512
-  addi x14, x2, 0 /* ptr_z */
+  addi x14, x2, 0
   jal  x1, seca2b
 
-  /* Compute z >>= alpha, i.e. keep only bit z[alpha], the message bit. */
-  addi x5, x2, 0 /* ptr_z */
-  addi x5, x5, 480 /* skip to bit-plane alpha = 15 */
-  addi x6, x8, 0 /* ptr_r */
+  /* Compute c >>= alpha, i.e. keep only bit c[alpha], the message bit. */
+  addi x5, x2, 0
+  addi x5, x5, 480
+  addi x6, x8, 0
   loopi 2, 4
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.lid x0, 0(x5++)
     bn.sid x0, 0(x6++)
-    /* Advance to bit-plane alpha of the next share. */
-    addi x5, x5, 480
+    addi   x5, x5, 480
   endloop
 
   /* Restore registers. */
   lw   x8, 1024(x2)
   addi x2, x2, 1056
   ret
-
-#define N_COEFFS 16
 
 /**
  * First-order masked comparison of a polynomial compressed with dv in {4, 5}.
@@ -2912,14 +2852,14 @@ poly_masked_compare_dv:
   addi x18, x12, 0
   addi x20, x14, 0
 
-  /* Compute t = poly_hocompress(cprime). */
-  addi x10, x8, 0 /* ptr_cprime */
-  addi x12, x2, 0 /* ptr_t */
-  addi x13, x15, 0 /* k */
+  /* Compute t = poly_hocompress(c'). */
+  addi x10, x8, 0
+  addi x12, x2, 0
+  addi x13, x15, 0
   jal  x1, poly_hocompress
 
   /* Decode + bitslice c. */
-  addi x11, x9, 0 /* ptr_c */
+  addi x11, x9, 0
 
   addi x4, x0, 4
   lw   x15, 344(x2)
@@ -3136,7 +3076,8 @@ _handle_kn4_dv:
   addi    x9, x0, 4
 
 _handle_common_dv:
-  /* t[0] ^= c ^ ((1 << N) - 1):  c-planes are now w0..w3 if x9 != 4 else w0..w4. */
+  /* t_0 ^= ~c, so that t is 1 exactly where the bits match. The c
+   * bit-planes are w0..w3 for dv = 4 and w0..w4 for dv = 5. */
   bn.subi w15, w31, 1
   addi    x5, x2, 0 /* ptr_t */
 
@@ -3171,14 +3112,14 @@ _handle_common_dv:
 _skip_bit_4:
   /* Compute r = secand(r, t). */
   addi x11, x0, 32
-  addi x12, x2, 0 /* ptr_t */
-  addi x13, x18, 0 /* share_str */
-  addi x16, x0, 32 /* output share_str */
+  addi x12, x2, 0
+  addi x13, x18, 0
+  addi x16, x0, 32
   /* After the secand, the input and output pointers will point to
    * next bit so we don't have to pass all the arguments above to secand again. */
   loop x9, 4
-    addi x10, x20, 0 /* ptr_r */
-    addi x15, x20, 0 /* ptr_r */
+    addi x10, x20, 0
+    addi x15, x20, 0
     jal  x1, secand
     nop
   endloop
@@ -3230,14 +3171,14 @@ poly_masked_compare_du:
   addi x18, x12, 0
   addi x20, x14, 0
 
-  /* Compute t = poly_hocompress(cprime). */
-  addi x10, x8, 0 /* ptr_cprime */
-  addi x12, x2, 0 /* ptr_t */
-  addi x13, x15, 0 /* k */
+  /* Compute t = poly_hocompress(c'). */
+  addi x10, x8, 0
+  addi x12, x2, 0
+  addi x13, x15, 0
   jal  x1, polyvec_hocompress
 
   /* Decode + bitslice c. */
-  addi x11, x9, 0 /* ptr_c */
+  addi x11, x9, 0
 
   addi x4, x0, 4
   lw   x15, 728(x2)
@@ -3419,7 +3360,7 @@ _handle_k4_du:
   endloop
   jal x1, _bitslice_transpose
   
-  addi x9, x0, 11 /* du */
+  addi x9, x0, 11
   beq  x0, x0, _handle_common_du
 
 _handle_kn4_du:
@@ -3526,12 +3467,13 @@ _handle_kn4_du:
   endloop
   jal x1, _bitslice_transpose
     
-  addi x9, x0, 10 /* du */
+  addi x9, x0, 10
 
 _handle_common_du:
-  /* t[0] ^= c ^ ((1 << N) - 1):  c-planes are now w0..w9. */
+  /* t_0 ^= ~c, so that t is 1 exactly where the bits match. The c
+   * bit-planes are w0..w9 for du = 10 and w0..w10 for du = 11. */
   bn.subi w15, w31, 1
-  addi    x5, x2, 0 /* ptr_t */
+  addi    x5, x2, 0
 
   bn.lid x4, 0(x5)
   bn.xor w0, w0, w15
@@ -3594,14 +3536,14 @@ _handle_common_du:
 _skip_bit_10:
   /* Compute r = secand(r, t). */
   addi x11, x0, 32
-  addi x12, x2, 0 /* ptr_t */
-  addi x13, x18, 0 /* share_str */
-  addi x16, x0, 32 /* output share_str */
+  addi x12, x2, 0
+  addi x13, x18, 0
+  addi x16, x0, 32
   /* After the secand, the input and output pointers will point to
    * next bit so we don't have to pass all the arguments above to secand again. */
   loop x9, 4
-    addi x10, x20, 0 /* ptr_r */
-    addi x15, x20, 0 /* ptr_r */
+    addi x10, x20, 0
+    addi x15, x20, 0
     jal  x1, secand
     nop
   endloop
@@ -3642,10 +3584,10 @@ finalize_cmp:
   /* Save the in/out address. */
   addi x8, x10, 0
 
-  /* Compute x &= (x >> 128). */
-  /* Compute t = x >> 128. */
+  /* Compute r &= (r >> 128). */
+  /* Compute t = r >> 128. */
   addi x4, x0, 1
-  addi x5, x2, 0 /* ptr_t */
+  addi x5, x2, 0
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
@@ -3654,7 +3596,7 @@ finalize_cmp:
     bn.rshi w1, w31, w0 >> 128
     bn.sid  x4, 0(x5++)
   endloop
-  /* Compute x &= t. */
+  /* Compute r &= t. */
   addi x10, x8, 0
   addi x11, x0, 32
   addi x12, x2, 0
@@ -3663,11 +3605,11 @@ finalize_cmp:
   addi x16, x0, 32
   jal  x1, secand
 
-  /* Compute x &= (x >> 64). */
-  /* Compute t = x >> 64. */
+  /* Compute r &= (r >> 64). */
+  /* Compute t = r >> 64. */
   addi x4, x0, 1
   addi x10, x8, 0
-  addi x5, x2, 0 /* ptr_t */
+  addi x5, x2, 0
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
@@ -3676,7 +3618,7 @@ finalize_cmp:
     bn.rshi w1, w31, w0 >> 64
     bn.sid  x4, 0(x5++)
   endloop
-  /* Compute x &= t. */
+  /* Compute r &= t. */
   addi x10, x8, 0
   /* x11 is still 32. */
   addi x12, x2, 0
@@ -3685,11 +3627,11 @@ finalize_cmp:
   /* x16 is still 32. */
   jal  x1, secand
 
-  /* Compute x &= (x >> 32). */
-  /* Compute t = x >> 32. */
+  /* Compute r &= (r >> 32). */
+  /* Compute t = r >> 32. */
   addi x4, x0, 1
   addi x10, x8, 0
-  addi x5, x2, 0 /* ptr_t */
+  addi x5, x2, 0
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
@@ -3698,7 +3640,7 @@ finalize_cmp:
     bn.rshi w1, w31, w0 >> 32
     bn.sid  x4, 0(x5++)
   endloop
-  /* Compute x &= t. */
+  /* Compute r &= t. */
   addi x10, x8, 0
   /* x11 is still 32. */
   addi x12, x2, 0
@@ -3707,11 +3649,11 @@ finalize_cmp:
   /* x16 is still 32. */
   jal  x1, secand
 
-  /* Compute x &= (x >> 16). */
-  /* Compute t = x >> 16. */
+  /* Compute r &= (r >> 16). */
+  /* Compute t = r >> 16. */
   addi x4, x0, 1
   addi x10, x8, 0
-  addi x5, x2, 0 /* ptr_t */
+  addi x5, x2, 0
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
@@ -3720,7 +3662,7 @@ finalize_cmp:
     bn.rshi w1, w31, w0 >> 16
     bn.sid  x4, 0(x5++)
   endloop
-  /* Compute x &= t. */
+  /* Compute r &= t. */
   addi x10, x8, 0
   /* x11 is still 32. */
   addi x12, x2, 0
@@ -3729,11 +3671,11 @@ finalize_cmp:
   /* x16 is still 32. */
   jal  x1, secand
 
-  /* Compute x &= (x >> 8). */
-  /* Compute t = x >> 8. */
+  /* Compute r &= (r >> 8). */
+  /* Compute t = r >> 8. */
   addi x4, x0, 1
   addi x10, x8, 0
-  addi x5, x2, 0 /* ptr_t */
+  addi x5, x2, 0
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
@@ -3742,7 +3684,7 @@ finalize_cmp:
     bn.rshi w1, w31, w0 >> 8
     bn.sid  x4, 0(x5++)
   endloop
-  /* Compute x &= t. */
+  /* Compute r &= t. */
   addi x10, x8, 0
   /* x11 is still 32. */
   addi x12, x2, 0
@@ -3751,11 +3693,11 @@ finalize_cmp:
   /* x16 is still 32. */
   jal  x1, secand
 
-  /* Compute x &= (x >> 4). */
-  /* Compute t = x >> 4. */
+  /* Compute r &= (r >> 4). */
+  /* Compute t = r >> 4. */
   addi x4, x0, 1
   addi x10, x8, 0
-  addi x5, x2, 0 /* ptr_t */
+  addi x5, x2, 0
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
@@ -3764,7 +3706,7 @@ finalize_cmp:
     bn.rshi w1, w31, w0 >> 4
     bn.sid  x4, 0(x5++)
   endloop
-  /* Compute x &= t. */
+  /* Compute r &= t. */
   addi x10, x8, 0
   /* x11 is still 32. */
   addi x12, x2, 0
@@ -3773,11 +3715,11 @@ finalize_cmp:
   /* x16 is still 32. */
   jal  x1, secand
 
-  /* Compute x &= (x >> 2). */
-  /* Compute t = x >> 2. */
+  /* Compute r &= (r >> 2). */
+  /* Compute t = r >> 2. */
   addi x4, x0, 1
   addi x10, x8, 0
-  addi x5, x2, 0 /* ptr_t */
+  addi x5, x2, 0
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
@@ -3786,7 +3728,7 @@ finalize_cmp:
     bn.rshi w1, w31, w0 >> 2
     bn.sid  x4, 0(x5++)
   endloop
-  /* Compute x &= t. */
+  /* Compute r &= t. */
   addi x10, x8, 0
   /* x11 is still 32. */
   addi x12, x2, 0
@@ -3795,11 +3737,11 @@ finalize_cmp:
   /* x16 is still 32. */
   jal  x1, secand
 
-  /* Compute x &= (x >> 1). */
-  /* Compute t = x >> 1. */
+  /* Compute r &= (r >> 1). */
+  /* Compute t = r >> 1. */
   addi x4, x0, 1
   addi x10, x8, 0
-  addi x5, x2, 0 /* ptr_t */
+  addi x5, x2, 0
   loopi 2, 5
     /* Whitening. */
     bn.xor  w0, w0, w0
@@ -3808,7 +3750,7 @@ finalize_cmp:
     bn.rshi w1, w31, w0 >> 1
     bn.sid  x4, 0(x5++)
   endloop
-  /* Compute x &= t. */
+  /* Compute r &= t. */
   addi x10, x8, 0
   /* x11 is still 32. */
   addi x12, x2, 0

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -271,17 +271,14 @@ secfulladder:
 .globl secadd
 .type secadd, @function
 secadd:
-  /* Reserve frame: 64 B carry c at 0(x2), plus saved x8, x17. */
+  /* Reserve frame: 64 B carry c at 0(x2), plus saved x8. */
   addi x2, x2, -96
   sw   x8, 64(x2)
-  sw   x17, 68(x2)
 
   /* Initialize c = 0. */
   bn.xor w0, w0, w0
-  add    x5, x2, x0
-  loopi 2, 1
-    bn.sid x0, 0(x5++)
-  endloop
+  bn.sid x0, 0(x2)
+  bn.sid x0, 32(x2)
 
   /* Ripple-carry adder. */
   addi x8, x17, -1
@@ -296,33 +293,28 @@ secadd:
   endloop
 
   /* Handle bit k - 1. */
-  add  x5, x2, x0
   addi x4, x0, 1
-  addi x6, x0, 2
-  addi x7, x0, 3
-  loopi 2, 14
+  loopi 2, 11
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
-    bn.xor w2, w2, w2
-    bn.xor w3, w3, w3
     /* r[k - 1] = x[k - 1] ^ y[k - 1] ^ c. */
     bn.lid x0, 0(x10)
-    bn.lid x4, 0(x12)
-    bn.lid x6, 0(x5)
-    bn.xor w3, w0, w1
-    bn.xor w3, w3, w2
-    bn.sid x7, 0(x15)
-    /* Adjust addresses. */
     add    x10, x10, x11
+    bn.lid x4, 0(x12)
     add    x12, x12, x13
-    add    x5, x5, x29
+    bn.xor w0, w0, w1
+    bn.lid x4, 0(x30++)
+    bn.xor w0, w0, w1
+    bn.sid x0, 0(x15)
     add    x15, x15, x16
   endloop
 
+  /* Restore x17. */
+  addi x17, x8, 1
+
   /* Restore registers and frame. */
   lw   x8, 64(x2)
-  lw   x17, 68(x2)
   addi x2, x2, 96
   ret
 

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -342,7 +342,7 @@ secadd:
 bitcopymask:
   /* Since q = 3329 = 0b110100000001, we copy x to bits 0, 8, 10 and 11 of r
    * and zeroize the remaining bits. */
-  addi   x4, x0, 31
+  addi x4, x0, 31
   loopi 2, 10
     /* Whitening. */
     bn.xor w0, w0, w0

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -875,9 +875,7 @@ seca2b:
 
   /* Build s = (x_0, 0). */
   add x7, x6, x0
-  loop x11, 3
-    /* Whitening. */
-    bn.xor w0, w0, w0
+  loop x11, 2
     bn.lid x0, 0(x10++)
     bn.sid x0, 0(x6++)
   endloop
@@ -891,12 +889,12 @@ seca2b:
   loop x11, 1
     bn.sid x0, 0(x5++)
   endloop
-  loop x11, 3
+  loop x11, 2
     bn.lid x0, 0(x10++)
     bn.sid x0, 0(x5++)
-    /* Whitening. */
-    bn.xor w0, w0, w0
   endloop
+  /* Whitening. */
+  bn.xor w0, w0, w0
 
   /* Save registers. */
   add x4, x11, x0
@@ -975,11 +973,13 @@ seca2bmodq:
   /* Initialize cin = 0. */
   bn.xor w2, w2, w2
 
+  /* Whitening. */
+  bn.xor w0, w0, w0
+  bn.xor w1, w1, w1
+  bn.xor w3, w3, w3
+
   /* Bits 0..7: p[i] = 1. */
-  loopi 8, 9
-    /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
+  loopi 8, 7
     bn.lid x0, 0(x10++)
     bn.not w3, w0
     bn.xor w1, w3, w2
@@ -990,9 +990,6 @@ seca2bmodq:
   endloop
 
   /* Bit 8: p[i] = 0. */
-  /* Whitening. */
-  bn.xor w0, w0, w0
-  bn.xor w1, w1, w1
   bn.lid x0, 0(x10++)
   bn.xor w1, w0, w2
   bn.sid x4, 0(x5++)
@@ -1000,9 +997,6 @@ seca2bmodq:
   bn.xor w2, w2, w0
 
   /* Bit 9: p[i] = 1. */
-  /* Whitening. */
-  bn.xor w0, w0, w0
-  bn.xor w1, w1, w1
   bn.lid x0, 0(x10++)
   bn.not w3, w0
   bn.xor w1, w3, w2
@@ -1012,10 +1006,7 @@ seca2bmodq:
   bn.xor w2, w2, w0
 
   /* Bits 10..11: p[i] = 0. */
-  loopi 2, 7
-    /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
+  loopi 2, 5
     bn.lid x0, 0(x10++)
     bn.xor w1, w0, w2
     bn.sid x4, 0(x5++)
@@ -1024,8 +1015,6 @@ seca2bmodq:
   endloop
 
   /* Bit 12: p[i] = 1 and x_0[i] = 0. */
-  /* Whitening. */
-  bn.xor w1, w1, w1
   bn.not w1, w2
   bn.sid x4, 0(x5++)
   /********** End inline s = secadd(p, x_0, k + 1). **********/
@@ -1041,12 +1030,11 @@ seca2bmodq:
   loopi 13, 1
     bn.sid x0, 0(x5++)
   endloop
-  loopi 12, 3
+  loopi 12, 2
     bn.lid x0, 0(x10++)
     bn.sid x0, 0(x5++)
-    /* Whitening. */
-    bn.xor w0, w0, w0
   endloop
+  bn.xor w0, w0, w0
   bn.sid x0, 0(x5++)
 
   /********** Start inline u = secadd(s, s', k + 1). **********/
@@ -1635,9 +1623,9 @@ _dv_params_done:
   add x5, x2, x8
   lw  x12, 1152(x2)
   loopi 2, 5
-    loop x9, 3
-      /* Whitening. */
-      bn.xor w0, w0, w0
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    loop x9, 2
       bn.lid x0, 0(x5++)
       bn.sid x0, 0(x12++)
     endloop
@@ -1855,9 +1843,9 @@ _du_params_done:
   add x5, x2, x8
   lw  x12, 1536(x2)
   loopi 2, 5
-    loop x9, 3
-      /* Whitening. */
-      bn.xor w0, w0, w0
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    loop x9, 2
       bn.lid x0, 0(x5++)
       bn.sid x0, 0(x12++)
     endloop
@@ -1998,30 +1986,26 @@ masked_cbd:
   slli x4, x18, 5 /* eta * 32 */
   add  x6, x8, x4
   /* Share 0. */
-  loop x12, 7
-    /* Whitening. */
-    bn.xor w0, w0, w0
+  /* Whitening. */
+  bn.xor w0, w0, w0
+  loop x12, 5
     /* Copy x_0. */
     bn.lid x0, 0(x10++)
     bn.sid x0, 0(x5++)
-    /* Whitening. */
-    bn.xor w0, w0, w0
     /* Copy ~y_0. */
     bn.lid x0, 0(x11++)
     bn.not w0, w0
     bn.sid x0, 0(x6++)
   endloop
   /* Share 1. */
+  /* Whitening. */
+  bn.xor w0, w0, w0
   add x5, x5, x4
   add x6, x6, x4
-  loop x12, 6
-    /* Whitening. */
-    bn.xor w0, w0, w0
+  loop x12, 4
     /* Copy x_1. */
     bn.lid x0, 0(x10++)
     bn.sid x0, 0(x5++)
-    /* Whitening. */
-    bn.xor w0, w0, w0
     /* Copy y_1. */
     bn.lid x0, 0(x11++)
     bn.sid x0, 0(x6++)

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -53,6 +53,8 @@
  *
  * Source: Alg.2 [CS20]
  *
+ * On return, x10, x12 and x15 are unchanged.
+ *
  * @param[in]  x10: dmem pointer to Boolean shares of x
  * @param[in]  x11: share stride of x
  * @param[in]  x12: dmem pointer to Boolean shares of y
@@ -114,10 +116,6 @@ secand:
   add     x5, x15, x16
   bn.sid  x4, 0(x5)
 
-  /* Advance x10, x12, x15 to the next bit. */
-  addi x10, x10, 32
-  addi x12, x12, 32
-  addi x15, x15, 32
   ret
 
 /**
@@ -131,6 +129,8 @@ secand:
  *   cout <- x ^ secand(a, x ^ cin)  (carry bit)
  *
  * Source: Alg.5 [BC22]
+ *
+ * On return, x10, x12, x15, x17, x30 are unchanged.
  *
  * @param[in]  x10: dmem pointer to Boolean shares of x
  * @param[in]  x11: share stride of x
@@ -237,10 +237,6 @@ secfulladder:
   add     x5, x30, x31
   bn.sid  x4, 0(x5)
 
-  /* Advance x10, x12, x15 to the next bit. */
-  addi x10, x10, 32
-  addi x12, x12, 32
-  addi x15, x15, 32
   ret
 
 /**
@@ -287,9 +283,11 @@ secadd:
   add  x30, x2, x0
   addi x31, x0, 32
   /* Handle bit i = 0..k - 2. */
-  loop x8, 2
+  loop x8, 4
     jal  x1, secfulladder
-    nop
+    addi x10, x10, 32
+    addi x12, x12, 32
+    addi x15, x15, 32
   endloop
 
   /* Handle bit k - 1. */
@@ -1069,9 +1067,11 @@ seca2bmodq:
   addi x29, x0, 32
   addi x30, x2, 832
   addi x31, x0, 32
-  loopi 12, 2
-    jal x1, secfulladder
-    nop
+  loopi 12, 4
+    jal  x1, secfulladder
+    addi x10, x10, 32
+    addi x12, x12, 32
+    addi x15, x15, 32
   endloop
 
   addi x4, x0, 1
@@ -1114,9 +1114,11 @@ seca2bmodq:
   addi x29, x0, 32
   addi x30, x2, 832
   addi x31, x0, 32
-  loopi 11, 2
-    jal x1, secfulladder
-    nop
+  loopi 11, 4
+    jal  x1, secfulladder
+    addi x10, x10, 32
+    addi x12, x12, 32
+    addi x15, x15, 32
   endloop
 
   addi x4, x0, 1
@@ -1339,9 +1341,11 @@ secb2amodq:
   addi x29, x0, 416
   addi x30, x9, 384
   addi x31, x0, 416
-  loopi 12, 2
+  loopi 12, 4
     jal  x1, secfulladder
-    nop
+    addi x10, x10, 32
+    addi x12, x12, 32
+    addi x15, x15, 32
   endloop
   /* Bit i = k is already a[k] ^ x[k] ^ cout = cout
    * since a[k] = x[k] = 0. */
@@ -1369,26 +1373,32 @@ secb2amodq:
   addi x31, x0, 32
 
   /* Bits 0..7: p[i] = 1. */
-  loopi 8, 2
+  loopi 8, 3
     jal  x1, secfulladder
-    addi x10, x10, -32
+    addi x12, x12, 32
+    addi x15, x15, 32
   endloop
   /* Bit 8: p[i] = 0. */
-  bn.xor  w0, w31, w31
-  bn.sid  x0, 0(x10)
-  jal     x1, secfulladder
-  addi    x10, x10, -32
+  bn.xor w0, w31, w31
+  bn.sid x0, 0(x10)
+  jal    x1, secfulladder
+  addi   x12, x12, 32
+  addi   x15, x15, 32
   /* Bit 9: p[i] = 1. */
   bn.subi w0, w31, 1
   bn.sid  x0, 0(x10)
   jal     x1, secfulladder
-  addi    x10, x10, -32
+  addi    x12, x12, 32
+  addi    x15, x15, 32
   /* Bits 10..11: p[i] = 0. */
-  bn.xor  w0, w31, w31
-  bn.sid  x0, 0(x10)
-  jal     x1, secfulladder
-  addi    x10, x10, -32
-  jal     x1, secfulladder
+  bn.xor w0, w31, w31
+  bn.sid x0, 0(x10)
+  jal    x1, secfulladder
+  addi   x12, x12, 32
+  addi   x15, x15, 32
+  jal    x1, secfulladder
+  addi   x12, x12, 32
+  addi   x15, x15, 32
   /* Bit 12: p[i] = 1. */
   addi   x4, x0, 1
   /* s[12] = p[12] ^ s[12] ^ c = ~(s[12] ^ c) since p[12] = 1. */
@@ -2044,11 +2054,10 @@ masked_cbd:
   addi x29, x0, 32
   add  x30, x8, x0
   add  x31, x5, x0
-  loop x18, 5
+  loop x18, 4
     jal  x1, secfulladder
-    addi x10, x10, 32  /* s[2 * (j + 1)] */
-    addi x12, x12, 32  /* s[2 * (j + 1) + 1] */
-    addi x15, x15, -32 /* a */
+    addi x10, x10, 64  /* s[2 * (j + 1)] */
+    addi x12, x12, 64  /* s[2 * (j + 1) + 1] */
     addi x30, x30, 32  /* s[j + 1] */
   endloop
 
@@ -2999,12 +3008,10 @@ _skip_bit_4:
   lw   x13, 324(x2)
   add  x15, x10, x0
   addi x16, x0, 32
-  /* After the secand, the input and output pointers will point to
-   * next bit so we don't have to pass all the arguments above to secand again. */
-  loop x8, 3
+  /* r is accumulated in place, so only t advances to the next bit. */
+  loop x8, 2
     jal  x1, secand
-    addi x10, x10, -32
-    addi x15, x15, -32
+    addi x12, x12, 32
   endloop
 
   /* Restore registers. */
@@ -3409,12 +3416,10 @@ _skip_bit_10:
   lw   x13, 712(x2)
   add  x15, x10, x0
   addi x16, x0, 32
-  /* After the secand, the input and output pointers will point to
-   * next bit so we don't have to pass all the arguments above to secand again. */
-  loop x8, 3
+  /* r is accumulated in place, so only t advances to the next bit. */
+  loop x8, 2
     jal  x1, secand
-    addi x10, x10, -32
-    addi x15, x15, -32
+    addi x12, x12, 32
   endloop
 
   /* Restore registers. */
@@ -3464,8 +3469,6 @@ finalize_cmp:
   add  x15, x10, x0
   addi x16, x0, 32
   jal  x1, secand
-  addi x10, x10, -32
-  addi x15, x15, -32
 
   /* Compute r &= (r >> 64). */
   /* Compute t = r >> 64. */
@@ -3479,15 +3482,7 @@ finalize_cmp:
     bn.sid  x0, 0(x5++)
   endloop
   /* Compute r &= t. */
-  /* x10 already points to r. */
-  /* x11 is still 32. */
-  add  x12, x2, x0
-  /* x13 is still 32. */
-  /* x15 already points to r. */
-  /* x16 is still 32. */
   jal  x1, secand
-  addi x10, x10, -32
-  addi x15, x15, -32
 
   /* Compute r &= (r >> 32). */
   /* Compute t = r >> 32. */
@@ -3501,15 +3496,7 @@ finalize_cmp:
     bn.sid  x0, 0(x5++)
   endloop
   /* Compute r &= t. */
-  /* x10 already points to r. */
-  /* x11 is still 32. */
-  add  x12, x2, x0
-  /* x13 is still 32. */
-  /* x15 already points to r. */
-  /* x16 is still 32. */
   jal  x1, secand
-  addi x10, x10, -32
-  addi x15, x15, -32
 
   /* Compute r &= (r >> 16). */
   /* Compute t = r >> 16. */
@@ -3523,15 +3510,7 @@ finalize_cmp:
     bn.sid  x0, 0(x5++)
   endloop
   /* Compute r &= t. */
-  /* x10 already points to r. */
-  /* x11 is still 32. */
-  add  x12, x2, x0
-  /* x13 is still 32. */
-  /* x15 already points to r. */
-  /* x16 is still 32. */
   jal  x1, secand
-  addi x10, x10, -32
-  addi x15, x15, -32
 
   /* Compute r &= (r >> 8). */
   /* Compute t = r >> 8. */
@@ -3545,15 +3524,7 @@ finalize_cmp:
     bn.sid  x0, 0(x5++)
   endloop
   /* Compute r &= t. */
-  /* x10 already points to r. */
-  /* x11 is still 32. */
-  add  x12, x2, x0
-  /* x13 is still 32. */
-  /* x15 already points to r. */
-  /* x16 is still 32. */
   jal  x1, secand
-  addi x10, x10, -32
-  addi x15, x15, -32
 
   /* Compute r &= (r >> 4). */
   /* Compute t = r >> 4. */
@@ -3567,15 +3538,7 @@ finalize_cmp:
     bn.sid  x0, 0(x5++)
   endloop
   /* Compute r &= t. */
-  /* x10 already points to r. */
-  /* x11 is still 32. */
-  add  x12, x2, x0
-  /* x13 is still 32. */
-  /* x15 already points to r. */
-  /* x16 is still 32. */
   jal  x1, secand
-  addi x10, x10, -32
-  addi x15, x15, -32
 
   /* Compute r &= (r >> 2). */
   /* Compute t = r >> 2. */
@@ -3589,15 +3552,7 @@ finalize_cmp:
     bn.sid  x0, 0(x5++)
   endloop
   /* Compute r &= t. */
-  /* x10 already points to r. */
-  /* x11 is still 32. */
-  add  x12, x2, x0
-  /* x13 is still 32. */
-  /* x15 already points to r. */
-  /* x16 is still 32. */
   jal  x1, secand
-  addi x10, x10, -32
-  addi x15, x15, -32
 
   /* Compute r &= (r >> 1). */
   /* Compute t = r >> 1. */
@@ -3611,15 +3566,7 @@ finalize_cmp:
     bn.sid  x0, 0(x5++)
   endloop
   /* Compute r &= t. */
-  /* x10 already points to r. */
-  /* x11 is still 32. */
-  add  x12, x2, x0
-  /* x13 is still 32. */
-  /* x15 already points to r. */
-  /* x16 is still 32. */
   jal  x1, secand
-  addi x10, x10, -32
-  addi x15, x15, -32
 
   addi x2, x2, 64
   ret

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -473,6 +473,10 @@ _rej_sample_loop:
   beq x0, x0, _rej_sample_loop
 
 _end_rej_sample_loop:
+  /* Whitening. */
+  bn.xor w0, w0, w0
+  bn.xor w3, w3, w3
+  bn.xor w4, w4, w4
   ret
 
 /**
@@ -531,6 +535,8 @@ refreshmodq:
     /* Whitening. */
     bn.xor       w0, w0, w0
   endloop
+  /* Whitening. */
+  bn.xor w1, w1, w1
 
   /* Restore stack. */
   addi x2, x2, 544
@@ -573,6 +579,26 @@ poly_to_bitsliced:
     bn.sid x4, 0(x10++)
     addi   x4, x4, 1
   endloop
+
+  /* Whitening. */
+  bn.xor w0, w0, w0
+  bn.xor w1, w1, w1
+  bn.xor w2, w2, w2
+  bn.xor w3, w3, w3
+  bn.xor w4, w4, w4
+  bn.xor w5, w5, w5
+  bn.xor w6, w6, w6
+  bn.xor w7, w7, w7
+  bn.xor w8, w8, w8
+  bn.xor w9, w9, w9
+  bn.xor w10, w10, w10
+  bn.xor w11, w11, w11
+  bn.xor w12, w12, w12
+  bn.xor w13, w13, w13
+  bn.xor w14, w14, w14
+  bn.xor w15, w15, w15
+  bn.xor w28, w28, w28
+  bn.xor w29, w29, w29
   ret
 
 /**
@@ -616,6 +642,26 @@ poly_from_bitsliced:
     bn.sid x4, 0(x11++)
     addi   x4, x4, -1
   endloop
+
+  /* Whitening. */
+  bn.xor w0, w0, w0
+  bn.xor w1, w1, w1
+  bn.xor w2, w2, w2
+  bn.xor w3, w3, w3
+  bn.xor w4, w4, w4
+  bn.xor w5, w5, w5
+  bn.xor w6, w6, w6
+  bn.xor w7, w7, w7
+  bn.xor w8, w8, w8
+  bn.xor w9, w9, w9
+  bn.xor w10, w10, w10
+  bn.xor w11, w11, w11
+  bn.xor w12, w12, w12
+  bn.xor w13, w13, w13
+  bn.xor w14, w14, w14
+  bn.xor w15, w15, w15
+  bn.xor w28, w28, w28
+  bn.xor w29, w29, w29
   ret
 
 /**
@@ -1204,7 +1250,7 @@ seconebitb2amodq:
   lw   x5, 1024(x2)
   addi x5, x5, 512 /* x_1 */
   add  x6, x2, x0  /* v */
-  loopi 16, 14
+  loopi 16, 18
     bn.lid       x0, 0(x5++)
     bn.subv.16h  w2, w0, w4
     /* Handle v_0. */
@@ -1214,6 +1260,9 @@ seconebitb2amodq:
     bn.subvm.16h w1, w3, w1
     bn.addvm.16h w1, w0, w1
     bn.sid       x4, 0(x6)
+    /* Whitening. */
+    bn.xor       w1, w1, w1
+    bn.xor       w3, w3, w3
     /* Handle v_1. */
     bn.lid       x4, 512(x6)
     bn.and       w3, w1, w2
@@ -1221,7 +1270,13 @@ seconebitb2amodq:
     bn.subvm.16h w1, w3, w1
     bn.sid       x4, 512(x6)
     addi         x6, x6, 32
+    /* Whitening. */
+    bn.xor       w1, w1, w1
+    bn.xor       w3, w3, w3
   endloop
+  /* Whitening. */
+  bn.xor w0, w0, w0
+  bn.xor w2, w2, w2
 
   /* Compute r = refreshmodq(v). */
   add x10, x2, x0
@@ -1292,6 +1347,8 @@ secb2amodq:
     bn.subv.16h w0, w1, w0
     bn.sid      x0, 0(x5++)
   endloop
+  /* Whitening. */
+  bn.xor w0, w0, w0
 
   /* Bitslice zp_0 and clear zp_1 (bitsliced). */
   addi   x10, x2, 32
@@ -1894,7 +1951,7 @@ masked_poly_frommsg:
 
   /* Unpack m, matching the bitslice layout from masked_poly_tomsg. */
   addi x4, x0, 1
-  loopi 2, 6
+  loopi 2, 7
     bn.lid x0, 0(x10++)
     loopi 16, 3
       bn.shv.16h w1, w0 >> 15
@@ -1903,6 +1960,7 @@ masked_poly_frommsg:
     endloop
     /* Whitening. */
     bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
   endloop
 
   /* Compute mp = seconebitb2amodq(m). */
@@ -2146,6 +2204,8 @@ _continue_1:
     bn.subvm.16h w0, w0, w1
     bn.sid       x0, 0(x5++)
   endloop
+  /* Whitening. */
+  bn.xor w0, w0, w0
 
   /* Restore registers and stack. */
   lw   x8, 1220(x2)
@@ -2293,20 +2353,22 @@ masked_poly_getnoise_eta_1:
 
   jal x1, _bitslice_eta_3
 
-  bn.xor w17, w17, w17
   bn.mov w17, w23
-  bn.xor w18, w18, w18
   bn.mov w18, w24
-  bn.xor w19, w19, w19
   bn.mov w19, w25
-  bn.xor w20, w20, w20
   bn.mov w20, w26
-  bn.xor w21, w21, w21
   bn.mov w21, w27
-  bn.xor w22, w22, w22
   bn.mov w22, w30
 
   jal x1, _bitslice_eta_3
+
+  /* Whitening. */
+  bn.xor w23, w23, w23
+  bn.xor w24, w24, w24
+  bn.xor w25, w25, w25
+  bn.xor w26, w26, w26
+  bn.xor w27, w27, w27
+  bn.xor w30, w30, w30
 
   beq  x0, x0, _getnoise_common
 
@@ -2369,6 +2431,15 @@ _getnoise_eta_2:
     bn.xor w29, w29, w29
   endloop
 
+  /* Whitening. */
+  bn.xor w18, w18, w18
+  bn.xor w19, w19, w19
+  bn.xor w20, w20, w20
+  bn.xor w21, w21, w21
+  bn.xor w22, w22, w22
+  bn.xor w23, w23, w23
+  bn.xor w24, w24, w24
+
 _getnoise_common:
   /* Compute r = masked_cbd(x, y, eta). */
   addi x10, x2, 192
@@ -2395,6 +2466,8 @@ _getnoise_common:
  * that masked_cbd consumes, one share per call. Called by
  * masked_poly_getnoise_eta_1 on the KYBER_K = 2 path.
  *
+ * @param[in,out] x10: dmem pointer to the x bit-planes
+ * @param[in,out] x11: dmem pointer to the y bit-planes
  * @param[in]     w17 to w22: the six digest words to bitslice
  * @param[in]     w31: all-zero register
  *
@@ -2540,6 +2613,12 @@ _bitslice_eta_3:
   bn.xor w13, w13, w13
   bn.xor w14, w14, w14
   bn.xor w15, w15, w15
+  bn.xor w17, w17, w17
+  bn.xor w18, w18, w18
+  bn.xor w19, w19, w19
+  bn.xor w20, w20, w20
+  bn.xor w21, w21, w21
+  bn.xor w22, w22, w22
   bn.xor w28, w28, w28
   bn.xor w29, w29, w29
   ret
@@ -2977,6 +3056,9 @@ _handle_common_dv:
   bn.sid  x4, 0(x5++)
 
 _skip_bit_4:
+  /* Whitening. */
+  bn.xor w17, w17, w17
+
   /* Compute r = secand(r, t). */
   lw   x10, 328(x2)
   addi x11, x0, 32
@@ -3386,6 +3468,9 @@ _handle_common_du:
   bn.sid x4, 0(x5++)
 
 _skip_bit_10:
+  /* Whitening. */
+  bn.xor w17, w17, w17
+
   /* Compute r = secand(r, t). */
   lw   x10, 716(x2)
   addi x11, x0, 32

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -431,48 +431,43 @@ refreshios:
 .type poly_rej_samp, @function
 poly_rej_samp:
   /* Load 19 * q - 1. */
-  addi      x5, x0, 1
-  la        x6, modulus_times_19_minus_1
-  bn.lid    x5++, 0(x6)
-  bn.shv.8s w1, w1 >> 16
+  addi   x4, x0, 1
+  la     x5, modulus_times_19_minus_1
+  bn.lid x4++, 0(x5)
 
   /* Load mont = 2^16 % q. */
-  la     x6, mont
-  bn.lid x5, 0(x6)
+  la     x5, mont
+  bn.lid x4, 0(x5)
 
   /* x10 + 512 is the last valid address. */
-  addi x5, x10, 512
-
-#if defined(MLKEM_REJ_SAMPLE_TEST)
-  addi x30, x0, 3
-#endif
+  addi x4, x10, 512
 
   /* Loop until 256 coefficients have been written to the output. */
 _rej_sample_loop:
   /* Get 16 randoms. */
 #if defined(MLKEM_REJ_SAMPLE_TEST)
-  bn.lid      x30, 0(x11++)
+  bn.lid      x0, 0(x11++)
 #else
-  bn.wsrr     w3, urnd
+  bn.wsrr     w0, urnd
 #endif
-  bn.trn1.16h w4, w3, w31
+  bn.trn1.16h w3, w0, w31
+  bn.subv.8s  w3, w1, w3
+  bn.shv.8s   w3, w3 >> 31
+  bn.trn2.16h w4, w0, w31
   bn.subv.8s  w4, w1, w4
   bn.shv.8s   w4, w4 >> 31
-  bn.trn2.16h w5, w3, w31
-  bn.subv.8s  w5, w1, w5
-  bn.shv.8s   w5, w5 >> 31
-  bn.trn1.16h w4, w4, w5
-  bn.xor      w4, w4, w31, FG0
-  csrrs       x6, fg0, x0 /* Read flag fg0. */
-  srli        x6, x6, 3   /* Extract fg0.z */
+  bn.trn1.16h w3, w3, w4
+  bn.xor      w3, w3, w31, FG0
+  csrrs       x5, fg0, x0 /* Read flag fg0. */
+  srli        x5, x5, 3   /* Extract fg0.z */
 
   /* If fg0.z == 0, there is at least one bad coeff. We throw away this
    * vector and sample again. */
-  beq x6, x0, _rej_sample_loop
+  beq x5, x0, _rej_sample_loop
 
   /* Once the whole vector is accepted, reduce the accepted candidates mod Q
    * using Montgomery. */
-  bn.mulv.16h.acc.z.lo w0, w3, w2
+  bn.mulv.16h.acc.z.lo w0, w0, w2
   bn.mulv.l.16h.lo     w0, w0, sw0.2
   bn.mulv.l.16h.acc.hi w0, w0, sw0.0
   bn.addvm.16h         w0, w0, w31
@@ -480,7 +475,7 @@ _rej_sample_loop:
 
   /* If we reach the last valid address, we've filled up a polynomial.
    * Otherwise, continue to sample. */
-  beq x10, x5, _end_rej_sample_loop
+  beq x10, x4, _end_rej_sample_loop
   beq x0, x0, _rej_sample_loop
 
 _end_rej_sample_loop:

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -143,6 +143,7 @@ secand:
  * @param[in]  x29: share stride of cin
  * @param[out] x30: dmem pointer to Boolean shares of cout
  * @param[in]  x31: share stride of cout
+ * @param[in]  w31: all-zero register
  *
  * clobbered registers: x4 to x5, w0 to w9
  * clobbered flag groups: FG0
@@ -151,92 +152,85 @@ secand:
 .globl secfulladder
 .type secfulladder, @function
 secfulladder:
-  add x4, x0, x0
-
-  /* Load x. */
-  bn.xor w0, w0, w0   /* Whitening. */
-  bn.lid x4++, 0(x10) /* w0 = x_0 */
-  bn.xor w1, w1, w1   /* Whitening. */
-  add    x5, x10, x11
-  bn.lid x4++, 0(x5)  /* w1 = x_1 */
-
-  /* Load y. */
-  bn.xor w2, w2, w2   /* Whitening. */
-  bn.lid x4++, 0(x12) /* w2 = y_0 */
-  bn.xor w3, w3, w3   /* Whitening. */
-  add    x5, x12, x13
-  bn.lid x4, 0(x5)    /* w3 = y_1 */
-
-  /* Compute sharewise a = x ^ y. */
-  bn.xor w4, w4, w4   /* Whitening. */
-  bn.xor w4, w0, w2
-  bn.xor w5, w5, w5   /* Whitening. */
-  bn.xor w5, w1, w3
-
-  /* Load cin. */
-  bn.xor w2, w2, w2   /* Whitening. */
-  addi   x4, x0, 2
+  /* Load share 0. */
+  addi   x4, x0, 1
+  bn.lid x0, 0(x12)   /* w0 = y_0 */
+  bn.lid x4++, 0(x10) /* w1 = x_0 */
   bn.lid x4++, 0(x17) /* w2 = cin_0 */
-  bn.xor w3, w3, w3   /* Whitening. */
-  add    x5, x17, x29
-  bn.lid x4++, 0(x5)  /* w3 = cin_1 */
+  /* Compute a_0 = x_0 ^ y_0. */
+  bn.xor w5, w1, w0
+  /* Compute r_0 = cin_0 ^ a_0. */
+  bn.xor w0, w2, w5
+  bn.sid x0, 0(x15)
+  /* Compute t_0 = x_0 ^ cin_0. */
+  bn.xor w7, w1, w2
+  /* Whitening. */
+  bn.xor w0, w31, w31
 
-  /* Compute r = cin ^ a. */
-  bn.xor w6, w6, w6   /* Whitening. */
-  bn.xor w6, w4, w2
-  addi   x4, x0, 6
-  bn.sid x4, 0(x15)
-  bn.xor w6, w6, w6   /* Whitening. */
-  bn.xor w6, w5, w3
+  /* Load share 1. */
+  add    x5, x12, x13
+  bn.lid x0, 0(x5)     /* w0 = y_1 */
+  add    x5, x10, x11
+  bn.lid x4++, 0(x5)   /* w3 = x_1 */
+  add    x5, x17, x29
+  bn.lid x4, 0(x5)     /* w4 = cin_1 */
+  /* Compute a_1 = x_1 ^ y_1. */
+  bn.xor w6, w3, w0
+  /* Compute r_1 = cin_1 ^ a_1. */
+  bn.xor w0, w4, w6
   add    x5, x15, x16
-  bn.sid x4, 0(x5)
+  bn.sid x0, 0(x5)
+  /* Compute t_1 = x_1 ^ cin_1. */
+  bn.xor w8, w3, w4
+  /* Whitening. */
+  bn.xor w0, w31, w31
 
   /* Compute cout = x ^ secand(a, x ^ cin). */
   /* Inline t = secand(a, x ^ cin) = secand(a, t).
-   *  - (a_0, a_1)     -> (w4, w5)
-   *  - (x_0, x_1)     -> (w0, w1)
-   *  - (cin_0, cin_1) -> (w2, w3) */
-
-  /* Compute t = x ^ cin. */
-  bn.xor w6, w6, w6    /* Whitening. */
-  bn.xor w6, w0, w2    /* w6 = t_0 */
-  bn.xor w7, w7, w7    /* Whitening. */
-  bn.xor w7, w1, w3    /* w7 = t_1 */
+   *  - (a_0, a_1) -> (w5, w6)
+   *  - (t_0, t_1) -> (w7, w8)
+   *  - (x_0, x_1) -> (w1, w3) */
 
   /* Refresh with one fresh random. */
-  bn.wsrr w8, urnd     /* w8 = s */
+  bn.wsrr w9, urnd     /* w9 = r */
+
+  bn.and  w2, w5, w7   /* a_0 & t_0 */
+  bn.xor  w0, w31, w31 /* Whitening. */
+  bn.and  w4, w6, w8   /* a_1 & t_1. */
+  bn.xor  w0, w31, w31 /* Whitening. */
 
   /* Pair (i, j) = (0, 1). */
-  bn.xor  w2, w2, w2   /* Whitening. */
-  bn.and  w2, w4, w6   /* w2 = a_0 &  t_0 */
-  bn.xor  w3, w3, w3   /* Whitening. */
-  bn.xor  w3, w7, w8   /* w3 = t_1 ^ s */
-  bn.and  w3, w4, w3   /* w3 &= a_0 */
-  bn.xor  w9, w9, w9   /* Whitening. */
-  bn.not  w9, w4       /* w9 = a_0 ^ 1 */
-  bn.and  w9, w9, w8   /* w9 &= s */
-  bn.xor  w3, w3, w9   /* w3 ^= w9 */
-  bn.xor  w2, w2, w3   /* w2 ^= w3 */
-  bn.xor  w3, w3, w3   /* Whitening. */
-  bn.xor  w3, w2, w0   /* cout_0 = x_0 ^ w2 */
-  addi    x4, x0, 3
-  bn.sid  x4, 0(x30)
+  bn.xor  w0, w8, w9   /* w0 = t_1 ^ r */
+  bn.and  w0, w0, w5   /* w0 &= a_0 */
+  bn.not  w5, w5       /* w5 = a_0 ^ 1 */
+  bn.and  w5, w5, w9   /* w5 &= r */
+  bn.xor  w0, w0, w5   /* w0 ^= w5 */
+  bn.xor  w0, w0, w2   /* w0 ^= w2 */
+  bn.xor  w0, w0, w1   /* cout_0 = x_0 ^ w0 */
+  bn.sid  x0, 0(x30)
+  /* Whitening. */
+  bn.xor  w0, w31, w31
+  bn.xor  w1, w31, w31
+  bn.xor  w2, w31, w31
+  bn.xor  w5, w31, w31
+  bn.xor  w8, w31, w31
 
   /* Pair (i, j) = (1, 0). */
-  bn.xor  w2, w2, w2   /* Whitening. */
-  bn.and  w2, w5, w7   /* w2 = a_1 &  t_1 */
-  bn.xor  w3, w3, w3   /* Whitening. */
-  bn.xor  w3, w6, w8   /* w3 = t_0 ^ s */
-  bn.and  w3, w5, w3   /* w3 &= a_1 */
-  bn.xor  w9, w9, w9   /* Whitening. */
-  bn.not  w9, w5       /* w9 = a_1 ^ 1 */
-  bn.and  w9, w9, w8   /* w9 &= s */
-  bn.xor  w3, w3, w9   /* w3 ^= w9 */
-  bn.xor  w2, w2, w3   /* w2 ^= w3 */
-  bn.xor  w3, w3, w3   /* Whitening. */
-  bn.xor  w3, w2, w1   /* cout_0 = x_1 ^ w2 */
+  bn.xor  w0, w7, w9   /* w0 = t_0 ^ r */
+  bn.and  w0, w0, w6   /* w0 &= a_1 */
+  bn.not  w6, w6       /* w6 = a_1 ^ 1 */
+  bn.and  w6, w6, w9   /* w6 &= r */
+  bn.xor  w0, w0, w6   /* w0 ^= w6 */
+  bn.xor  w0, w0, w4   /* w0 ^= w4 */
+  bn.xor  w0, w0, w3   /* cout_1 = x_1 ^ w0 */
   add     x5, x30, x31
-  bn.sid  x4, 0(x5)
+  bn.sid  x0, 0(x5)
+  /* Whitening. */
+  bn.xor  w0, w31, w31
+  bn.xor  w3, w31, w31
+  bn.xor  w4, w31, w31
+  bn.xor  w6, w31, w31
+  bn.xor  w7, w31, w31
 
   ret
 

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -3038,34 +3038,25 @@ _skip_bit_4:
 poly_masked_compare_du:
   /* Allocate t scratch (2 shares * 352 B, du = 11 worst case) + saves. */
   addi x2, x2, -736
-  sw   x8, 708(x2)
-  sw   x9, 712(x2)
-  sw   x18, 716(x2)
-  sw   x20, 724(x2)
-  sw   x15, 728(x2)
+  sw   x11, 708(x2)
+  sw   x12, 712(x2)
+  sw   x14, 716(x2)
+  sw   x15, 720(x2)
+  sw   x8, 724(x2)
 
-  /* Save input/output addresses. */
-  add x8, x10, x0
-  add x9, x11, x0
-  add x18, x12, x0
-  add x20, x14, x0
-
-  /* Compute t = poly_hocompress(c'). */
-  add x10, x8, x0
+  /* Compute t = polyvec_hocompress(c'). */
+  /* x10 already points to c'. */
   add x12, x2, x0
   add x13, x15, x0
   jal x1, polyvec_hocompress
 
   /* Decode + bitslice c. */
-  add  x11, x9, x0
-
-  addi x4, x0, 4
-  lw   x15, 728(x2)
-  bne  x15, x4, _handle_kn4_du
-
-_handle_k4_du:
+  lw   x11, 708(x2)
+  addi x5, x0, 4
+  lw   x15, 720(x2)
+  addi x4, x0, 17
+  bne  x15, x5, _handle_kn4_du
   /* group 0 -> w15 */
-  addi   x4, x0, 17
   bn.lid x4, 0(x11++)
   loopi 16, 2
     bn.rshi w15, w17, w15 >> 16
@@ -3239,114 +3230,112 @@ _handle_k4_du:
   endloop
   jal x1, _bitslice_transpose
 
-  addi x9, x0, 11
+  addi x8, x0, 11
   beq  x0, x0, _handle_common_du
 
 _handle_kn4_du:
-  addi x4, x0, 17
   addi x5, x0, 15
-  addi x6, x0, 18
   loopi 2, 69
     /* group i + 0 */
     bn.lid x4, 0(x11++)
     loopi 16, 2
-      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w0, w17, w0 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.movr x5, x6
+    bn.movr x5, x0
     addi    x5, x5, -1
 
     /* group i + 1 */
     loopi 9, 2
-      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w0, w17, w0 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.rshi w18, w17, w18 >> 6
+    bn.rshi w0, w17, w0 >> 6
     bn.lid  x4, 0(x11++)
-    bn.rshi w18, w17, w18 >> 10
+    bn.rshi w0, w17, w0 >> 10
     bn.rshi w17, w31, w17 >> 4
     loopi 6, 2
-      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w0, w17, w0 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.movr x5, x6
+    bn.movr x5, x0
     addi    x5, x5, -1
 
     /* group i + 2 */
     loopi 16, 2
-      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w0, w17, w0 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.movr x5, x6
+    bn.movr x5, x0
     addi    x5, x5, -1
 
     /* group i + 3 */
     loopi 3, 2
-      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w0, w17, w0 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.rshi w18, w17, w18 >> 2
+    bn.rshi w0, w17, w0 >> 2
     bn.lid  x4, 0(x11++)
-    bn.rshi w18, w17, w18 >> 14
+    bn.rshi w0, w17, w0 >> 14
     bn.rshi w17, w31, w17 >> 8
     loopi 12, 2
-      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w0, w17, w0 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.movr x5, x6
+    bn.movr x5, x0
     addi    x5, x5, -1
 
     /* group i + 4 */
     loopi 12, 2
-      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w0, w17, w0 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.rshi w18, w17, w18 >> 8
+    bn.rshi w0, w17, w0 >> 8
     bn.lid  x4, 0(x11++)
-    bn.rshi w18, w17, w18 >> 8
+    bn.rshi w0, w17, w0 >> 8
     bn.rshi w17, w31, w17 >> 2
     loopi 3, 2
-      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w0, w17, w0 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.movr x5, x6
+    bn.movr x5, x0
     addi    x5, x5, -1
 
     /* group i + 5 */
     loopi 16, 2
-      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w0, w17, w0 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.movr x5, x6
+    bn.movr x5, x0
     addi    x5, x5, -1
 
     /* group i + 6 */
     loopi 6, 2
-      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w0, w17, w0 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.rshi w18, w17, w18 >> 4
+    bn.rshi w0, w17, w0 >> 4
     bn.lid  x4, 0(x11++)
-    bn.rshi w18, w17, w18 >> 12
+    bn.rshi w0, w17, w0 >> 12
     bn.rshi w17, w31, w17 >> 6
     loopi 9, 2
-      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w0, w17, w0 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.movr x5, x6
+    bn.movr x5, x0
     addi    x5, x5, -1
 
     /* group i + 7 */
     loopi 16, 2
-      bn.rshi w18, w17, w18 >> 16
+      bn.rshi w0, w17, w0 >> 16
       bn.rshi w17, w31, w17 >> 10
     endloop
-    bn.movr x5, x6
+    bn.movr x5, x0
     addi    x5, x5, -1
   endloop
   jal x1, _bitslice_transpose
 
-  addi x9, x0, 10
+  addi x8, x0, 10
 
 _handle_common_du:
   /* t_0 ^= ~c, so that t is 1 exactly where the bits match. The c
@@ -3405,7 +3394,7 @@ _handle_common_du:
   bn.sid x4, 0(x5++)
 
   addi   x6, x0, 10
-  beq    x9, x6, _skip_bit_10
+  beq    x8, x6, _skip_bit_10
 
   bn.lid x4, 0(x5)
   bn.xor w10, w10, w15
@@ -3414,25 +3403,22 @@ _handle_common_du:
 
 _skip_bit_10:
   /* Compute r = secand(r, t). */
+  lw   x10, 716(x2)
   addi x11, x0, 32
   add  x12, x2, x0
-  add  x13, x18, x0
+  lw   x13, 712(x2)
+  add  x15, x10, x0
   addi x16, x0, 32
   /* After the secand, the input and output pointers will point to
    * next bit so we don't have to pass all the arguments above to secand again. */
-  loop x9, 4
-    add x10, x20, x0
-    add x15, x20, x0
-    jal x1, secand
-    nop
+  loop x8, 3
+    jal  x1, secand
+    addi x10, x10, -32
+    addi x15, x15, -32
   endloop
 
   /* Restore registers. */
-  lw   x8, 708(x2)
-  lw   x9, 712(x2)
-  lw   x18, 716(x2)
-  lw   x20, 724(x2)
-  lw   x15, 728(x2)
+  lw   x8, 724(x2)
   addi x2, x2, 736
   ret
 

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -2189,9 +2189,9 @@ masked_poly_getnoise_eta_init:
   addi  x5, x0, 33
   slli  x5, x5, 5
   addi  x5, x5, SHAKE256_CFG
-  addi  x6, x0, 1
-  slli  x6, x6, 20
-  add   x5, x5, x6
+  addi  x4, x0, 1
+  slli  x4, x4, 20
+  add   x5, x5, x4
   csrrw x0, kmac_cfg, x5
 
   /* Send seed. */
@@ -2273,16 +2273,14 @@ masked_poly_getnoise_eta_1:
   addi x2, x2, -416
   sw   x8, 384(x2)
   sw   x9, 388(x2)
-  sw   x18, 392(x2)
-  sw   x19, 396(x2)
   add  x8, x10, x0
   add  x9, x11, x0
-  addi x18, x2, 192
+
+  addi x10, x2, 192 /* x */
+  add  x11, x2, x0  /* y */
 
   addi x4, x0, 3
-  bne  x10, x4, _getnoise_eta_2
-
-  add  x5, x2, x0
+  bne  x8, x4, _getnoise_eta_2
 
   bn.wsrr w17, kmac_digest
   bn.wsrr w23, kmac_digest1
@@ -2302,11 +2300,11 @@ masked_poly_getnoise_eta_1:
 
   add x4, x0, x0
   loopi 3, 2
-    bn.sid x4, 0(x18++)
+    bn.sid x4, 0(x10++)
     addi   x4, x4, 1
   endloop
   loopi 3, 2
-    bn.sid x4, 0(x5++)
+    bn.sid x4, 0(x11++)
     addi   x4, x4, 1
   endloop
 
@@ -2327,18 +2325,17 @@ masked_poly_getnoise_eta_1:
 
   add x4, x0, x0
   loopi 3, 2
-    bn.sid x4, 0(x18++)
+    bn.sid x4, 0(x10++)
     addi   x4, x4, 1
   endloop
   loopi 3, 2
-    bn.sid x4, 0(x5++)
+    bn.sid x4, 0(x11++)
     addi   x4, x4, 1
   endloop
 
   beq  x0, x0, _getnoise_common
 
 _getnoise_eta_2:
-
   bn.wsrr w17, kmac_digest
   bn.wsrr w21, kmac_digest1
   bn.wsrr w18, kmac_digest
@@ -2348,11 +2345,9 @@ _getnoise_eta_2:
   bn.wsrr w20, kmac_digest
   bn.wsrr w24, kmac_digest1
 
-  addi x5, x0, 25
+  addi x5, x0, 17
   addi x6, x0, 17
-  addi x7, x0, 26
-  add  x28, x2, x0
-  loopi 2, 38
+  loopi 2, 37
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
@@ -2370,8 +2365,6 @@ _getnoise_eta_2:
     bn.xor w13, w13, w13
     bn.xor w14, w14, w14
     bn.xor w15, w15, w15
-    bn.xor w25, w25, w25
-    bn.xor w26, w26, w26
     bn.xor w28, w28, w28
     bn.xor w29, w29, w29
 
@@ -2380,10 +2373,10 @@ _getnoise_eta_2:
       bn.movr x5, x6
       loopi 4, 5
         loopi 16, 2
-          bn.rshi w26, w25, w26 >> 16
-          bn.rshi w25, w31, w25 >> 4
+          bn.rshi w0, w17, w0 >> 16
+          bn.rshi w17, w31, w17 >> 4
         endloop
-        bn.movr x4, x7
+        bn.movr x4, x0
         addi    x4, x4, -1
       endloop
       addi x6, x6, 1
@@ -2391,13 +2384,16 @@ _getnoise_eta_2:
 
     jal x1, _bitslice_transpose
 
-    bn.sid x0, 0(x18++)
+    bn.sid x0, 0(x10++)
     addi   x4, x0, 1
-    bn.sid x4, 0(x18++)
+    bn.sid x4, 0(x10++)
     addi   x4, x4, 1
-    bn.sid x4, 0(x28++)
+    bn.sid x4, 0(x11++)
     addi   x4, x4, 1
-    bn.sid x4, 0(x28++)
+    bn.sid x4, 0(x11++)
+
+    /* Whitening. */
+    bn.xor w17, w17, w17
   endloop
 
 _getnoise_common:
@@ -2416,8 +2412,6 @@ _getnoise_common:
   /* Restore registers and stack. */
   lw   x8, 384(x2)
   lw   x9, 388(x2)
-  lw   x18, 392(x2)
-  lw   x19, 396(x2)
   addi x2, x2, 416
   ret
 

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -61,6 +61,7 @@
  * @param[in]  x13: share stride of y
  * @param[out] x15: dmem pointer to Boolean shares of r
  * @param[in]  x16: share stride of r
+ * @param[in]  w31: all-zero register
  *
  * clobbered registers: x4 to x5, w0 to w3, w5 to w8
  * clobbered flag groups: FG0
@@ -69,52 +70,52 @@
 .globl secand
 .type secand, @function
 secand:
-  add x4, x0, x0
+  /* Compute t_0 = x_0 & y_0. */
+  addi   x4, x0, 1
+  bn.lid x4++, 0(x10)  /* w1 = x_0 */
+  bn.lid x4++, 0(x12)  /* w2 = y_0 */
+  bn.and w5, w1, w2    /* w5 = t_0 */
+  bn.xor w0, w31, w31  /* Whitening. */
 
-  /* Load x. */
-  bn.xor w0, w0, w0   /* Whitening. */
-  bn.lid x4++, 0(x10) /* w0 = x_0 */
-  bn.xor w1, w1, w1   /* Whitening. */
+  /* Compute t_1 = x_1 & y_1. */
   add    x5, x10, x11
-  bn.lid x4++, 0(x5)  /* w1 = x_1 */
-
-  /* Load y. */
-  bn.xor w2, w2, w2   /* Whitening. */
-  bn.lid x4++, 0(x12) /* w2 = y_0 */
-  bn.xor w3, w3, w3   /* Whitening. */
+  bn.lid x4++, 0(x5)   /* w3 = x_1 */
   add    x5, x12, x13
-  bn.lid x4, 0(x5)    /* w3 = y_1 */
+  bn.lid x4, 0(x5)     /* w4 = y_1 */
+  bn.and w6, w3, w4    /* w6 = t_1 */
+  bn.xor w0, w31, w31  /* Whitening. */
 
   /* Refresh with one fresh random. */
-  bn.wsrr w5, urnd    /* w5 = s */
+  bn.wsrr w7, urnd    /* w7 = s */
 
   /* Pair (i, j) = (0, 1). */
-  bn.xor  w6, w6, w6  /* Whitening. */
-  bn.and  w6, w0, w2  /* w6 = x_0 & y_0 */
-  bn.xor  w7, w7, w7  /* Whitening. */
-  bn.xor  w7, w3, w5  /* w7 = y_1 ^ s */
-  bn.and  w7, w0, w7  /* w7 &= x_0 */
-  bn.xor  w8, w8, w8  /* Whitening. */
-  bn.not  w8, w0      /* w8 = x_0 ^ 1 */
-  bn.and  w8, w8, w5  /* w8 &= s */
-  bn.xor  w7, w7, w8  /* w7 ^= w8 */
-  bn.xor  w6, w6, w7  /* r_0 = (w6 ^ w7) */
-  addi    x4, x0, 6
-  bn.sid  x4, 0(x15)
+  bn.xor w0, w4, w7   /* w0 = y_1 ^ s */
+  bn.and w0, w0, w1   /* w0 &= x_0 */
+  bn.not w1, w1       /* w1 = x_0 ^ 1 */
+  bn.and w1, w1, w7   /* w1 &= s */
+  bn.xor w0, w0, w1   /* w0 ^= w1 */
+  bn.xor w0, w0, w5   /* r_0 = (w0 ^= t_0) */
+  bn.sid x0, 0(x15)
+  /* Whitening. */
+  bn.xor w0, w31, w31
+  bn.xor w1, w31, w31
+  bn.xor w4, w31, w31
+  bn.xor w5, w31, w31
 
   /* Pair (i, j) = (1, 0). */
-  bn.xor  w6, w6, w6  /* Whitening. */
-  bn.and  w6, w1, w3  /* w6 = x_1 & y_1 */
-  bn.xor  w7, w7, w7  /* Whitening. */
-  bn.xor  w7, w2, w5  /* w7 = y_0 ^ s */
-  bn.and  w7, w1, w7  /* w7 &= x_1 */
-  bn.xor  w8, w8, w8  /* Whitening. */
-  bn.not  w8, w1      /* w8 = x_1 ^ 1 */
-  bn.and  w8, w8, w5  /* w8 &= s */
-  bn.xor  w7, w7, w8  /* w7 ^= w8 */
-  bn.xor  w6, w6, w7  /* r_1 = (w6 ^ w7) */
-  add     x5, x15, x16
-  bn.sid  x4, 0(x5)
+  bn.xor w0, w2, w7   /* w0 = y_0 ^ s */
+  bn.and w0, w0, w3   /* w0 &= x_1 */
+  bn.not w3, w3       /* w3 = x_1 ^ 1 */
+  bn.and w3, w3, w7   /* w3 &= s */
+  bn.xor w0, w0, w3   /* w0 ^= w3 */
+  bn.xor w0, w0, w6   /* r_1 = (w0 ^= t_1) */
+  add    x5, x15, x16
+  bn.sid x0, 0(x5)
+  /* Whitening. */
+  bn.xor w0, w31, w31
+  bn.xor w2, w31, w31
+  bn.xor w3, w31, w31
+  bn.xor w6, w31, w31
 
   ret
 

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -1894,9 +1894,9 @@ _du_params_done:
  * clobbered flag groups: FG0
  */
 
-.globl onebitdecompress
-.type onebitdecompress, @function
-onebitdecompress:
+.globl masked_poly_frommsg
+.type masked_poly_frommsg, @function
+masked_poly_frommsg:
   /* Save the output base pointer; reused as scratch across the call. */
   addi x2, x2, -32
   sw   x8, 0(x2)

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -905,18 +905,18 @@ seca2b:
   endloop
 
   /* Save registers. */
-  add x5, x11, x0
-  add x6, x12, x0
-  add x28, x14, x0
+  add x4, x11, x0
+  add x5, x12, x0
+  add x6, x14, x0
 
   /* Compute r = secadd(s, s', k). */
   add x10, x7, x0
-  add x11, x6, x0
+  add x11, x5, x0
   add x12, x2, x0
-  add x13, x6, x0
-  add x15, x28, x0
-  add x16, x6, x0
-  add x17, x5, x0
+  add x13, x5, x0
+  add x15, x6, x0
+  add x16, x5, x0
+  add x17, x4, x0
   jal x1, secadd
 
   /* Restore x2 and x3. */

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -1295,9 +1295,8 @@ secb2amodq:
   /* zp = x2 + 32 */
 
   /* Sample r_0 = rand, then compute zp = q - rand. */
-  bn.wsrr w16, mod
   add     x10, x12, x0
-  jal x1, poly_rej_samp
+  jal     x1, poly_rej_samp
   addi    x4, x0, 1
   la      x5, modulus_bn
   bn.lid  x4, 0(x5)

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -2593,10 +2593,10 @@ _bitslice_eta_3:
 .globl masked_poly_tomsg
 .type masked_poly_tomsg, @function
 masked_poly_tomsg:
-  /* Allocate the z scratch and save callee-saved registers. */
+  /* Allocate the z scratch, save x8 and spill the output pointer. */
   addi x2, x2, -1056
   sw   x8, 1024(x2)
-  add  x8, x12, x0
+  sw   x12, 1028(x2)
 
   /* Load all constants. */
   addi      x4, x0, 17
@@ -2622,7 +2622,6 @@ masked_poly_tomsg:
    *  - x >>= s
    *  - x &= ((1 << (1 + alpha)) - 1).
    */
-  addi x5, x0, 21
   add  x6, x2, x0 /* z */
 
   loopi 2, 44
@@ -2666,8 +2665,8 @@ masked_poly_tomsg:
       bn.mulv.8s.odd.hi  w20, w20, w17
       bn.add             w20, w19, w20 >> 8
       /* Combine results. */
-      bn.trn1.16h        w21, w21, w20
-      bn.movr            x4, x5
+      bn.trn1.16h        w0, w21, w20
+      bn.movr            x4, x0
       addi               x4, x4, -1
     endloop
 
@@ -2692,15 +2691,14 @@ masked_poly_tomsg:
   jal  x1, seca2b
 
   /* Compute c >>= alpha, i.e. keep only bit c[alpha], the message bit. */
-  add  x5, x2, x0
-  addi x5, x5, 480
-  add  x6, x8, x0
+  addi x5, x2, 480
+  lw   x6, 1028(x2)
   loopi 2, 4
     /* Whitening. */
     bn.xor w0, w0, w0
-    bn.lid x0, 0(x5++)
+    bn.lid x0, 0(x5)
+    addi   x5, x5, 512
     bn.sid x0, 0(x6++)
-    addi   x5, x5, 480
   endloop
 
   /* Restore registers. */

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -289,9 +289,6 @@ secadd:
   /* Handle bit k - 1. */
   addi x4, x0, 1
   loopi 2, 11
-    /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
     /* r[k - 1] = x[k - 1] ^ y[k - 1] ^ c. */
     bn.lid x0, 0(x10)
     add    x10, x10, x11
@@ -302,6 +299,9 @@ secadd:
     bn.xor w0, w0, w1
     bn.sid x0, 0(x15)
     add    x15, x15, x16
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
   endloop
 
   /* Restore x17. */
@@ -338,8 +338,6 @@ bitcopymask:
    * and zeroize the remaining bits. */
   addi x4, x0, 31
   loopi 2, 10
-    /* Whitening. */
-    bn.xor w0, w0, w0
     bn.lid x0, 0(x10)
     add    x10, x10, x11
     /* Copy x to bit 0. */
@@ -355,6 +353,8 @@ bitcopymask:
     /* Copy x to bit 10..11. */
     bn.sid x0, 0(x13++)
     bn.sid x0, 0(x13++)
+    /* Whitening. */
+    bn.xor w0, w0, w0
   endloop
   ret
 
@@ -388,8 +388,6 @@ refreshios:
   loop x11, 9
     /* s <- urnd. */
     bn.wsrr w1, urnd
-    /* Whitening. */
-    bn.xor  w0, w0, w0
     /* r_0 = x_0 ^ s. */
     bn.lid  x0, 0(x10++)
     bn.xor  w0, w0, w1
@@ -400,6 +398,8 @@ refreshios:
     bn.lid  x0, 0(x5++)
     bn.xor  w0, w0, w1
     bn.sid  x0, 0(x6++)
+    /* Whitening. */
+    bn.xor  w0, w0, w0
   endloop
   ret
 
@@ -518,8 +518,6 @@ refreshmodq:
   loopi 16, 9
     /* Load rand. */
     bn.lid       x4, 0(x5++)
-    /* Whitening. */
-    bn.xor       w0, w0, w0
     /* r_0 = x_0 + rand. */
     bn.lid       x0, 0(x10++)
     bn.addvm.16h w0, w0, w1
@@ -530,6 +528,8 @@ refreshmodq:
     bn.lid       x0, 0(x6++)
     bn.subvm.16h w0, w0, w1
     bn.sid       x0, 0(x7++)
+    /* Whitening. */
+    bn.xor       w0, w0, w0
   endloop
 
   /* Restore stack. */
@@ -973,11 +973,6 @@ seca2bmodq:
   /* Initialize cin = 0. */
   bn.xor w2, w2, w2
 
-  /* Whitening. */
-  bn.xor w0, w0, w0
-  bn.xor w1, w1, w1
-  bn.xor w3, w3, w3
-
   /* Bits 0..7: p[i] = 1. */
   loopi 8, 7
     bn.lid x0, 0(x10++)
@@ -1017,10 +1012,15 @@ seca2bmodq:
   /* Bit 12: p[i] = 1 and x_0[i] = 0. */
   bn.not w1, w2
   bn.sid x4, 0(x5++)
+
+  /* Whitening. */
+  bn.xor w0, w0, w0
+  bn.xor w1, w1, w1
+  bn.xor w2, w2, w2
+  bn.xor w3, w3, w3
   /********** End inline s = secadd(p, x_0, k + 1). **********/
 
   /* Build s = (s, 0) for (k + 1) bits. */
-  bn.xor w0, w0, w0
   loopi 13, 1
     bn.sid x0, 0(x5++)
   endloop
@@ -1061,9 +1061,6 @@ seca2bmodq:
 
   addi x4, x0, 1
   loopi 2, 11
-    /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
     /* u[12] = s[12] ^ s'[12] ^ c. */
     bn.lid x0, 0(x10)
     add    x10, x10, x11
@@ -1074,6 +1071,9 @@ seca2bmodq:
     bn.xor w0, w0, w1
     bn.sid x0, 0(x15)
     add    x15, x15, x16
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
   endloop
   /********** End inline u = secadd(s, s', k + 1). **********/
 
@@ -1108,9 +1108,6 @@ seca2bmodq:
 
   addi x4, x0, 1
   loopi 2, 11
-    /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
     /* r[11] = a[11] ^ u[11] ^ c. */
     bn.lid x0, 0(x10)
     add    x10, x10, x11
@@ -1121,6 +1118,9 @@ seca2bmodq:
     bn.xor w0, w0, w1
     bn.sid x0, 0(x15)
     add    x15, x15, x16
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
   endloop
   /********** End inline r = secadd(a, u, k). **********/
 
@@ -1387,9 +1387,6 @@ secb2amodq:
   /* Bit 12: p[i] = 1. */
   addi   x4, x0, 1
   /* s[12] = p[12] ^ s[12] ^ c = ~(s[12] ^ c) since p[12] = 1. */
-  /* Whitening. */
-  bn.xor w0, w0, w0
-  bn.xor w1, w1, w1
   /* s_0 */
   bn.lid x0, 0(x12)
   bn.lid x4, 0(x17)
@@ -1398,15 +1395,18 @@ secb2amodq:
   bn.not w0, w0
   bn.sid x0, 0(x12)
   add    x12, x12, x13
-
   /* Whitening. */
   bn.xor w0, w0, w0
   bn.xor w1, w1, w1
+
   /* s_1 */
   bn.lid x0, 0(x12)
   bn.lid x4, 0(x17)
   bn.xor w0, w0, w1
   bn.sid x0, 0(x12)
+  /* Whitening. */
+  bn.xor w0, w0, w0
+  bn.xor w1, w1, w1
   /********** End inline s = secadd(s, p = 2^(k + 1) - q, k + 1). **********/
 
   /* Compute a = bitcopymask(s[k], (k + 1) * 32). */
@@ -1535,28 +1535,6 @@ _dv_params_done:
    *  - x &= ((1 << (dv + alpha)) - 1).
    */
   loopi 2, 56
-    /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
-    bn.xor w2, w2, w2
-    bn.xor w3, w3, w3
-    bn.xor w4, w4, w4
-    bn.xor w5, w5, w5
-    bn.xor w6, w6, w6
-    bn.xor w7, w7, w7
-    bn.xor w8, w8, w8
-    bn.xor w9, w9, w9
-    bn.xor w10, w10, w10
-    bn.xor w11, w11, w11
-    bn.xor w12, w12, w12
-    bn.xor w13, w13, w13
-    bn.xor w14, w14, w14
-    bn.xor w15, w15, w15
-    bn.xor w20, w20, w20
-    bn.xor w21, w21, w21
-    bn.xor w28, w28, w28
-    bn.xor w29, w29, w29
-
     addi x4, x0, 15
     loopi 16, 18
       bn.lid             x0, 0(x10++)
@@ -1610,6 +1588,28 @@ _dv_params_done:
     /* For the first share, w19 holds 2^(alpha - 1).
      * After that, we clear w19 so that bn.add acts as a shift. */
     bn.xor w19, w19, w19
+
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    bn.xor w4, w4, w4
+    bn.xor w5, w5, w5
+    bn.xor w6, w6, w6
+    bn.xor w7, w7, w7
+    bn.xor w8, w8, w8
+    bn.xor w9, w9, w9
+    bn.xor w10, w10, w10
+    bn.xor w11, w11, w11
+    bn.xor w12, w12, w12
+    bn.xor w13, w13, w13
+    bn.xor w14, w14, w14
+    bn.xor w15, w15, w15
+    bn.xor w20, w20, w20
+    bn.xor w21, w21, w21
+    bn.xor w28, w28, w28
+    bn.xor w29, w29, w29
   endloop
 
   /* Compute c = seca2b(z), k = dv + alpha = 18, share bytes = 576. */
@@ -1623,13 +1623,13 @@ _dv_params_done:
   add x5, x2, x8
   lw  x12, 1152(x2)
   loopi 2, 5
-    /* Whitening. */
-    bn.xor w0, w0, w0
     loop x9, 2
       bn.lid x0, 0(x5++)
       bn.sid x0, 0(x12++)
     endloop
     add x5, x5, x8
+    /* Whitening. */
+    bn.xor w0, w0, w0
   endloop
 
   /* Restore registers. */
@@ -1719,29 +1719,6 @@ _du_params_done:
    *  - x &= ((1 << (du + alpha)) - 1).
    */
   loopi 2, 83
-    /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
-    bn.xor w2, w2, w2
-    bn.xor w3, w3, w3
-    bn.xor w4, w4, w4
-    bn.xor w5, w5, w5
-    bn.xor w6, w6, w6
-    bn.xor w7, w7, w7
-    bn.xor w8, w8, w8
-    bn.xor w9, w9, w9
-    bn.xor w10, w10, w10
-    bn.xor w11, w11, w11
-    bn.xor w12, w12, w12
-    bn.xor w13, w13, w13
-    bn.xor w14, w14, w14
-    bn.xor w15, w15, w15
-    bn.xor w19, w19, w19
-    bn.xor w20, w20, w20
-    bn.xor w21, w21, w21
-    bn.xor w28, w28, w28
-    bn.xor w29, w29, w29
-
     addi x4, x0, 15
     loopi 16, 44
       bn.lid          x0, 0(x10++)
@@ -1830,6 +1807,29 @@ _du_params_done:
     /* For the first share, w30 holds 2^(alpha - 1).
      * After that, we clear w30 for the 2nd share. */
     bn.xor w30, w30, w30
+
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    bn.xor w4, w4, w4
+    bn.xor w5, w5, w5
+    bn.xor w6, w6, w6
+    bn.xor w7, w7, w7
+    bn.xor w8, w8, w8
+    bn.xor w9, w9, w9
+    bn.xor w10, w10, w10
+    bn.xor w11, w11, w11
+    bn.xor w12, w12, w12
+    bn.xor w13, w13, w13
+    bn.xor w14, w14, w14
+    bn.xor w15, w15, w15
+    bn.xor w19, w19, w19
+    bn.xor w20, w20, w20
+    bn.xor w21, w21, w21
+    bn.xor w28, w28, w28
+    bn.xor w29, w29, w29
   endloop
 
   /* Compute c = seca2b(z), k = du + alpha = 24, share bytes = 768. */
@@ -1843,13 +1843,13 @@ _du_params_done:
   add x5, x2, x8
   lw  x12, 1536(x2)
   loopi 2, 5
-    /* Whitening. */
-    bn.xor w0, w0, w0
     loop x9, 2
       bn.lid x0, 0(x5++)
       bn.sid x0, 0(x12++)
     endloop
     add x5, x5, x8
+    /* Whitening. */
+    bn.xor w0, w0, w0
   endloop
 
   /* Restore registers. */
@@ -1894,16 +1894,15 @@ masked_poly_frommsg:
 
   /* Unpack m, matching the bitslice layout from masked_poly_tomsg. */
   addi x4, x0, 1
-  loopi 2, 7
-    /* Whitening. */
-    bn.xor w0, w0, w0
+  loopi 2, 6
     bn.lid x0, 0(x10++)
     loopi 16, 3
       bn.shv.16h w1, w0 >> 15
       bn.shv.16h w0, w0 << 1
       bn.sid     x4, 0(x12++)
     endloop
-    nop
+    /* Whitening. */
+    bn.xor w0, w0, w0
   endloop
 
   /* Compute mp = seconebitb2amodq(m). */
@@ -1915,9 +1914,7 @@ masked_poly_frommsg:
   la      x5, const_qp1_half_mul_2_16_modq /* ((q + 1) / 2) * (2^16) mod q. */
   addi    x4, x0, 1
   bn.lid  x4, 0(x5)
-  loopi 2, 9
-    /* Whitening. */
-    bn.xor w0, w0, w0
+  loopi 2, 8
     loopi 16, 6
       bn.lid               x0, 0(x8)
       bn.mulv.16h.acc.z.lo w0, w0, w1
@@ -1926,7 +1923,8 @@ masked_poly_frommsg:
       bn.addvm.16h         w0, w0, w31
       bn.sid               x0, 0(x8++)
     endloop
-    nop
+    /* Whitening. */
+    bn.xor w0, w0, w0
   endloop
 
   /* Restore the output base pointer and stack. */
@@ -1986,8 +1984,6 @@ masked_cbd:
   slli x4, x18, 5 /* eta * 32 */
   add  x6, x8, x4
   /* Share 0. */
-  /* Whitening. */
-  bn.xor w0, w0, w0
   loop x12, 5
     /* Copy x_0. */
     bn.lid x0, 0(x10++)
@@ -1997,9 +1993,9 @@ masked_cbd:
     bn.not w0, w0
     bn.sid x0, 0(x6++)
   endloop
-  /* Share 1. */
   /* Whitening. */
   bn.xor w0, w0, w0
+  /* Share 1. */
   add x5, x5, x4
   add x6, x6, x4
   loop x12, 4
@@ -2010,6 +2006,8 @@ masked_cbd:
     bn.lid x0, 0(x11++)
     bn.sid x0, 0(x6++)
   endloop
+  /* Whitening. */
+  bn.xor w0, w0, w0
 
   /* The block below does as follows:
    *  - ell <- 2 * eta
@@ -2050,11 +2048,11 @@ masked_cbd:
   /* b[0] <- a. */
   add x5, x2, x0
   loopi 2, 4
-    /* Whitening. */
-    bn.xor w0, w0, w0
     bn.lid x0, 0(x17++)
     bn.sid x0, 0(x5)
     addi   x5, x5, 384
+    /* Whitening. */
+    bn.xor w0, w0, w0
   endloop
 
   /********** Iteration i = 1, ell = eta. **********/
@@ -2065,11 +2063,11 @@ masked_cbd:
   addi x6, x8, 64
   slli x4, x18, 6 /* (2 * eta) * 32 */
   loopi 2, 4
-    /* Whitening. */
-    bn.xor w0, w0, w0
     bn.lid x0, 0(x6)
     add    x6, x6, x4
     bn.sid x0, 0(x5++)
+    /* Whitening. */
+    bn.xor w0, w0, w0
   endloop
   beq x0, x0, _continue_1
 
@@ -2098,11 +2096,11 @@ _continue_1:
   /* b[1] <- a. */
   addi x5, x2, 32
   loopi 2, 4
-    /* Whitening. */
-    bn.xor w0, w0, w0
     bn.lid x0, 0(x17++)
     bn.sid x0, 0(x5)
     addi   x5, x5, 384
+    /* Whitening. */
+    bn.xor w0, w0, w0
   endloop
 
   /********** Iteration i = 2, ell = eta // 2 = 1. **********/
@@ -2111,12 +2109,12 @@ _continue_1:
   add  x6, x8, x0
   slli x7, x18, 6
   loopi 2, 5
-    /* Whitening. */
-    bn.xor w0, w0, w0
     bn.lid x0, 0(x6)
     add    x6, x6, x7
     bn.sid x0, 0(x5)
     addi   x5, x5, 384
+    /* Whitening. */
+    bn.xor w0, w0, w0
   endloop
 
   /* Clear bits b[3..k - 1]. */
@@ -2190,12 +2188,12 @@ masked_poly_getnoise_eta_init:
   csrrw x0, kmac_cfg, x5
 
   /* Send seed. */
-  bn.xor  w0, w0, w0 /* Whitening. */
   bn.lid  x0, 0(x10++)
   bn.wsrw kmac_msg, w0
   bn.xor  w0, w0, w0 /* Whitening. */
   bn.lid  x0, 0(x10++)
   bn.wsrw kmac_msg1, w0
+  bn.xor  w0, w0, w0 /* Whitening. */
 
   /* Send nonce. */
   li      x5, 1
@@ -2295,16 +2293,6 @@ masked_poly_getnoise_eta_1:
 
   jal x1, _bitslice_eta_3
 
-  add x4, x0, x0
-  loopi 3, 2
-    bn.sid x4, 0(x10++)
-    addi   x4, x4, 1
-  endloop
-  loopi 3, 2
-    bn.sid x4, 0(x11++)
-    addi   x4, x4, 1
-  endloop
-
   bn.xor w17, w17, w17
   bn.mov w17, w23
   bn.xor w18, w18, w18
@@ -2319,16 +2307,6 @@ masked_poly_getnoise_eta_1:
   bn.mov w22, w30
 
   jal x1, _bitslice_eta_3
-
-  add x4, x0, x0
-  loopi 3, 2
-    bn.sid x4, 0(x10++)
-    addi   x4, x4, 1
-  endloop
-  loopi 3, 2
-    bn.sid x4, 0(x11++)
-    addi   x4, x4, 1
-  endloop
 
   beq  x0, x0, _getnoise_common
 
@@ -2345,26 +2323,6 @@ _getnoise_eta_2:
   addi x5, x0, 17
   addi x6, x0, 17
   loopi 2, 37
-    /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
-    bn.xor w2, w2, w2
-    bn.xor w3, w3, w3
-    bn.xor w4, w4, w4
-    bn.xor w5, w5, w5
-    bn.xor w6, w6, w6
-    bn.xor w7, w7, w7
-    bn.xor w8, w8, w8
-    bn.xor w9, w9, w9
-    bn.xor w10, w10, w10
-    bn.xor w11, w11, w11
-    bn.xor w12, w12, w12
-    bn.xor w13, w13, w13
-    bn.xor w14, w14, w14
-    bn.xor w15, w15, w15
-    bn.xor w28, w28, w28
-    bn.xor w29, w29, w29
-
     addi x4, x0, 15
     loopi 4, 8
       bn.movr x5, x6
@@ -2390,7 +2348,25 @@ _getnoise_eta_2:
     bn.sid x4, 0(x11++)
 
     /* Whitening. */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    bn.xor w4, w4, w4
+    bn.xor w5, w5, w5
+    bn.xor w6, w6, w6
+    bn.xor w7, w7, w7
+    bn.xor w8, w8, w8
+    bn.xor w9, w9, w9
+    bn.xor w10, w10, w10
+    bn.xor w11, w11, w11
+    bn.xor w12, w12, w12
+    bn.xor w13, w13, w13
+    bn.xor w14, w14, w14
+    bn.xor w15, w15, w15
     bn.xor w17, w17, w17
+    bn.xor w28, w28, w28
+    bn.xor w29, w29, w29
   endloop
 
 _getnoise_common:
@@ -2427,26 +2403,6 @@ _getnoise_common:
  */
 
 _bitslice_eta_3:
-  /* Whitening. */
-  bn.xor w0, w0, w0
-  bn.xor w1, w1, w1
-  bn.xor w2, w2, w2
-  bn.xor w3, w3, w3
-  bn.xor w4, w4, w4
-  bn.xor w5, w5, w5
-  bn.xor w6, w6, w6
-  bn.xor w7, w7, w7
-  bn.xor w8, w8, w8
-  bn.xor w9, w9, w9
-  bn.xor w10, w10, w10
-  bn.xor w11, w11, w11
-  bn.xor w12, w12, w12
-  bn.xor w13, w13, w13
-  bn.xor w14, w14, w14
-  bn.xor w15, w15, w15
-  bn.xor w28, w28, w28
-  bn.xor w29, w29, w29
-
   loopi 16, 2
     bn.rshi w15, w17, w15 >> 16
     bn.rshi w17, w31, w17 >> 6
@@ -2556,6 +2512,36 @@ _bitslice_eta_3:
   endloop
 
   jal x1, _bitslice_transpose
+
+  add x4, x0, x0
+  loopi 3, 2
+    bn.sid x4, 0(x10++)
+    addi   x4, x4, 1
+  endloop
+  loopi 3, 2
+    bn.sid x4, 0(x11++)
+    addi   x4, x4, 1
+  endloop
+
+  /* Whitening. */
+  bn.xor w0, w0, w0
+  bn.xor w1, w1, w1
+  bn.xor w2, w2, w2
+  bn.xor w3, w3, w3
+  bn.xor w4, w4, w4
+  bn.xor w5, w5, w5
+  bn.xor w6, w6, w6
+  bn.xor w7, w7, w7
+  bn.xor w8, w8, w8
+  bn.xor w9, w9, w9
+  bn.xor w10, w10, w10
+  bn.xor w11, w11, w11
+  bn.xor w12, w12, w12
+  bn.xor w13, w13, w13
+  bn.xor w14, w14, w14
+  bn.xor w15, w15, w15
+  bn.xor w28, w28, w28
+  bn.xor w29, w29, w29
   ret
 
 /* Undefine gadget-local macros. */
@@ -2623,28 +2609,6 @@ masked_poly_tomsg:
   add  x6, x2, x0 /* z */
 
   loopi 2, 44
-    /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
-    bn.xor w2, w2, w2
-    bn.xor w3, w3, w3
-    bn.xor w4, w4, w4
-    bn.xor w5, w5, w5
-    bn.xor w6, w6, w6
-    bn.xor w7, w7, w7
-    bn.xor w8, w8, w8
-    bn.xor w9, w9, w9
-    bn.xor w10, w10, w10
-    bn.xor w11, w11, w11
-    bn.xor w12, w12, w12
-    bn.xor w13, w13, w13
-    bn.xor w14, w14, w14
-    bn.xor w15, w15, w15
-    bn.xor w20, w20, w20
-    bn.xor w21, w21, w21
-    bn.xor w28, w28, w28
-    bn.xor w29, w29, w29
-
     addi x4, x0, 15
     loopi 16, 16
       bn.lid             x0, 0(x10++)
@@ -2679,6 +2643,28 @@ masked_poly_tomsg:
     /* For the first share, w19 holds 2^(alpha - 1).
      * After that, we clear w19 so that bn.add acts as a shift. */
     bn.xor w19, w19, w19
+
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
+    bn.xor w3, w3, w3
+    bn.xor w4, w4, w4
+    bn.xor w5, w5, w5
+    bn.xor w6, w6, w6
+    bn.xor w7, w7, w7
+    bn.xor w8, w8, w8
+    bn.xor w9, w9, w9
+    bn.xor w10, w10, w10
+    bn.xor w11, w11, w11
+    bn.xor w12, w12, w12
+    bn.xor w13, w13, w13
+    bn.xor w14, w14, w14
+    bn.xor w15, w15, w15
+    bn.xor w20, w20, w20
+    bn.xor w21, w21, w21
+    bn.xor w28, w28, w28
+    bn.xor w29, w29, w29
   endloop
 
   /* Compute c = seca2b(z), k = 1 + alpha = 16, share bytes = 512. */
@@ -2692,11 +2678,11 @@ masked_poly_tomsg:
   addi x5, x2, 480
   lw   x6, 1028(x2)
   loopi 2, 4
-    /* Whitening. */
-    bn.xor w0, w0, w0
     bn.lid x0, 0(x5)
     addi   x5, x5, 512
     bn.sid x0, 0(x6++)
+    /* Whitening. */
+    bn.xor w0, w0, w0
   endloop
 
   /* Restore registers. */
@@ -3447,11 +3433,11 @@ finalize_cmp:
   add  x5, x2, x0
   add  x6, x10, x0
   loopi 2, 4
-    /* Whitening. */
-    bn.xor  w0, w0, w0
     bn.lid  x0, 0(x6++)
     bn.rshi w0, w31, w0 >> 128
     bn.sid  x0, 0(x5++)
+    /* Whitening. */
+    bn.xor  w0, w0, w0
   endloop
   /* Compute r &= t. */
   /* x10 already points to r. */
@@ -3467,11 +3453,11 @@ finalize_cmp:
   add  x5, x2, x0
   add  x6, x10, x0
   loopi 2, 4
-    /* Whitening. */
-    bn.xor  w0, w0, w0
     bn.lid  x0, 0(x6++)
     bn.rshi w0, w31, w0 >> 64
     bn.sid  x0, 0(x5++)
+    /* Whitening. */
+    bn.xor  w0, w0, w0
   endloop
   /* Compute r &= t. */
   jal  x1, secand
@@ -3481,11 +3467,11 @@ finalize_cmp:
   add  x5, x2, x0
   add  x6, x10, x0
   loopi 2, 4
-    /* Whitening. */
-    bn.xor  w0, w0, w0
     bn.lid  x0, 0(x6++)
     bn.rshi w0, w31, w0 >> 32
     bn.sid  x0, 0(x5++)
+    /* Whitening. */
+    bn.xor  w0, w0, w0
   endloop
   /* Compute r &= t. */
   jal  x1, secand
@@ -3495,11 +3481,11 @@ finalize_cmp:
   add  x5, x2, x0
   add  x6, x10, x0
   loopi 2, 4
-    /* Whitening. */
-    bn.xor  w0, w0, w0
     bn.lid  x0, 0(x6++)
     bn.rshi w0, w31, w0 >> 16
     bn.sid  x0, 0(x5++)
+    /* Whitening. */
+    bn.xor  w0, w0, w0
   endloop
   /* Compute r &= t. */
   jal  x1, secand
@@ -3509,11 +3495,11 @@ finalize_cmp:
   add  x5, x2, x0
   add  x6, x10, x0
   loopi 2, 4
-    /* Whitening. */
-    bn.xor  w0, w0, w0
     bn.lid  x0, 0(x6++)
     bn.rshi w0, w31, w0 >> 8
     bn.sid  x0, 0(x5++)
+    /* Whitening. */
+    bn.xor  w0, w0, w0
   endloop
   /* Compute r &= t. */
   jal  x1, secand
@@ -3523,11 +3509,11 @@ finalize_cmp:
   add  x5, x2, x0
   add  x6, x10, x0
   loopi 2, 4
-    /* Whitening. */
-    bn.xor  w0, w0, w0
     bn.lid  x0, 0(x6++)
     bn.rshi w0, w31, w0 >> 4
     bn.sid  x0, 0(x5++)
+    /* Whitening. */
+    bn.xor  w0, w0, w0
   endloop
   /* Compute r &= t. */
   jal  x1, secand
@@ -3537,11 +3523,11 @@ finalize_cmp:
   add  x5, x2, x0
   add  x6, x10, x0
   loopi 2, 4
-    /* Whitening. */
-    bn.xor  w0, w0, w0
     bn.lid  x0, 0(x6++)
     bn.rshi w0, w31, w0 >> 2
     bn.sid  x0, 0(x5++)
+    /* Whitening. */
+    bn.xor  w0, w0, w0
   endloop
   /* Compute r &= t. */
   jal  x1, secand
@@ -3551,11 +3537,11 @@ finalize_cmp:
   add  x5, x2, x0
   add  x6, x10, x0
   loopi 2, 4
-    /* Whitening. */
-    bn.xor  w0, w0, w0
     bn.lid  x0, 0(x6++)
     bn.rshi w0, w31, w0 >> 1
     bn.sid  x0, 0(x5++)
+    /* Whitening. */
+    bn.xor  w0, w0, w0
   endloop
   /* Compute r &= t. */
   jal  x1, secand

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -1493,14 +1493,13 @@ secb2amodq:
 .globl poly_hocompress
 .type poly_hocompress, @function
 poly_hocompress:
-  /* Allocate t_0..1, z scratch and save callee-saved registers. */
+  /* Allocate the t, z scratch, save x8, x9 and spill the output pointer. */
   addi x2, x2, -1024
   add  x7, x2, x0 /* t */
   addi x2, x2, -1184
-  sw   x9, 1152(x2)
-  sw   x18, 1156(x2)
-  sw   x19, 1160(x2)
-  add  x9, x12, x0
+  sw   x12, 1152(x2)
+  sw   x8, 1156(x2)
+  sw   x9, 1160(x2)
 
   /* Load all constants. */
   addi      x4, x0, 17
@@ -1515,19 +1514,18 @@ poly_hocompress:
   bn.shv.8s w19, w19 >> 31
   bn.shv.8s w19, w19 << 12
 
-  /* Select alpha-dependent parameters: w19 = 2^(alpha - 1), x18 = the
-   * extraction byte offset alpha * 32, x19 = dv. */
+  /* Select alpha-dependent parameters: w19 = 2^(alpha - 1), x8 = the
+   * extraction byte offset alpha * 32, x9 = dv. */
   addi      x4, x0, 4
-  addi      x18, x0, 416  /* alpha * 32, alpha = 13 */
-  addi      x19, x0, 5
+  addi      x8, x0, 416  /* alpha * 32, alpha = 13 */
+  addi      x9, x0, 5
   beq       x13, x4, _dv_params_done
   bn.shv.8s w19, w19 << 1
-  addi      x18, x0, 448  /* alpha * 32, alpha = 14 (k != 4) */
-  addi      x19, x0, 4
-_dv_params_done:
+  addi      x8, x0, 448  /* alpha * 32, alpha = 14 (k != 4) */
+  addi      x9, x0, 4
 
-  add  x6, x2, x0 /* z */
-  addi x28, x6, 512
+_dv_params_done:
+  add x6, x2, x0 /* z */
 
   /* Compute z_0 = Compressq(x_0, dv + alpha) + 2^(alpha - 1),
    *         z_1 = Compressq(x_1, dv + alpha).
@@ -1540,7 +1538,7 @@ _dv_params_done:
    *  - x >>= s
    *  - x &= ((1 << (dv + alpha)) - 1).
    */
-  loopi 2, 58
+  loopi 2, 56
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
@@ -1588,10 +1586,6 @@ _dv_params_done:
       addi               x4, x4, -1
     endloop
 
-    /* For the first share, w19 holds 2^(alpha - 1).
-     * After that, we clear w19 so that bn.add acts as a shift. */
-    bn.xor w19, w19, w19
-
     /* Bitslice the first 16 bits. */
     jal x1, _bitslice_transpose
 
@@ -1600,7 +1594,6 @@ _dv_params_done:
       bn.sid x4, 0(x6++)
       addi   x4, x4, 1
     endloop
-    addi x6, x6, 64 /* Skip the last 2 bits. */
 
     /* Bitslice the last 2 bits. */
     addi x4, x0, 15
@@ -1614,10 +1607,13 @@ _dv_params_done:
 
     add x4, x0, x0
     loopi 2, 2
-      bn.sid x4, 0(x28++)
+      bn.sid x4, 0(x6++)
       addi   x4, x4, 1
     endloop
-    addi x28, x28, 512 /* Skip the first 16 bits. */
+
+    /* For the first share, w19 holds 2^(alpha - 1).
+     * After that, we clear w19 so that bn.add acts as a shift. */
+    bn.xor w19, w19, w19
   endloop
 
   /* Compute c = seca2b(z), k = dv + alpha = 18, share bytes = 576. */
@@ -1628,23 +1624,21 @@ _dv_params_done:
   jal  x1, seca2b
 
   /* Compute r = c >> alpha: keep the bits c[alpha]...c[dv + alpha]. */
-  add x5, x2, x0
-  add x5, x5, x18
-  add x6, x9, x0
+  add x5, x2, x8
+  lw  x12, 1152(x2)
   loopi 2, 5
-    loop x19, 3
+    loop x9, 3
       /* Whitening. */
       bn.xor w0, w0, w0
       bn.lid x0, 0(x5++)
-      bn.sid x0, 0(x6++)
+      bn.sid x0, 0(x12++)
     endloop
-    add x5, x5, x18
+    add x5, x5, x8
   endloop
 
   /* Restore registers. */
-  lw   x9, 1152(x2)
-  lw   x18, 1156(x2)
-  lw   x19, 1160(x2)
+  lw   x8, 1156(x2)
+  lw   x9, 1160(x2)
   addi x2, x2, 1184
   addi x2, x2, 1024
   ret

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -389,26 +389,23 @@ bitcopymask:
 .globl refreshios
 .type refreshios, @function
 refreshios:
-  add  x5, x10, x12 /* x_1 */
-  add  x6, x14, x12 /* r_1 */
-  addi x4, x0, 1
-  loop x11, 11
+  add x5, x10, x12 /* x_1 */
+  add x6, x14, x12 /* r_1 */
+  loop x11, 9
     /* s <- urnd. */
-    bn.wsrr w2, urnd
+    bn.wsrr w1, urnd
     /* Whitening. */
     bn.xor  w0, w0, w0
-    bn.xor  w1, w1, w1
     /* r_0 = x_0 ^ s. */
     bn.lid  x0, 0(x10++)
-    bn.xor  w1, w0, w2
-    bn.sid  x4, 0(x14++)
+    bn.xor  w0, w0, w1
+    bn.sid  x0, 0(x14++)
     /* Whitening. */
     bn.xor  w0, w0, w0
-    bn.xor  w1, w1, w1
     /* r_1 = x_1 ^ s. */
     bn.lid  x0, 0(x5++)
-    bn.xor  w1, w0, w2
-    bn.sid  x4, 0(x6++)
+    bn.xor  w0, w0, w1
+    bn.sid  x0, 0(x6++)
   endloop
   ret
 

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -63,7 +63,7 @@
  * @param[in]  x16: share stride of r
  * @param[in]  w31: all-zero register
  *
- * clobbered registers: x4 to x5, w0 to w3, w5 to w8
+ * clobbered registers: x4 to x5, w0 to w7
  * clobbered flag groups: FG0
  */
 
@@ -560,7 +560,7 @@ refreshmodq:
  * @param[out] x11: dmem pointer to bitsliced representation r
  * @param[in]  w31: all-zero register
  *
- * clobbered registers: x4, x10, w0 to w15, w28 to w29
+ * clobbered registers: x4, x10, w0 to w15, w24 to w25
  * clobbered flag groups: FG0
  */
 
@@ -602,7 +602,7 @@ poly_to_bitsliced:
  * @param[out] x11: dmem pointer to r
  * @param[in]  w31: all-zero register
  *
- * clobbered registers: x4, x10 to x11, w0 to w15, w28 to w29
+ * clobbered registers: x4, x10 to x11, w0 to w15, w24 to w25
  * clobbered flag groups: FG0
  */
 
@@ -641,7 +641,7 @@ poly_from_bitsliced:
  * @param[in,out] w0 to w15: bit matrices to transpose
  * @param[in]     w31: all-zero register
  *
- * clobbered registers: w0 to w15, w28 to w29
+ * clobbered registers: w0 to w15, w24 to w25
  * clobbered flag groups: FG0
  */
 
@@ -1281,7 +1281,7 @@ seconebitb2amodq:
  * @param[in]  mod: q = 3329
  *
  * clobbered registers: x2, x4 to x6, x8 to x17, x29 to x31,
- *                      w0 to w15, w28 to w29, acch, acc
+ *                      w0 to w15, w24 to w25, acch, acc
  * clobbered flag groups: FG0
  */
 
@@ -1509,7 +1509,7 @@ secb2amodq:
  * @param[in]  w31: all-zero register
  *
  * clobbered registers: x2 to x17, x29 to x31,
- *                      w0 to w15, w17 to w21, w28 to w29
+ *                      w0 to w15, w17 to w18, w20 to w22, w24 to w25
  * clobbered flag groups: FG0
  */
 
@@ -1672,7 +1672,7 @@ _dv_params_done:
  * @param[in]  w31: all-zero register
  *
  * clobbered registers: x2 to x17, x29 to x31,
- *                      w0 to w15, w17 to w21, w28 to w30, acc
+ *                      w0 to w15, w17 to w22, w24 to w25, acc
  * clobbered flag groups: FG0
  */
 
@@ -1943,7 +1943,7 @@ masked_poly_frommsg:
  * @param[in]  mod: q = 3329
  *
  * clobbered registers: x2, x4 to x18, x29 to x31,
- *                      w0 to w15, w28 to w29, acch, acc
+ *                      w0 to w15, w24 to w25, acch, acc
  * clobbered flag groups: FG0
  */
 
@@ -2382,7 +2382,7 @@ _getnoise_common:
  * @param[in]     w17 to w22: the six digest words to bitslice
  * @param[in]     w31: all-zero register
  *
- * clobbered registers: w0 to w15, w17 to w22, w28 to w29
+ * clobbered registers: x4, x10 to x11, w0 to w15, w17 to w22, w24 to w25
  * clobbered flag groups: FG0
  */
 
@@ -2536,7 +2536,7 @@ _bitslice_eta_3:
  * @param[in]  w31: all-zero register
  *
  * clobbered registers: x2 to x8, x10 to x17, x29 to x31,
- *                      w0 to w15, w17 to w21, w28 to w29
+ *                      w0 to w15, w17 to w18, w20 to w22, w24 to w25
  * clobbered flag groups: FG0
  */
 
@@ -2654,7 +2654,7 @@ masked_poly_tomsg:
  * @param[in]     w31: all-zero register
  *
  * clobbered registers: x2 to x17, x29 to x31,
- *                      w0 to w15, w17 to w21, w28 to w29
+ *                      w0 to w15, w17 to w18, w20 to w22, w24 to w25
  * clobbered flag groups: FG0
  */
 
@@ -2962,7 +2962,7 @@ _skip_bit_4:
  * @param[in]     w31: all-zero register
  *
  * clobbered registers: x2 to x17, x29 to x31,
- *                      w0 to w15, w17 to w21, w28 to w30, acc
+ *                      w0 to w15, w17 to w22, w24 to w25, acc
  * clobbered flag groups: FG0
  */
 
@@ -3369,8 +3369,7 @@ _skip_bit_10:
  *                     of masked_poly_compare_{du, dv}
  * @param[in]     w31: all-zero register
  *
- * clobbered registers: x2, x4 to x6, x11 to x13, x15 to x16,
- *                      w0 to w3, w5 to w8
+ * clobbered registers: x2, x4 to x6, x11 to x13, x15 to x16, w0 to w7
  * clobbered flag groups: FG0
  */
 

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -1675,31 +1675,30 @@ _dv_params_done:
 .globl polyvec_hocompress
 .type polyvec_hocompress, @function
 polyvec_hocompress:
-  /* Allocate t_0..1, z scratch and save callee-saved registers. */
+  /* Allocate the t, z scratch, save x8, x9 and spill the output pointer. */
   addi x2, x2, -1024
   add  x7, x2, x0 /* t */
   addi x2, x2, -1568
-  sw   x9, 1536(x2)
-  sw   x18, 1540(x2)
-  sw   x19, 1544(x2)
-  add  x9, x12, x0
+  sw   x12, 1536(x2)
+  sw   x8, 1540(x2)
+  sw   x9, 1544(x2)
 
   /* Create 2^(alpha - 1). */
   bn.subi   w30, w31, 1
   bn.shv.8s w30, w30 >> 31
   bn.shv.8s w30, w30 << 12
 
-  /* Select alpha-dependent parameters: w30 = 2^(alpha - 1), x18 = the
-   * extraction byte offset alpha * 32, x19 = dv. */
+  /* Select alpha-dependent parameters: w30 = 2^(alpha - 1), x8 = the
+   * extraction byte offset alpha * 32, x9 = dv. */
   addi      x4, x0, 4
-  addi      x18, x0, 416  /* alpha * 32, alpha = 13 */
-  addi      x19, x0, 11
+  addi      x8, x0, 416  /* alpha * 32, alpha = 13 */
+  addi      x9, x0, 11
   beq       x13, x4, _du_params_done
   bn.shv.8s w30, w30 << 1
-  addi      x18, x0, 448  /* alpha * 32, alpha = 14 (k != 4) */
-  addi      x19, x0, 10
-_du_params_done:
+  addi      x8, x0, 448  /* alpha * 32, alpha = 14 (k != 4) */
+  addi      x9, x0, 10
 
+_du_params_done:
   /* Load all constants. */
   addi       x4, x0, 17
   la         x5, const_m_du
@@ -1707,9 +1706,7 @@ _du_params_done:
   la         x5, const_1664
   bn.lid     x4, 0(x5)
 
-  addi x5, x0, 21
-  add  x6, x2, x0   /* z */
-  addi x28, x6, 512 /* Skip the first 16 bits. */
+  add x6, x2, x0 /* z */
 
   /* Compute z_0 = Compressq(x_0, du + alpha) + 2^(alpha - 1),
    *         z_1 = Compressq(x_1, du + alpha).
@@ -1722,7 +1719,7 @@ _du_params_done:
    *  - x >>= s
    *  - x &= ((1 << (du + alpha)) - 1).
    */
-  loopi 2, 85
+  loopi 2, 83
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
@@ -1748,7 +1745,7 @@ _du_params_done:
 
     addi x4, x0, 15
     loopi 16, 44
-      bn.lid           x0, 0(x10++)
+      bn.lid          x0, 0(x10++)
       /* Handle even-positioned coeffs. */
       bn.trn1.16h      w19, w0, w31
       /* Handle coeff[0] - coeff[4] - coeff[8] - coeff[12]. */
@@ -1799,16 +1796,12 @@ _du_params_done:
       bn.addv.8s      w19, w19, w30
       bn.addv.8s      w20, w20, w30
       /* Combine the results before bitslicing. */
-      bn.trn1.16h     w21, w19, w20
-      bn.movr         x4, x5
+      bn.trn2.16h     w0, w19, w20
+      bn.sid          x0, 0(x7++)
+      bn.trn1.16h     w0, w19, w20
+      bn.movr         x4, x0
       addi            x4, x4, -1
-      bn.trn2.16h     w21, w19, w20
-      bn.sid          x5, 0(x7++)
     endloop
-
-    /* For the first share, w30 holds 2^(alpha - 1).
-     * After that, we clear w30 for the 2nd share. */
-    bn.xor w30, w30, w30
 
     /* Bitslice the first 16 bits. */
     jal x1, _bitslice_transpose
@@ -1818,7 +1811,6 @@ _du_params_done:
       bn.sid x4, 0(x6++)
       addi   x4, x4, 1
     endloop
-    addi x6, x6, 256 /* Skip the last 8 bits. */
 
     /* Bitslice the last 8 bits. */
     addi x4, x0, 15
@@ -1832,10 +1824,13 @@ _du_params_done:
 
     add x4, x0, x0
     loopi 8, 2
-      bn.sid x4, 0(x28++)
+      bn.sid x4, 0(x6++)
       addi   x4, x4, 1
     endloop
-    addi x28, x28, 512 /* Skip the first 16 bits. */
+
+    /* For the first share, w30 holds 2^(alpha - 1).
+     * After that, we clear w30 for the 2nd share. */
+    bn.xor w30, w30, w30
   endloop
 
   /* Compute c = seca2b(z), k = du + alpha = 24, share bytes = 768. */
@@ -1846,23 +1841,21 @@ _du_params_done:
   jal  x1, seca2b
 
   /* Compute r = c >> alpha: keep the bits c[alpha]...c[du + alpha]. */
-  add x5, x2, x0
-  add x5, x5, x18
-  add x6, x9, x0
+  add x5, x2, x8
+  lw  x12, 1536(x2)
   loopi 2, 5
-    loop x19, 3
+    loop x9, 3
       /* Whitening. */
       bn.xor w0, w0, w0
       bn.lid x0, 0(x5++)
-      bn.sid x0, 0(x6++)
+      bn.sid x0, 0(x12++)
     endloop
-    add x5, x5, x18
+    add x5, x5, x8
   endloop
 
   /* Restore registers. */
-  lw   x9, 1536(x2)
-  lw   x18, 1540(x2)
-  lw   x19, 1544(x2)
+  lw   x8, 1540(x2)
+  lw   x9, 1544(x2)
   addi x2, x2, 1568
   addi x2, x2, 1024
   ret

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -1276,74 +1276,68 @@ seconebitb2amodq:
 .type secb2amodq, @function
 secb2amodq:
   /* Frame (2656 B, 2 shares):
-   *   x2 +    0 : saved x8, x18, x19, x20, x21
+   *   x2 +    0 : saved x10, x12, x8, x9
    *   x2 +   32 : zp / scratch (1024 B)
    *   x2 + 1056 : s            ( 832 B)
    *   x2 + 1888 : a, b, c, zp  (bitsliced, 768 B) */
   addi x2, x2, -2048
   addi x2, x2, -608
-  sw x8, 0(x2)
-  sw x18, 4(x2)
-  sw x19, 8(x2)
-  sw x20, 12(x2)
-  sw x21, 16(x2)
+  sw   x10, 0(x2)
+  sw   x12, 4(x2)
+  sw   x8, 8(x2)
+  sw   x9, 12(x2)
 
   /* Save input/output addresses and buffer bases. */
-  add  x8, x10, x0
-  add  x18, x12, x0
-  addi x19, x2, 1888 /* a, b, c, zp (bitsliced) */
-  addi x20, x2, 1056 /* s */
+  addi x8, x2, 1888 /* a, b, c, zp (bitsliced) */
+  addi x9, x2, 1056 /* s */
   /* zp = x2 + 32 */
 
   /* Sample r_0 = rand, then compute zp = q - rand. */
-  addi    x4, x0, 30
+  bn.wsrr w16, mod
+  add     x10, x12, x0
+  jal x1, poly_rej_samp
+  addi    x4, x0, 1
   la      x5, modulus_bn
   bn.lid  x4, 0(x5)
-  add     x10, x12, x0
-  addi    x7, x2, 32
-  bn.wsrr w16, mod
-  jal x1, poly_rej_samp
+  addi    x5, x2, 32
   loopi 16, 3
     bn.lid      x0, 0(x12++)
-    bn.subv.16h w0, w30, w0
-    bn.sid      x0, 0(x7++)
+    bn.subv.16h w0, w1, w0
+    bn.sid      x0, 0(x5++)
   endloop
 
   /* Bitslice zp_0 and clear zp_1 (bitsliced). */
-  addi x10, x2, 32
-  add  x11, x19, x0
-  jal  x1, poly_to_bitsliced
-  addi x11, x11, 384
+  addi   x10, x2, 32
+  add    x11, x8, x0  /* zp (bitsliced) */
+  jal    x1, poly_to_bitsliced
+  addi   x11, x11, 384
   bn.xor w0, w0, w0
   loopi 12, 1
     bn.sid x0, 0(x11++)
   endloop
 
   /* Compute a = seca2bmodq(zp). */
-  add  x10, x19, x0
-  add  x12, x19, x0
-  jal  x1, seca2bmodq
+  add x10, x8, x0
+  add x12, x8, x0
+  jal x1, seca2bmodq
 
   /* Compute b = secaddmodq(a, x). */
   /********** Start inline b = secaddmodq(a, x). **********/
   /********** Start inline s = secadd(a, x, k + 1). **********/
   /* Initialize c = 0. */
   bn.xor w0, w0, w0
-  addi   x5, x20, 384
-  loopi 2, 2
-    bn.sid x0, 0(x5)
-    addi   x5, x5, 416
-  endloop
+  bn.sid x0, 384(x9)
+  bn.sid x0, 800(x9)
 
-  add  x10, x19, x0
+  add  x10, x8, x0
   addi x11, x0, 384
-  add  x12, x8, x0
+  lw   x12, 0(x2)
   addi x13, x0, 384
-  add  x15, x20, x0
+  add  x15, x9, x0
   addi x16, x0, 416
-  addi x17, x20, 384
+  addi x17, x9, 384
   addi x29, x0, 416
-  addi x30, x20, 384
+  addi x30, x9, 384
   addi x31, x0, 416
   loopi 12, 2
     jal  x1, secfulladder
@@ -1355,130 +1349,114 @@ secb2amodq:
 
   /********** Start inline s = secadd(s, p = 2^(k + 1) - q, k + 1). **********/
   /* Initialize c = 0. */
-  addi   x5, x2, 32
   bn.xor w0, w0, w0
-  loopi 2, 1
-    bn.sid x0, 0(x5++)
-  endloop
-  add x21, x5, x0 /* p */
+  bn.sid x0, 32(x2)
+  bn.sid x0, 64(x2)
 
-  add     x5, x21, x0
-  bn.subi w1, w0, 1
-  addi    x4, x0, 1
-  bn.sid  x4, 0(x5++)
-  bn.sid  x0, 0(x5++)
+  bn.sid  x0, 128(x2)
+  bn.subi w0, w31, 1
+  bn.sid  x0, 96(x2)
 
-  add  x10, x21, x0
+  addi x10, x2, 96
   addi x11, x0, 32
-  add  x12, x20, x0
+  add  x12, x9, x0
   addi x13, x0, 416
-  add  x15, x20, x0
+  add  x15, x9, x0
   addi x16, x0, 416
   addi x17, x2, 32
   addi x29, x0, 32
   addi x30, x2, 32
   addi x31, x0, 32
+
   /* Bits 0..7: p[i] = 1. */
   loopi 8, 2
     jal  x1, secfulladder
     addi x10, x10, -32
   endloop
-
   /* Bit 8: p[i] = 0. */
-  bn.xor w0, w0, w0
-  bn.sid x0, 0(x10)
-  add    x10, x21, x0
-  jal    x1, secfulladder
-  /* Bit 9: p[i] = 1. */
-  bn.xor  w0, w0, w0
-  bn.subi w0, w0, 1
-  add     x10, x21, x0
+  bn.xor  w0, w31, w31
   bn.sid  x0, 0(x10)
   jal     x1, secfulladder
+  addi    x10, x10, -32
+  /* Bit 9: p[i] = 1. */
+  bn.subi w0, w31, 1
+  bn.sid  x0, 0(x10)
+  jal     x1, secfulladder
+  addi    x10, x10, -32
   /* Bits 10..11: p[i] = 0. */
-  bn.xor w0, w0, w0
-  add    x10, x21, x0
-  bn.sid x0, 0(x10)
-  jal    x1, secfulladder
-  add    x10, x21, x0
-  jal    x1, secfulladder
-
+  bn.xor  w0, w31, w31
+  bn.sid  x0, 0(x10)
+  jal     x1, secfulladder
+  addi    x10, x10, -32
+  jal     x1, secfulladder
   /* Bit 12: p[i] = 1. */
-  addi x4, x0, 1
-  addi x6, x0, 2
+  addi   x4, x0, 1
   /* s[12] = p[12] ^ s[12] ^ c = ~(s[12] ^ c) since p[12] = 1. */
   /* Whitening. */
   bn.xor w0, w0, w0
   bn.xor w1, w1, w1
-  bn.xor w2, w2, w2
-  bn.xor w3, w3, w3
   /* s_0 */
   bn.lid x0, 0(x12)
   bn.lid x4, 0(x17)
-  bn.xor w3, w0, w1
-  bn.not w2, w3
-  bn.sid x6, 0(x12)
-  add    x12, x12, x13
   add    x17, x17, x29
+  bn.xor w0, w0, w1
+  bn.not w0, w0
+  bn.sid x0, 0(x12)
+  add    x12, x12, x13
 
   /* Whitening. */
   bn.xor w0, w0, w0
   bn.xor w1, w1, w1
-  bn.xor w2, w2, w2
   /* s_1 */
   bn.lid x0, 0(x12)
   bn.lid x4, 0(x17)
-  bn.xor w2, w0, w1
-  bn.sid x6, 0(x12)
+  bn.xor w0, w0, w1
+  bn.sid x0, 0(x12)
   /********** End inline s = secadd(s, p = 2^(k + 1) - q, k + 1). **********/
 
   /* Compute a = bitcopymask(s[k], (k + 1) * 32). */
-  addi x10, x20, 384
+  addi x10, x9, 384
   addi x11, x0, 416
-  add  x13, x19, x0
+  add  x13, x8, x0
   jal  x1, bitcopymask
 
   /* Compute r = secadd(a, s, k). */
-  add  x10, x19, x0
+  add  x10, x8, x0
   addi x11, x0, 384
-  add  x12, x20, x0
+  add  x12, x9, x0
   addi x13, x0, 416
-  add  x15, x19, x0
+  add  x15, x8, x0
   addi x16, x0, 384
   addi x17, x0, 12
   jal  x1, secadd
   /********** End inline b = secaddmodq(a, x). **********/
 
   /* Compute c = refreshios(b, k, k * 32). */
-  add  x10, x19, x0
+  add  x10, x8, x0
   addi x11, x0, 12
   addi x12, x0, 384
-  add  x14, x19, x0
+  add  x14, x8, x0
   jal  x1, refreshios
 
   /* Unmask c. */
-  add  x5, x19, x0
+  add  x5, x8, x0
   addi x4, x0, 1
-  loopi 12, 5
-    addi   x6, x5, 384
+  loopi 12, 4
     bn.lid x0, 0(x5)
-    bn.lid x4, 0(x6)
+    bn.lid x4, 384(x5)
     bn.xor w0, w0, w1
     bn.sid x0, 0(x5++)
   endloop
 
   /* Convert c from bitsliced to normal representation, into r_1. */
-  add  x10, x19, x0
-  add  x11, x18, x0
+  add  x10, x8, x0
+  lw   x11, 4(x2)
   addi x11, x11, 512
   jal x1, poly_from_bitsliced
 
-  /* Restore registers. */
-  lw x8, 0(x2)
-  lw x18, 4(x2)
-  lw x19, 8(x2)
-  lw x20, 12(x2)
-  lw x21, 16(x2)
+  /* Restore registers and frame. */
+  lw   x8, 8(x2)
+  lw   x9, 12(x2)
   addi x2, x2, 2047
   addi x2, x2, 609
   ret

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -430,11 +430,11 @@ refreshios:
 poly_rej_samp:
   /* Load 19 * q - 1. */
   addi   x4, x0, 1
-  la     x5, modulus_times_19_minus_1
+  la     x5, const_q19m1
   bn.lid x4++, 0(x5)
 
-  /* Load mont = 2^16 % q. */
-  la     x5, mont
+  /* Load 2^16 mod q. */
+  la     x5, const_2_16_modq
   bn.lid x4, 0(x5)
 
   /* x10 + 512 is the last valid address. */
@@ -1298,7 +1298,7 @@ secb2amodq:
   add     x10, x12, x0
   jal     x1, poly_rej_samp
   addi    x4, x0, 1
-  la      x5, modulus_bn
+  la      x5, const_q
   bn.lid  x4, 0(x5)
   addi    x5, x2, 32
   loopi 16, 3
@@ -1514,7 +1514,7 @@ poly_hocompress_dv:
   addi      x4, x0, 17
   la        x5, const_m_dv
   bn.lid    x4++, 0(x5)
-  la        x5, modulus_over_2
+  la        x5, const_qp1_half
   bn.lid    x4++, 0(x5)
   bn.shv.8s w18, w18 >> 16
 
@@ -1712,7 +1712,7 @@ _du_params_done:
   addi       x4, x0, 17
   la         x5, const_m_du
   bn.lid     x4++, 0(x5)
-  la         x5, modulus_bn
+  la         x5, const_q
   bn.lid     x4, 0(x5)
   bn.shv.8s  w18, w18 >> 17 /* 0x680 in 8 32-bit lanes. */
   bn.trn1.8s w18, w18, w31  /* 0x680 in 4 64-bit lanes. */
@@ -1924,7 +1924,7 @@ masked_poly_frommsg:
   jal  x1, seconebitb2amodq
 
   /* mp *= (q + 1) / 2 mod q, coefficient-wise (Montgomery). */
-  la      x5, modulus_over_2_m2_16  /* ((q + 1) / 2) * (2^16) mod q. */
+  la      x5, const_qp1_half_mul_2_16_modq /* ((q + 1) / 2) * (2^16) mod q. */
   addi    x4, x0, 1
   bn.lid  x4, 0(x5)
   loopi 2, 9
@@ -2612,7 +2612,7 @@ masked_poly_tomsg:
   addi      x4, x0, 17
   la        x5, const_m_dv
   bn.lid    x4++, 0(x5)
-  la        x5, modulus_over_2
+  la        x5, const_qp1_half
   bn.lid    x4++, 0(x5)
   bn.shv.8s w18, w18 >> 16
 

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -955,10 +955,9 @@ seca2bmodq:
    *   x2 +    0 : s' / a   (832 B)
    *   x2 +  832 : carry c  ( 64 B)
    *   x2 +  896 : s / u    (832 B)
-   *   x2 + 1728 : saved x18 */
+   *   x2 + 1728 : saved x12 */
   addi x2, x2, -1760
-  sw   x18, 1728(x2)
-  add  x18, x12, x0
+  sw   x12, 1728(x2)
 
   /* Compute s = p + x_0, k + 1 bits (one share).
    * p = 2^(k + 1) - q = 4863 = 0b1001011111111.
@@ -990,8 +989,8 @@ seca2bmodq:
     bn.not w3, w0
     bn.xor w1, w3, w2
     bn.sid x4, 0(x5++)
-    bn.xor w2, w0, w2
-    bn.and w2, w3, w2
+    bn.xor w2, w2, w0
+    bn.and w2, w2, w3
     bn.xor w2, w2, w0
   endloop
 
@@ -1013,8 +1012,8 @@ seca2bmodq:
   bn.not w3, w0
   bn.xor w1, w3, w2
   bn.sid x4, 0(x5++)
-  bn.xor w2, w0, w2
-  bn.and w2, w3, w2
+  bn.xor w2, w2, w0
+  bn.and w2, w2, w3
   bn.xor w2, w2, w0
 
   /* Bits 10..11: p[i] = 0. */
@@ -1057,11 +1056,8 @@ seca2bmodq:
 
   /********** Start inline u = secadd(s, s', k + 1). **********/
   /* Initialize c = 0. */
-  addi  x5, x2, 832
-  bn.xor w0, w0, w0
-  loopi 2, 1
-    bn.sid x0, 0(x5++)
-  endloop
+  bn.sid x0, 832(x2)
+  bn.sid x0, 864(x2)
 
   addi x10, x2, 896
   addi x11, x0, 416
@@ -1079,25 +1075,19 @@ seca2bmodq:
   endloop
 
   addi x4, x0, 1
-  addi x6, x0, 2
-  addi x7, x0, 3
-  loopi 2, 14
+  loopi 2, 11
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
-    bn.xor w2, w2, w2
-    bn.xor w3, w3, w3
     /* u[12] = s[12] ^ s'[12] ^ c. */
     bn.lid x0, 0(x10)
-    bn.lid x4, 0(x12)
-    bn.lid x6, 0(x17)
-    bn.xor w3, w0, w1
-    bn.xor w3, w3, w2
-    bn.sid x7, 0(x15)
-    /* Adjust addresses. */
     add    x10, x10, x11
+    bn.lid x4, 0(x12)
     add    x12, x12, x13
-    add    x17, x17, x29
+    bn.xor w0, w0, w1
+    bn.lid x4, 0(x30++)
+    bn.xor w0, w0, w1
+    bn.sid x0, 0(x15)
     add    x15, x15, x16
   endloop
   /********** End inline u = secadd(s, s', k + 1). **********/
@@ -1110,17 +1100,15 @@ seca2bmodq:
 
   /********** Start inline r = secadd(a, u, k). **********/
   /* Initialize c = 0. */
-  addi  x5, x2, 832
   bn.xor w0, w0, w0
-  loopi 2, 1
-    bn.sid x0, 0(x5++)
-  endloop
+  bn.sid x0, 832(x2)
+  bn.sid x0, 864(x2)
 
   add  x10, x2, x0
   addi x11, x0, 384
   addi x12, x2, 896
   addi x13, x0, 416
-  add  x15, x18, x0
+  lw   x15, 1728(x2)
   addi x16, x0, 384
   addi x17, x2, 832
   addi x29, x0, 32
@@ -1132,31 +1120,24 @@ seca2bmodq:
   endloop
 
   addi x4, x0, 1
-  addi x6, x0, 2
-  addi x7, x0, 3
-  loopi 2, 14
+  loopi 2, 11
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
-    bn.xor w2, w2, w2
-    bn.xor w3, w3, w3
     /* r[11] = a[11] ^ u[11] ^ c. */
     bn.lid x0, 0(x10)
-    bn.lid x4, 0(x12)
-    bn.lid x6, 0(x17)
-    bn.xor w3, w0, w1
-    bn.xor w3, w3, w2
-    bn.sid x7, 0(x15)
-    /* Adjust addresses. */
     add    x10, x10, x11
+    bn.lid x4, 0(x12)
     add    x12, x12, x13
-    add    x17, x17, x29
+    bn.xor w0, w0, w1
+    bn.lid x4, 0(x30++)
+    bn.xor w0, w0, w1
+    bn.sid x0, 0(x15)
     add    x15, x15, x16
   endloop
   /********** End inline r = secadd(a, u, k). **********/
 
-  /* Restore x18 and frame. */
-  lw   x18, 1728(x2)
+  /* Restore frame. */
   addi x2, x2, 1760
   ret
 

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -150,26 +150,21 @@ secand:
 .globl secfulladder
 .type secfulladder, @function
 secfulladder:
-  /* Save addresses. */
-  add x5, x10, x0
-  add x6, x12, x0
-  add x7, x15, x0
-  add x28, x17, x0
+  add x4, x0, x0
 
   /* Load x. */
   bn.xor w0, w0, w0   /* Whitening. */
-  bn.lid x0, 0(x5)    /* w0 = x_0 */
-  add    x5, x5, x11
-  addi   x4, x0, 1
+  bn.lid x4++, 0(x10) /* w0 = x_0 */
   bn.xor w1, w1, w1   /* Whitening. */
+  add    x5, x10, x11
   bn.lid x4++, 0(x5)  /* w1 = x_1 */
 
   /* Load y. */
   bn.xor w2, w2, w2   /* Whitening. */
-  bn.lid x4++, 0(x6)  /* w2 = y_0 */
-  add    x6, x6, x13
+  bn.lid x4++, 0(x12) /* w2 = y_0 */
   bn.xor w3, w3, w3   /* Whitening. */
-  bn.lid x4, 0(x6)    /* w3 = y_1 */
+  add    x5, x12, x13
+  bn.lid x4, 0(x5)    /* w3 = y_1 */
 
   /* Compute sharewise a = x ^ y. */
   bn.xor w4, w4, w4   /* Whitening. */
@@ -180,20 +175,20 @@ secfulladder:
   /* Load cin. */
   bn.xor w2, w2, w2   /* Whitening. */
   addi   x4, x0, 2
-  bn.lid x4++, 0(x28) /* w2 = cin_0 */
-  add    x28, x28, x29
+  bn.lid x4++, 0(x17) /* w2 = cin_0 */
   bn.xor w3, w3, w3   /* Whitening. */
-  bn.lid x4++, 0(x28) /* w3 = cin_1 */
+  add    x5, x17, x29
+  bn.lid x4++, 0(x5)  /* w3 = cin_1 */
 
   /* Compute r = cin ^ a. */
   bn.xor w6, w6, w6   /* Whitening. */
   bn.xor w6, w4, w2
   addi   x4, x0, 6
-  bn.sid x4, 0(x7)
-  add    x7, x7, x16
+  bn.sid x4, 0(x15)
   bn.xor w6, w6, w6   /* Whitening. */
   bn.xor w6, w5, w3
-  bn.sid x4, 0(x7)
+  add    x5, x15, x16
+  bn.sid x4, 0(x5)
 
   /* Compute cout = x ^ secand(a, x ^ cin). */
   /* Inline t = secand(a, x ^ cin) = secand(a, t).
@@ -223,10 +218,8 @@ secfulladder:
   bn.xor  w2, w2, w3   /* w2 ^= w3 */
   bn.xor  w3, w3, w3   /* Whitening. */
   bn.xor  w3, w2, w0   /* cout_0 = x_0 ^ w2 */
-  add     x7, x30, x0
   addi    x4, x0, 3
-  bn.sid  x4, 0(x7)
-  add     x7, x7, x31
+  bn.sid  x4, 0(x30)
 
   /* Pair (i, j) = (1, 0). */
   bn.xor  w2, w2, w2   /* Whitening. */
@@ -241,7 +234,8 @@ secfulladder:
   bn.xor  w2, w2, w3   /* w2 ^= w3 */
   bn.xor  w3, w3, w3   /* Whitening. */
   bn.xor  w3, w2, w1   /* cout_0 = x_1 ^ w2 */
-  bn.sid  x4, 0(x7)
+  add     x5, x30, x31
+  bn.sid  x4, 0(x5)
 
   /* Advance x10, x12, x15 to the next bit. */
   addi x10, x10, 32

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -515,26 +515,27 @@ refreshmodq:
   add x10, x2, x0
   jal x1, poly_rej_samp
 
-  add  x5, x2, 0    /* rand */
+  add  x5, x2, x0   /* rand */
   lw   x10, 512(x2)
   addi x6, x10, 512 /* x_1 */
   lw   x12, 516(x2)
   addi x7, x12, 512 /* r_1 */
   addi x4, x0, 1
-  addi x28, x0, 2
   loopi 16, 9
-    /* r_0 = x_0 + rand. */
-    bn.lid       x0, 0(x5++)
-    bn.lid       x4, 0(x10++)
-    bn.addvm.16h w2, w1, w0
-    bn.sid       x28, 0(x12++)
+    /* Load rand. */
+    bn.lid       x4, 0(x5++)
     /* Whitening. */
-    bn.xor       w1, w1, w1
-    bn.xor       w2, w2, w2
+    bn.xor       w0, w0, w0
+    /* r_0 = x_0 + rand. */
+    bn.lid       x0, 0(x10++)
+    bn.addvm.16h w0, w0, w1
+    bn.sid       x0, 0(x12++)
+    /* Whitening. */
+    bn.xor       w0, w0, w0
     /* r_1 = x_1 - rand. */
-    bn.lid       x4, 0(x6++)
-    bn.subvm.16h w2, w1, w0
-    bn.sid       x28, 0(x7++)
+    bn.lid       x0, 0(x6++)
+    bn.subvm.16h w0, w0, w1
+    bn.sid       x0, 0(x7++)
   endloop
 
   /* Restore stack. */

--- a/sw/acc/crypto/mlkem/gadgets.s
+++ b/sw/acc/crypto/mlkem/gadgets.s
@@ -2732,33 +2732,24 @@ masked_poly_tomsg:
 poly_masked_compare_dv:
   /* Allocate t scratch (2 shares * 160 B, dv = 5 worst case) + saves. */
   addi x2, x2, -352
-  sw   x8, 324(x2)
-  sw   x9, 328(x2)
-  sw   x18, 332(x2)
-  sw   x20, 340(x2)
-  sw   x15, 344(x2)
-
-  /* Save input/output addresses. */
-  add x8, x10, x0
-  add x9, x11, x0
-  add x18, x12, x0
-  add x20, x14, x0
+  sw   x11, 320(x2)
+  sw   x12, 324(x2)
+  sw   x14, 328(x2)
+  sw   x15, 332(x2)
+  sw   x8, 336(x2)
 
   /* Compute t = poly_hocompress(c'). */
-  add x10, x8, x0
+  /* x10 already points to c'. */
   add x12, x2, x0
   add x13, x15, x0
   jal x1, poly_hocompress
 
   /* Decode + bitslice c. */
-  add  x11, x9, x0
-
-  addi x4, x0, 4
-  lw   x15, 344(x2)
-  bne  x15, x4, _handle_kn4_dv
-
-_handle_k4_dv:
+  lw     x11, 320(x2)
   addi   x4, x0, 17
+  addi   x5, x0, 4
+  lw     x15, 332(x2)
+  bne    x15, x5, _handle_kn4_dv
   bn.lid x4, 0(x11++)
   /* group 0 -> w15 */
   loopi 16, 2
@@ -2874,11 +2865,10 @@ _handle_k4_dv:
   endloop
   jal x1, _bitslice_transpose
 
-  addi    x9, x0, 5
-  beq     x0, x0, _handle_common_dv
+  addi x8, x0, 5
+  beq  x0, x0, _handle_common_dv
 
 _handle_kn4_dv:
-  addi x4, x0, 17
   bn.lid x4, 0(x11++)
   /* group 0 -> w15 */
   loopi 16, 2
@@ -2965,13 +2955,13 @@ _handle_kn4_dv:
   endloop
   jal x1, _bitslice_transpose
 
-  addi    x9, x0, 4
+  addi x8, x0, 4
 
 _handle_common_dv:
   /* t_0 ^= ~c, so that t is 1 exactly where the bits match. The c
    * bit-planes are w0..w3 for dv = 4 and w0..w4 for dv = 5. */
   bn.subi w15, w31, 1
-  add     x5, x2, x0 /* ptr_t */
+  add     x5, x2, x0
 
   bn.lid  x4, 0(x5)
   bn.xor  w0, w0, w15
@@ -2994,7 +2984,7 @@ _handle_common_dv:
   bn.sid  x4, 0(x5++)
 
   addi    x6, x0, 4
-  beq     x9, x6, _skip_bit_4
+  beq     x8, x6, _skip_bit_4
 
   bn.lid  x4, 0(x5)
   bn.xor  w4, w4, w15
@@ -3003,25 +2993,22 @@ _handle_common_dv:
 
 _skip_bit_4:
   /* Compute r = secand(r, t). */
+  lw   x10, 328(x2)
   addi x11, x0, 32
   add  x12, x2, x0
-  add  x13, x18, x0
+  lw   x13, 324(x2)
+  add  x15, x10, x0
   addi x16, x0, 32
   /* After the secand, the input and output pointers will point to
    * next bit so we don't have to pass all the arguments above to secand again. */
-  loop x9, 4
-    add x10, x20, x0
-    add x15, x20, x0
-    jal x1, secand
-    nop
+  loop x8, 3
+    jal  x1, secand
+    addi x10, x10, -32
+    addi x15, x15, -32
   endloop
 
   /* Restore registers. */
-  lw   x8, 324(x2)
-  lw   x9, 328(x2)
-  lw   x18, 332(x2)
-  lw   x20, 340(x2)
-  lw   x15, 344(x2)
+  lw   x8, 336(x2)
   addi x2, x2, 352
   ret
 

--- a/sw/acc/crypto/mlkem/intt.s
+++ b/sw/acc/crypto/mlkem/intt.s
@@ -21,7 +21,7 @@
  * This routine is constant time.
  *
  * @param[in]  x10: dmem pointer to x
- * @param[in]  x11: dmem pointer to the twiddle factors twiddles_intt, whose
+ * @param[in]  x11: dmem pointer to the twiddle factors const_tw_intt, whose
  *                  last element folds in the final scaling by n^-1
  * @param[out] x12: dmem pointer to r
  * @param[in]  w16 (sw0): sw0.0 = q = 3329 (1st 16-bit lane),

--- a/sw/acc/crypto/mlkem/mlkem_consts.s
+++ b/sw/acc/crypto/mlkem/mlkem_consts.s
@@ -65,14 +65,14 @@ modulus_over_2_m2_16:
 /* 19 * q - 1. */
 .globl modulus_times_19_minus_1
 modulus_times_19_minus_1:
-  .word 0xf712f712
-  .word 0xf712f712
-  .word 0xf712f712
-  .word 0xf712f712
-  .word 0xf712f712
-  .word 0xf712f712
-  .word 0xf712f712
-  .word 0xf712f712
+  .word 0x0000f712
+  .word 0x0000f712
+  .word 0x0000f712
+  .word 0x0000f712
+  .word 0x0000f712
+  .word 0x0000f712
+  .word 0x0000f712
+  .word 0x0000f712
 
 /* 2^16 mod q. */
 .globl mont

--- a/sw/acc/crypto/mlkem/mlkem_consts.s
+++ b/sw/acc/crypto/mlkem/mlkem_consts.s
@@ -14,9 +14,9 @@
 
 .data
 .balign 32
-/* qinv = -q^-1 mod 2^16 = 3327. */
-.globl modulus_inv
-modulus_inv:
+/* mqinv = -q^-1 mod 2^16 = 3327. */
+.globl const_mqinv
+const_mqinv:
   .word 0x00000cff
   .word 0x00000000
   .word 0x00000000
@@ -27,8 +27,8 @@ modulus_inv:
   .word 0x00000000
 
 /* q = 3329 in every 16-bit slot. */
-.globl modulus_bn
-modulus_bn:
+.globl const_q
+const_q:
   .word 0x0d010d01
   .word 0x0d010d01
   .word 0x0d010d01
@@ -39,8 +39,8 @@ modulus_bn:
   .word 0x0d010d01
 
 /* (q + 1) / 2 = 1665. */
-.globl modulus_over_2
-modulus_over_2:
+.globl const_qp1_half
+const_qp1_half:
   .word 0x06810681
   .word 0x06810681
   .word 0x06810681
@@ -51,8 +51,8 @@ modulus_over_2:
   .word 0x06810681
 
 /* ((q + 1) / 2) * (2^16) % q. */
-.globl modulus_over_2_m2_16
-modulus_over_2_m2_16:
+.globl const_qp1_half_mul_2_16_modq
+const_qp1_half_mul_2_16_modq:
   .word 0x0af70af7
   .word 0x0af70af7
   .word 0x0af70af7
@@ -63,8 +63,8 @@ modulus_over_2_m2_16:
   .word 0x0af70af7
 
 /* 19 * q - 1. */
-.globl modulus_times_19_minus_1
-modulus_times_19_minus_1:
+.globl const_q19m1
+const_q19m1:
   .word 0x0000f712
   .word 0x0000f712
   .word 0x0000f712
@@ -75,8 +75,8 @@ modulus_times_19_minus_1:
   .word 0x0000f712
 
 /* 2^16 mod q. */
-.globl mont
-mont:
+.globl const_2_16_modq
+const_2_16_modq:
   .word 0x08ed08ed
   .word 0x08ed08ed
   .word 0x08ed08ed
@@ -87,8 +87,8 @@ mont:
   .word 0x08ed08ed
 
 /* 2^32 mod q. */
-.globl const_tomont
-const_tomont:
+.globl const_2_32_modq
+const_2_32_modq:
   .word 0x05490549
   .word 0x05490549
   .word 0x05490549
@@ -122,8 +122,8 @@ const_m_du:
   .word 0x680bb055
   .word 0x0013afb7
 
-.globl cbd2_const
-cbd2_const:
+.globl const_cbd2
+const_cbd2:
   /* const1 */
   .word 0x55555555
   .word 0x55555555
@@ -143,8 +143,8 @@ cbd2_const:
   .word 0x33333333
   .word 0x33333333
 
-.globl cbd3_const
-cbd3_const:
+.globl const_cbd3
+const_cbd3:
   /* const1 */
   .word 0x49249249
   .word 0x92492492
@@ -164,8 +164,8 @@ cbd3_const:
   .word 0xc71c71c7
   .word 0x71c71c71
 
-.globl twiddles_ntt
-twiddles_ntt:
+.globl const_tw_ntt
+const_tw_ntt:
   /* Layer 1--4 */
   .half 0x0a0b
   .half 0x0b9a
@@ -300,8 +300,8 @@ twiddles_ntt:
   .word 0x03df03df
   .word 0x065c065c
 
-.globl twiddles_intt
-twiddles_intt:
+.globl const_tw_intt
+const_tw_intt:
   /* Layer 7 */
   .word 0x06a506a5
   .word 0x09220922
@@ -436,8 +436,8 @@ twiddles_intt:
   .half 0x078c /* ((758 * 2^16) mod q) * (1 / 128) mod q. */
   .half 0x05a1 /* ((2^32 mod q) * (1 / 128)) mod q. */
 
-.globl twiddles_basemul
-twiddles_basemul:
+.globl const_tw_basemul
+const_tw_basemul:
   .word 0x081e08b2
   .word 0x04e3044f
   .word 0x036701ae

--- a/sw/acc/crypto/mlkem/mlkem_consts.s
+++ b/sw/acc/crypto/mlkem/mlkem_consts.s
@@ -122,17 +122,6 @@ const_m_du:
   .word 0x680bb055
   .word 0x0013afb7
 
-.globl const_1664
-const_1664:
-  .word 0x00000680
-  .word 0x00000000
-  .word 0x00000680
-  .word 0x00000000
-  .word 0x00000680
-  .word 0x00000000
-  .word 0x00000680
-  .word 0x00000000
-
 .globl cbd2_const
 cbd2_const:
   /* const1 */

--- a/sw/acc/crypto/mlkem/mlkem_decap.s
+++ b/sw/acc/crypto/mlkem/mlkem_decap.s
@@ -57,7 +57,8 @@
  * clobbered flag groups: FG0
  *
  * HARDENED
- * clobbered registers: x2 to x31, w0 to w30, acc, acch, mod
+ * clobbered registers: x2 to x19, x21 to x31,
+ *                      w0 to w15, w17 to w30, acc, mod, acch
  * clobbered flag groups: FG0
  */
 

--- a/sw/acc/crypto/mlkem/mlkem_decap.s
+++ b/sw/acc/crypto/mlkem/mlkem_decap.s
@@ -146,10 +146,6 @@ _continue:
   la   x6, mtmp
   addi x4, x0, 1
   loopi 2, 11
-    /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
-    bn.xor w2, w2, w2
     bn.lid x0, 0(x5++)
     loopi 16, 5
       bn.shv.16h w2, w0 >> 15
@@ -160,6 +156,10 @@ _continue:
       bn.shv.16h w0, w0 << 1
     endloop
     bn.sid x4, 0(x6++)
+    /* Whitening. */
+    bn.xor w0, w0, w0
+    bn.xor w1, w1, w1
+    bn.xor w2, w2, w2
   endloop
 
   /* Initialize SHA3-512 operation. */
@@ -172,12 +172,12 @@ _continue:
   csrrw   x0, kmac_cfg, x5
   /* Send m. */
   la      x5, mtmp
-  bn.xor  w0, w0, w0    /* Whitening. */
   bn.lid  x0, 0(x5++)
   bn.wsrw kmac_msg, w0  /* m[0] */
   bn.xor  w0, w0, w0    /* Whitening. */
   bn.lid  x0, 0(x5)
   bn.wsrw kmac_msg1, w0 /* m[1] */
+  bn.xor  w0, w0, w0    /* Whitening. */
   /* Send h. */
   la      x5, dptr_h
   lw      x5, 0(x5)
@@ -187,19 +187,19 @@ _continue:
   bn.wsrw kmac_msg1, w0 /* 0 */
   /* Retrieve K_true. */
   la      x5, kr
-  bn.xor  w0, w0, w0    /* Whitening. */
   bn.wsrr w0, kmac_digest
   bn.sid  x0, 0(x5++)
   bn.xor  w0, w0, w0    /* Whitening. */
   bn.wsrr w0, kmac_digest1
   bn.sid  x0, 0(x5++)
+  bn.xor  w0, w0, w0    /* Whitening. */
   /* Retrieve r'. */
-  bn.xor  w0, w0, w0    /* Whitening. */
   bn.wsrr w0, kmac_digest
   bn.sid  x0, 0(x5++)
   bn.xor  w0, w0, w0    /* Whitening. */
   bn.wsrr w0, kmac_digest1
   bn.sid  x0, 0(x5++)
+  bn.xor  w0, w0, w0    /* Whitening. */
 
 #else
   /* Initialize SHA3-512 operation. */
@@ -248,6 +248,7 @@ _continue:
   bn.xor  w0, w0, w0 /* Whitening. */
   bn.lid  x0, 64(x5)
   bn.wsrw kmac_msg1, w0
+  bn.xor  w0, w0, w0 /* Whitening. */
 #endif
 
   /* Send c. */
@@ -264,12 +265,12 @@ _continue:
   endloop
   /* Retrieve K_false. */
   la      x5, ss_false
-  bn.xor  w0, w0, w0 /* Whitening. */
   bn.wsrr w0, kmac_digest
   bn.sid  x0, 0(x5++)
   bn.xor  w0, w0, w0 /* Whitening. */
   bn.wsrr w0, kmac_digest1
   bn.sid  x0, 0(x5)
+  bn.xor  w0, w0, w0 /* Whitening. */
 #else
   loop x5, 2
     bn.lid  x0, 0(x10++)

--- a/sw/acc/crypto/mlkem/mlkem_decap.s
+++ b/sw/acc/crypto/mlkem/mlkem_decap.s
@@ -157,9 +157,9 @@ _continue:
     endloop
     bn.sid x4, 0(x6++)
     /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
-    bn.xor w2, w2, w2
+    bn.xor w0, w31, w31
+    bn.xor w1, w31, w31
+    bn.xor w2, w31, w31
   endloop
 
   /* Initialize SHA3-512 operation. */
@@ -174,32 +174,32 @@ _continue:
   la      x5, mtmp
   bn.lid  x0, 0(x5++)
   bn.wsrw kmac_msg, w0  /* m[0] */
-  bn.xor  w0, w0, w0    /* Whitening. */
+  bn.xor  w0, w31, w31  /* Whitening. */
   bn.lid  x0, 0(x5)
   bn.wsrw kmac_msg1, w0 /* m[1] */
-  bn.xor  w0, w0, w0    /* Whitening. */
+  bn.xor  w0, w31, w31  /* Whitening. */
   /* Send h. */
   la      x5, dptr_h
   lw      x5, 0(x5)
   bn.lid  x0, 0(x5)
   bn.wsrw kmac_msg, w0  /* h */
-  bn.xor  w0, w0, w0
+  bn.xor  w0, w31, w31
   bn.wsrw kmac_msg1, w0 /* 0 */
   /* Retrieve K_true. */
   la      x5, kr
   bn.wsrr w0, kmac_digest
   bn.sid  x0, 0(x5++)
-  bn.xor  w0, w0, w0    /* Whitening. */
+  bn.xor  w0, w31, w31  /* Whitening. */
   bn.wsrr w0, kmac_digest1
   bn.sid  x0, 0(x5++)
-  bn.xor  w0, w0, w0    /* Whitening. */
+  bn.xor  w0, w31, w31  /* Whitening. */
   /* Retrieve r'. */
   bn.wsrr w0, kmac_digest
   bn.sid  x0, 0(x5++)
-  bn.xor  w0, w0, w0    /* Whitening. */
+  bn.xor  w0, w31, w31  /* Whitening. */
   bn.wsrr w0, kmac_digest1
   bn.sid  x0, 0(x5++)
-  bn.xor  w0, w0, w0    /* Whitening. */
+  bn.xor  w0, w31, w31  /* Whitening. */
 
 #else
   /* Initialize SHA3-512 operation. */
@@ -245,10 +245,10 @@ _continue:
   bn.lid  x0, 32(x5)
   bn.wsrw kmac_msg, w0
 #ifdef HARDENED
-  bn.xor  w0, w0, w0 /* Whitening. */
+  bn.xor  w0, w31, w31 /* Whitening. */
   bn.lid  x0, 64(x5)
   bn.wsrw kmac_msg1, w0
-  bn.xor  w0, w0, w0 /* Whitening. */
+  bn.xor  w0, w31, w31 /* Whitening. */
 #endif
 
   /* Send c. */
@@ -267,10 +267,10 @@ _continue:
   la      x5, ss_false
   bn.wsrr w0, kmac_digest
   bn.sid  x0, 0(x5++)
-  bn.xor  w0, w0, w0 /* Whitening. */
+  bn.xor  w0, w31, w31 /* Whitening. */
   bn.wsrr w0, kmac_digest1
   bn.sid  x0, 0(x5)
-  bn.xor  w0, w0, w0 /* Whitening. */
+  bn.xor  w0, w31, w31 /* Whitening. */
 #else
   loop x5, 2
     bn.lid  x0, 0(x10++)

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_dec.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_dec.s
@@ -287,17 +287,12 @@ indcpa_dec:
 
   /* poly_sub only subtracted m from share 0 of v, so negate the remaining
    * shares 1..d - 1 to make the shared value equal v - m. */
-  addi   x5, x0, NSHARES
-  addi   x5, x5, -1
+  /* Whitening. */
   bn.xor w0, w0, w0
-  loop x5, 5
-    loopi 16, 3
-      bn.lid       x0, 0(x11)
-      bn.subvm.16h w0, w31, w0
-      bn.sid       x0, 0(x11++)
-    endloop
-    /* Whitening. */
-    bn.xor w0, w0, w0
+  loopi 16, 3
+    bn.lid       x0, 0(x11)
+    bn.subvm.16h w0, w31, w0
+    bn.sid       x0, 0(x11++)
   endloop
 
   /*** Step 6: r = masked_poly_tomsg(m). ***/

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_dec.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_dec.s
@@ -60,7 +60,7 @@
  *
  * HARDENED
  * clobbered registers: x2 to x19, x21 to x25, x29 to x31,
- *                      w0 to w15, w17 to w26, w28 to w29, acch, acc, mod
+ *                      w0 to w15, w17 to w26, acch, acc, mod
  * clobbered flag groups: FG0
  */
 

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_dec.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_dec.s
@@ -282,6 +282,9 @@ indcpa_dec:
   la  x11, mpoly_m
   add x12, x11, x0
   jal x1, poly_sub
+  /* Whitening. */
+  bn.xor w0, w0, w0
+  bn.xor w1, w1, w1
 
   /* poly_sub only subtracted m from share 0 of v, so negate the remaining
    * shares 1..d - 1 to make the shared value equal v - m. */

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_dec.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_dec.s
@@ -81,8 +81,8 @@ indcpa_dec:
   la x21, mpoly_sk
   la x22, poly_b
   la x23, mpoly_m
-  la x24, twiddles_ntt
-  la x25, twiddles_basemul
+  la x24, const_tw_ntt
+  la x25, const_tw_basemul
 
 #ifndef HARDENED
   /*** Step 1: unpack dk_pke[0] and compute the first product. ***/
@@ -147,7 +147,7 @@ indcpa_dec:
 
   /*** Step 3: m = intt(m). ***/
   add    x10, x23, x0
-  la     x11, twiddles_intt
+  la     x11, const_tw_intt
   add    x12, x10, x0
   jal    x1, intt
   bn.wsrw mod, w16
@@ -264,7 +264,7 @@ indcpa_dec:
 
   /*** Step 3: m = intt(m). ***/
   add x10, x23, x0
-  la  x11, twiddles_intt
+  la  x11, const_tw_intt
   add x12, x10, x0
   loopi NSHARES, 3
     jal x1, whitening

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_dec.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_dec.s
@@ -176,8 +176,8 @@ indcpa_dec:
   loopi NSHARES, 3
     jal     x1, poly_frombytes
     /* Whitening. */
-    bn.xor  w0, w0, w0
-    bn.xor  w1, w1, w1
+    bn.xor  w0, w31, w31
+    bn.xor  w1, w31, w31
   endloop
   add x9, x10, x0
 
@@ -221,8 +221,8 @@ indcpa_dec:
     loopi NSHARES, 3
       jal    x1, poly_frombytes
       /* Whitening. */
-      bn.xor w0, w0, w0
-      bn.xor w1, w1, w1
+      bn.xor w0, w31, w31
+      bn.xor w1, w31, w31
     endloop
     add x9, x10, x0
 
@@ -283,8 +283,8 @@ indcpa_dec:
   add x12, x11, x0
   jal x1, poly_sub
   /* Whitening. */
-  bn.xor w0, w0, w0
-  bn.xor w1, w1, w1
+  bn.xor w0, w31, w31
+  bn.xor w1, w31, w31
 
   /* poly_sub only subtracted m from share 0 of v, so negate the remaining
    * shares 1..d - 1 to make the shared value equal v - m. */
@@ -294,7 +294,7 @@ indcpa_dec:
     bn.sid       x0, 0(x11++)
   endloop
   /* Whitening. */
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
 
   /*** Step 6: r = masked_poly_tomsg(m). ***/
   la  x10, mpoly_m

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_dec.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_dec.s
@@ -173,12 +173,11 @@ indcpa_dec:
   /* Unpack dk_pke[0]. */
   add x10, x9, x0
   add x11, x21, x0
-  loopi NSHARES, 4
+  loopi NSHARES, 3
+    jal     x1, poly_frombytes
     /* Whitening. */
     bn.xor  w0, w0, w0
     bn.xor  w1, w1, w1
-    jal     x1, poly_frombytes
-    nop
   endloop
   add x9, x10, x0
 
@@ -207,24 +206,23 @@ indcpa_dec:
   add x12, x25, x0
   add x13, x23, x0
   loopi NSHARES, 4
-    jal x1, whitening
     add x10, x22, x0
     jal x1, basemul
+    jal x1, whitening
     nop
   endloop
 
   /*** Step 2: accumulate the remaining products, for j = 1..k - 1. ***/
   addi x19, x19, -1
-  loop x19, 32
+  loop x19, 31
     /* Unpack dk_pke[j]. */
     add x10, x9, x0
     add x11, x21, x0
-    loopi NSHARES, 4
+    loopi NSHARES, 3
+      jal    x1, poly_frombytes
       /* Whitening. */
       bn.xor w0, w0, w0
       bn.xor w1, w1, w1
-      jal    x1, poly_frombytes
-      nop
     endloop
     add x9, x10, x0
 
@@ -254,9 +252,9 @@ indcpa_dec:
     add x12, x25, x0
     add x13, x23, x0
     loopi NSHARES, 4
-      jal x1, whitening
       add x10, x22, x0
       jal x1, basemul_acc
+      jal x1, whitening
       nop
     endloop
     nop
@@ -267,8 +265,8 @@ indcpa_dec:
   la  x11, const_tw_intt
   add x12, x10, x0
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, intt
+    jal x1, whitening
     nop
   endloop
   bn.wsrw mod, w16
@@ -287,13 +285,13 @@ indcpa_dec:
 
   /* poly_sub only subtracted m from share 0 of v, so negate the remaining
    * shares 1..d - 1 to make the shared value equal v - m. */
-  /* Whitening. */
-  bn.xor w0, w0, w0
   loopi 16, 3
     bn.lid       x0, 0(x11)
     bn.subvm.16h w0, w31, w0
     bn.sid       x0, 0(x11++)
   endloop
+  /* Whitening. */
+  bn.xor w0, w0, w0
 
   /*** Step 6: r = masked_poly_tomsg(m). ***/
   la  x10, mpoly_m

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_dec.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_dec.s
@@ -59,7 +59,7 @@
  * clobbered flag groups: FG0
  *
  * HARDENED
- * clobbered registers: x2 to x19, x21 to x25, x28 to x31,
+ * clobbered registers: x2 to x19, x21 to x25, x29 to x31,
  *                      w0 to w15, w17 to w26, w28 to w29, acch, acc, mod
  * clobbered flag groups: FG0
  */

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_enc.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_enc.s
@@ -123,14 +123,14 @@ _continue_compute_v:
   bn.shv.16h w0, w16 << 1
   bn.wsrw    mod, w0
   la         x10, mpolyvec_sp
-  la         x11, twiddles_ntt
+  la         x11, const_tw_ntt
   add        x12, x10, x0
   jal        x1, ntt
 
   /* Compute v = ek_pke[0] * sp[0]. */
   la      x10, poly_pk
   la      x11, mpolyvec_sp
-  la      x12, twiddles_basemul
+  la      x12, const_tw_basemul
   la      x13, mpoly_v
   jal     x1, basemul
   add     x24, x11, x0
@@ -174,14 +174,14 @@ _handle_k4_compute_v:
   bn.shv.16h w0, w16 << 1
   bn.wsrw    mod, w0
   add        x10, x24, x0
-  la         x11, twiddles_ntt
+  la         x11, const_tw_ntt
   add        x12, x10, x0
   jal        x1, ntt
 
   /* Compute v += ek_pke[1] * sp[1]. */
   la      x10, poly_pk
   add     x11, x24, x0
-  la      x12, twiddles_basemul
+  la      x12, const_tw_basemul
   la      x13, mpoly_v
   jal     x1, basemul_acc
   add     x24, x11, x0
@@ -211,14 +211,14 @@ _handle_k3_compute_v:
   bn.shv.16h w0, w16 << 1
   bn.wsrw    mod, w0
   add        x10, x24, x0
-  la         x11, twiddles_ntt
+  la         x11, const_tw_ntt
   add        x12, x10, x0
   jal       x1, ntt
 
   /* Compute v += ek_pke[2] * sp[2]. */
   la      x10, poly_pk
   add     x11, x24, x0
-  la      x12, twiddles_basemul
+  la      x12, const_tw_basemul
   la      x13, mpoly_v
   jal     x1, basemul_acc
   add     x24, x11, x0
@@ -241,7 +241,7 @@ _handle_k2_compute_v:
   bn.shv.16h w0, w16 << 1
   bn.wsrw    mod, w0
   add        x10, x24, x0
-  la         x11, twiddles_ntt
+  la         x11, const_tw_ntt
   add        x12, x10, x0
   jal        x1, ntt
 
@@ -254,13 +254,13 @@ _handle_k2_compute_v:
   /* Compute v += ek_pke[3] * sp[3]. */
   la  x10, poly_pk
   add x11, x24, x0
-  la  x12, twiddles_basemul
+  la  x12, const_tw_basemul
   la  x13, mpoly_v
   jal x1, basemul_acc
 
   /* Compute v = intt(v). */
   la      x10, mpoly_v
-  la      x11, twiddles_intt
+  la      x11, const_tw_intt
   add     x12, x10, x0
   jal     x1, intt
   bn.wsrw mod, w16
@@ -357,7 +357,7 @@ _handle_k2_compute_v:
     bn.wsrw    mod, w0
     la         x10, poly_at
     la         x11, mpolyvec_sp
-    la         x12, twiddles_basemul
+    la         x12, const_tw_basemul
     la         x13, mpoly_b
     jal        x1, basemul
     add        x24, x11, x0
@@ -381,7 +381,7 @@ _handle_k2_compute_v:
       bn.wsrw    mod, w0
       la         x10, poly_at
       add        x11, x24, x0
-      la         x12, twiddles_basemul
+      la         x12, const_tw_basemul
       la         x13, mpoly_b
       jal        x1, basemul_acc
       add        x24, x11, x0
@@ -397,13 +397,13 @@ _handle_k2_compute_v:
     bn.wsrw    mod, w0
     la         x10, poly_at
     add        x11, x24, x0
-    la         x12, twiddles_basemul
+    la         x12, const_tw_basemul
     la         x13, mpoly_b
     jal        x1, basemul_acc
 
     /* Compute b = intt(b). */
     la      x10, mpoly_b
-    la      x11, twiddles_intt
+    la      x11, const_tw_intt
     add     x12, x10, x0
     jal     x1, intt
     bn.wsrw mod, w16
@@ -459,7 +459,7 @@ _handle_k2_compute_v:
   bn.wsrw    mod, w0
   la         x10, poly_at
   la         x11, mpolyvec_sp
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   jal        x1, basemul
   add        x24, x11, x0
@@ -483,7 +483,7 @@ _handle_k2_compute_v:
     bn.wsrw    mod, w0
     la         x10, poly_at
     add        x11, x24, x0
-    la         x12, twiddles_basemul
+    la         x12, const_tw_basemul
     la         x13, mpoly_b
     jal        x1, basemul_acc
     add        x24, x11, x0
@@ -499,13 +499,13 @@ _handle_k2_compute_v:
   bn.wsrw    mod, w0
   la         x10, poly_at
   add        x11, x24, x0
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   jal        x1, basemul_acc
 
   /* Compute b = intt(b). */
   la      x10, mpoly_b
-  la      x11, twiddles_intt
+  la      x11, const_tw_intt
   add     x12, x10, x0
   jal     x1, intt
   bn.wsrw mod, w16
@@ -542,7 +542,7 @@ _handle_k2_compute_b:
   bn.wsrw    mod, w0
   la         x10, poly_at
   la         x11, mpolyvec_sp
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   jal        x1, basemul
   add        x24, x11, x0
@@ -557,13 +557,13 @@ _handle_k2_compute_b:
   bn.wsrw    mod, w0
   la         x10, poly_at
   add        x11, x24, x0
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   jal        x1, basemul_acc
 
   /* Compute b = intt(b). */
   la      x10, mpoly_b
-  la      x11, twiddles_intt
+  la      x11, const_tw_intt
   add     x12, x10, x0
   jal     x1, intt
   bn.wsrw mod, w16
@@ -616,7 +616,7 @@ _handle_k2_compute_b:
   bn.wsrw    mod, w0
   la         x10, poly_at
   la         x11, mpolyvec_sp
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   jal        x1, basemul
   add        x24, x11, x0
@@ -631,13 +631,13 @@ _handle_k2_compute_b:
   bn.wsrw    mod, w0
   la         x10, poly_at
   add        x11, x24, x0
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   jal        x1, basemul_acc
 
   /* Compute b = intt(b). */
   la      x10, mpoly_b
-  la      x11, twiddles_intt
+  la      x11, const_tw_intt
   add     x12, x10, x0
   jal     x1, intt
   bn.wsrw mod, w16

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_enc_cmp.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_enc_cmp.s
@@ -1103,7 +1103,7 @@ _handle_k2_compute_v:
   add x12, x26, x0
   add x14, x2, x0
   add x15, x21, x0
-  jal x1, poly_masked_compare_dv
+  jal x1, masked_poly_compare_dv
   /**************************************************************************/
 
 
@@ -1262,7 +1262,7 @@ _handle_k2_compute_v:
     add  x12, x27, x0
     add  x14, x2, x0
     addi x15, x21, 2
-    jal  x1, poly_masked_compare_du
+    jal  x1, masked_poly_compare_du
     add  x19, x19, x27
   endloop
 
@@ -1371,7 +1371,7 @@ _handle_k2_compute_v:
   add  x12, x27, x0
   add  x14, x2, x0
   addi x15, x21, 2
-  jal  x1, poly_masked_compare_du
+  jal  x1, masked_poly_compare_du
   /**************************************************************************/
   beq  x0, x0, _finalize_compare
 
@@ -1471,7 +1471,7 @@ _handle_k2_compute_b:
   addi x12, x0, 320
   add  x14, x2, x0
   add  x15, x21, x0
-  jal  x1, poly_masked_compare_du
+  jal  x1, masked_poly_compare_du
 
   /* Generate at[1][0]. */
   la  x11, poly_at
@@ -1548,7 +1548,7 @@ _handle_k2_compute_b:
   addi x12, x0, 320
   add  x14, x2, x0
   add  x15, x21, x0
-  jal  x1, poly_masked_compare_du
+  jal  x1, masked_poly_compare_du
   /**************************************************************************/
 
   /*** Step 4: w0 = acc, reduced by finalize_cmp and unmasked. ***/

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_enc_cmp.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_enc_cmp.s
@@ -26,7 +26,7 @@
  * bytes for k = 2, 3 and cv = 160 and cu = 352 bytes for k = 4. The input
  * ciphertext is laid out as c = u || v, with u in c[0 : k * cu] and v in
  * c[k * cu : k * cu + cv].
- *  Step 1: kpoly = poly_frommsg(m)       // onebitdecompress(m) when d > 1
+ *  Step 1: kpoly = poly_frommsg(m)       // masked_poly_frommsg(m) when d > 1
  *  Step 2: recompute v and compare it against c[k * cu : k * cu + cv].
  *          for i = 0..k - 1:
  *            ek_pke[i] = poly_frombytes(ek_pke[384 * i : 384 * (i + 1)])
@@ -808,10 +808,10 @@ _continue:
   bn.xor  w0, w31, w31
   bn.sid  x0, 0(x5++)
 
-  /*** Step 1: kpoly = onebitdecompress(m). ***/
+  /*** Step 1: kpoly = masked_poly_frommsg(m). ***/
   /* x10 already points to m. */
   la   x12, mpoly_k
-  jal  x1, onebitdecompress
+  jal  x1, masked_poly_frommsg
 
   /*** Step 2: recompute v and compare it against c[k * cu : k * cu + cv]. ***/
   /* The following block will:

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_enc_cmp.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_enc_cmp.s
@@ -59,7 +59,8 @@
  * clobbered flag groups: FG0
  *
  * HARDENED
- * clobbered registers: x2 to x24, x26 to x31, w0 to w30, acc, mod, acch
+ * clobbered registers: x2 to x19, x21 to x24, x26 to x31,
+ *                      w0 to w15, w17 to w30, acc, mod, acch
  * clobbered flag groups: FG0
  */
 

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_enc_cmp.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_enc_cmp.s
@@ -799,20 +799,14 @@ _compute_k4_consts:
 
 _continue:
   /* Adjust stack for comparison result r. */
-  addi x6, x0, NSHARES
-  slli x5, x6, 5
-  sub  x2, x2, x5
+  addi x2, x2, -64
 
   /* The first share of r is (1 << N) - 1. The other shares are 0. */
   add     x5, x2, x0
-  bn.xor  w0, w0, w0
-  bn.subi w0, w0, 1
+  bn.subi w0, w31, 1
   bn.sid  x0, 0(x5++)
-  bn.xor  w0, w0, w0
-  addi    x6, x6, -1 /* nshares - 1 */
-  loop x6, 1
-    bn.sid x0, 0(x5++)
-  endloop
+  bn.xor  w0, w31, w31
+  bn.sid  x0, 0(x5++)
 
   /*** Step 1: kpoly = onebitdecompress(m). ***/
   /* x10 already points to m. */
@@ -1566,13 +1560,9 @@ _finalize_compare:
   /* Unmask comparison result. */
   add    x10, x2, x0
   bn.lid x0, 0(x10++)
-  addi   x5, x0, NSHARES
-  addi   x5, x5, -1 /* nshares - 1 */
   addi   x4, x0, 1
-  loop x5, 2
-    bn.lid x4, 0(x10++)
-    bn.xor w0, w0, w1
-  endloop
+  bn.lid x4, 0(x10++)
+  bn.xor w0, w0, w1
 
   add  x2, x3, x0
   lw   x3, 0(x2)

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_enc_cmp.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_enc_cmp.s
@@ -838,7 +838,7 @@ _continue_compute_v:
   /* Prepare for initial `poly_getnoise_eta_1` call: generate sp. */
   add    x10, x18, x0
   la     x11, nonce
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
   bn.sid x0, 0(x11)
   jal    x1, masked_poly_getnoise_eta_init
 
@@ -1055,8 +1055,8 @@ _handle_k2_compute_v:
   loopi NSHARES, 3
     jal    x1, poly_add
     /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
+    bn.xor w0, w31, w31
+    bn.xor w1, w31, w31
   endloop
 
   /* Generate epp. */
@@ -1077,8 +1077,8 @@ _handle_k2_compute_v:
   loopi NSHARES, 3
     jal    x1, poly_add
     /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
+    bn.xor w0, w31, w31
+    bn.xor w1, w31, w31
   endloop
 
   /* Generate ep[0]. */
@@ -1089,7 +1089,7 @@ _handle_k2_compute_v:
   /* Prepare for generating at[0][0]. */
   add    x10, x9, x0
   la     x11, seed_ij
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
   bn.sid x0, 0(x11)
   jal    x1, poly_gen_matrix_init
 
@@ -1237,8 +1237,8 @@ _handle_k2_compute_v:
     loopi NSHARES, 3
       jal    x1, poly_add
       /* Whitening. */
-      bn.xor w0, w0, w0
-      bn.xor w1, w1, w1
+      bn.xor w0, w31, w31
+      bn.xor w1, w31, w31
     endloop
 
     /* Generate ep[i + 1]. */
@@ -1358,8 +1358,8 @@ _handle_k2_compute_v:
   loopi NSHARES, 3
     jal    x1, poly_add
     /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
+    bn.xor w0, w31, w31
+    bn.xor w1, w31, w31
   endloop
 
   /* Compare b and c[i * cu : (i + 1) * cu]. Accumulate output to r. */
@@ -1445,8 +1445,8 @@ _handle_k2_compute_b:
   loopi NSHARES, 3
     jal    x1, poly_add
     /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
+    bn.xor w0, w31, w31
+    bn.xor w1, w31, w31
   endloop
 
   /* Generate ep[1]. */
@@ -1533,8 +1533,8 @@ _handle_k2_compute_b:
   loopi NSHARES, 3
     jal    x1, poly_add
     /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
+    bn.xor w0, w31, w31
+    bn.xor w1, w31, w31
   endloop
 
   /* Compare b and c[i * cu : (i + 1) * cu]. Accumulate output to r. */

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_enc_cmp.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_enc_cmp.s
@@ -148,14 +148,14 @@ _continue_compute_v:
   bn.shv.16h w0, w16 << 1
   bn.wsrw    mod, w0
   la         x10, mpolyvec_sp
-  la         x11, twiddles_ntt
+  la         x11, const_tw_ntt
   add        x12, x10, x0
   jal        x1, ntt
 
   /* Compute v = ek_pke[0] * sp[0]. */
   la      x10, poly_pk
   la      x11, mpolyvec_sp
-  la      x12, twiddles_basemul
+  la      x12, const_tw_basemul
   la      x13, mpoly_v
   jal     x1, basemul
   add     x24, x11, x0
@@ -201,14 +201,14 @@ _handle_k4_compute_v:
   bn.shv.16h w0, w16 << 1
   bn.wsrw    mod, w0
   add        x10, x24, x0
-  la         x11, twiddles_ntt
+  la         x11, const_tw_ntt
   add        x12, x10, x0
   jal        x1, ntt
 
   /* Compute v += ek_pke[1] * sp[1]. */
   la      x10, poly_pk
   add     x11, x24, x0
-  la      x12, twiddles_basemul
+  la      x12, const_tw_basemul
   la      x13, mpoly_v
   jal     x1, basemul_acc
   add     x24, x11, x0
@@ -238,14 +238,14 @@ _handle_k3_compute_v:
   bn.shv.16h w0, w16 << 1
   bn.wsrw    mod, w0
   add        x10, x24, x0
-  la         x11, twiddles_ntt
+  la         x11, const_tw_ntt
   add        x12, x10, x0
   jal        x1, ntt
 
   /* Compute v += ek_pke[2] * sp[2]. */
   la      x10, poly_pk
   add     x11, x24, x0
-  la      x12, twiddles_basemul
+  la      x12, const_tw_basemul
   la      x13, mpoly_v
   jal     x1, basemul_acc
   add     x24, x11, x0
@@ -268,7 +268,7 @@ _handle_k2_compute_v:
   bn.shv.16h w0, w16 << 1
   bn.wsrw    mod, w0
   add        x10, x24, x0
-  la         x11, twiddles_ntt
+  la         x11, const_tw_ntt
   add        x12, x10, x0
   jal        x1, ntt
 
@@ -281,13 +281,13 @@ _handle_k2_compute_v:
   /* Compute v += ek_pke[3] * sp[3]. */
   la  x10, poly_pk
   add x11, x24, x0
-  la  x12, twiddles_basemul
+  la  x12, const_tw_basemul
   la  x13, mpoly_v
   jal x1, basemul_acc
 
   /* Compute v = intt(v). */
   la      x10, mpoly_v
-  la      x11, twiddles_intt
+  la      x11, const_tw_intt
   add     x12, x10, x0
   jal     x1, intt
   bn.wsrw mod, w16
@@ -404,7 +404,7 @@ _handle_k2_compute_v:
     bn.wsrw    mod, w0
     la         x10, poly_at
     la         x11, mpolyvec_sp
-    la         x12, twiddles_basemul
+    la         x12, const_tw_basemul
     la         x13, mpoly_b
     jal        x1, basemul
     add        x24, x11, x0
@@ -428,7 +428,7 @@ _handle_k2_compute_v:
       bn.wsrw    mod, w0
       la         x10, poly_at
       add        x11, x24, x0
-      la         x12, twiddles_basemul
+      la         x12, const_tw_basemul
       la         x13, mpoly_b
       jal        x1, basemul_acc
       add        x24, x11, x0
@@ -444,13 +444,13 @@ _handle_k2_compute_v:
     bn.wsrw    mod, w0
     la         x10, poly_at
     add        x11, x24, x0
-    la         x12, twiddles_basemul
+    la         x12, const_tw_basemul
     la         x13, mpoly_b
     jal        x1, basemul_acc
 
     /* Compute b = intt(b). */
     la      x10, mpoly_b
-    la      x11, twiddles_intt
+    la      x11, const_tw_intt
     add     x12, x10, x0
     jal     x1, intt
     bn.wsrw mod, w16
@@ -525,7 +525,7 @@ _handle_k2_compute_v:
   bn.wsrw    mod, w0
   la         x10, poly_at
   la         x11, mpolyvec_sp
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   jal        x1, basemul
   add        x24, x11, x0
@@ -549,7 +549,7 @@ _handle_k2_compute_v:
     bn.wsrw    mod, w0
     la         x10, poly_at
     add        x11, x24, x0
-    la         x12, twiddles_basemul
+    la         x12, const_tw_basemul
     la         x13, mpoly_b
     jal        x1, basemul_acc
     add        x24, x11, x0
@@ -565,13 +565,13 @@ _handle_k2_compute_v:
   bn.wsrw    mod, w0
   la         x10, poly_at
   add        x11, x24, x0
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   jal        x1, basemul_acc
 
   /* Compute b = intt(b). */
   la      x10, mpoly_b
-  la      x11, twiddles_intt
+  la      x11, const_tw_intt
   add     x12, x10, x0
   jal     x1, intt
   bn.wsrw mod, w16
@@ -631,7 +631,7 @@ _handle_k2_compute_b:
   bn.wsrw    mod, w0
   la         x10, poly_at
   la         x11, mpolyvec_sp
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   jal        x1, basemul
   add        x24, x11, x0
@@ -646,13 +646,13 @@ _handle_k2_compute_b:
   bn.wsrw    mod, w0
   la         x10, poly_at
   add        x11, x24, x0
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   jal        x1, basemul_acc
 
   /* Compute b = intt(b). */
   la      x10, mpoly_b
-  la      x11, twiddles_intt
+  la      x11, const_tw_intt
   add     x12, x10, x0
   jal     x1, intt
   bn.wsrw mod, w16
@@ -724,7 +724,7 @@ _handle_k2_compute_b:
   bn.wsrw    mod, w0
   la         x10, poly_at
   la         x11, mpolyvec_sp
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   jal        x1, basemul
   add        x24, x11, x0
@@ -739,13 +739,13 @@ _handle_k2_compute_b:
   bn.wsrw    mod, w0
   la         x10, poly_at
   add        x11, x24, x0
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   jal        x1, basemul_acc
 
   /* Compute b = intt(b). */
   la      x10, mpoly_b
-  la      x11, twiddles_intt
+  la      x11, const_tw_intt
   add     x12, x10, x0
   jal     x1, intt
   bn.wsrw mod, w16
@@ -864,7 +864,7 @@ _continue_compute_v:
   bn.shv.16h w0, w16 << 1
   bn.wsrw    mod, w0
   la         x10, mpolyvec_sp
-  la         x11, twiddles_ntt
+  la         x11, const_tw_ntt
   add        x12, x10, x0
   loopi NSHARES, 3
     jal x1, whitening
@@ -876,7 +876,7 @@ _continue_compute_v:
   la  x8, poly_pk
   add x10, x8, x0
   la  x11, mpolyvec_sp
-  la  x12, twiddles_basemul
+  la  x12, const_tw_basemul
   la  x13, mpoly_v
   loopi NSHARES, 3
     jal x1, whitening
@@ -925,7 +925,7 @@ _handle_k4_compute_v:
   bn.shv.16h w0, w16 << 1
   bn.wsrw    mod, w0
   add        x10, x24, x0
-  la         x11, twiddles_ntt
+  la         x11, const_tw_ntt
   add        x12, x10, x0
   loopi NSHARES, 3
     jal x1, whitening
@@ -937,7 +937,7 @@ _handle_k4_compute_v:
   la  x8, poly_pk
   add x10, x8, x0
   add x11, x24, x0
-  la  x12, twiddles_basemul
+  la  x12, const_tw_basemul
   la  x13, mpoly_v
   loopi NSHARES, 3
     jal x1, whitening
@@ -971,7 +971,7 @@ _handle_k3_compute_v:
   bn.shv.16h w0, w16 << 1
   bn.wsrw    mod, w0
   add        x10, x24, x0
-  la         x11, twiddles_ntt
+  la         x11, const_tw_ntt
   add        x12, x10, x0
   loopi NSHARES, 3
     jal x1, whitening
@@ -983,7 +983,7 @@ _handle_k3_compute_v:
   la  x8, poly_pk
   add x10, x8, x0
   add x11, x24, x0
-  la  x12, twiddles_basemul
+  la  x12, const_tw_basemul
   la  x13, mpoly_v
   loopi NSHARES, 3
     jal x1, whitening
@@ -1010,7 +1010,7 @@ _handle_k2_compute_v:
   bn.shv.16h w0, w16 << 1
   bn.wsrw    mod, w0
   add        x10, x24, x0
-  la         x11, twiddles_ntt
+  la         x11, const_tw_ntt
   add        x12, x10, x0
   loopi NSHARES, 3
     jal x1, whitening
@@ -1028,7 +1028,7 @@ _handle_k2_compute_v:
   la  x8, poly_pk
   add x10, x8, x0
   add x11, x24, x0
-  la  x12, twiddles_basemul
+  la  x12, const_tw_basemul
   la  x13, mpoly_v
   loopi NSHARES, 3
     jal x1, whitening
@@ -1038,7 +1038,7 @@ _handle_k2_compute_v:
 
   /* Compute v = intt(v). */
   la  x10, mpoly_v
-  la  x11, twiddles_intt
+  la  x11, const_tw_intt
   add x12, x10, x0
   loopi NSHARES, 3
     jal x1, whitening
@@ -1154,7 +1154,7 @@ _handle_k2_compute_v:
     la         x22, poly_at
     add        x10, x22, x0
     la         x11, mpolyvec_sp
-    la         x12, twiddles_basemul
+    la         x12, const_tw_basemul
     la         x13, mpoly_b
     loopi NSHARES, 3
       jal x1, whitening
@@ -1183,7 +1183,7 @@ _handle_k2_compute_v:
       la         x22, poly_at
       add        x10, x22, x0
       add        x11, x24, x0
-      la         x12, twiddles_basemul
+      la         x12, const_tw_basemul
       la         x13, mpoly_b
       loopi NSHARES, 3
         jal x1, whitening
@@ -1204,7 +1204,7 @@ _handle_k2_compute_v:
     la         x22, poly_at
     add        x10, x22, x0
     add        x11, x24, x0
-    la         x12, twiddles_basemul
+    la         x12, const_tw_basemul
     la         x13, mpoly_b
     loopi NSHARES, 3
       jal x1, whitening
@@ -1214,7 +1214,7 @@ _handle_k2_compute_v:
 
     /* Compute b = intt(b). */
     la  x10, mpoly_b
-    la  x11, twiddles_intt
+    la  x11, const_tw_intt
     add x12, x10, x0
     loopi NSHARES, 3
       jal x1, whitening
@@ -1284,7 +1284,7 @@ _handle_k2_compute_v:
   la         x22, poly_at
   add        x10, x22, x0
   la         x11, mpolyvec_sp
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   loopi NSHARES, 3
     jal x1, whitening
@@ -1313,7 +1313,7 @@ _handle_k2_compute_v:
     la         x22, poly_at
     add        x10, x22, x0
     add        x11, x24, x0
-    la         x12, twiddles_basemul
+    la         x12, const_tw_basemul
     la         x13, mpoly_b
     loopi NSHARES, 3
       jal x1, whitening
@@ -1334,7 +1334,7 @@ _handle_k2_compute_v:
   la         x22, poly_at
   add        x10, x22, x0
   add        x11, x24, x0
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   loopi NSHARES, 3
     jal x1, whitening
@@ -1344,7 +1344,7 @@ _handle_k2_compute_v:
 
   /* Compute b = intt(b). */
   la  x10, mpoly_b
-  la  x11, twiddles_intt
+  la  x11, const_tw_intt
   add x12, x10, x0
   loopi NSHARES, 3
     jal x1, whitening
@@ -1394,7 +1394,7 @@ _handle_k2_compute_b:
   la         x22, poly_at
   add        x10, x22, x0
   la         x11, mpolyvec_sp
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   loopi NSHARES, 3
     jal x1, whitening
@@ -1414,7 +1414,7 @@ _handle_k2_compute_b:
   la         x22, poly_at
   add        x10, x22, x0
   add        x11, x24, x0
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   loopi NSHARES, 3
     jal x1, whitening
@@ -1424,7 +1424,7 @@ _handle_k2_compute_b:
 
   /* Compute b = intt(b). */
   la  x10, mpoly_b
-  la  x11, twiddles_intt
+  la  x11, const_tw_intt
   add x12, x10, x0
   loopi NSHARES, 3
     jal x1, whitening
@@ -1491,7 +1491,7 @@ _handle_k2_compute_b:
   la         x22, poly_at
   add        x10, x22, x0
   la         x11, mpolyvec_sp
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   loopi NSHARES, 3
     jal x1, whitening
@@ -1511,7 +1511,7 @@ _handle_k2_compute_b:
   la         x22, poly_at
   add        x10, x22, x0
   add        x11, x24, x0
-  la         x12, twiddles_basemul
+  la         x12, const_tw_basemul
   la         x13, mpoly_b
   loopi NSHARES, 3
     jal x1, whitening
@@ -1521,7 +1521,7 @@ _handle_k2_compute_b:
 
   /* Compute b = intt(b). */
   la  x10, mpoly_b
-  la  x11, twiddles_intt
+  la  x11, const_tw_intt
   add x12, x10, x0
   loopi NSHARES, 3
     jal x1, whitening

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_enc_cmp.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_enc_cmp.s
@@ -868,8 +868,8 @@ _continue_compute_v:
   la         x11, const_tw_ntt
   add        x12, x10, x0
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, ntt
+    jal x1, whitening
     nop
   endloop
 
@@ -880,8 +880,8 @@ _continue_compute_v:
   la  x12, const_tw_basemul
   la  x13, mpoly_v
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, basemul
+    jal x1, whitening
     add x10, x8, x0
   endloop
   add     x24, x11, x0
@@ -929,8 +929,8 @@ _handle_k4_compute_v:
   la         x11, const_tw_ntt
   add        x12, x10, x0
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, ntt
+    jal x1, whitening
     nop
   endloop
 
@@ -941,8 +941,8 @@ _handle_k4_compute_v:
   la  x12, const_tw_basemul
   la  x13, mpoly_v
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, basemul_acc
+    jal x1, whitening
     add x10, x8, x0
   endloop
   add     x24, x11, x0
@@ -975,8 +975,8 @@ _handle_k3_compute_v:
   la         x11, const_tw_ntt
   add        x12, x10, x0
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, ntt
+    jal x1, whitening
     nop
   endloop
 
@@ -987,8 +987,8 @@ _handle_k3_compute_v:
   la  x12, const_tw_basemul
   la  x13, mpoly_v
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, basemul_acc
+    jal x1, whitening
     add x10, x8, x0
   endloop
   add     x24, x11, x0
@@ -1014,8 +1014,8 @@ _handle_k2_compute_v:
   la         x11, const_tw_ntt
   add        x12, x10, x0
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, ntt
+    jal x1, whitening
     nop
   endloop
 
@@ -1032,8 +1032,8 @@ _handle_k2_compute_v:
   la  x12, const_tw_basemul
   la  x13, mpoly_v
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, basemul_acc
+    jal x1, whitening
     add x10, x8, x0
   endloop
 
@@ -1042,8 +1042,8 @@ _handle_k2_compute_v:
   la  x11, const_tw_intt
   add x12, x10, x0
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, intt
+    jal x1, whitening
     nop
   endloop
   bn.wsrw mod, w16
@@ -1052,12 +1052,11 @@ _handle_k2_compute_v:
   la  x10, mpoly_v
   la  x11, mpoly_k
   add x12, x10, x0
-  loopi NSHARES, 4
+  loopi NSHARES, 3
+    jal    x1, poly_add
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
-    jal    x1, poly_add
-    nop
   endloop
 
   /* Generate epp. */
@@ -1075,12 +1074,11 @@ _handle_k2_compute_v:
   la  x10, mpoly_v
   la  x11, mpoly_epp
   add x12, x10, x0
-  loopi NSHARES, 4
+  loopi NSHARES, 3
+    jal    x1, poly_add
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
-    jal    x1, poly_add
-    nop
   endloop
 
   /* Generate ep[0]. */
@@ -1136,7 +1134,7 @@ _handle_k2_compute_v:
   slli x23, x8, 8   /* (k - 1) * 0x0100 */
   addi x23, x23, -1
 
-  loop x8, 117
+  loop x8, 116
     /* Generate at[i][0]. */
     la   x11, poly_at
     jal  x1, poly_gen_matrix
@@ -1158,8 +1156,8 @@ _handle_k2_compute_v:
     la         x12, const_tw_basemul
     la         x13, mpoly_b
     loopi NSHARES, 3
-      jal x1, whitening
       jal x1, basemul
+      jal x1, whitening
       add x10, x22, x0
     endloop
     add     x24, x11, x0
@@ -1187,8 +1185,8 @@ _handle_k2_compute_v:
       la         x12, const_tw_basemul
       la         x13, mpoly_b
       loopi NSHARES, 3
-        jal x1, whitening
         jal x1, basemul_acc
+        jal x1, whitening
         add x10, x22, x0
       endloop
       add     x24, x11, x0
@@ -1208,8 +1206,8 @@ _handle_k2_compute_v:
     la         x12, const_tw_basemul
     la         x13, mpoly_b
     loopi NSHARES, 3
-      jal x1, whitening
       jal x1, basemul_acc
+      jal x1, whitening
       add x10, x22, x0
     endloop
 
@@ -1218,8 +1216,8 @@ _handle_k2_compute_v:
     la  x11, const_tw_intt
     add x12, x10, x0
     loopi NSHARES, 3
-      jal x1, whitening
       jal x1, intt
+      jal x1, whitening
       nop
     endloop
     bn.wsrw mod, w16
@@ -1236,12 +1234,11 @@ _handle_k2_compute_v:
     la  x10, mpoly_b
     la  x11, mpoly_ep
     add x12, x10, x0
-    loopi NSHARES, 4
+    loopi NSHARES, 3
+      jal    x1, poly_add
       /* Whitening. */
       bn.xor w0, w0, w0
       bn.xor w1, w1, w1
-      jal    x1, poly_add
-      nop
     endloop
 
     /* Generate ep[i + 1]. */
@@ -1288,8 +1285,8 @@ _handle_k2_compute_v:
   la         x12, const_tw_basemul
   la         x13, mpoly_b
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, basemul
+    jal x1, whitening
     add x10, x22, x0
   endloop
   add     x24, x11, x0
@@ -1317,8 +1314,8 @@ _handle_k2_compute_v:
     la         x12, const_tw_basemul
     la         x13, mpoly_b
     loopi NSHARES, 3
-      jal x1, whitening
       jal x1, basemul_acc
+      jal x1, whitening
       add x10, x22, x0
     endloop
     add     x24, x11, x0
@@ -1338,8 +1335,8 @@ _handle_k2_compute_v:
   la         x12, const_tw_basemul
   la         x13, mpoly_b
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, basemul_acc
+    jal x1, whitening
     add x10, x22, x0
   endloop
 
@@ -1348,8 +1345,8 @@ _handle_k2_compute_v:
   la  x11, const_tw_intt
   add x12, x10, x0
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, intt
+    jal x1, whitening
     nop
   endloop
   bn.wsrw mod, w16
@@ -1358,12 +1355,11 @@ _handle_k2_compute_v:
   la  x10, mpoly_b
   la  x11, mpoly_ep
   add x12, x10, x0
-  loopi NSHARES, 4
+  loopi NSHARES, 3
+    jal    x1, poly_add
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
-    jal    x1, poly_add
-    nop
   endloop
 
   /* Compare b and c[i * cu : (i + 1) * cu]. Accumulate output to r. */
@@ -1398,8 +1394,8 @@ _handle_k2_compute_b:
   la         x12, const_tw_basemul
   la         x13, mpoly_b
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, basemul
+    jal x1, whitening
     add x10, x22, x0
   endloop
   add     x24, x11, x0
@@ -1418,8 +1414,8 @@ _handle_k2_compute_b:
   la         x12, const_tw_basemul
   la         x13, mpoly_b
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, basemul_acc
+    jal x1, whitening
     add x10, x22, x0
   endloop
 
@@ -1428,8 +1424,8 @@ _handle_k2_compute_b:
   la  x11, const_tw_intt
   add x12, x10, x0
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, intt
+    jal x1, whitening
     nop
   endloop
   bn.wsrw mod, w16
@@ -1446,12 +1442,11 @@ _handle_k2_compute_b:
   la   x10, mpoly_b
   la   x11, mpoly_ep
   addi x12, x10, 0
-  loopi NSHARES, 4
+  loopi NSHARES, 3
+    jal    x1, poly_add
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
-    jal    x1, poly_add
-    nop
   endloop
 
   /* Generate ep[1]. */
@@ -1495,8 +1490,8 @@ _handle_k2_compute_b:
   la         x12, const_tw_basemul
   la         x13, mpoly_b
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, basemul
+    jal x1, whitening
     add x10, x22, x0
   endloop
   add     x24, x11, x0
@@ -1515,8 +1510,8 @@ _handle_k2_compute_b:
   la         x12, const_tw_basemul
   la         x13, mpoly_b
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, basemul_acc
+    jal x1, whitening
     add x10, x22, x0
   endloop
 
@@ -1525,8 +1520,8 @@ _handle_k2_compute_b:
   la  x11, const_tw_intt
   add x12, x10, x0
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, intt
+    jal x1, whitening
     nop
   endloop
   bn.wsrw mod, w16
@@ -1535,12 +1530,11 @@ _handle_k2_compute_b:
   la  x10, mpoly_b
   la  x11, mpoly_ep
   add x12, x10, x0
-  loopi NSHARES, 4
+  loopi NSHARES, 3
+    jal    x1, poly_add
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
-    jal    x1, poly_add
-    nop
   endloop
 
   /* Compare b and c[i * cu : (i + 1) * cu]. Accumulate output to r. */

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_keypair.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_keypair.s
@@ -57,7 +57,8 @@
  * clobbered flag groups: FG0
  *
  * HARDENED
- * clobbered registers: x2, x4 to x31, w0 to w30, mod, acch, acc
+ * clobbered registers: x2, x4 to x31,
+ *                      w0 to w15, w17 to w30, mod, acch, acc
  * clobbered flag groups: FG0
  */
 

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_keypair.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_keypair.s
@@ -604,7 +604,7 @@ _continue:
   addi x5, x0, 0x0100
   sub  x27, x5, x19 /* 0x0100 - (k - 1) */
 
-  loop x19, 109
+  loop x19, 105
     /* Generate a[i][0]. */
     add x11, x25, x0
     jal x1, poly_gen_matrix
@@ -737,17 +737,12 @@ _continue:
     /* Unmask pk. */
     addi x4, x0, 1
     add  x5, x26, x0
-    addi x6, x0, NSHARES
-    addi x6, x6, -1
-    loopi 16, 7
-      addi   x7, x5, 512
-      bn.lid x0, 0(x5)
-      loop x6, 3
-        bn.lid       x4, 0(x7)
-        bn.addvm.16h w0, w0, w1
-        addi         x7, x7, 512
-      endloop
-      bn.sid x0, 0(x5++)
+    addi x6, x5, 512
+    loopi 16, 4
+      bn.lid       x0, 0(x5)
+      bn.lid       x4, 0(x6++)
+      bn.addvm.16h w0, w0, w1
+      bn.sid       x0, 0(x5++)
     endloop
 
     bn.wsrw mod, w16
@@ -883,17 +878,12 @@ _continue:
   /* Unmask pk. */
   addi x4, x0, 1
   add  x5, x26, x0
-  addi x6, x0, NSHARES
-  addi x6, x6, -1
-  loopi 16, 7
-    addi   x7, x5, 512
-    bn.lid x0, 0(x5)
-    loop x6, 3
-      bn.lid       x4, 0(x7)
-      bn.addvm.16h w0, w0, w1
-      addi         x7, x7, 512
-    endloop
-    bn.sid x0, 0(x5++)
+  addi x6, x5, 512
+  loopi 16, 4
+    bn.lid       x0, 0(x5)
+    bn.lid       x4, 0(x6++)
+    bn.addvm.16h w0, w0, w1
+    bn.sid       x0, 0(x5++)
   endloop
 
   bn.wsrw mod, w16

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_keypair.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_keypair.s
@@ -449,12 +449,12 @@ _continue:
   add     x5, x5, x6
   csrrw   x0, kmac_cfg, x5
   /* Send seed. */
-  bn.xor  w0, w0, w0 /* Whitening. */
   bn.lid  x0, 0(x10++)
   bn.wsrw kmac_msg, w0
   bn.xor  w0, w0, w0 /* Whitening. */
   bn.lid  x0, 0(x10)
   bn.wsrw kmac_msg1, w0
+  bn.xor  w0, w0, w0 /* Whitening. */
   /* Send k. */
   addi    x5, x0, 1
   csrrw   x0, kmac_partial_write, x5
@@ -472,12 +472,12 @@ _continue:
   bn.xor  w0, w0, w1
   bn.sid  x0, 0(x5++)
   /* Retrieve noiseseed. */
-  bn.xor  w0, w0, w0 /* Whitening. */
   bn.wsrr w0, kmac_digest
   bn.sid  x0, 0(x5++)
   bn.xor  w0, w0, w0 /* Whitening. */
   bn.wsrr w0, kmac_digest1
   bn.sid  x0, 0(x5++)
+  bn.xor  w0, w0, w0 /* Whitening. */
 
   /*** Step 2: Generate dk_pke. ***/
   /* The following block will:
@@ -497,7 +497,7 @@ _continue:
   la     x23, const_tw_ntt
 
   addi x19, x19, -1 /* k - 1 */
-  loop x19, 28
+  loop x19, 27
     /* Generate sk[i]. */
     add x10, x20, x0
     add x11, x22, x0
@@ -518,8 +518,8 @@ _continue:
     add        x11, x23, x0
     add        x12, x10, x0
     loopi NSHARES, 3
-      jal x1, whitening
       jal x1, ntt
+      jal x1, whitening
       nop
     endloop
     bn.wsrw mod, w16
@@ -527,12 +527,11 @@ _continue:
     /* Pack dk_pke[i] <- sk[i]. */
     add x10, x22, x0
     add x11, x18, x0
-    loopi NSHARES, 4
+    loopi NSHARES, 3
+      jal x1, poly_tobytes
       /* Whitening. */
       bn.xor w0, w0, w0
       bn.xor w1, w1, w1
-      jal x1, poly_tobytes
-      nop
     endloop
     add x22, x10, x0
     add x18, x11, x0
@@ -551,8 +550,8 @@ _continue:
   add x11, x23, x0
   add x12, x10, x0
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, ntt
+    jal x1, whitening
     nop
   endloop
   bn.wsrw mod, w16
@@ -567,12 +566,11 @@ _continue:
   /* Pack dk_pke[k - 1] <- sk[k - 1]. */
   add x10, x22, x0
   add x11, x18, x0
-  loopi NSHARES, 4
+  loopi NSHARES, 3
+    jal    x1, poly_tobytes
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
-    jal    x1, poly_tobytes
-    nop
   endloop
 
   /* Save current addresses of sk. */
@@ -605,7 +603,7 @@ _continue:
   addi x5, x0, 0x0100
   sub  x27, x5, x19 /* 0x0100 - (k - 1) */
 
-  loop x19, 105
+  loop x19, 103
     /* Generate a[i][0]. */
     add x11, x25, x0
     jal x1, poly_gen_matrix
@@ -627,8 +625,8 @@ _continue:
     add x12, x23, x0
     add x13, x26, x0
     loopi NSHARES, 3
-      jal x1, whitening
       jal x1, basemul
+      jal x1, whitening
       add x10, x25, x0
     endloop
     add x22, x11, x0
@@ -655,8 +653,8 @@ _continue:
       add x12, x23, x0
       add x13, x26, x0
       loopi NSHARES, 3
-        jal x1, whitening
         jal x1, basemul_acc
+        jal x1, whitening
         add x10, x25, x0
       endloop
       add x22, x11, x0
@@ -681,8 +679,8 @@ _continue:
     add x12, x23, x0
     add x13, x26, x0
     loopi NSHARES, 3
-      jal x1, whitening
       jal x1, basemul_acc
+      jal x1, whitening
       add x10, x25, x0
     endloop
     bn.wsrw mod, w16
@@ -702,12 +700,11 @@ _continue:
 
     /* Compute pk = tomont(pk). */
     add x10, x26, x0
-    loopi NSHARES, 4
+    loopi NSHARES, 3
+      jal    x1, poly_tomont
       /* Whitening. */
       bn.xor w0, w0, w0
       bn.xor w1, w1, w1
-      jal    x1, poly_tomont
-      nop
     endloop
 
     /* Compute e[i] = ntt(e[i]). */
@@ -718,8 +715,8 @@ _continue:
     la  x11, const_tw_ntt
     add x12, x10, x0
     loopi NSHARES, 3
-      jal x1, whitening
       jal x1, ntt
+      jal x1, whitening
       nop
     endloop
 
@@ -727,12 +724,11 @@ _continue:
     add x10, x26, x0
     la  x11, mpoly_e
     add x12, x26, x0
-    loopi NSHARES, 4
+    loopi NSHARES, 3
+      jal    x1, poly_add
       /* Whitening. */
       bn.xor w0, w0, w0
       bn.xor w1, w1, w1
-      jal    x1, poly_add
-      nop
     endloop
 
     /* Unmask pk. */
@@ -776,8 +772,8 @@ _continue:
   add x12, x23, x0
   add x13, x26, x0
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, basemul
+    jal x1, whitening
     add x10, x25, x0
   endloop
   add x22, x11, x0
@@ -804,8 +800,8 @@ _continue:
     add x12, x23, x0
     add x13, x26, x0
     loopi NSHARES, 3
-      jal x1, whitening
       jal x1, basemul_acc
+      jal x1, whitening
       add x10, x25, x0
     endloop
     add x22, x11, x0
@@ -830,8 +826,8 @@ _continue:
   add x12, x23, x0
   add x13, x26, x0
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, basemul_acc
+    jal x1, whitening
     add x10, x25, x0
   endloop
   bn.wsrw mod, w16
@@ -843,12 +839,11 @@ _continue:
 
   /* Compute pk = tomont(pk). */
   add x10, x26, x0
-  loopi NSHARES, 4
+  loopi NSHARES, 3
+    jal    x1, poly_tomont
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
-    jal    x1, poly_tomont
-    nop
   endloop
 
   /* Compute e[k - 1] = ntt(e[k - 1]). */
@@ -859,8 +854,8 @@ _continue:
   la  x11, const_tw_ntt
   add x12, x10, x0
   loopi NSHARES, 3
-    jal x1, whitening
     jal x1, ntt
+    jal x1, whitening
     nop
   endloop
 
@@ -868,12 +863,11 @@ _continue:
   add x10, x26, x0
   la  x11, mpoly_e
   add x12, x26, x0
-  loopi NSHARES, 4
+  loopi NSHARES, 3
+    jal    x1, poly_add
     /* Whitening. */
     bn.xor w0, w0, w0
     bn.xor w1, w1, w1
-    jal    x1, poly_add
-    nop
   endloop
 
   /* Unmask pk. */

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_keypair.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_keypair.s
@@ -451,20 +451,20 @@ _continue:
   /* Send seed. */
   bn.lid  x0, 0(x10++)
   bn.wsrw kmac_msg, w0
-  bn.xor  w0, w0, w0 /* Whitening. */
+  bn.xor  w0, w31, w31 /* Whitening. */
   bn.lid  x0, 0(x10)
   bn.wsrw kmac_msg1, w0
-  bn.xor  w0, w0, w0 /* Whitening. */
+  bn.xor  w0, w31, w31 /* Whitening. */
   /* Send k. */
   addi    x5, x0, 1
   csrrw   x0, kmac_partial_write, x5
   la      x5, buf
-  bn.xor  w0, w0, w0
+  bn.xor  w0, w31, w31
   bn.sid  x0, 0(x5)
   sw      x13, 0(x5)
   bn.lid  x0, 0(x5)
   bn.wsrw kmac_msg, w0
-  bn.xor  w0, w0, w0
+  bn.xor  w0, w31, w31
   bn.wsrw kmac_msg1, w0
   /* Retrieve publicseed. */
   bn.wsrr w0, kmac_digest
@@ -474,10 +474,10 @@ _continue:
   /* Retrieve noiseseed. */
   bn.wsrr w0, kmac_digest
   bn.sid  x0, 0(x5++)
-  bn.xor  w0, w0, w0 /* Whitening. */
+  bn.xor  w0, w31, w31 /* Whitening. */
   bn.wsrr w0, kmac_digest1
   bn.sid  x0, 0(x5++)
-  bn.xor  w0, w0, w0 /* Whitening. */
+  bn.xor  w0, w31, w31 /* Whitening. */
 
   /*** Step 2: Generate dk_pke. ***/
   /* The following block will:
@@ -487,7 +487,7 @@ _continue:
   /**************************************************************************/
   la     x8, buf
   la     x21, nonce
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
   bn.sid x0, 0(x21)
   /* Prepare for generating sk[0]. */
   addi   x10, x8, 32
@@ -530,8 +530,8 @@ _continue:
     loopi NSHARES, 3
       jal x1, poly_tobytes
       /* Whitening. */
-      bn.xor w0, w0, w0
-      bn.xor w1, w1, w1
+      bn.xor w0, w31, w31
+      bn.xor w1, w31, w31
     endloop
     add x22, x10, x0
     add x18, x11, x0
@@ -559,7 +559,7 @@ _continue:
   /* Prepare for generating a[0][0]. */
   add    x10, x8, x0
   la     x11, seed_ij
-  bn.xor w0, w0, w0
+  bn.xor w0, w31, w31
   bn.sid x0, 0(x11)
   jal    x1, poly_gen_matrix_init
 
@@ -569,8 +569,8 @@ _continue:
   loopi NSHARES, 3
     jal    x1, poly_tobytes
     /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
+    bn.xor w0, w31, w31
+    bn.xor w1, w31, w31
   endloop
 
   /* Save current addresses of sk. */
@@ -703,8 +703,8 @@ _continue:
     loopi NSHARES, 3
       jal    x1, poly_tomont
       /* Whitening. */
-      bn.xor w0, w0, w0
-      bn.xor w1, w1, w1
+      bn.xor w0, w31, w31
+      bn.xor w1, w31, w31
     endloop
 
     /* Compute e[i] = ntt(e[i]). */
@@ -727,8 +727,8 @@ _continue:
     loopi NSHARES, 3
       jal    x1, poly_add
       /* Whitening. */
-      bn.xor w0, w0, w0
-      bn.xor w1, w1, w1
+      bn.xor w0, w31, w31
+      bn.xor w1, w31, w31
     endloop
 
     /* Unmask pk. */
@@ -842,8 +842,8 @@ _continue:
   loopi NSHARES, 3
     jal    x1, poly_tomont
     /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
+    bn.xor w0, w31, w31
+    bn.xor w1, w31, w31
   endloop
 
   /* Compute e[k - 1] = ntt(e[k - 1]). */
@@ -866,8 +866,8 @@ _continue:
   loopi NSHARES, 3
     jal    x1, poly_add
     /* Whitening. */
-    bn.xor w0, w0, w0
-    bn.xor w1, w1, w1
+    bn.xor w0, w31, w31
+    bn.xor w1, w31, w31
   endloop
 
   /* Unmask pk. */

--- a/sw/acc/crypto/mlkem/mlkem_indcpa_keypair.s
+++ b/sw/acc/crypto/mlkem/mlkem_indcpa_keypair.s
@@ -119,7 +119,7 @@ _continue:
   add    x11, x21, x0
   jal    x1, poly_getnoise_eta_init
   la     x22, mpolyvec_sk
-  la     x23, twiddles_ntt
+  la     x23, const_tw_ntt
 
   addi x19, x19, -1 /* k - 1 */
   loop x19, 21
@@ -201,7 +201,7 @@ _continue:
 
   la   x21, nonce
   la   x22, mpolyvec_sk
-  la   x23, twiddles_basemul
+  la   x23, const_tw_basemul
   la   x24, seed_ij
   la   x25, poly_at /* also mpoly_e */
   la   x26, mpoly_pk
@@ -301,7 +301,7 @@ _continue:
     bn.shv.16h w0, w16 << 1
     bn.wsrw    mod, w0
     la         x10, mpoly_e
-    la         x11, twiddles_ntt
+    la         x11, const_tw_ntt
     add        x12, x10, x0
     jal        x1, ntt
     bn.wsrw    mod, w16
@@ -401,7 +401,7 @@ _continue:
   bn.shv.16h w0, w16 << 1
   bn.wsrw    mod, w0
   la         x10, mpoly_e
-  la         x11, twiddles_ntt
+  la         x11, const_tw_ntt
   add        x12, x10, x0
   jal        x1, ntt
   bn.wsrw    mod, w16
@@ -493,7 +493,7 @@ _continue:
   add    x11, x21, x0
   jal    x1, masked_poly_getnoise_eta_init
   la     x22, mpolyvec_sk
-  la     x23, twiddles_ntt
+  la     x23, const_tw_ntt
 
   addi x19, x19, -1 /* k - 1 */
   loop x19, 28
@@ -595,7 +595,7 @@ _continue:
   /**************************************************************************/
   la   x21, nonce
   la   x22, mpolyvec_sk
-  la   x23, twiddles_basemul
+  la   x23, const_tw_basemul
   la   x24, seed_ij
   la   x25, poly_at /* also mpoly_e */
   la   x26, mpoly_pk
@@ -714,7 +714,7 @@ _continue:
     bn.wsrw    mod, w0
 
     la  x10, mpoly_e
-    la  x11, twiddles_ntt
+    la  x11, const_tw_ntt
     add x12, x10, x0
     loopi NSHARES, 3
       jal x1, whitening
@@ -855,7 +855,7 @@ _continue:
   bn.wsrw    mod, w0
 
   la  x10, mpoly_e
-  la  x11, twiddles_ntt
+  la  x11, const_tw_ntt
   add x12, x10, x0
   loopi NSHARES, 3
     jal x1, whitening

--- a/sw/acc/crypto/mlkem/mlkem_keypair.s
+++ b/sw/acc/crypto/mlkem/mlkem_keypair.s
@@ -47,7 +47,8 @@
  * clobbered flag groups: FG0
  *
  * HARDENED
- * clobbered registers: x2, x4 to x31, w0 to w30, mod, acch, acc
+ * clobbered registers: x2, x4 to x31,
+ *                      w0 to w15, w17 to w30, mod, acch, acc
  * clobbered flag groups: FG0
  */
 

--- a/sw/acc/crypto/mlkem/mlkem_keypair.s
+++ b/sw/acc/crypto/mlkem/mlkem_keypair.s
@@ -126,6 +126,7 @@ _continue:
   bn.xor w0, w0, w0 /* Whitening. */
   bn.lid x0, 96(x5)
   bn.sid x0, 32(x6)
+  bn.xor w0, w0, w0 /* Whitening. */
 #else
   bn.lid x0, 32(x5)
   bn.sid x0, 0(x6)

--- a/sw/acc/crypto/mlkem/mlkem_keypair.s
+++ b/sw/acc/crypto/mlkem/mlkem_keypair.s
@@ -123,10 +123,10 @@ _continue:
 #ifdef HARDENED
   bn.lid x0, 64(x5)
   bn.sid x0, 0(x6)
-  bn.xor w0, w0, w0 /* Whitening. */
+  bn.xor w0, w31, w31 /* Whitening. */
   bn.lid x0, 96(x5)
   bn.sid x0, 32(x6)
-  bn.xor w0, w0, w0 /* Whitening. */
+  bn.xor w0, w31, w31 /* Whitening. */
 #else
   bn.lid x0, 32(x5)
   bn.sid x0, 0(x6)

--- a/sw/acc/crypto/mlkem/ntt.s
+++ b/sw/acc/crypto/mlkem/ntt.s
@@ -20,7 +20,7 @@
  * This routine is constant time.
  *
  * @param[in]  x10: dmem pointer to x
- * @param[in]  x11: dmem pointer to the twiddle factors twiddles_ntt
+ * @param[in]  x11: dmem pointer to the twiddle factors const_tw_ntt
  * @param[out] x12: dmem pointer to r
  * @param[in]  w16 (sw0): sw0.0 = q = 3329 (1st 16-bit lane),
  *                        sw0.2 = -q^-1 mod 2^16 = 3327 (3rd 16-bit lane)

--- a/sw/acc/crypto/mlkem/pack_ciphertext.s
+++ b/sw/acc/crypto/mlkem/pack_ciphertext.s
@@ -35,7 +35,7 @@
 .type poly_compress, @function
 poly_compress:
   /* Load constants. */
-  la        x5, modulus_over_2
+  la        x5, const_qp1_half
   addi      x4, x0, 2
   bn.lid    x4, 0(x5) /* w2 = (0x681)^16 */
   la        x5, const_m_dv
@@ -249,7 +249,7 @@ _poly_compress_16:
 .type poly_polyvec_compress, @function
 poly_polyvec_compress:
   /* Load constants. */
-  la        x5, modulus_over_2
+  la        x5, const_qp1_half
   addi      x4, x0, 2
   bn.lid    x4, 0(x5) /* w2 = (0x681)^16 */
   la        x5, const_m_dv

--- a/sw/acc/crypto/mlkem/pack_keys.s
+++ b/sw/acc/crypto/mlkem/pack_keys.s
@@ -23,6 +23,7 @@
  * @param[in]  x10: dmem pointer to the input polynomial
  * @param[out] x11: dmem pointer to the output byte array
  * @param[in]  w31: all-zero register
+ * @param[in]  mod: q = 3329
  *
  * clobbered registers: x4, x10 to x11, w0 to w1
  * clobbered flag groups: none

--- a/sw/acc/crypto/mlkem/pack_keys.s
+++ b/sw/acc/crypto/mlkem/pack_keys.s
@@ -114,44 +114,44 @@ poly_frombytes:
 
     loopi 16, 2
       bn.rshi w1, w0, w1 >> 16
-      bn.rshi w0, w0, w0 >> 12
+      bn.rshi w0, w31, w0 >> 12
     endloop
     bn.and w1, w1, w2
     bn.sid x4, 0(x11++)
 
     loopi 5, 2
       bn.rshi w1, w0, w1 >> 16
-      bn.rshi w0, w0, w0 >> 12
+      bn.rshi w0, w31, w0 >> 12
     endloop
     bn.rshi w1, w0, w1 >> 4
     bn.lid  x0, 0(x10++)
     bn.rshi w1, w0, w1 >> 12
-    bn.rshi w0, w0, w0 >> 8
+    bn.rshi w0, w31, w0 >> 8
     loopi 10, 2
       bn.rshi w1, w0, w1 >> 16
-      bn.rshi w0, w0, w0 >> 12
+      bn.rshi w0, w31, w0 >> 12
     endloop
     bn.and w1, w1, w2
     bn.sid x4, 0(x11++)
 
     loopi 10, 2
       bn.rshi w1, w0, w1 >> 16
-      bn.rshi w0, w0, w0 >> 12
+      bn.rshi w0, w31, w0 >> 12
     endloop
     bn.rshi w1, w0, w1 >> 8
     bn.lid  x0, 0(x10++)
     bn.rshi w1, w0, w1 >> 8
-    bn.rshi w0, w0, w0 >> 4
+    bn.rshi w0, w31, w0 >> 4
     loopi 5, 2
       bn.rshi w1, w0, w1 >> 16
-      bn.rshi w0, w0, w0 >> 12
+      bn.rshi w0, w31, w0 >> 12
     endloop
     bn.and w1, w1, w2
     bn.sid x4, 0(x11++)
 
     loopi 16, 2
       bn.rshi w1, w0, w1 >> 16
-      bn.rshi w0, w0, w0 >> 12
+      bn.rshi w0, w31, w0 >> 12
     endloop
     bn.and w1, w1, w2
     bn.sid x4, 0(x11++)

--- a/sw/acc/crypto/mlkem/poly.s
+++ b/sw/acc/crypto/mlkem/poly.s
@@ -31,7 +31,7 @@
 .globl poly_frommsg
 .type poly_frommsg, @function
 poly_frommsg:
-  la     x5, modulus_over_2
+  la     x5, const_qp1_half
   addi   x4, x0, 3
   bn.lid x4, 0(x5)
 
@@ -72,7 +72,7 @@ poly_frommsg:
 .type poly_tomsg, @function
 poly_tomsg:
   /* Load constants. */
-  la        x5, modulus_over_2
+  la        x5, const_qp1_half
   addi      x4, x0, 2
   bn.lid    x4, 0(x5) /* w2 = (0x681)^16 */
   la        x5, const_m_dv
@@ -191,7 +191,7 @@ poly_sub:
 .globl poly_tomont
 .type poly_tomont, @function
 poly_tomont:
-  la     x5, const_tomont
+  la     x5, const_2_32_modq
   add    x4, x0, x0
   bn.lid x4++, 0(x5)
 

--- a/sw/acc/crypto/mlkem/poly_gen_matrix.s
+++ b/sw/acc/crypto/mlkem/poly_gen_matrix.s
@@ -88,7 +88,7 @@ poly_gen_matrix:
 
   /* Load modulus. */
   li      x4, 3
-  la      x6, modulus_bn
+  la      x6, const_q
   bn.lid  x4, 0(x6)
   bn.rshi mod, w31, mod >> 240 /* Only keep mod in lowest word */
 

--- a/sw/acc/crypto/mlkem/poly_gen_matrix.s
+++ b/sw/acc/crypto/mlkem/poly_gen_matrix.s
@@ -97,18 +97,22 @@ poly_gen_matrix:
 
   /* Loop until 256 coefficients have been written to the output. */
 _rej_sample_loop:
-  /* With one SHAKE squeeze, we get 32 bytes of data. From this, we can try to
-   * build 20 coefficients with 3 bytes each two (3 bytes --> 2 coeffs) and are left with 2 bytes
-   * remainder. We then take the two remaining bytes and one byte from the
-   * next squeeze operation and try to get another 2 coefficient, leaving us
-   * with 31 bytes from which we can, again, try to read 20 coefficients and
-   * are left with 1 byte remainder. From the next 32 bytes, we take 2 bytes
-   * and try to build 2 coefficients with the remaining 1 byte. Finally, we
-   * are left with 30 bytes which we can try to turn into 20 coefficients
-   * without any remainder. lcm(3, 32) = 96, meaning we use 96 bytes of SHAKE
-   * output each (full) iteration of the main loop. In case we reach the
-   * target amount of coefficients, we jump to _end_rej_sample_loop and exit. */
-
+  /* Each candidate coefficient is 12 bits wide, so 3 bytes yield 2
+   * candidates, while one SHAKE squeeze yields 32 bytes. Since 3 does not
+   * divide 32, the split of a squeeze into candidates shifts by one byte
+   * every time, and the pattern only repeats after lcm(3, 32) = 96 bytes.
+   * One full iteration of this loop therefore consumes three squeezes and
+   * produces 96 / 3 * 2 = 64 candidates:
+   *
+   *   squeeze 1: 30 bytes                    -> 20 candidates, 2 bytes left
+   *   carry:      2 bytes + 1 byte of next   ->  2 candidates
+   *   squeeze 2: 30 of the remaining 31      -> 20 candidates, 1 byte left
+   *   carry:      1 byte  + 2 bytes of next  ->  2 candidates
+   *   squeeze 3: the remaining 30 bytes      -> 20 candidates, none left
+   *
+   * A candidate is only accepted if it is smaller than q, so the number of
+   * coefficients actually written out is smaller and varies. As soon as 256
+   * coefficients have been written, we leave via _end_rej_sample_loop. */
   bn.wsrr    shake_reg, kmac_digest
   jal        x1, _poly_uniform_inner_loop
   beq        x11, x5, _end_rej_sample_loop

--- a/sw/acc/crypto/mlkem/whitening.s
+++ b/sw/acc/crypto/mlkem/whitening.s
@@ -3,6 +3,22 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /**
+ * Whitening steps for ML-KEM.
+ *
+ * The entry points below form a single fall-through chain, ordered so that
+ * each one clears its own registers and then falls into the next:
+ *
+ *   whitening                    -> w23
+ *   whitening_getnoise_eta_e3    -> w20 to w22
+ *   whitening_du                 -> w19
+ *   whitening_dv                 -> w18
+ *   whitening_bitslice_transpose -> w0 to w15, w24, then ret
+ *   whitening_getnoise_eta_e2    -> w0 to w15, w24, then ret
+ *
+ * Do not insert code between the entry points.
+ */
+
+/**
  * Whitening step for NTT, INTT and pair-pointwise multiplication.
  *
  * Zeroize the clobbered WDRs containing coefficients of secret values
@@ -21,6 +37,106 @@
 .globl whitening
 .type whitening, @function
 whitening:
+  bn.xor w23, w31, w31
+
+/**
+ * Whitening step for _bitslice_eta_3.
+ *
+ * Zeroize the clobbered WDRs containing coefficients of secret values that
+ * _bitslice_eta_3 uses, that is the six digest words w17 to w22, the bit
+ * matrices w0 to w15 they are shifted into, and the transpose scratch w24 and
+ * w25. Wide registers that contain constants are not wiped.
+ *
+ * This routine is constant time.
+ *
+ * clobbered registers: w0 to w15, w17 to w22, w24 to w25
+ * clobbered flag groups: FG0
+ */
+
+.globl whitening_getnoise_eta_e3
+.type whitening_getnoise_eta_e3, @function
+whitening_getnoise_eta_e3:
+  bn.xor w20, w31, w31
+  bn.xor w21, w31, w31
+  bn.xor w22, w31, w31
+
+/**
+ * Whitening step for polyvec_hocompress.
+ *
+ * Zeroize the clobbered WDRs containing coefficients of secret values that the
+ * modulus switch step in polyvec_hocompress uses, that is the temporaries w17
+ * to w19. Wide registers that contain constants (w20 to w22) are not wiped.
+ *
+ * This routine is constant time.
+ *
+ * clobbered registers: w0 to w15, w17 to w19, w24 to w25
+ * clobbered flag groups: FG0
+ */
+
+.globl whitening_du
+.type whitening_du, @function
+whitening_du:
+  bn.xor w19, w31, w31
+
+/**
+ * Whitening step for poly_hocompress and masked_poly_tomsg.
+ *
+ * Zeroize the clobbered WDRs containing coefficients of secret values that the
+ * modulus switch step in poly_hocompress and masked_poly_tomsg uses, that is
+ * the temporaries w17 and w18. Wide registers that contain constants (w20 to
+ * w22) are not wiped.
+ *
+ * This routine is constant time.
+ *
+ * clobbered registers: w0 to w15, w17 to w18, w24 to w25
+ * clobbered flag groups: FG0
+ */
+
+.globl whitening_dv
+.type whitening_dv, @function
+whitening_dv:
+  bn.xor w17, w31, w31
+  bn.xor w18, w31, w31
+
+/**
+ * Whitening step for _bitslice_transpose.
+ *
+ * Zeroize the clobbered WDRs containing coefficients of secret values that
+ * _bitslice_transpose uses: the bit matrices w0 to w15 and the temporaries w24
+ * and w25. Wide registers that contain constants are not wiped.
+ *
+ * This is the tail of the chain and holds the only `ret`.
+ *
+ * This routine is constant time.
+ *
+ * clobbered registers: w0 to w15, w24 to w25
+ * clobbered flag groups: FG0
+ */
+
+.globl whitening_bitslice_transpose
+.type whitening_bitslice_transpose, @function
+whitening_bitslice_transpose:
+
+/**
+ * Whitening step for _getnoise_eta_2.
+ *
+ * Zeroize the clobbered WDRs containing coefficients of secret values that
+ * _getnoise_eta_2 uses. Only the bitslicing scratch is wiped here, that is the
+ * bit matrices w0 to w15 and the temporaries w24 and w25: the squeeze words
+ * w17 to w23 are still live across the loop and _getnoise_eta_2 clears them
+ * itself before returning. Wide registers that contain constants are not wiped.
+ *
+ * This is the tail of the chain and holds the only `ret`.
+ *
+ * This routine is constant time.
+ *
+ * clobbered registers: w0 to w15, w24 to w25
+ * clobbered flag groups: FG0
+ */
+
+.globl whitening_getnoise_eta_e2
+.type whitening_getnoise_eta_e2, @function
+whitening_getnoise_eta_e2:
   bn.xor w0, w31, w31
   bn.xor w1, w31, w31
   bn.xor w2, w31, w31
@@ -37,13 +153,6 @@ whitening:
   bn.xor w13, w31, w31
   bn.xor w14, w31, w31
   bn.xor w15, w31, w31
-  bn.xor w17, w31, w31
-  bn.xor w18, w31, w31
-  bn.xor w19, w31, w31
-  bn.xor w20, w31, w31
-  bn.xor w21, w31, w31
-  bn.xor w22, w31, w31
-  bn.xor w23, w31, w31
   bn.xor w24, w31, w31
   bn.xor w25, w31, w31
   ret

--- a/sw/acc/crypto/mlkem/whitening.s
+++ b/sw/acc/crypto/mlkem/whitening.s
@@ -11,6 +11,9 @@
  *
  * This routine is constant time.
  *
+ * @param[in]     w0 to w15, w17 to w25: registers to be whitened
+ * @param[in]     w31: all-zero register
+ *
  * clobbered registers: w0 to w15, w17 to w25
  * clobbered flag groups: FG0
  */
@@ -18,29 +21,29 @@
 .globl whitening
 .type whitening, @function
 whitening:
-  bn.xor w0, w0, w0
-  bn.xor w1, w1, w1
-  bn.xor w2, w2, w2
-  bn.xor w3, w3, w3
-  bn.xor w4, w4, w4
-  bn.xor w5, w5, w5
-  bn.xor w6, w6, w6
-  bn.xor w7, w7, w7
-  bn.xor w8, w8, w8
-  bn.xor w9, w9, w9
-  bn.xor w10, w10, w10
-  bn.xor w11, w11, w11
-  bn.xor w12, w12, w12
-  bn.xor w13, w13, w13
-  bn.xor w14, w14, w14
-  bn.xor w15, w15, w15
-  bn.xor w17, w17, w17
-  bn.xor w18, w18, w18
-  bn.xor w19, w19, w19
-  bn.xor w20, w20, w20
-  bn.xor w21, w21, w21
-  bn.xor w22, w22, w22
-  bn.xor w23, w23, w23
-  bn.xor w24, w24, w24
-  bn.xor w25, w25, w25
+  bn.xor w0, w31, w31
+  bn.xor w1, w31, w31
+  bn.xor w2, w31, w31
+  bn.xor w3, w31, w31
+  bn.xor w4, w31, w31
+  bn.xor w5, w31, w31
+  bn.xor w6, w31, w31
+  bn.xor w7, w31, w31
+  bn.xor w8, w31, w31
+  bn.xor w9, w31, w31
+  bn.xor w10, w31, w31
+  bn.xor w11, w31, w31
+  bn.xor w12, w31, w31
+  bn.xor w13, w31, w31
+  bn.xor w14, w31, w31
+  bn.xor w15, w31, w31
+  bn.xor w17, w31, w31
+  bn.xor w18, w31, w31
+  bn.xor w19, w31, w31
+  bn.xor w20, w31, w31
+  bn.xor w21, w31, w31
+  bn.xor w22, w31, w31
+  bn.xor w23, w31, w31
+  bn.xor w24, w31, w31
+  bn.xor w25, w31, w31
   ret

--- a/sw/acc/crypto/run_mlkem.s
+++ b/sw/acc/crypto/run_mlkem.s
@@ -64,12 +64,12 @@ start:
   /* All-zero register. */
   bn.xor  w31, w31, w31
 
-  /* mod = qinv | q.*/
+  /* mod = mqinv | q.*/
   li      x5, 16
-  la      x6, modulus_bn
+  la      x6, const_q
   bn.lid  x5++, 0(x6)
   bn.rshi w16, w31, w16 >> 240
-  la      x6, modulus_inv
+  la      x6, const_mqinv
   bn.lid  x5, 0(x6)
   bn.or   w16, w16, w17 << 32
   bn.wsrw mod, w16

--- a/sw/acc/crypto/tests/mlkem/gadgets/BUILD
+++ b/sw/acc/crypto/tests/mlkem/gadgets/BUILD
@@ -229,10 +229,10 @@ py_binary(
     for i in range(NTESTS)
 ]
 
-# poly_masked_compare_dv
+# masked_poly_compare_dv
 py_binary(
-    name = "poly_masked_compare_dv_testgen",
-    srcs = ["poly_masked_compare_dv_testgen.py"],
+    name = "masked_poly_compare_dv_testgen",
+    srcs = ["masked_poly_compare_dv_testgen.py"],
     imports = [
         "../../../../../../hw/ip/acc/util",
     ],
@@ -243,14 +243,14 @@ py_binary(
 
 [
     acc_autogen_sim_test(
-        name = "poly_masked_compare_dv_test{}".format(
+        name = "masked_poly_compare_dv_test{}".format(
             str(i),
         ),
-        srcs = ["poly_masked_compare_dv_test.s"],
+        srcs = ["masked_poly_compare_dv_test.s"],
         pqc = True,
         seed = i,
         stats = STATS,
-        testgen = ":poly_masked_compare_dv_testgen",
+        testgen = ":masked_poly_compare_dv_testgen",
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
@@ -259,10 +259,10 @@ py_binary(
     for i in range(NTESTS)
 ]
 
-# poly_masked_compare_du
+# masked_poly_compare_du
 py_binary(
-    name = "poly_masked_compare_du_testgen",
-    srcs = ["poly_masked_compare_du_testgen.py"],
+    name = "masked_poly_compare_du_testgen",
+    srcs = ["masked_poly_compare_du_testgen.py"],
     imports = [
         "../../../../../../hw/ip/acc/util",
     ],
@@ -273,14 +273,14 @@ py_binary(
 
 [
     acc_autogen_sim_test(
-        name = "poly_masked_compare_du_test{}".format(
+        name = "masked_poly_compare_du_test{}".format(
             str(i),
         ),
-        srcs = ["poly_masked_compare_du_test.s"],
+        srcs = ["masked_poly_compare_du_test.s"],
         pqc = True,
         seed = i,
         stats = STATS,
-        testgen = ":poly_masked_compare_du_testgen",
+        testgen = ":masked_poly_compare_du_testgen",
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",

--- a/sw/acc/crypto/tests/mlkem/gadgets/BUILD
+++ b/sw/acc/crypto/tests/mlkem/gadgets/BUILD
@@ -109,10 +109,10 @@ py_binary(
     for i in range(NTESTS)
 ]
 
-# poly_hocompress
+# poly_hocompress_dv
 py_binary(
-    name = "poly_hocompress_testgen",
-    srcs = ["poly_hocompress_testgen.py"],
+    name = "poly_hocompress_dv_testgen",
+    srcs = ["poly_hocompress_dv_testgen.py"],
     imports = [
         "../../../../../../hw/ip/acc/util",
     ],
@@ -123,14 +123,14 @@ py_binary(
 
 [
     acc_autogen_sim_test(
-        name = "poly_hocompress_test{}".format(
+        name = "poly_hocompress_dv_test{}".format(
             str(i),
         ),
-        srcs = ["poly_hocompress_test.s"],
+        srcs = ["poly_hocompress_dv_test.s"],
         pqc = True,
         seed = i,
         stats = STATS,
-        testgen = ":poly_hocompress_testgen",
+        testgen = ":poly_hocompress_dv_testgen",
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
@@ -139,10 +139,10 @@ py_binary(
     for i in range(NTESTS)
 ]
 
-# polyvec_hocompress
+# poly_hocompress_du
 py_binary(
-    name = "polyvec_hocompress_testgen",
-    srcs = ["polyvec_hocompress_testgen.py"],
+    name = "poly_hocompress_du_testgen",
+    srcs = ["poly_hocompress_du_testgen.py"],
     imports = [
         "../../../../../../hw/ip/acc/util",
     ],
@@ -153,14 +153,14 @@ py_binary(
 
 [
     acc_autogen_sim_test(
-        name = "polyvec_hocompress_test{}".format(
+        name = "poly_hocompress_du_test{}".format(
             str(i),
         ),
-        srcs = ["polyvec_hocompress_test.s"],
+        srcs = ["poly_hocompress_du_test.s"],
         pqc = True,
         seed = i,
         stats = STATS,
-        testgen = ":polyvec_hocompress_testgen",
+        testgen = ":poly_hocompress_du_testgen",
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",

--- a/sw/acc/crypto/tests/mlkem/gadgets/BUILD
+++ b/sw/acc/crypto/tests/mlkem/gadgets/BUILD
@@ -380,10 +380,10 @@ py_binary(
     for i in range(NTESTS)
 ]
 
-# onebitdecompress
+# masked_poly_frommsg
 py_binary(
-    name = "onebitdecompress_testgen",
-    srcs = ["onebitdecompress_testgen.py"],
+    name = "masked_poly_frommsg_testgen",
+    srcs = ["masked_poly_frommsg_testgen.py"],
     imports = [
         "../../../../../../hw/ip/acc/util",
     ],
@@ -394,14 +394,14 @@ py_binary(
 
 [
     acc_autogen_sim_test(
-        name = "onebitdecompress_test{}".format(
+        name = "masked_poly_frommsg_test{}".format(
             str(i),
         ),
-        srcs = ["onebitdecompress_test.s"],
+        srcs = ["masked_poly_frommsg_test.s"],
         pqc = True,
         seed = i,
         stats = STATS,
-        testgen = ":onebitdecompress_testgen",
+        testgen = ":masked_poly_frommsg_testgen",
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",

--- a/sw/acc/crypto/tests/mlkem/gadgets/BUILD
+++ b/sw/acc/crypto/tests/mlkem/gadgets/BUILD
@@ -48,6 +48,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -76,6 +77,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -104,6 +106,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -134,6 +137,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -164,6 +168,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -194,6 +199,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -224,6 +230,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets_rej_sample_test",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -254,6 +261,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -275,6 +283,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -305,6 +314,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -326,6 +336,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -356,6 +367,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -387,6 +399,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -417,6 +430,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -447,6 +461,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -476,6 +491,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -506,6 +522,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -536,6 +553,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -566,6 +584,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -596,6 +615,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -626,6 +646,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -656,6 +677,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)
@@ -686,6 +708,7 @@ py_binary(
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",
+            "//sw/acc/crypto/mlkem:whitening",
         ],
     )
     for i in range(NTESTS)

--- a/sw/acc/crypto/tests/mlkem/gadgets/BUILD
+++ b/sw/acc/crypto/tests/mlkem/gadgets/BUILD
@@ -259,6 +259,27 @@ py_binary(
     for i in range(NTESTS)
 ]
 
+[
+    acc_autogen_sim_test(
+        name = "masked_poly_compare_dv_false_test{}".format(
+            str(i),
+        ),
+        srcs = ["masked_poly_compare_dv_test.s"],
+        pqc = True,
+        seed = i,
+        stats = STATS,
+        testgen = ":masked_poly_compare_dv_testgen",
+        testgen_args = [
+            "-i",
+        ],
+        deps = [
+            "//sw/acc/crypto/mlkem:consts",
+            "//sw/acc/crypto/mlkem:gadgets",
+        ],
+    )
+    for i in range(NTESTS)
+]
+
 # masked_poly_compare_du
 py_binary(
     name = "masked_poly_compare_du_testgen",
@@ -281,6 +302,27 @@ py_binary(
         seed = i,
         stats = STATS,
         testgen = ":masked_poly_compare_du_testgen",
+        deps = [
+            "//sw/acc/crypto/mlkem:consts",
+            "//sw/acc/crypto/mlkem:gadgets",
+        ],
+    )
+    for i in range(NTESTS)
+]
+
+[
+    acc_autogen_sim_test(
+        name = "masked_poly_compare_du_false_test{}".format(
+            str(i),
+        ),
+        srcs = ["masked_poly_compare_du_test.s"],
+        pqc = True,
+        seed = i,
+        stats = STATS,
+        testgen = ":masked_poly_compare_du_testgen",
+        testgen_args = [
+            "-i",
+        ],
         deps = [
             "//sw/acc/crypto/mlkem:consts",
             "//sw/acc/crypto/mlkem:gadgets",

--- a/sw/acc/crypto/tests/mlkem/gadgets/bitcopymask_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/bitcopymask_test.s
@@ -10,27 +10,22 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* dmem[r] <= bitcopymask(dmem[x]) */
+  /* r <- bitcopymask(x). */
   la   x10, xb
   addi x11, x0, 32
   la   x13, rb
   jal  x1, bitcopymask
 
-  /* Compute r */
+  /* r <- unmask(rb). */
   la     x2, rb
-  la     x3, r
+  addi   x3, x2, 384
+  la     x5, r
   li     x4, 1
-  li     x5, NSHARES
-  addi   x5, x5, -1
-  loopi 12, 7
-    addi   x6, x2, 384
+  loopi 12, 4
     bn.lid x0, 0(x2++)
-    loop x5, 3
-      bn.lid x4, 0(x6)
-      addi   x6, x6, 384
-      bn.xor w0, w0, w1
-    endloop
-    bn.sid x0, 0(x3++)
+    bn.lid x4, 0(x3++)
+    bn.xor w0, w0, w1
+    bn.sid x0, 0(x5++)
   endloop
 
   ecall
@@ -38,4 +33,4 @@ main:
 .data
 .balign 32
 r:
-  .zero 32 * 12
+  .zero 384

--- a/sw/acc/crypto/tests/mlkem/gadgets/bitcopymask_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/bitcopymask_test.s
@@ -7,35 +7,35 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* dmem[r] <= bitcopymask(dmem[x]) */
-    la   x10, xb
-    addi x11, x0, 32
-    la   x13, rb
-    jal  x1, bitcopymask
+  /* dmem[r] <= bitcopymask(dmem[x]) */
+  la   x10, xb
+  addi x11, x0, 32
+  la   x13, rb
+  jal  x1, bitcopymask
 
-    /* Compute r */
-    la     x2, rb
-    la     x3, r
-    li     x4, 1
-    li     x5, NSHARES
-    addi   x5, x5, -1
-    loopi 12, 7
-        addi   x6, x2, 384
-        bn.lid x0, 0(x2++)
-        loop x5, 3
-            bn.lid x4, 0(x6)
-            addi   x6, x6, 384
-            bn.xor w0, w0, w1
-        endloop
-        bn.sid x0, 0(x3++)
+  /* Compute r */
+  la     x2, rb
+  la     x3, r
+  li     x4, 1
+  li     x5, NSHARES
+  addi   x5, x5, -1
+  loopi 12, 7
+    addi   x6, x2, 384
+    bn.lid x0, 0(x2++)
+    loop x5, 3
+      bn.lid x4, 0(x6)
+      addi   x6, x6, 384
+      bn.xor w0, w0, w1
     endloop
+    bn.sid x0, 0(x3++)
+  endloop
 
-    ecall
+  ecall
 
 .data
 .balign 32
 r:
-    .zero 32 * 12
+  .zero 32 * 12

--- a/sw/acc/crypto/tests/mlkem/gadgets/bitcopymask_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/bitcopymask_testgen.py
@@ -11,6 +11,8 @@ from shared.testgen import write_test_data, write_test_exp, write_test_dexp
 
 N = 256
 NSHARES = 2
+Q = 3329
+K = 12
 
 
 def gen_bitcopymask_test(
@@ -20,26 +22,26 @@ def gen_bitcopymask_test(
     if seed is not None:
         random.seed(seed)
 
-    nshares = NSHARES
-
+    # Generate input.
     r = 0
     x_bytes = bytes()
-    for _ in range(nshares):
+    for _ in range(NSHARES):
         bit = random.getrandbits(1)
         r ^= bit
         x_bytes += int.to_bytes(bit, byteorder="little", length=32)
 
     # Generate expected result.
-    r *= 3329
+    r *= Q
     r_bytes = bytes()
-    for i in range(12):
-        ri = (r >> i) & 1
-        r_bytes += int.to_bytes(ri, byteorder="little", length=32)
-
-    rb_bytes = int.to_bytes(0, byteorder="little", length=32 * 12 * nshares)
+    for bit in range(K):
+        rbit = (r >> bit) & 1
+        r_bytes += int.to_bytes(rbit, byteorder="little", length=32)
 
     # Write input values.
-    inputs = {'xb': x_bytes, 'rb': rb_bytes}
+    inputs = {
+        'xb': x_bytes,
+        'rb': int.to_bytes(0, byteorder="little", length=32 * 12 * NSHARES)
+    }
     write_test_data(inputs, data_file)
 
     # Write expected register values (none).

--- a/sw/acc/crypto/tests/mlkem/gadgets/finalize_cmp_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/finalize_cmp_test.s
@@ -2,7 +2,6 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NSHARES 2
 #define STACK_SIZE 15360
 
 .section .text.start
@@ -11,23 +10,17 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* Load stack pointer. */
-  la x2, stack_end
-
-  /* x <= finalize_cmp(x): AND-reduce the 256 comparison bits to bit 0. */
+  /* x <- finalize_cmp(x): AND-reduce the 256 comparison bits to bit 0. */
+  la   x2, stack_end
   la   x10, x
   jal  x1, finalize_cmp
 
-  /* Recombine x; bit 0 holds the comparison result. */
+  /* Unmask x; bit 0 holds the comparison result. */
   addi   x4, x0, 1
-  la     x10, x
-  addi   x11, x0, NSHARES
-  addi   x11, x11, -1
-  bn.lid x0, 0(x10++)
-  loop x11, 2
-    bn.lid x4, 0(x10++)
-    bn.xor w0, w0, w1
-  endloop
+  la     x2, x
+  bn.lid x0, 0(x2++)
+  bn.lid x4, 0(x2)
+  bn.xor w0, w0, w1
 
   ecall
 
@@ -36,3 +29,4 @@ main:
 stack:
   .zero STACK_SIZE
 stack_end:
+  .zero 0

--- a/sw/acc/crypto/tests/mlkem/gadgets/finalize_cmp_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/finalize_cmp_test.s
@@ -8,32 +8,31 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* Load stack pointer. */
-    la x2, stack_end
+  /* Load stack pointer. */
+  la x2, stack_end
 
-    /* x <= finalize_cmp(x): AND-reduce the 256 comparison bits to bit 0. */
-    la   x10, x
-    jal  x1, finalize_cmp
+  /* x <= finalize_cmp(x): AND-reduce the 256 comparison bits to bit 0. */
+  la   x10, x
+  jal  x1, finalize_cmp
 
-    /* Recombine x; bit 0 holds the comparison result. */
-    addi   x4, x0, 1
-    la     x10, x
-    addi   x11, x0, NSHARES
-    addi   x11, x11, -1
-    bn.lid x0, 0(x10++)
-    loop x11, 2
-        bn.lid x4, 0(x10++)
-        bn.xor w0, w0, w1
-    endloop
+  /* Recombine x; bit 0 holds the comparison result. */
+  addi   x4, x0, 1
+  la     x10, x
+  addi   x11, x0, NSHARES
+  addi   x11, x11, -1
+  bn.lid x0, 0(x10++)
+  loop x11, 2
+    bn.lid x4, 0(x10++)
+    bn.xor w0, w0, w1
+  endloop
 
-    ecall
+  ecall
 
 .data
 .balign 32
 stack:
-    .zero STACK_SIZE
+  .zero STACK_SIZE
 stack_end:
-    .zero 0

--- a/sw/acc/crypto/tests/mlkem/gadgets/finalize_cmp_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/finalize_cmp_testgen.py
@@ -31,22 +31,35 @@ def gen_finalize_cmp_test(
     x = (int.to_bytes(share0, byteorder="little", length=32)
          + int.to_bytes(v ^ share0, byteorder="little", length=32))
 
+    # Write input values.
     write_test_data({'x': x}, data_file)
+
+    # Write expected register values.
     write_test_exp({'w0': int.to_bytes(expected, byteorder="little",
                                        length=32)}, exp_file)
+
+    # Write expected dmem values (none).
     write_test_dexp({}, dexp_file)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('-s', '--seed', type=int, required=False,
-                        help='Seed value for pseudorandomness.')
-    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for input DMEM values.')
-    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for expected register values.')
-    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for expected DMEM values.')
+    parser.add_argument('-s', '--seed',
+                        type=int,
+                        required=False,
+                        help=('Seed value for pseudorandomness.'))
+    parser.add_argument('data',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for input DMEM values.'))
+    parser.add_argument('exp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected register values.'))
+    parser.add_argument('dexp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected DMEM values.'))
     args = parser.parse_args()
 
     with args.data, args.exp, args.dexp:

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_compare_du_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_compare_du_test.s
@@ -27,12 +27,19 @@ main:
   addi x15, x0, 2
   jal  x1, masked_poly_compare_du
 
-  /* Unmask r; both compares matched, so every bit is set. */
+  /* w0 <- unmask(r). */
   addi   x4, x0, 1
   la     x10, r
   bn.lid x0, 0(x10++)
   bn.lid x4, 0(x10++)
   bn.xor w0, w0, w1
+
+  /* If both compares matches, every bit is set. Otherwise, we
+   * set the result to all 0 for comparison with the expected result
+   * for the masked_poly_compare_du_false_test. */
+  bn.subi w1, w31, 1
+  bn.cmp  w0, w1, FG0
+  bn.sel  w0, w0, w31, FG0.z
 
   ecall
 

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_compare_du_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_compare_du_test.s
@@ -10,22 +10,22 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* r <- poly_masked_compare_dv(xv, cv_dv5), k = 4 path (dv = 5). */
+  /* r <- masked_poly_compare_du(xu, cu_du11), k = 4 path (du = 11). */
   la   x2, stack_end
-  la   x10, xv
-  la   x11, cv_dv5
-  addi x12, x0, 160
+  la   x10, xu
+  la   x11, cu_du11
+  addi x12, x0, 352
   la   x14, r
   addi x15, x0, 4
-  jal  x1, poly_masked_compare_dv
+  jal  x1, masked_poly_compare_du
 
-  /* r &= poly_masked_compare_dv(xv, cv_dv4), k != 4 path (dv = 4). */
-  la   x10, xv
-  la   x11, cv_dv4
-  addi x12, x0, 128
+  /* r &= masked_poly_compare_du(xu, cu_du10), k != 4 path (du = 10). */
+  la   x10, xu
+  la   x11, cu_du10
+  addi x12, x0, 320
   la   x14, r
   addi x15, x0, 2
-  jal  x1, poly_masked_compare_dv
+  jal  x1, masked_poly_compare_du
 
   /* Unmask r; both compares matched, so every bit is set. */
   addi   x4, x0, 1

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_compare_du_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_compare_du_testgen.py
@@ -37,7 +37,7 @@ def random_shared_poly() -> Tuple[bytes, List[int]]:
     return shares, r
 
 
-def gen_poly_masked_compare_du_test(
+def gen_masked_poly_compare_du_test(
         seed: Optional[int],
         data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
     if seed is not None:
@@ -81,5 +81,5 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     with args.data, args.exp, args.dexp:
-        gen_poly_masked_compare_du_test(args.seed, args.data, args.exp,
+        gen_masked_poly_compare_du_test(args.seed, args.data, args.exp,
                                         args.dexp)

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_compare_du_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_compare_du_testgen.py
@@ -39,21 +39,38 @@ def random_shared_poly() -> Tuple[bytes, List[int]]:
 
 def gen_masked_poly_compare_du_test(
         seed: Optional[int],
-        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO, invalid=False):
     if seed is not None:
         random.seed(seed)
 
     # One polynomial compared against its compression at du = 10 (k != 4) and
     # du = 11 (k = 4). Both match, so the recombined output is all ones.
     xu, ru = random_shared_poly()
+    r = (1 << N) - 1
+
+    # Generate the packed reference ciphertext.
+    cu_du10_bytes = compress_poly(ru, 10)
+    cu_du11_bytes = compress_poly(ru, 11)
+
+    if invalid:
+        # Pick a random index in the ciphertext and modify a random bytes.
+        idx = random.randrange(320)
+        cu_du10_bytes = cu_du10_bytes[:idx] + bytes(cu_du10_bytes[idx] ^ 1) + \
+            cu_du10_bytes[idx + 1:]
+        idx = random.randrange(352)
+        cu_du11_bytes = cu_du11_bytes[:idx] + bytes(cu_du11_bytes[idx] ^ 1) + \
+            cu_du11_bytes[idx + 1:]
+        # Since the reference ciphertext is changed, the comparison does not
+        # match. So the recombined output is not all ones.
+        r = 0
 
     # Write input values.
     write_test_data({'xu': xu,
-                     'cu_du10': compress_poly(ru, 10),
-                     'cu_du11': compress_poly(ru, 11)}, data_file)
+                     'cu_du10': cu_du10_bytes,
+                     'cu_du11': cu_du11_bytes}, data_file)
 
     # Write expected register values.
-    write_test_exp({'w0': int.to_bytes((1 << N) - 1, byteorder="little",
+    write_test_exp({'w0': int.to_bytes(r, byteorder="little",
                                        length=32)}, exp_file)
 
     # Write expected dmem values (none).
@@ -66,6 +83,9 @@ if __name__ == '__main__':
                         type=int,
                         required=False,
                         help=('Seed value for pseudorandomness.'))
+    parser.add_argument('-i', '--invalid',
+                        action='store_true',
+                        help=('Set in order to make the decapsulation input invalid.'))
     parser.add_argument('data',
                         metavar='FILE',
                         type=argparse.FileType('w'),
@@ -82,4 +102,4 @@ if __name__ == '__main__':
 
     with args.data, args.exp, args.dexp:
         gen_masked_poly_compare_du_test(args.seed, args.data, args.exp,
-                                        args.dexp)
+                                        args.dexp, args.invalid)

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_compare_dv_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_compare_dv_test.s
@@ -10,22 +10,22 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* r <- poly_masked_compare_du(xu, cu_du11), k = 4 path (du = 11). */
+  /* r <- masked_poly_compare_dv(xv, cv_dv5), k = 4 path (dv = 5). */
   la   x2, stack_end
-  la   x10, xu
-  la   x11, cu_du11
-  addi x12, x0, 352
+  la   x10, xv
+  la   x11, cv_dv5
+  addi x12, x0, 160
   la   x14, r
   addi x15, x0, 4
-  jal  x1, poly_masked_compare_du
+  jal  x1, masked_poly_compare_dv
 
-  /* r &= poly_masked_compare_du(xu, cu_du10), k != 4 path (du = 10). */
-  la   x10, xu
-  la   x11, cu_du10
-  addi x12, x0, 320
+  /* r &= masked_poly_compare_dv(xv, cv_dv4), k != 4 path (dv = 4). */
+  la   x10, xv
+  la   x11, cv_dv4
+  addi x12, x0, 128
   la   x14, r
   addi x15, x0, 2
-  jal  x1, poly_masked_compare_du
+  jal  x1, masked_poly_compare_dv
 
   /* Unmask r; both compares matched, so every bit is set. */
   addi   x4, x0, 1

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_compare_dv_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_compare_dv_test.s
@@ -27,12 +27,19 @@ main:
   addi x15, x0, 2
   jal  x1, masked_poly_compare_dv
 
-  /* Unmask r; both compares matched, so every bit is set. */
+  /* w0 <- unmask(r). */
   addi   x4, x0, 1
   la     x10, r
   bn.lid x0, 0(x10++)
   bn.lid x4, 0(x10++)
   bn.xor w0, w0, w1
+
+  /* If both compares matches, every bit is set. Otherwise, we
+   * set the result to all 0 for comparison with the expected result
+   * for the masked_poly_compare_dv_false_test. */
+  bn.subi w1, w31, 1
+  bn.cmp  w0, w1, FG0
+  bn.sel  w0, w0, w31, FG0.z
 
   ecall
 

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_compare_dv_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_compare_dv_testgen.py
@@ -37,7 +37,7 @@ def random_shared_poly() -> Tuple[bytes, List[int]]:
     return shares, r
 
 
-def gen_poly_masked_compare_dv_test(
+def gen_masked_poly_compare_dv_test(
         seed: Optional[int],
         data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
     if seed is not None:
@@ -81,5 +81,5 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     with args.data, args.exp, args.dexp:
-        gen_poly_masked_compare_dv_test(args.seed, args.data, args.exp,
+        gen_masked_poly_compare_dv_test(args.seed, args.data, args.exp,
                                         args.dexp)

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_compare_dv_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_compare_dv_testgen.py
@@ -39,21 +39,38 @@ def random_shared_poly() -> Tuple[bytes, List[int]]:
 
 def gen_masked_poly_compare_dv_test(
         seed: Optional[int],
-        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
+        data_file: TextIO, exp_file: TextIO, dexp_file: TextIO, invalid=False):
     if seed is not None:
         random.seed(seed)
 
     # One polynomial compared against its compression at dv = 4 (k != 4) and
     # dv = 5 (k = 4). Both match, so the recombined output is all ones.
     xv, rv = random_shared_poly()
+    r = (1 << N) - 1
+
+    # Generate the packed reference ciphertext.
+    cv_dv4_bytes = compress_poly(rv, 4)
+    cv_dv5_bytes = compress_poly(rv, 5)
+
+    if invalid:
+        # Pick a random index in the ciphertext and modify a random bytes.
+        idx = random.randrange(128)
+        cv_dv4_bytes = cv_dv4_bytes[:idx] + bytes(cv_dv4_bytes[idx] ^ 1) + \
+            cv_dv4_bytes[idx + 1:]
+        idx = random.randrange(160)
+        cv_dv5_bytes = cv_dv5_bytes[:idx] + bytes(cv_dv5_bytes[idx] ^ 1) + \
+            cv_dv5_bytes[idx + 1:]
+        # Since the reference ciphertext is changed, the comparison does not
+        # match. So the recombined output is not all ones.
+        r = 0
 
     # Write input values.
     write_test_data({'xv': xv,
-                     'cv_dv4': compress_poly(rv, 4),
-                     'cv_dv5': compress_poly(rv, 5)}, data_file)
+                     'cv_dv4': cv_dv4_bytes,
+                     'cv_dv5': cv_dv5_bytes}, data_file)
 
     # Write expected register values.
-    write_test_exp({'w0': int.to_bytes((1 << N) - 1, byteorder="little",
+    write_test_exp({'w0': int.to_bytes(r, byteorder="little",
                                        length=32)}, exp_file)
 
     # Write expected dmem values (none).
@@ -66,6 +83,9 @@ if __name__ == '__main__':
                         type=int,
                         required=False,
                         help=('Seed value for pseudorandomness.'))
+    parser.add_argument('-i', '--invalid',
+                        action='store_true',
+                        help=('Set in order to make the decapsulation input invalid.'))
     parser.add_argument('data',
                         metavar='FILE',
                         type=argparse.FileType('w'),
@@ -82,4 +102,4 @@ if __name__ == '__main__':
 
     with args.data, args.exp, args.dexp:
         gen_masked_poly_compare_dv_test(args.seed, args.data, args.exp,
-                                        args.dexp)
+                                        args.dexp, args.invalid)

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_frommsg_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_frommsg_test.s
@@ -10,12 +10,12 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* w16 = mod = qinv | q. */
+  /* w16 = mod = mqinv | q. */
   addi    x4, x0, 16
-  la      x5, modulus_bn
+  la      x5, const_q
   bn.lid  x4++, 0(x5)
   bn.rshi w16, w31, w16 >> 240
-  la      x5, modulus_inv
+  la      x5, const_mqinv
   bn.lid  x4, 0(x5)
   bn.or   w16, w16, w17 << 32
   bn.wsrw mod, w16

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_frommsg_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_frommsg_test.s
@@ -20,11 +20,11 @@ main:
   bn.or   w16, w16, w17 << 32
   bn.wsrw mod, w16
 
-  /* ra <- onebitdecompress(xb). */
+  /* ra <- masked_poly_frommsg(xb). */
   la  x2, stack_end
   la  x10, xb
   la  x12, ra
-  jal x1, onebitdecompress
+  jal x1, masked_poly_frommsg
 
   /* r <- unmask(ra). */
   la   x2, ra

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_frommsg_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_frommsg_testgen.py
@@ -22,7 +22,7 @@ def frommsg(a: int, q: int) -> List[int]:
     return r
 
 
-def gen_onebitdecompress_test(
+def gen_masked_poly_frommsg_test(
         seed: Optional[int],
         data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
     if seed is not None:
@@ -87,4 +87,4 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     with args.data, args.exp, args.dexp:
-        gen_onebitdecompress_test(args.seed, args.data, args.exp, args.dexp)
+        gen_masked_poly_frommsg_test(args.seed, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_getnoise_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_getnoise_test.s
@@ -2,9 +2,6 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NSHARES 2
-#define N_WDR 16
-#define NB_POLY 512
 #define STACK_SIZE 20000
 
 .section .text.start
@@ -13,83 +10,78 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* MOD <= dmem[modulus] = KYBER_Q */
-  la      x6, modulus_bn
-  bn.lid  x0, 0(x6)
+  /* mod = q. */
+  la      x5, modulus_bn
+  bn.lid  x0, 0(x5)
   bn.rshi w0, w31, w0 >> 240
-  bn.wsrw 0x0, w0
+  bn.wsrw mod, w0
 
-  /* reta_1_e2 <= recombine(masked_poly_getnoise_eta_1(seed, nonce, eta = 2)) */
-  la  x2, stack_end
-  la  x10, seed
-  la  x11, nonce
-  jal x1, masked_poly_getnoise_eta_init
-  li  x10, 2
-  la  x11, ra
-  jal x1, masked_poly_getnoise_eta_1
-  la   x2, ra
-  la   x3, reta_1_e2
-  li   x4, 1
-  li   x5, NSHARES
-  addi x5, x5, -1
-  loopi N_WDR, 7
-    addi   x6, x2, NB_POLY
-    bn.lid x0, 0(x2++)
-    loop x5, 3
-      bn.lid       x4, 0(x6)
-      bn.addvm.16h w0, w0, w1
-      addi         x6, x6, NB_POLY
-    endloop
-    bn.sid x0, 0(x3++)
+  /* ra <- masked_poly_getnoise_eta_1(seed, nonce, eta = 2). */
+  la   x2, stack_end
+  la   x10, seed
+  la   x11, nonce
+  jal  x1, masked_poly_getnoise_eta_init
+
+  li   x10, 2
+  la   x11, ra
+  jal  x1, masked_poly_getnoise_eta_1
+
+  /* reta_1_e2 <- unmask(ra). */
+  la     x2, ra
+  addi   x3, x2, 512
+  la     x5, reta_1_e2
+  li     x4, 1
+  loopi 16, 4
+    bn.lid       x0, 0(x2++)
+    bn.lid       x4, 0(x3++)
+    bn.addvm.16h w0, w0, w1
+    bn.sid       x0, 0(x5++)
   endloop
 
-  /* reta_1_e3 <= recombine(masked_poly_getnoise_eta_1(seed, nonce, eta = 3)) */
+  /* ra <- masked_poly_getnoise_eta_1(seed, nonce, eta = 3). */
   la  x2, stack_end
   la  x10, seed
   la  x11, nonce
   jal x1, masked_poly_getnoise_eta_init
+
   li  x10, 3
   la  x11, ra
   jal x1, masked_poly_getnoise_eta_1
-  la   x2, ra
-  la   x3, reta_1_e3
-  li   x4, 1
-  li   x5, NSHARES
-  addi x5, x5, -1
-  loopi N_WDR, 7
-    addi   x6, x2, NB_POLY
-    bn.lid x0, 0(x2++)
-    loop x5, 3
-      bn.lid       x4, 0(x6)
-      bn.addvm.16h w0, w0, w1
-      addi         x6, x6, NB_POLY
-    endloop
-    bn.sid x0, 0(x3++)
+
+  /* reta_1_e3 <- unmask(ra). */
+  la     x2, ra
+  addi   x3, x2, 512
+  la     x5, reta_1_e3
+  li     x4, 1
+  loopi 16, 4
+    bn.lid       x0, 0(x2++)
+    bn.lid       x4, 0(x3++)
+    bn.addvm.16h w0, w0, w1
+    bn.sid       x0, 0(x5++)
   endloop
 
-  /* reta_2 <= recombine(masked_poly_getnoise_eta_2(seed, nonce, eta = 2)) */
+  /* ra <- masked_poly_getnoise_eta_2(seed, nonce, eta = 2). */
   la  x2, stack_end
   la  x10, seed
   la  x11, nonce
   jal x1, masked_poly_getnoise_eta_init
+
   li  x10, 2
   la  x11, ra
   jal x1, masked_poly_getnoise_eta_2
-  la   x2, ra
-  la   x3, reta_2
-  li   x4, 1
-  li   x5, NSHARES
-  addi x5, x5, -1
-  loopi N_WDR, 7
-    addi   x6, x2, NB_POLY
-    bn.lid x0, 0(x2++)
-    loop x5, 3
-      bn.lid       x4, 0(x6)
-      bn.addvm.16h w0, w0, w1
-      addi         x6, x6, NB_POLY
-    endloop
-    bn.sid x0, 0(x3++)
+
+  /* reta_2 <- unmask(ra). */
+  la     x2, ra
+  addi   x3, x2, 512
+  la     x5, reta_2
+  li     x4, 1
+  loopi 16, 4
+    bn.lid       x0, 0(x2++)
+    bn.lid       x4, 0(x3++)
+    bn.addvm.16h w0, w0, w1
+    bn.sid       x0, 0(x5++)
   endloop
+
   ecall
 
 .data
@@ -99,10 +91,10 @@ stack:
 stack_end:
 
 reta_1_e2:
-  .zero 32 * N_WDR
+  .zero 512
 
 reta_1_e3:
-  .zero 32 * N_WDR
+  .zero 512
 
 reta_2:
-  .zero 32 * N_WDR
+  .zero 512

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_getnoise_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_getnoise_test.s
@@ -10,97 +10,99 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* MOD <= dmem[modulus] = KYBER_Q */
-    la      x6, modulus_bn
-    bn.lid  x0, 0(x6)
-    bn.rshi w0, w31, w0 >> 240
-    bn.wsrw 0x0, w0
+  /* MOD <= dmem[modulus] = KYBER_Q */
+  la      x6, modulus_bn
+  bn.lid  x0, 0(x6)
+  bn.rshi w0, w31, w0 >> 240
+  bn.wsrw 0x0, w0
 
-    /* reta_1_e2 <= recombine(masked_poly_getnoise_eta_1(seed, nonce, eta = 2)) */
-    la  x2, stack_end
-    la  x10, seed
-    la  x11, nonce
-    jal x1, masked_poly_getnoise_eta_init
-    li  x10, 2
-    la  x11, ra
-    jal x1, masked_poly_getnoise_eta_1
-    la   x2, ra
-    la   x3, reta_1_e2
-    li   x4, 1
-    li   x5, NSHARES
-    addi x5, x5, -1
-    loopi N_WDR, 7
-        addi   x6, x2, NB_POLY
-        bn.lid x0, 0(x2++)
-        loop x5, 3
-            bn.lid       x4, 0(x6)
-            bn.addvm.16h w0, w0, w1
-            addi         x6, x6, NB_POLY
-        endloop
-        bn.sid x0, 0(x3++)
+  /* reta_1_e2 <= recombine(masked_poly_getnoise_eta_1(seed, nonce, eta = 2)) */
+  la  x2, stack_end
+  la  x10, seed
+  la  x11, nonce
+  jal x1, masked_poly_getnoise_eta_init
+  li  x10, 2
+  la  x11, ra
+  jal x1, masked_poly_getnoise_eta_1
+  la   x2, ra
+  la   x3, reta_1_e2
+  li   x4, 1
+  li   x5, NSHARES
+  addi x5, x5, -1
+  loopi N_WDR, 7
+    addi   x6, x2, NB_POLY
+    bn.lid x0, 0(x2++)
+    loop x5, 3
+      bn.lid       x4, 0(x6)
+      bn.addvm.16h w0, w0, w1
+      addi         x6, x6, NB_POLY
     endloop
+    bn.sid x0, 0(x3++)
+  endloop
 
-    /* reta_1_e3 <= recombine(masked_poly_getnoise_eta_1(seed, nonce, eta = 3)) */
-    la  x2, stack_end
-    la  x10, seed
-    la  x11, nonce
-    jal x1, masked_poly_getnoise_eta_init
-    li  x10, 3
-    la  x11, ra
-    jal x1, masked_poly_getnoise_eta_1
-    la   x2, ra
-    la   x3, reta_1_e3
-    li   x4, 1
-    li   x5, NSHARES
-    addi x5, x5, -1
-    loopi N_WDR, 7
-        addi   x6, x2, NB_POLY
-        bn.lid x0, 0(x2++)
-        loop x5, 3
-            bn.lid       x4, 0(x6)
-            bn.addvm.16h w0, w0, w1
-            addi         x6, x6, NB_POLY
-        endloop
-        bn.sid x0, 0(x3++)
+  /* reta_1_e3 <= recombine(masked_poly_getnoise_eta_1(seed, nonce, eta = 3)) */
+  la  x2, stack_end
+  la  x10, seed
+  la  x11, nonce
+  jal x1, masked_poly_getnoise_eta_init
+  li  x10, 3
+  la  x11, ra
+  jal x1, masked_poly_getnoise_eta_1
+  la   x2, ra
+  la   x3, reta_1_e3
+  li   x4, 1
+  li   x5, NSHARES
+  addi x5, x5, -1
+  loopi N_WDR, 7
+    addi   x6, x2, NB_POLY
+    bn.lid x0, 0(x2++)
+    loop x5, 3
+      bn.lid       x4, 0(x6)
+      bn.addvm.16h w0, w0, w1
+      addi         x6, x6, NB_POLY
     endloop
+    bn.sid x0, 0(x3++)
+  endloop
 
-    /* reta_2 <= recombine(masked_poly_getnoise_eta_2(seed, nonce, eta = 2)) */
-    la  x2, stack_end
-    la  x10, seed
-    la  x11, nonce
-    jal x1, masked_poly_getnoise_eta_init
-    li  x10, 2
-    la  x11, ra
-    jal x1, masked_poly_getnoise_eta_2
-    la   x2, ra
-    la   x3, reta_2
-    li   x4, 1
-    li   x5, NSHARES
-    addi x5, x5, -1
-    loopi N_WDR, 7
-        addi   x6, x2, NB_POLY
-        bn.lid x0, 0(x2++)
-        loop x5, 3
-            bn.lid       x4, 0(x6)
-            bn.addvm.16h w0, w0, w1
-            addi         x6, x6, NB_POLY
-        endloop
-        bn.sid x0, 0(x3++)
+  /* reta_2 <= recombine(masked_poly_getnoise_eta_2(seed, nonce, eta = 2)) */
+  la  x2, stack_end
+  la  x10, seed
+  la  x11, nonce
+  jal x1, masked_poly_getnoise_eta_init
+  li  x10, 2
+  la  x11, ra
+  jal x1, masked_poly_getnoise_eta_2
+  la   x2, ra
+  la   x3, reta_2
+  li   x4, 1
+  li   x5, NSHARES
+  addi x5, x5, -1
+  loopi N_WDR, 7
+    addi   x6, x2, NB_POLY
+    bn.lid x0, 0(x2++)
+    loop x5, 3
+      bn.lid       x4, 0(x6)
+      bn.addvm.16h w0, w0, w1
+      addi         x6, x6, NB_POLY
     endloop
-    ecall
+    bn.sid x0, 0(x3++)
+  endloop
+  ecall
 
 .data
 .balign 32
 stack:
-    .zero STACK_SIZE
+  .zero STACK_SIZE
 stack_end:
 
 reta_1_e2:
-    .zero 32 * N_WDR
+  .zero 32 * N_WDR
+
 reta_1_e3:
-    .zero 32 * N_WDR
+  .zero 32 * N_WDR
+
 reta_2:
-    .zero 32 * N_WDR
+  .zero 32 * N_WDR

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_getnoise_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_getnoise_test.s
@@ -10,21 +10,26 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* mod = q. */
+  /* mod = qinv | q. */
+  add     x4, x0, x0
   la      x5, modulus_bn
-  bn.lid  x0, 0(x5)
+  bn.lid  x4++, 0(x5)
   bn.rshi w0, w31, w0 >> 240
+  la      x5, modulus_inv
+  bn.lid  x4, 0(x5)
+  bn.or   w0, w0, w1 << 32
   bn.wsrw mod, w0
 
   /* ra <- masked_poly_getnoise_eta_1(seed, nonce, eta = 2). */
-  la   x2, stack_end
-  la   x10, seed
-  la   x11, nonce
-  jal  x1, masked_poly_getnoise_eta_init
+  la  x2, stack_end
+  la  x10, seed
+  la  x11, nonce
+  jal x1, masked_poly_getnoise_eta_init
 
-  li   x10, 2
-  la   x11, ra
-  jal  x1, masked_poly_getnoise_eta_1
+  bn.wsrr w16, mod
+  li      x10, 2
+  la      x11, ra
+  jal     x1, masked_poly_getnoise_eta_1
 
   /* reta_1_e2 <- unmask(ra). */
   la     x2, ra
@@ -44,9 +49,10 @@ main:
   la  x11, nonce
   jal x1, masked_poly_getnoise_eta_init
 
-  li  x10, 3
-  la  x11, ra
-  jal x1, masked_poly_getnoise_eta_1
+  bn.wsrr w16, mod
+  li      x10, 3
+  la      x11, ra
+  jal     x1, masked_poly_getnoise_eta_1
 
   /* reta_1_e3 <- unmask(ra). */
   la     x2, ra
@@ -66,9 +72,10 @@ main:
   la  x11, nonce
   jal x1, masked_poly_getnoise_eta_init
 
-  li  x10, 2
-  la  x11, ra
-  jal x1, masked_poly_getnoise_eta_2
+  bn.wsrr w16, mod
+  li      x10, 2
+  la      x11, ra
+  jal     x1, masked_poly_getnoise_eta_2
 
   /* reta_2 <- unmask(ra). */
   la     x2, ra

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_getnoise_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_getnoise_test.s
@@ -10,12 +10,12 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* w16 = mod = qinv | q. */
+  /* w16 = mod = mqinv | q. */
   addi    x4, x0, 16
-  la      x5, modulus_bn
+  la      x5, const_q
   bn.lid  x4++, 0(x5)
   bn.rshi w16, w31, w16 >> 240
-  la      x5, modulus_inv
+  la      x5, const_mqinv
   bn.lid  x4, 0(x5)
   bn.or   w16, w16, w17 << 32
   bn.wsrw mod, w16

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_getnoise_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_getnoise_test.s
@@ -10,15 +10,15 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* mod = qinv | q. */
-  add     x4, x0, x0
+  /* w16 = mod = qinv | q. */
+  addi    x4, x0, 16
   la      x5, modulus_bn
   bn.lid  x4++, 0(x5)
-  bn.rshi w0, w31, w0 >> 240
+  bn.rshi w16, w31, w16 >> 240
   la      x5, modulus_inv
   bn.lid  x4, 0(x5)
-  bn.or   w0, w0, w1 << 32
-  bn.wsrw mod, w0
+  bn.or   w16, w16, w17 << 32
+  bn.wsrw mod, w16
 
   /* ra <- masked_poly_getnoise_eta_1(seed, nonce, eta = 2). */
   la  x2, stack_end
@@ -26,10 +26,9 @@ main:
   la  x11, nonce
   jal x1, masked_poly_getnoise_eta_init
 
-  bn.wsrr w16, mod
-  li      x10, 2
-  la      x11, ra
-  jal     x1, masked_poly_getnoise_eta_1
+  li  x10, 2
+  la  x11, ra
+  jal x1, masked_poly_getnoise_eta_1
 
   /* reta_1_e2 <- unmask(ra). */
   la     x2, ra
@@ -49,10 +48,9 @@ main:
   la  x11, nonce
   jal x1, masked_poly_getnoise_eta_init
 
-  bn.wsrr w16, mod
-  li      x10, 3
-  la      x11, ra
-  jal     x1, masked_poly_getnoise_eta_1
+  li  x10, 3
+  la  x11, ra
+  jal x1, masked_poly_getnoise_eta_1
 
   /* reta_1_e3 <- unmask(ra). */
   la     x2, ra
@@ -72,10 +70,9 @@ main:
   la  x11, nonce
   jal x1, masked_poly_getnoise_eta_init
 
-  bn.wsrr w16, mod
-  li      x10, 2
-  la      x11, ra
-  jal     x1, masked_poly_getnoise_eta_2
+  li  x10, 2
+  la  x11, ra
+  jal x1, masked_poly_getnoise_eta_2
 
   /* reta_2 <- unmask(ra). */
   la     x2, ra

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_getnoise_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_getnoise_testgen.py
@@ -13,8 +13,7 @@ from shared.testgen import write_test_data, write_test_exp, write_test_dexp
 
 N = 256
 NSHARES = 2
-N_WDR = 16
-BITSIZE = 16
+K = 16
 Q = 3329
 
 
@@ -62,7 +61,7 @@ def getnoise(seed: bytes, nonce: int, eta: int) -> int:
     shake = SHAKE256.new(seed + bytes([nonce]))
     buf = shake.read(eta * N // 4)
     r = _cbd3(buf) if eta == 3 else _cbd2(buf)
-    return sum(r[i] << (i * BITSIZE) for i in range(N))
+    return sum(r[i] << (i * K) for i in range(N))
 
 
 def gen_masked_poly_getnoise_test(
@@ -82,30 +81,45 @@ def gen_masked_poly_getnoise_test(
 
     # eta_1 is exercised at both ETA1 values (2 and 3); eta_2 uses eta = 2.
     def pack(v):
-        return int.to_bytes(v, byteorder="little", length=32 * N_WDR)
+        return int.to_bytes(v, byteorder="little", length=512)
     reta1_e2 = pack(getnoise(coins, nonce, 2))
     reta1_e3 = pack(getnoise(coins, nonce, 3))
     reta2 = pack(getnoise(coins, nonce, 2))
 
-    ra_bytes = int.to_bytes(0, byteorder='little', length=32 * N_WDR * NSHARES)
+    # Write input values.
+    inputs = {
+        'seed': seed_bytes,
+        'nonce': nonce_byte,
+        'ra': int.to_bytes(0, byteorder='little', length=512 * NSHARES)
+    }
+    write_test_data(inputs, data_file)
 
-    write_test_data({'seed': seed_bytes, 'nonce': nonce_byte, 'ra': ra_bytes},
-                    data_file)
+    # Write expected register values (none).
     write_test_exp({}, exp_file)
+
+    # Write expected dmem values.
     write_test_dexp({'reta_1_e2': reta1_e2, 'reta_1_e3': reta1_e3,
                      'reta_2': reta2}, dexp_file)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('-s', '--seed', type=int, required=False,
-                        help='Seed value for pseudorandomness.')
-    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for input DMEM values.')
-    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for expected register values.')
-    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for expected DMEM values.')
+    parser.add_argument('-s', '--seed',
+                        type=int,
+                        required=False,
+                        help=('Seed value for pseudorandomness.'))
+    parser.add_argument('data',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for input DMEM values.'))
+    parser.add_argument('exp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected register values.'))
+    parser.add_argument('dexp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected DMEM values.'))
     args = parser.parse_args()
 
     with args.data, args.exp, args.dexp:

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_tomsg_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_tomsg_test.s
@@ -8,41 +8,39 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* Load stack pointer */
-    la x2, stack_end
+  /* Load stack pointer */
+  la x2, stack_end
 
-    /* dmem[rb] <= masked_poly_tomsg(dmem[xa]). */
-    la  x10, xa
-    la  x12, rb
-    jal x1, masked_poly_tomsg
+  /* dmem[rb] <= masked_poly_tomsg(dmem[xa]). */
+  la  x10, xa
+  la  x12, rb
+  jal x1, masked_poly_tomsg
 
-    /* Compute r. */
-    la     x2, rb
-    la     x3, r
-    li     x4, 1
-    li     x5, NSHARES
-    addi   x5, x5, -1
-    bn.lid x0, 0(x2++)
-    loop x5, 2
-        bn.lid x4, 0(x2++)
-        bn.xor w0, w0, w1
-    endloop
-    bn.sid x0, 0(x3++)
+  /* Compute r. */
+  la     x2, rb
+  la     x3, r
+  li     x4, 1
+  li     x5, NSHARES
+  addi   x5, x5, -1
+  bn.lid x0, 0(x2++)
+  loop x5, 2
+    bn.lid x4, 0(x2++)
+    bn.xor w0, w0, w1
+  endloop
+  bn.sid x0, 0(x3++)
 
-    ecall
+  ecall
 
 .data
 .balign 32
 stack:
-    .zero STACK_SIZE
+  .zero STACK_SIZE
 stack_end:
-
 
 .data
 .balign 32
-
 r:
-    .zero 32
+  .zero 32

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_tomsg_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_tomsg_test.s
@@ -2,7 +2,6 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NSHARES 2
 #define STACK_SIZE 20000
 
 .section .text.start
@@ -11,26 +10,20 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* Load stack pointer */
-  la x2, stack_end
-
-  /* dmem[rb] <= masked_poly_tomsg(dmem[xa]). */
+  /* rb <- masked_poly_tomsg(xa). */
+  la  x2, stack_end
   la  x10, xa
   la  x12, rb
   jal x1, masked_poly_tomsg
 
-  /* Compute r. */
+  /* r <- unmask(rb). */
   la     x2, rb
-  la     x3, r
   li     x4, 1
-  li     x5, NSHARES
-  addi   x5, x5, -1
   bn.lid x0, 0(x2++)
-  loop x5, 2
-    bn.lid x4, 0(x2++)
-    bn.xor w0, w0, w1
-  endloop
-  bn.sid x0, 0(x3++)
+  bn.lid x4, 0(x2)
+  bn.xor w0, w0, w1
+  la     x2, r
+  bn.sid x0, 0(x2)
 
   ecall
 
@@ -40,7 +33,5 @@ stack:
   .zero STACK_SIZE
 stack_end:
 
-.data
-.balign 32
 r:
   .zero 32

--- a/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_tomsg_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/masked_poly_tomsg_testgen.py
@@ -11,24 +11,31 @@ from shared.testgen import write_test_data, write_test_exp, write_test_dexp
 
 N = 256
 NSHARES = 2
+Q = 3329
 
 
-def bitslice_vec(x: List[int], k: int) -> List[int]:
-    r = [0] * k
-    one = sum(1 << (i * 16) for i in range(16))
+def bitslice_vec(x: List[int], k: int) -> bytes:
     mask = (1 << N) - 1
-    x_int = sum(x[i] << (i * 16) for i in range(N))
-    for i in range(16):
+    # Generate 1 in 16 16-bit lanes.
+    vone = sum(1 << (lane * 16) for lane in range(16))
+
+    r = [0] * k
+    x_int = sum(x[coeff] << (coeff * 16) for coeff in range(N))
+    for _ in range(16):
         t = x_int & mask
         x_int >>= N
-        for j in range(k):
-            r[j] <<= 1
-            r[j] |= (t & one)
+        for bit in range(k):
+            r[bit] <<= 1
+            r[bit] |= (t & vone)
             t >>= 1
-    return r
+
+    r_bytes = bytes()
+    for bit in range(k):
+        r_bytes += int.to_bytes(r[bit], byteorder="little", length=32)
+    return r_bytes
 
 
-def tomsg(x: List[int], q: int) -> List[int]:
+def tomsg(x: List[int], q: int) -> bytes:
     """Convert polynomial to 32-byte message."""
     for i in range(N):
         x[i] = (((x[i] << 1) + q // 2) // q) & 1
@@ -43,25 +50,25 @@ def gen_masked_poly_tomsg_test(
     if seed is not None:
         random.seed(seed)
 
-    q = 3329
-
     # Generate input.
     x = [0] * N
+    r = [0] * N
     x_bytes = bytes()
     for _ in range(NSHARES):
-        t = [random.randint(0, q - 1) for _ in range(N)]
-        x = [(x[j] + t[j]) % q for j in range(N)]
-        tmp = sum(t[j] << (j * 16) for j in range(N))
-        x_bytes += int.to_bytes(tmp, byteorder="little", length=512)
+        for coeff in range(N):
+            x[coeff] = random.randint(0, Q - 1)
+            r[coeff] = (r[coeff] + x[coeff]) % Q
+        x_int = sum(x[coeff] << (coeff * 16) for coeff in range(N))
+        x_bytes += int.to_bytes(x_int, byteorder="little", length=512)
 
     # Generate expected result.
-    r = tomsg(x, q)
-    r_bytes = int.to_bytes(r[0], byteorder="little", length=32)
-
-    rb_bytes = int.to_bytes(0, byteorder='little', length=32 * NSHARES)
+    r_bytes = tomsg(r, Q)
 
     # Write input values.
-    inputs = {'xa': x_bytes, 'rb': rb_bytes}
+    inputs = {
+        'xa': x_bytes,
+        'rb': int.to_bytes(0, byteorder='little', length=32 * NSHARES)
+    }
     write_test_data(inputs, data_file)
 
     # Write expected register values (none).

--- a/sw/acc/crypto/tests/mlkem/gadgets/onebitdecompress_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/onebitdecompress_test.s
@@ -10,51 +10,51 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* Load stack pointer */
-    la x2, stack_end
+  /* Load stack pointer */
+  la x2, stack_end
 
-    /* Load R || Q to mod. */
-    addi    x4, x0, 0
-    la      x5, modulus_bn
-    bn.lid  x4++, 0(x5)
-    bn.rshi w0, w31, w0 >> 240
-    la      x5, modulus_inv
-    bn.lid  x4, 0(x5)
-    bn.or   w0, w0, w1 << 32 /* mod = R | Q */
-    bn.wsrw mod, w0
+  /* Load R || Q to mod. */
+  addi    x4, x0, 0
+  la      x5, modulus_bn
+  bn.lid  x4++, 0(x5)
+  bn.rshi w0, w31, w0 >> 240
+  la      x5, modulus_inv
+  bn.lid  x4, 0(x5)
+  bn.or   w0, w0, w1 << 32 /* mod = R | Q */
+  bn.wsrw mod, w0
 
-    /* dmem[ra] <= onebitdecompress(dmem[xb]) */
-    bn.wsrr w16, mod
-    la      x10, xb
-    la      x12, ra
-    jal     x1, onebitdecompress
+  /* dmem[ra] <= onebitdecompress(dmem[xb]) */
+  bn.wsrr w16, mod
+  la      x10, xb
+  la      x12, ra
+  jal     x1, onebitdecompress
 
-    /* Compute r */
-    la   x2, ra
-    la   x3, r
-    li   x4, 1
-    li   x5, NSHARES
-    addi x5, x5, -1
-    loopi N_WDR, 7
-        addi   x6, x2, NB_POLY
-        bn.lid x0, 0(x2++)
-        loop x5, 3
-            bn.lid       x4, 0(x6)
-            bn.addvm.16h w0, w0, w1
-            addi         x6, x6, NB_POLY
-        endloop
-        bn.sid x0, 0(x3++)
+  /* Compute r */
+  la   x2, ra
+  la   x3, r
+  li   x4, 1
+  li   x5, NSHARES
+  addi x5, x5, -1
+  loopi N_WDR, 7
+    addi   x6, x2, NB_POLY
+    bn.lid x0, 0(x2++)
+    loop x5, 3
+      bn.lid       x4, 0(x6)
+      bn.addvm.16h w0, w0, w1
+      addi         x6, x6, NB_POLY
     endloop
-    ecall
+    bn.sid x0, 0(x3++)
+  endloop
+  ecall
 
 .data
 .balign 32
 stack:
-    .zero STACK_SIZE
+  .zero STACK_SIZE
 stack_end:
 
 r:
-    .zero 512 * NSHARES
+  .zero 512 * NSHARES

--- a/sw/acc/crypto/tests/mlkem/gadgets/onebitdecompress_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/onebitdecompress_test.s
@@ -2,9 +2,6 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NSHARES 2
-#define N_WDR 16
-#define NB_POLY 512
 #define STACK_SIZE 20000
 
 .section .text.start
@@ -13,41 +10,35 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* Load stack pointer */
-  la x2, stack_end
-
-  /* Load R || Q to mod. */
-  addi    x4, x0, 0
+  /* mod = qinv | q. */
+  add     x4, x0, x0
   la      x5, modulus_bn
   bn.lid  x4++, 0(x5)
   bn.rshi w0, w31, w0 >> 240
   la      x5, modulus_inv
   bn.lid  x4, 0(x5)
-  bn.or   w0, w0, w1 << 32 /* mod = R | Q */
+  bn.or   w0, w0, w1 << 32
   bn.wsrw mod, w0
 
-  /* dmem[ra] <= onebitdecompress(dmem[xb]) */
+  /* ra <- onebitdecompress(xb). */
   bn.wsrr w16, mod
+  la      x2, stack_end
   la      x10, xb
   la      x12, ra
   jal     x1, onebitdecompress
 
-  /* Compute r */
+  /* r <- unmask(ra). */
   la   x2, ra
-  la   x3, r
+  addi x3, x2, 512
+  la   x5, r
   li   x4, 1
-  li   x5, NSHARES
-  addi x5, x5, -1
-  loopi N_WDR, 7
-    addi   x6, x2, NB_POLY
-    bn.lid x0, 0(x2++)
-    loop x5, 3
-      bn.lid       x4, 0(x6)
-      bn.addvm.16h w0, w0, w1
-      addi         x6, x6, NB_POLY
-    endloop
-    bn.sid x0, 0(x3++)
+  loopi 16, 4
+    bn.lid       x0, 0(x2++)
+    bn.lid       x4, 0(x3++)
+    bn.addvm.16h w0, w0, w1
+    bn.sid       x0, 0(x5++)
   endloop
+
   ecall
 
 .data
@@ -57,4 +48,4 @@ stack:
 stack_end:
 
 r:
-  .zero 512 * NSHARES
+  .zero 512

--- a/sw/acc/crypto/tests/mlkem/gadgets/onebitdecompress_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/onebitdecompress_test.s
@@ -10,22 +10,21 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* mod = qinv | q. */
-  add     x4, x0, x0
+  /* w16 = mod = qinv | q. */
+  addi    x4, x0, 16
   la      x5, modulus_bn
   bn.lid  x4++, 0(x5)
-  bn.rshi w0, w31, w0 >> 240
+  bn.rshi w16, w31, w16 >> 240
   la      x5, modulus_inv
   bn.lid  x4, 0(x5)
-  bn.or   w0, w0, w1 << 32
-  bn.wsrw mod, w0
+  bn.or   w16, w16, w17 << 32
+  bn.wsrw mod, w16
 
   /* ra <- onebitdecompress(xb). */
-  bn.wsrr w16, mod
-  la      x2, stack_end
-  la      x10, xb
-  la      x12, ra
-  jal     x1, onebitdecompress
+  la  x2, stack_end
+  la  x10, xb
+  la  x12, ra
+  jal x1, onebitdecompress
 
   /* r <- unmask(ra). */
   la   x2, ra

--- a/sw/acc/crypto/tests/mlkem/gadgets/onebitdecompress_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/onebitdecompress_testgen.py
@@ -11,6 +11,7 @@ from shared.testgen import write_test_data, write_test_exp, write_test_dexp
 
 N = 256
 NSHARES = 2
+Q = 3329
 
 
 def frommsg(a: int, q: int) -> List[int]:
@@ -27,48 +28,62 @@ def gen_onebitdecompress_test(
     if seed is not None:
         random.seed(seed)
 
-    operand_nbytes = 512 * NSHARES
-
     # Random Boolean shares of the message; r is their unmasked XOR.
-    r = 0
+    rt = 0
     x_bytes = bytes()
     for _ in range(NSHARES):
-        t = random.getrandbits(N)
-        r ^= t
-        x_bytes += int.to_bytes(t, byteorder="little", length=32)
+        x = random.getrandbits(N)
+        rt ^= x
+        x_bytes += int.to_bytes(x, byteorder="little", length=32)
 
     # Reference: undo the bitslice layout, then Decompress_q(m, 1).
-    exp = 0
-    one = sum(1 << (i * 16) for i in range(16))
-    one = (one << 15) & ((1 << N) - 1)
-    for i in range(16):
-        t = r & one
-        r <<= 1
+    r_int = 0
+    t = 1 << 15
+    v2_15 = sum(t << (lane * 16) for lane in range(16))
+    v2_15 &= (1 << N) - 1
+    for lane in range(16):
+        t = rt & v2_15
+        rt <<= 1
         t >>= 15
-        for j in range(i * 16, (i + 1) * 16):
-            exp |= ((t & 1) << j)
+        for i in range(lane * 16, (lane + 1) * 16):
+            r_int |= ((t & 1) << i)
             t >>= 16
-    exp = frommsg(exp, 3329)
-    exp = sum(exp[i] << (i * 16) for i in range(N))
-    r_bytes = int.to_bytes(exp, byteorder='little', length=512)
+    r = frommsg(r_int, Q)
+    r_int = sum(r[coeff] << (coeff * 16) for coeff in range(N))
+    r_bytes = int.to_bytes(r_int, byteorder='little', length=512)
 
-    ra_bytes = int.to_bytes(0, byteorder='little', length=operand_nbytes)
+    # Write input values.
+    inputs = {
+        'xb': x_bytes,
+        'ra': int.to_bytes(0, byteorder='little', length=512 * NSHARES)
+    }
+    write_test_data(inputs, data_file)
 
-    write_test_data({'xb': x_bytes, 'ra': ra_bytes}, data_file)
+    # Write expected register values (none).
     write_test_exp({}, exp_file)
+
+    # Write expected dmem values.
     write_test_dexp({'r': r_bytes}, dexp_file)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('-s', '--seed', type=int, required=False,
-                        help='Seed value for pseudorandomness.')
-    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for input DMEM values.')
-    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for expected register values.')
-    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for expected DMEM values.')
+    parser.add_argument('-s', '--seed',
+                        type=int,
+                        required=False,
+                        help=('Seed value for pseudorandomness.'))
+    parser.add_argument('data',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for input DMEM values.'))
+    parser.add_argument('exp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected register values.'))
+    parser.add_argument('dexp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected DMEM values.'))
     args = parser.parse_args()
 
     with args.data, args.exp, args.dexp:

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_from_bitsliced_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_from_bitsliced_test.s
@@ -2,15 +2,13 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NB_POLY 512
-
 .section .text.start
 
 main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* dmem[rn] <= poly_from_bitsliced(dmem[rbs]) */
+  /* rn <- poly_from_bitsliced(rbs). */
   la  x10, rbs
   la  x11, rn
   jal x1, poly_from_bitsliced
@@ -20,4 +18,4 @@ main:
 .data
 .balign 32
 rn:
-  .zero NB_POLY
+  .zero 512

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_from_bitsliced_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_from_bitsliced_test.s
@@ -7,17 +7,17 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* dmem[rn] <= poly_from_bitsliced(dmem[rbs]) */
-    la  x10, rbs
-    la  x11, rn
-    jal x1, poly_from_bitsliced
+  /* dmem[rn] <= poly_from_bitsliced(dmem[rbs]) */
+  la  x10, rbs
+  la  x11, rn
+  jal x1, poly_from_bitsliced
 
-    ecall
+  ecall
 
 .data
 .balign 32
 rn:
-    .zero NB_POLY
+  .zero NB_POLY

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_from_bitsliced_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_from_bitsliced_testgen.py
@@ -5,11 +5,33 @@
 
 import argparse
 import random
-from typing import TextIO, Optional
+from typing import TextIO, Optional, List
 
 from shared.testgen import write_test_data, write_test_exp, write_test_dexp
 
 N = 256
+K = 12
+
+
+def bitslice_vec(x: List[int], k: int) -> bytes:
+    mask = (1 << N) - 1
+    # Generate 1 in 16 16-bit lanes.
+    vone = sum(1 << (lane * 16) for lane in range(16))
+
+    r = [0] * k
+    x_int = sum(x[coeff] << (coeff * 16) for coeff in range(N))
+    for _ in range(16):
+        t = x_int & mask
+        x_int >>= N
+        for bit in range(k):
+            r[bit] <<= 1
+            r[bit] |= (t & vone)
+            t >>= 1
+
+    r_bytes = bytes()
+    for bit in range(k):
+        r_bytes += int.to_bytes(r[bit], byteorder="little", length=32)
+    return r_bytes
 
 
 def gen_poly_from_bitsliced_test(
@@ -19,29 +41,14 @@ def gen_poly_from_bitsliced_test(
     if seed is not None:
         random.seed(seed)
 
-    k = 12
-
     # Generate the expected output: random k-bit coefficients, one per lane.
-    x = [random.randint(0, (1 << k) - 1) for _ in range(N)]
-    x_int = sum((x[j] << (j * 16)) for j in range(N))
+    x = [random.randint(0, (1 << K) - 1) for _ in range(N)]
+    x_int = sum((x[coeff] << (coeff * 16)) for coeff in range(N))
     x_bytes = int.to_bytes(x_int, byteorder="little", length=512)
 
     # Bitslice it to build the gadget input: word j holds bit j of every
     # coefficient.
-    mask = (1 << N) - 1
-    one = sum(1 << (i * 16) for i in range(16))
-    r = [0] * k
-    for i in range(16):
-        t = x_int & mask
-        x_int >>= N
-        for j in range(k):
-            r[j] <<= 1
-            r[j] |= (t & one)
-            t >>= 1
-
-    rbs_bytes = bytes()
-    for i in range(k):
-        rbs_bytes += int.to_bytes(r[i] & mask, byteorder="little", length=32)
+    rbs_bytes = bitslice_vec(x, K)
 
     # Write input values.
     inputs = {'rbs': rbs_bytes}

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_hocompress_du_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_hocompress_du_test.s
@@ -10,38 +10,38 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* dv = 4 (k = 2): rbv <- poly_hocompress(xa). */
+  /* du = 10 (k = 2): rbu <- poly_hocompress_du(xa). */
   la  x2, stack_end
   la  x10, xa
-  la  x12, rbv
+  la  x12, rbu
   li  x13, 2
-  jal x1, poly_hocompress
+  jal x1, poly_hocompress_du
 
-  /* rv4 <- unmask(rbv). */
-  la     x2, rbv
-  addi   x3, x2, 128
-  la     x5, rv4
+  /* ru10 <- unmask(rbu). */
+  la     x2, rbu
+  addi   x3, x2, 320
+  la     x5, ru10
   li     x4, 1
-  loopi 4, 4
+  loopi 10, 4
     bn.lid x0, 0(x2++)
     bn.lid x4, 0(x3++)
     bn.xor w0, w0, w1
     bn.sid x0, 0(x5++)
   endloop
 
-  /* dv = 5 (k = 4): rbv <- poly_hocompress(xa). */
+  /* du = 11 (k = 4): rbu <- poly_hocompress_du(xa). */
   la  x2, stack_end
   la  x10, xa
-  la  x12, rbv
+  la  x12, rbu
   li  x13, 4
-  jal x1, poly_hocompress
+  jal x1, poly_hocompress_du
 
-  /* rv5 <- unmask(rbv). */
-  la     x2, rbv
-  addi   x3, x2, 160
-  la     x5, rv5
+  /* ru11 <- unmask(rbu). */
+  la     x2, rbu
+  addi   x3, x2, 352
+  la     x5, ru11
   li     x4, 1
-  loopi 5, 4
+  loopi 11, 4
     bn.lid x0, 0(x2++)
     bn.lid x4, 0(x3++)
     bn.xor w0, w0, w1
@@ -56,8 +56,8 @@ stack:
   .zero STACK_SIZE
 stack_end:
 
-rv4:
-  .zero 32 * 4
+ru10:
+  .zero 32 * 10
 
-rv5:
-  .zero 32 * 5
+ru11:
+  .zero 32 * 11

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_hocompress_du_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_hocompress_du_testgen.py
@@ -40,7 +40,7 @@ def bitslice_vec(x: List[int], k: int) -> bytes:
     return r_bytes
 
 
-def gen_polyvec_hocompress_test(
+def gen_poly_hocompress_du_test(
         seed: Optional[int],
         data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
     if seed is not None:
@@ -97,4 +97,4 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     with args.data, args.exp, args.dexp:
-        gen_polyvec_hocompress_test(args.seed, args.data, args.exp, args.dexp)
+        gen_poly_hocompress_du_test(args.seed, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_hocompress_dv_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_hocompress_dv_test.s
@@ -10,38 +10,38 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* du = 10 (k = 2): rbu <- polyvec_hocompress(xa). */
+  /* dv = 4 (k = 2): rbv <- poly_hocompress_dv(xa). */
   la  x2, stack_end
   la  x10, xa
-  la  x12, rbu
+  la  x12, rbv
   li  x13, 2
-  jal x1, polyvec_hocompress
+  jal x1, poly_hocompress_dv
 
-  /* ru10 <- unmask(rbu). */
-  la     x2, rbu
-  addi   x3, x2, 320
-  la     x5, ru10
+  /* rv4 <- unmask(rbv). */
+  la     x2, rbv
+  addi   x3, x2, 128
+  la     x5, rv4
   li     x4, 1
-  loopi 10, 4
+  loopi 4, 4
     bn.lid x0, 0(x2++)
     bn.lid x4, 0(x3++)
     bn.xor w0, w0, w1
     bn.sid x0, 0(x5++)
   endloop
 
-  /* du = 11 (k = 4): rbu <- polyvec_hocompress(xa). */
+  /* dv = 5 (k = 4): rbv <- poly_hocompress_dv(xa). */
   la  x2, stack_end
   la  x10, xa
-  la  x12, rbu
+  la  x12, rbv
   li  x13, 4
-  jal x1, polyvec_hocompress
+  jal x1, poly_hocompress_dv
 
-  /* ru11 <- unmask(rbu). */
-  la     x2, rbu
-  addi   x3, x2, 352
-  la     x5, ru11
+  /* rv5 <- unmask(rbv). */
+  la     x2, rbv
+  addi   x3, x2, 160
+  la     x5, rv5
   li     x4, 1
-  loopi 11, 4
+  loopi 5, 4
     bn.lid x0, 0(x2++)
     bn.lid x4, 0(x3++)
     bn.xor w0, w0, w1
@@ -56,8 +56,8 @@ stack:
   .zero STACK_SIZE
 stack_end:
 
-ru10:
-  .zero 32 * 10
+rv4:
+  .zero 32 * 4
 
-ru11:
-  .zero 32 * 11
+rv5:
+  .zero 32 * 5

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_hocompress_dv_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_hocompress_dv_testgen.py
@@ -40,7 +40,7 @@ def bitslice_vec(x: List[int], k: int) -> bytes:
     return r_bytes
 
 
-def gen_poly_hocompress_test(
+def gen_poly_hocompress_dv_test(
         seed: Optional[int],
         data_file: TextIO, exp_file: TextIO, dexp_file: TextIO):
     if seed is not None:
@@ -97,4 +97,4 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     with args.data, args.exp, args.dexp:
-        gen_poly_hocompress_test(args.seed, args.data, args.exp, args.dexp)
+        gen_poly_hocompress_dv_test(args.seed, args.data, args.exp, args.dexp)

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_hocompress_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_hocompress_test.s
@@ -2,7 +2,6 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NSHARES 2
 #define STACK_SIZE 20000
 
 .section .text.start
@@ -18,22 +17,16 @@ main:
   li  x13, 2
   jal x1, poly_hocompress
 
-  /* Unmask rbv -> rv4 (dv = 4, share stride 4 * 32). */
+  /* rv4 <- unmask(rbv). */
   la     x2, rbv
-  la     x3, rv4
+  addi   x3, x2, 128
+  la     x5, rv4
   li     x4, 1
-  li     x5, NSHARES
-  addi   x5, x5, -1
-  li     x6, 4
-  loop x6, 7
-    addi   x7, x2, 128
+  loopi 4, 4
     bn.lid x0, 0(x2++)
-    loop x5, 3
-      bn.lid x4, 0(x7)
-      bn.xor w0, w0, w1
-      addi   x7, x7, 128
-    endloop
-    bn.sid x0, 0(x3++)
+    bn.lid x4, 0(x3++)
+    bn.xor w0, w0, w1
+    bn.sid x0, 0(x5++)
   endloop
 
   /* dv = 5 (k = 4): rbv <- poly_hocompress(xa). */
@@ -43,22 +36,16 @@ main:
   li  x13, 4
   jal x1, poly_hocompress
 
-  /* Unmask rbv -> rv5 (dv = 5, share stride 5 * 32). */
+  /* rv5 <- unmask(rbv). */
   la     x2, rbv
-  la     x3, rv5
+  addi   x3, x2, 160
+  la     x5, rv5
   li     x4, 1
-  li     x5, NSHARES
-  addi   x5, x5, -1
-  li     x6, 5
-  loop x6, 7
-    addi   x7, x2, 160
+  loopi 5, 4
     bn.lid x0, 0(x2++)
-    loop x5, 3
-      bn.lid x4, 0(x7)
-      bn.xor w0, w0, w1
-      addi   x7, x7, 160
-    endloop
-    bn.sid x0, 0(x3++)
+    bn.lid x4, 0(x3++)
+    bn.xor w0, w0, w1
+    bn.sid x0, 0(x5++)
   endloop
 
   ecall
@@ -69,8 +56,6 @@ stack:
   .zero STACK_SIZE
 stack_end:
 
-.data
-.balign 32
 rv4:
   .zero 32 * 4
 

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_hocompress_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_hocompress_test.s
@@ -8,70 +8,71 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* dv = 4 (k = 2): rbv <- poly_hocompress(xa). */
-    la  x2, stack_end
-    la  x10, xa
-    la  x12, rbv
-    li  x13, 2
-    jal x1, poly_hocompress
+  /* dv = 4 (k = 2): rbv <- poly_hocompress(xa). */
+  la  x2, stack_end
+  la  x10, xa
+  la  x12, rbv
+  li  x13, 2
+  jal x1, poly_hocompress
 
-    /* Unmask rbv -> rv4 (dv = 4, share stride 4 * 32). */
-    la     x2, rbv
-    la     x3, rv4
-    li     x4, 1
-    li     x5, NSHARES
-    addi   x5, x5, -1
-    li     x6, 4
-    loop x6, 7
-        addi   x7, x2, 128
-        bn.lid x0, 0(x2++)
-        loop x5, 3
-            bn.lid x4, 0(x7)
-            bn.xor w0, w0, w1
-            addi   x7, x7, 128
-        endloop
-        bn.sid x0, 0(x3++)
+  /* Unmask rbv -> rv4 (dv = 4, share stride 4 * 32). */
+  la     x2, rbv
+  la     x3, rv4
+  li     x4, 1
+  li     x5, NSHARES
+  addi   x5, x5, -1
+  li     x6, 4
+  loop x6, 7
+    addi   x7, x2, 128
+    bn.lid x0, 0(x2++)
+    loop x5, 3
+      bn.lid x4, 0(x7)
+      bn.xor w0, w0, w1
+      addi   x7, x7, 128
     endloop
+    bn.sid x0, 0(x3++)
+  endloop
 
-    /* dv = 5 (k = 4): rbv <- poly_hocompress(xa). */
-    la  x2, stack_end
-    la  x10, xa
-    la  x12, rbv
-    li  x13, 4
-    jal x1, poly_hocompress
+  /* dv = 5 (k = 4): rbv <- poly_hocompress(xa). */
+  la  x2, stack_end
+  la  x10, xa
+  la  x12, rbv
+  li  x13, 4
+  jal x1, poly_hocompress
 
-    /* Unmask rbv -> rv5 (dv = 5, share stride 5 * 32). */
-    la     x2, rbv
-    la     x3, rv5
-    li     x4, 1
-    li     x5, NSHARES
-    addi   x5, x5, -1
-    li     x6, 5
-    loop x6, 7
-        addi   x7, x2, 160
-        bn.lid x0, 0(x2++)
-        loop x5, 3
-            bn.lid x4, 0(x7)
-            bn.xor w0, w0, w1
-            addi   x7, x7, 160
-        endloop
-        bn.sid x0, 0(x3++)
+  /* Unmask rbv -> rv5 (dv = 5, share stride 5 * 32). */
+  la     x2, rbv
+  la     x3, rv5
+  li     x4, 1
+  li     x5, NSHARES
+  addi   x5, x5, -1
+  li     x6, 5
+  loop x6, 7
+    addi   x7, x2, 160
+    bn.lid x0, 0(x2++)
+    loop x5, 3
+      bn.lid x4, 0(x7)
+      bn.xor w0, w0, w1
+      addi   x7, x7, 160
     endloop
+    bn.sid x0, 0(x3++)
+  endloop
 
-    ecall
+  ecall
 
 .data
 .balign 32
 stack:
-    .zero STACK_SIZE
+  .zero STACK_SIZE
 stack_end:
 
 .data
 .balign 32
 rv4:
-    .zero 32 * 4
+  .zero 32 * 4
+
 rv5:
-    .zero 32 * 5
+  .zero 32 * 5

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_hocompress_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_hocompress_testgen.py
@@ -5,7 +5,7 @@
 
 import argparse
 import random
-from typing import TextIO, Optional
+from typing import TextIO, Optional, List
 
 from shared.testgen import write_test_data, write_test_exp, write_test_dexp
 
@@ -19,20 +19,25 @@ def compress(x: int, d: int) -> int:
     return (((x << d) + Q // 2) // Q) & ((1 << d) - 1)
 
 
-def bitslice(coeffs: list, d: int) -> bytes:
-    """Bitslice N d-bit coefficients into d planes of 32 bytes."""
-    m = (1 << N) - 1
-    one = sum(1 << (i * 16) for i in range(16)) & m
-    rt = [sum(coeffs[j + i] << (i * 16) for i in range(16))
-          for j in range(0, N, 16)]
-    out = bytes()
-    for _ in range(d):
-        t = 0
-        for j in range(16):
-            t = (t << 1) | (rt[j] & one)
-            rt[j] >>= 1
-        out += int.to_bytes(t, byteorder="little", length=32)
-    return out
+def bitslice_vec(x: List[int], k: int) -> bytes:
+    mask = (1 << N) - 1
+    # Generate 1 in 16 16-bit lanes.
+    vone = sum(1 << (lane * 16) for lane in range(16))
+
+    r = [0] * k
+    x_int = sum(x[coeff] << (coeff * 16) for coeff in range(N))
+    for _ in range(16):
+        t = x_int & mask
+        x_int >>= N
+        for bit in range(k):
+            r[bit] <<= 1
+            r[bit] |= (t & vone)
+            t >>= 1
+
+    r_bytes = bytes()
+    for bit in range(k):
+        r_bytes += int.to_bytes(r[bit], byteorder="little", length=32)
+    return r_bytes
 
 
 def gen_poly_hocompress_test(
@@ -42,37 +47,53 @@ def gen_poly_hocompress_test(
         random.seed(seed)
 
     # Random arithmetic shares of x; r is their unmasked sum mod q.
+    x = [0] * N
     r = [0] * N
     x_bytes = bytes()
     for _ in range(NSHARES):
-        xi = [random.randint(0, Q - 1) for _ in range(N)]
-        r = [(r[j] + xi[j]) % Q for j in range(N)]
-        x_bytes += int.to_bytes(sum(xi[j] << (j * 16) for j in range(N)),
-                                byteorder="little", length=512)
+        for coeff in range(N):
+            x[coeff] = random.randint(0, Q - 1)
+            r[coeff] = (r[coeff] + x[coeff]) % Q
+        x_int = sum(x[coeff] << (coeff * 16) for coeff in range(N))
+        x_bytes += int.to_bytes(x_int, byteorder="little", length=512)
 
     # Reference compressions for both dv values (dv = 4 for k != 4, dv = 5 for
     # k == 4); the gadget is exercised at both.
-    rv4 = bitslice([compress(r[i], 4) for i in range(N)], 4)
-    rv5 = bitslice([compress(r[i], 5) for i in range(N)], 5)
+    rv4 = bitslice_vec([compress(r[i], 4) for i in range(N)], 4)
+    rv5 = bitslice_vec([compress(r[i], 5) for i in range(N)], 5)
 
-    # Output buffer, reused for both calls and sized for the larger dv = 5 case.
-    rbv = int.to_bytes(0, byteorder='little', length=32 * 5 * NSHARES)
+    # Write input values.
+    inputs = {
+        'xa': x_bytes,
+        'rbv': int.to_bytes(0, byteorder='little', length=32 * 5 * NSHARES)
+    }
+    write_test_data(inputs, data_file)
 
-    write_test_data({'xa': x_bytes, 'rbv': rbv}, data_file)
+    # Write expected register values (none).
     write_test_exp({}, exp_file)
+
+    # Write expected dmem values.
     write_test_dexp({'rv4': rv4, 'rv5': rv5}, dexp_file)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('-s', '--seed', type=int, required=False,
-                        help='Seed value for pseudorandomness.')
-    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for input DMEM values.')
-    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for expected register values.')
-    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for expected DMEM values.')
+    parser.add_argument('-s', '--seed',
+                        type=int,
+                        required=False,
+                        help=('Seed value for pseudorandomness.'))
+    parser.add_argument('data',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for input DMEM values.'))
+    parser.add_argument('exp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected register values.'))
+    parser.add_argument('dexp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected DMEM values.'))
     args = parser.parse_args()
 
     with args.data, args.exp, args.dexp:

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_masked_compare_du_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_masked_compare_du_test.s
@@ -8,54 +8,54 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* Load stack pointer. */
-    la x2, stack_end
+  /* Load stack pointer. */
+  la x2, stack_end
 
-    /* r <= poly_masked_compare_du(xu, cu_du11), k = 4 path (du = 11). */
-    la   x10, xu
-    la   x11, cu_du11
-    addi x12, x0, 352 /* du = 11 share stride */
-    la   x14, r
-    addi x15, x0, 4 /* k */
-    jal  x1, poly_masked_compare_du
+  /* r <= poly_masked_compare_du(xu, cu_du11), k = 4 path (du = 11). */
+  la   x10, xu
+  la   x11, cu_du11
+  addi x12, x0, 352 /* du = 11 share stride */
+  la   x14, r
+  addi x15, x0, 4 /* k */
+  jal  x1, poly_masked_compare_du
 
-    /* r &= poly_masked_compare_du(xu, cu_du10), k != 4 path (du = 10). */
-    la   x10, xu
-    la   x11, cu_du10
-    addi x12, x0, 320 /* du = 10 share stride */
-    la   x14, r
-    addi x15, x0, 2 /* k */
-    jal  x1, poly_masked_compare_du
+  /* r &= poly_masked_compare_du(xu, cu_du10), k != 4 path (du = 10). */
+  la   x10, xu
+  la   x11, cu_du10
+  addi x12, x0, 320 /* du = 10 share stride */
+  la   x14, r
+  addi x15, x0, 2 /* k */
+  jal  x1, poly_masked_compare_du
 
-    /* Recombine r; both compares matched, so every bit is set. */
-    addi   x4, x0, 1
-    la     x10, r
-    addi   x11, x0, NSHARES
-    addi   x11, x11, -1
-    bn.lid x0, 0(x10++)
-    loop x11, 2
-        bn.lid x4, 0(x10++)
-        bn.xor w0, w0, w1
-    endloop
+  /* Recombine r; both compares matched, so every bit is set. */
+  addi   x4, x0, 1
+  la     x10, r
+  addi   x11, x0, NSHARES
+  addi   x11, x11, -1
+  bn.lid x0, 0(x10++)
+  loop x11, 2
+    bn.lid x4, 0(x10++)
+    bn.xor w0, w0, w1
+  endloop
 
-    ecall
+  ecall
 
 .data
 .balign 32
 stack:
-    .zero STACK_SIZE
+  .zero STACK_SIZE
 stack_end:
 
 r:
-    .word 0xffffffff
-    .word 0xffffffff
-    .word 0xffffffff
-    .word 0xffffffff
-    .word 0xffffffff
-    .word 0xffffffff
-    .word 0xffffffff
-    .word 0xffffffff
-    .zero 32 * (NSHARES - 1)
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .zero 32 * (NSHARES - 1)

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_masked_compare_du_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_masked_compare_du_test.s
@@ -2,7 +2,6 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NSHARES 2
 #define STACK_SIZE 15360
 
 .section .text.start
@@ -11,35 +10,29 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* Load stack pointer. */
-  la x2, stack_end
-
-  /* r <= poly_masked_compare_du(xu, cu_du11), k = 4 path (du = 11). */
+  /* r <- poly_masked_compare_du(xu, cu_du11), k = 4 path (du = 11). */
+  la   x2, stack_end
   la   x10, xu
   la   x11, cu_du11
-  addi x12, x0, 352 /* du = 11 share stride */
+  addi x12, x0, 352
   la   x14, r
-  addi x15, x0, 4 /* k */
+  addi x15, x0, 4
   jal  x1, poly_masked_compare_du
 
   /* r &= poly_masked_compare_du(xu, cu_du10), k != 4 path (du = 10). */
   la   x10, xu
   la   x11, cu_du10
-  addi x12, x0, 320 /* du = 10 share stride */
+  addi x12, x0, 320
   la   x14, r
-  addi x15, x0, 2 /* k */
+  addi x15, x0, 2
   jal  x1, poly_masked_compare_du
 
-  /* Recombine r; both compares matched, so every bit is set. */
+  /* Unmask r; both compares matched, so every bit is set. */
   addi   x4, x0, 1
   la     x10, r
-  addi   x11, x0, NSHARES
-  addi   x11, x11, -1
   bn.lid x0, 0(x10++)
-  loop x11, 2
-    bn.lid x4, 0(x10++)
-    bn.xor w0, w0, w1
-  endloop
+  bn.lid x4, 0(x10++)
+  bn.xor w0, w0, w1
 
   ecall
 
@@ -58,4 +51,4 @@ r:
   .word 0xffffffff
   .word 0xffffffff
   .word 0xffffffff
-  .zero 32 * (NSHARES - 1)
+  .zero 32

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_masked_compare_du_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_masked_compare_du_testgen.py
@@ -25,13 +25,15 @@ def compress_poly(coeffs: List[int], d: int) -> bytes:
 
 def random_shared_poly() -> Tuple[bytes, List[int]]:
     """Return NSHARES random arithmetic shares (packed) and their sum mod Q."""
+    s = [0] * N
     r = [0] * N
     shares = bytes()
     for _ in range(NSHARES):
-        s = [random.randint(0, Q - 1) for _ in range(N)]
-        r = [(r[j] + s[j]) % Q for j in range(N)]
-        shares += int.to_bytes(sum(s[j] << (j * 16) for j in range(N)),
-                               byteorder="little", length=512)
+        for coeff in range(N):
+            s[coeff] = random.randint(0, Q - 1)
+            r[coeff] = (r[coeff] + s[coeff]) % Q
+        s_int = sum(s[coeff] << (coeff * 16) for coeff in range(N))
+        shares += int.to_bytes(s_int, byteorder="little", length=512)
     return shares, r
 
 
@@ -44,24 +46,38 @@ def gen_poly_masked_compare_du_test(
     # One polynomial compared against its compression at du = 10 (k != 4) and
     # du = 11 (k = 4). Both match, so the recombined output is all ones.
     xu, ru = random_shared_poly()
+
+    # Write input values.
     write_test_data({'xu': xu,
                      'cu_du10': compress_poly(ru, 10),
                      'cu_du11': compress_poly(ru, 11)}, data_file)
+
+    # Write expected register values.
     write_test_exp({'w0': int.to_bytes((1 << N) - 1, byteorder="little",
                                        length=32)}, exp_file)
+
+    # Write expected dmem values (none).
     write_test_dexp({}, dexp_file)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('-s', '--seed', type=int, required=False,
-                        help='Seed value for pseudorandomness.')
-    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for input DMEM values.')
-    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for expected register values.')
-    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for expected DMEM values.')
+    parser.add_argument('-s', '--seed',
+                        type=int,
+                        required=False,
+                        help=('Seed value for pseudorandomness.'))
+    parser.add_argument('data',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for input DMEM values.'))
+    parser.add_argument('exp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected register values.'))
+    parser.add_argument('dexp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected DMEM values.'))
     args = parser.parse_args()
 
     with args.data, args.exp, args.dexp:

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_masked_compare_dv_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_masked_compare_dv_test.s
@@ -8,54 +8,54 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* Load stack pointer. */
-    la x2, stack_end
+  /* Load stack pointer. */
+  la x2, stack_end
 
-    /* r <= poly_masked_compare_dv(xv, cv_dv5), k = 4 path (dv = 5). */
-    la   x10, xv
-    la   x11, cv_dv5
-    addi x12, x0, 160 /* dv = 5 share stride */
-    la   x14, r
-    addi x15, x0, 4 /* k */
-    jal  x1, poly_masked_compare_dv
+  /* r <= poly_masked_compare_dv(xv, cv_dv5), k = 4 path (dv = 5). */
+  la   x10, xv
+  la   x11, cv_dv5
+  addi x12, x0, 160 /* dv = 5 share stride */
+  la   x14, r
+  addi x15, x0, 4 /* k */
+  jal  x1, poly_masked_compare_dv
 
-    /* r &= poly_masked_compare_dv(xv, cv_dv4), k != 4 path (dv = 4). */
-    la   x10, xv
-    la   x11, cv_dv4
-    addi x12, x0, 128 /* dv = 4 share stride */
-    la   x14, r
-    addi x15, x0, 2 /* k */
-    jal  x1, poly_masked_compare_dv
+  /* r &= poly_masked_compare_dv(xv, cv_dv4), k != 4 path (dv = 4). */
+  la   x10, xv
+  la   x11, cv_dv4
+  addi x12, x0, 128 /* dv = 4 share stride */
+  la   x14, r
+  addi x15, x0, 2 /* k */
+  jal  x1, poly_masked_compare_dv
 
-    /* Recombine r; both compares matched, so every bit is set. */
-    addi   x4, x0, 1
-    la     x10, r
-    addi   x11, x0, NSHARES
-    addi   x11, x11, -1
-    bn.lid x0, 0(x10++)
-    loop x11, 2
-        bn.lid x4, 0(x10++)
-        bn.xor w0, w0, w1
-    endloop
+  /* Recombine r; both compares matched, so every bit is set. */
+  addi   x4, x0, 1
+  la     x10, r
+  addi   x11, x0, NSHARES
+  addi   x11, x11, -1
+  bn.lid x0, 0(x10++)
+  loop x11, 2
+    bn.lid x4, 0(x10++)
+    bn.xor w0, w0, w1
+  endloop
 
-    ecall
+  ecall
 
 .data
 .balign 32
 stack:
-    .zero STACK_SIZE
+  .zero STACK_SIZE
 stack_end:
 
 r:
-    .word 0xffffffff
-    .word 0xffffffff
-    .word 0xffffffff
-    .word 0xffffffff
-    .word 0xffffffff
-    .word 0xffffffff
-    .word 0xffffffff
-    .word 0xffffffff
-    .zero 32 * (NSHARES - 1)
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .word 0xffffffff
+  .zero 32 * (NSHARES - 1)

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_masked_compare_dv_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_masked_compare_dv_test.s
@@ -2,7 +2,6 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NSHARES 2
 #define STACK_SIZE 15360
 
 .section .text.start
@@ -11,35 +10,29 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* Load stack pointer. */
-  la x2, stack_end
-
-  /* r <= poly_masked_compare_dv(xv, cv_dv5), k = 4 path (dv = 5). */
+  /* r <- poly_masked_compare_dv(xv, cv_dv5), k = 4 path (dv = 5). */
+  la   x2, stack_end
   la   x10, xv
   la   x11, cv_dv5
-  addi x12, x0, 160 /* dv = 5 share stride */
+  addi x12, x0, 160
   la   x14, r
-  addi x15, x0, 4 /* k */
+  addi x15, x0, 4
   jal  x1, poly_masked_compare_dv
 
   /* r &= poly_masked_compare_dv(xv, cv_dv4), k != 4 path (dv = 4). */
   la   x10, xv
   la   x11, cv_dv4
-  addi x12, x0, 128 /* dv = 4 share stride */
+  addi x12, x0, 128
   la   x14, r
-  addi x15, x0, 2 /* k */
+  addi x15, x0, 2
   jal  x1, poly_masked_compare_dv
 
-  /* Recombine r; both compares matched, so every bit is set. */
+  /* Unmask r; both compares matched, so every bit is set. */
   addi   x4, x0, 1
   la     x10, r
-  addi   x11, x0, NSHARES
-  addi   x11, x11, -1
   bn.lid x0, 0(x10++)
-  loop x11, 2
-    bn.lid x4, 0(x10++)
-    bn.xor w0, w0, w1
-  endloop
+  bn.lid x4, 0(x10++)
+  bn.xor w0, w0, w1
 
   ecall
 
@@ -58,4 +51,4 @@ r:
   .word 0xffffffff
   .word 0xffffffff
   .word 0xffffffff
-  .zero 32 * (NSHARES - 1)
+  .zero 32

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_masked_compare_dv_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_masked_compare_dv_testgen.py
@@ -25,13 +25,15 @@ def compress_poly(coeffs: List[int], d: int) -> bytes:
 
 def random_shared_poly() -> Tuple[bytes, List[int]]:
     """Return NSHARES random arithmetic shares (packed) and their sum mod Q."""
+    s = [0] * N
     r = [0] * N
     shares = bytes()
     for _ in range(NSHARES):
-        s = [random.randint(0, Q - 1) for _ in range(N)]
-        r = [(r[j] + s[j]) % Q for j in range(N)]
-        shares += int.to_bytes(sum(s[j] << (j * 16) for j in range(N)),
-                               byteorder="little", length=512)
+        for coeff in range(N):
+            s[coeff] = random.randint(0, Q - 1)
+            r[coeff] = (r[coeff] + s[coeff]) % Q
+        s_int = sum(s[coeff] << (coeff * 16) for coeff in range(N))
+        shares += int.to_bytes(s_int, byteorder="little", length=512)
     return shares, r
 
 
@@ -44,24 +46,38 @@ def gen_poly_masked_compare_dv_test(
     # One polynomial compared against its compression at dv = 4 (k != 4) and
     # dv = 5 (k = 4). Both match, so the recombined output is all ones.
     xv, rv = random_shared_poly()
+
+    # Write input values.
     write_test_data({'xv': xv,
                      'cv_dv4': compress_poly(rv, 4),
                      'cv_dv5': compress_poly(rv, 5)}, data_file)
+
+    # Write expected register values.
     write_test_exp({'w0': int.to_bytes((1 << N) - 1, byteorder="little",
                                        length=32)}, exp_file)
+
+    # Write expected dmem values (none).
     write_test_dexp({}, dexp_file)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('-s', '--seed', type=int, required=False,
-                        help='Seed value for pseudorandomness.')
-    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for input DMEM values.')
-    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for expected register values.')
-    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for expected DMEM values.')
+    parser.add_argument('-s', '--seed',
+                        type=int,
+                        required=False,
+                        help=('Seed value for pseudorandomness.'))
+    parser.add_argument('data',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for input DMEM values.'))
+    parser.add_argument('exp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected register values.'))
+    parser.add_argument('dexp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected DMEM values.'))
     args = parser.parse_args()
 
     with args.data, args.exp, args.dexp:

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_rej_samp_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_rej_samp_test.s
@@ -8,12 +8,12 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* w16 = mod = qinv | q. */
+  /* w16 = mod = mqinv | q. */
   addi    x4, x0, 16
-  la      x5, modulus_bn
+  la      x5, const_q
   bn.lid  x4++, 0(x5)
   bn.rshi w16, w31, w16 >> 240
-  la      x5, modulus_inv
+  la      x5, const_mqinv
   bn.lid  x4, 0(x5)
   bn.or   w16, w16, w17 << 32
   bn.wsrw mod, w16

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_rej_samp_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_rej_samp_test.s
@@ -8,20 +8,19 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* mod = qinv | q. */
-  add     x4, x0, x0
+  /* w16 = mod = qinv | q. */
+  addi    x4, x0, 16
   la      x5, modulus_bn
   bn.lid  x4++, 0(x5)
-  bn.rshi w0, w31, w0 >> 240
+  bn.rshi w16, w31, w16 >> 240
   la      x5, modulus_inv
   bn.lid  x4, 0(x5)
-  bn.or   w0, w0, w1 << 32
-  bn.wsrw mod, w0
+  bn.or   w16, w16, w17 << 32
+  bn.wsrw mod, w16
 
   /* r <- poly_rej_samp(rand_in). */
-  bn.wsrr w16, mod
-  la      x10, r
-  la      x11, rand_in
-  jal     x1, poly_rej_samp
+  la  x10, r
+  la  x11, rand_in
+  jal x1, poly_rej_samp
 
   ecall

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_rej_samp_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_rej_samp_test.s
@@ -8,8 +8,8 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* MOD <= R | Q; sw0 (w16) <= MOD. */
-  addi    x4, x0, 0
+  /* mod = qinv | q. */
+  add     x4, x0, x0
   la      x5, modulus_bn
   bn.lid  x4++, 0(x5)
   bn.rshi w0, w31, w0 >> 240
@@ -17,11 +17,11 @@ main:
   bn.lid  x4, 0(x5)
   bn.or   w0, w0, w1 << 32
   bn.wsrw mod, w0
-  bn.wsrr w16, mod
 
-  /* dmem[r] <= poly_rej_samp(dmem[rand_in]) */
-  la  x10, r
-  la  x11, rand_in
-  jal x1, poly_rej_samp
+  /* r <- poly_rej_samp(rand_in). */
+  bn.wsrr w16, mod
+  la      x10, r
+  la      x11, rand_in
+  jal     x1, poly_rej_samp
 
   ecall

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_rej_samp_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_rej_samp_test.s
@@ -5,23 +5,23 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* MOD <= R | Q; sw0 (w16) <= MOD. */
-    addi    x4, x0, 0
-    la      x5, modulus_bn
-    bn.lid  x4++, 0(x5)
-    bn.rshi w0, w31, w0 >> 240
-    la      x5, modulus_inv
-    bn.lid  x4, 0(x5)
-    bn.or   w0, w0, w1 << 32
-    bn.wsrw mod, w0
-    bn.wsrr w16, mod
+  /* MOD <= R | Q; sw0 (w16) <= MOD. */
+  addi    x4, x0, 0
+  la      x5, modulus_bn
+  bn.lid  x4++, 0(x5)
+  bn.rshi w0, w31, w0 >> 240
+  la      x5, modulus_inv
+  bn.lid  x4, 0(x5)
+  bn.or   w0, w0, w1 << 32
+  bn.wsrw mod, w0
+  bn.wsrr w16, mod
 
-    /* dmem[r] <= poly_rej_samp(dmem[rand_in]) */
-    la  x10, r
-    la  x11, rand_in
-    jal x1, poly_rej_samp
+  /* dmem[r] <= poly_rej_samp(dmem[rand_in]) */
+  la  x10, r
+  la  x11, rand_in
+  jal x1, poly_rej_samp
 
-    ecall
+  ecall

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_rej_samp_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_rej_samp_testgen.py
@@ -9,11 +9,11 @@ from typing import TextIO, Optional
 
 from shared.testgen import write_test_data, write_test_exp, write_test_dexp
 
-KYBER_Q = 3329
+Q = 3329
 N = 256  # number of output coefficients
-# Largest multiple of q below 2**16; a batch is rejected if any of its 16
+# Largest multiple of Q below 2**16; a batch is rejected if any of its 16
 # candidates is >= LIMIT.
-LIMIT = 19 * KYBER_Q
+LIMIT = 19 * Q
 
 
 def gen_poly_rej_samp_test(
@@ -34,14 +34,17 @@ def gen_poly_rej_samp_test(
         # The gadget accepts the whole word only if every candidate < 19*q,
         # then reduces each accepted candidate mod q.
         if all(c < LIMIT for c in word):
-            coeffs += [c % KYBER_Q for c in word]
+            coeffs += [c % Q for c in word]
 
     r_bytes = bytes()
     for c in coeffs:
         r_bytes += int.to_bytes(c, byteorder="little", length=2)
 
     # Write input values (output buffer zero-initialized).
-    inputs = {'rand_in': rand_in, 'r': int.to_bytes(0, byteorder="little", length=2 * N)}
+    inputs = {
+        'rand_in': rand_in,
+        'r': int.to_bytes(0, byteorder="little", length=2 * N)
+    }
     write_test_data(inputs, data_file)
 
     # Write expected register values (none).

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_to_bitsliced_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_to_bitsliced_test.s
@@ -5,17 +5,17 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* dmem[rbs] <= poly_to_bitsliced(dmem[xa]) */
-    la  x10, xa
-    la  x11, rbs
-    jal x1, poly_to_bitsliced
+  /* dmem[rbs] <= poly_to_bitsliced(dmem[xa]) */
+  la  x10, xa
+  la  x11, rbs
+  jal x1, poly_to_bitsliced
 
-    ecall
+  ecall
 
 .data
 .balign 32
 rbs:
-    .zero 32 * 12
+  .zero 32 * 12

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_to_bitsliced_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_to_bitsliced_test.s
@@ -8,7 +8,7 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* dmem[rbs] <= poly_to_bitsliced(dmem[xa]) */
+  /* rbs <- poly_to_bitsliced(xa). */
   la  x10, xa
   la  x11, rbs
   jal x1, poly_to_bitsliced

--- a/sw/acc/crypto/tests/mlkem/gadgets/poly_to_bitsliced_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/poly_to_bitsliced_testgen.py
@@ -5,11 +5,33 @@
 
 import argparse
 import random
-from typing import TextIO, Optional
+from typing import TextIO, Optional, List
 
 from shared.testgen import write_test_data, write_test_exp, write_test_dexp
 
 N = 256
+K = 12
+
+
+def bitslice_vec(x: List[int], k: int) -> bytes:
+    mask = (1 << N) - 1
+    # Generate 1 in 16 16-bit lanes.
+    vone = sum(1 << (lane * 16) for lane in range(16))
+
+    r = [0] * k
+    x_int = sum(x[coeff] << (coeff * 16) for coeff in range(N))
+    for _ in range(16):
+        t = x_int & mask
+        x_int >>= N
+        for bit in range(k):
+            r[bit] <<= 1
+            r[bit] |= (t & vone)
+            t >>= 1
+
+    r_bytes = bytes()
+    for bit in range(k):
+        r_bytes += int.to_bytes(r[bit], byteorder="little", length=32)
+    return r_bytes
 
 
 def gen_poly_to_bitsliced_test(
@@ -19,28 +41,13 @@ def gen_poly_to_bitsliced_test(
     if seed is not None:
         random.seed(seed)
 
-    k = 12
-
     # Generate input: random k-bit coefficients, one per 16-bit lane.
-    x = [random.randint(0, (1 << k) - 1) for _ in range(N)]
-    x_int = sum((x[j] << (j * 16)) for j in range(N))
+    x = [random.randint(0, (1 << K) - 1) for _ in range(N)]
+    x_int = sum((x[coeff] << (coeff * 16)) for coeff in range(N))
     x_bytes = int.to_bytes(x_int, byteorder="little", length=512)
 
     # Generate expected result.
-    mask = (1 << N) - 1
-    one = sum(1 << (i * 16) for i in range(16))
-    r = [0] * k
-    for i in range(16):
-        t = x_int & mask
-        x_int >>= N
-        for j in range(k):
-            r[j] <<= 1
-            r[j] |= (t & one)
-            t >>= 1
-
-    r_bytes = bytes()
-    for i in range(k):
-        r_bytes += int.to_bytes(r[i] & mask, byteorder="little", length=32)
+    r_bytes = bitslice_vec(x, K)
 
     # Write input values.
     inputs = {'xa': x_bytes}

--- a/sw/acc/crypto/tests/mlkem/gadgets/polyvec_hocompress_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/polyvec_hocompress_test.s
@@ -2,7 +2,6 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NSHARES 2
 #define STACK_SIZE 20000
 
 .section .text.start
@@ -18,22 +17,16 @@ main:
   li  x13, 2
   jal x1, polyvec_hocompress
 
-  /* Unmask rbu -> ru10 (du = 10, share stride 10 * 32). */
+  /* ru10 <- unmask(rbu). */
   la     x2, rbu
-  la     x3, ru10
+  addi   x3, x2, 320
+  la     x5, ru10
   li     x4, 1
-  li     x5, NSHARES
-  addi   x5, x5, -1
-  li     x6, 10
-  loop x6, 7
-    addi   x7, x2, 320
+  loopi 10, 4
     bn.lid x0, 0(x2++)
-    loop x5, 3
-      bn.lid x4, 0(x7)
-      bn.xor w0, w0, w1
-      addi   x7, x7, 320
-    endloop
-    bn.sid x0, 0(x3++)
+    bn.lid x4, 0(x3++)
+    bn.xor w0, w0, w1
+    bn.sid x0, 0(x5++)
   endloop
 
   /* du = 11 (k = 4): rbu <- polyvec_hocompress(xa). */
@@ -43,22 +36,16 @@ main:
   li  x13, 4
   jal x1, polyvec_hocompress
 
-  /* Unmask rbu -> ru11 (du = 11, share stride 11 * 32). */
+  /* ru11 <- unmask(rbu). */
   la     x2, rbu
-  la     x3, ru11
+  addi   x3, x2, 352
+  la     x5, ru11
   li     x4, 1
-  li     x5, NSHARES
-  addi   x5, x5, -1
-  li     x6, 11
-  loop x6, 7
-    addi   x7, x2, 352
+  loopi 11, 4
     bn.lid x0, 0(x2++)
-    loop x5, 3
-      bn.lid x4, 0(x7)
-      bn.xor w0, w0, w1
-      addi   x7, x7, 352
-    endloop
-    bn.sid x0, 0(x3++)
+    bn.lid x4, 0(x3++)
+    bn.xor w0, w0, w1
+    bn.sid x0, 0(x5++)
   endloop
 
   ecall
@@ -69,8 +56,6 @@ stack:
   .zero STACK_SIZE
 stack_end:
 
-.data
-.balign 32
 ru10:
   .zero 32 * 10
 

--- a/sw/acc/crypto/tests/mlkem/gadgets/polyvec_hocompress_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/polyvec_hocompress_test.s
@@ -8,70 +8,71 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* du = 10 (k = 2): rbu <- polyvec_hocompress(xa). */
-    la  x2, stack_end
-    la  x10, xa
-    la  x12, rbu
-    li  x13, 2
-    jal x1, polyvec_hocompress
+  /* du = 10 (k = 2): rbu <- polyvec_hocompress(xa). */
+  la  x2, stack_end
+  la  x10, xa
+  la  x12, rbu
+  li  x13, 2
+  jal x1, polyvec_hocompress
 
-    /* Unmask rbu -> ru10 (du = 10, share stride 10 * 32). */
-    la     x2, rbu
-    la     x3, ru10
-    li     x4, 1
-    li     x5, NSHARES
-    addi   x5, x5, -1
-    li     x6, 10
-    loop x6, 7
-        addi   x7, x2, 320
-        bn.lid x0, 0(x2++)
-        loop x5, 3
-            bn.lid x4, 0(x7)
-            bn.xor w0, w0, w1
-            addi   x7, x7, 320
-        endloop
-        bn.sid x0, 0(x3++)
+  /* Unmask rbu -> ru10 (du = 10, share stride 10 * 32). */
+  la     x2, rbu
+  la     x3, ru10
+  li     x4, 1
+  li     x5, NSHARES
+  addi   x5, x5, -1
+  li     x6, 10
+  loop x6, 7
+    addi   x7, x2, 320
+    bn.lid x0, 0(x2++)
+    loop x5, 3
+      bn.lid x4, 0(x7)
+      bn.xor w0, w0, w1
+      addi   x7, x7, 320
     endloop
+    bn.sid x0, 0(x3++)
+  endloop
 
-    /* du = 11 (k = 4): rbu <- polyvec_hocompress(xa). */
-    la  x2, stack_end
-    la  x10, xa
-    la  x12, rbu
-    li  x13, 4
-    jal x1, polyvec_hocompress
+  /* du = 11 (k = 4): rbu <- polyvec_hocompress(xa). */
+  la  x2, stack_end
+  la  x10, xa
+  la  x12, rbu
+  li  x13, 4
+  jal x1, polyvec_hocompress
 
-    /* Unmask rbu -> ru11 (du = 11, share stride 11 * 32). */
-    la     x2, rbu
-    la     x3, ru11
-    li     x4, 1
-    li     x5, NSHARES
-    addi   x5, x5, -1
-    li     x6, 11
-    loop x6, 7
-        addi   x7, x2, 352
-        bn.lid x0, 0(x2++)
-        loop x5, 3
-            bn.lid x4, 0(x7)
-            bn.xor w0, w0, w1
-            addi   x7, x7, 352
-        endloop
-        bn.sid x0, 0(x3++)
+  /* Unmask rbu -> ru11 (du = 11, share stride 11 * 32). */
+  la     x2, rbu
+  la     x3, ru11
+  li     x4, 1
+  li     x5, NSHARES
+  addi   x5, x5, -1
+  li     x6, 11
+  loop x6, 7
+    addi   x7, x2, 352
+    bn.lid x0, 0(x2++)
+    loop x5, 3
+      bn.lid x4, 0(x7)
+      bn.xor w0, w0, w1
+      addi   x7, x7, 352
     endloop
+    bn.sid x0, 0(x3++)
+  endloop
 
-    ecall
+  ecall
 
 .data
 .balign 32
 stack:
-    .zero STACK_SIZE
+  .zero STACK_SIZE
 stack_end:
 
 .data
 .balign 32
 ru10:
-    .zero 32 * 10
+  .zero 32 * 10
+
 ru11:
-    .zero 32 * 11
+  .zero 32 * 11

--- a/sw/acc/crypto/tests/mlkem/gadgets/polyvec_hocompress_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/polyvec_hocompress_testgen.py
@@ -5,7 +5,7 @@
 
 import argparse
 import random
-from typing import TextIO, Optional
+from typing import TextIO, Optional, List
 
 from shared.testgen import write_test_data, write_test_exp, write_test_dexp
 
@@ -19,20 +19,25 @@ def compress(x: int, d: int) -> int:
     return (((x << d) + Q // 2) // Q) & ((1 << d) - 1)
 
 
-def bitslice(coeffs: list, d: int) -> bytes:
-    """Bitslice N d-bit coefficients into d planes of 32 bytes."""
-    m = (1 << N) - 1
-    one = sum(1 << (i * 16) for i in range(16)) & m
-    rt = [sum(coeffs[j + i] << (i * 16) for i in range(16))
-          for j in range(0, N, 16)]
-    out = bytes()
-    for _ in range(d):
-        t = 0
-        for j in range(16):
-            t = (t << 1) | (rt[j] & one)
-            rt[j] >>= 1
-        out += int.to_bytes(t, byteorder="little", length=32)
-    return out
+def bitslice_vec(x: List[int], k: int) -> bytes:
+    mask = (1 << N) - 1
+    # Generate 1 in 16 16-bit lanes.
+    vone = sum(1 << (lane * 16) for lane in range(16))
+
+    r = [0] * k
+    x_int = sum(x[coeff] << (coeff * 16) for coeff in range(N))
+    for _ in range(16):
+        t = x_int & mask
+        x_int >>= N
+        for bit in range(k):
+            r[bit] <<= 1
+            r[bit] |= (t & vone)
+            t >>= 1
+
+    r_bytes = bytes()
+    for bit in range(k):
+        r_bytes += int.to_bytes(r[bit], byteorder="little", length=32)
+    return r_bytes
 
 
 def gen_polyvec_hocompress_test(
@@ -42,37 +47,53 @@ def gen_polyvec_hocompress_test(
         random.seed(seed)
 
     # Random arithmetic shares of x; r is their unmasked sum mod q.
+    x = [0] * N
     r = [0] * N
     x_bytes = bytes()
     for _ in range(NSHARES):
-        xi = [random.randint(0, Q - 1) for _ in range(N)]
-        r = [(r[j] + xi[j]) % Q for j in range(N)]
-        x_bytes += int.to_bytes(sum(xi[j] << (j * 16) for j in range(N)),
-                                byteorder="little", length=512)
+        for coeff in range(N):
+            x[coeff] = random.randint(0, Q - 1)
+            r[coeff] = (r[coeff] + x[coeff]) % Q
+        x_int = sum(x[coeff] << (coeff * 16) for coeff in range(N))
+        x_bytes += int.to_bytes(x_int, byteorder="little", length=512)
 
     # Reference compressions for both du values (du = 10 for k != 4, du = 11 for
     # k == 4); the gadget is exercised at both.
-    ru10 = bitslice([compress(r[i], 10) for i in range(N)], 10)
-    ru11 = bitslice([compress(r[i], 11) for i in range(N)], 11)
+    ru10 = bitslice_vec([compress(r[i], 10) for i in range(N)], 10)
+    ru11 = bitslice_vec([compress(r[i], 11) for i in range(N)], 11)
 
-    # Output buffer, reused for both calls and sized for the larger du = 11 case.
-    rbu = int.to_bytes(0, byteorder='little', length=32 * 11 * NSHARES)
+    # Write input values.
+    inputs = {
+        'xa': x_bytes,
+        'rbu': int.to_bytes(0, byteorder='little', length=32 * 11 * NSHARES)
+    }
+    write_test_data(inputs, data_file)
 
-    write_test_data({'xa': x_bytes, 'rbu': rbu}, data_file)
+    # Write expected register values (none).
     write_test_exp({}, exp_file)
+
+    # Write expected dmem values.
     write_test_dexp({'ru10': ru10, 'ru11': ru11}, dexp_file)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('-s', '--seed', type=int, required=False,
-                        help='Seed value for pseudorandomness.')
-    parser.add_argument('data', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for input DMEM values.')
-    parser.add_argument('exp', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for expected register values.')
-    parser.add_argument('dexp', metavar='FILE', type=argparse.FileType('w'),
-                        help='Output file for expected DMEM values.')
+    parser.add_argument('-s', '--seed',
+                        type=int,
+                        required=False,
+                        help=('Seed value for pseudorandomness.'))
+    parser.add_argument('data',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for input DMEM values.'))
+    parser.add_argument('exp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected register values.'))
+    parser.add_argument('dexp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected DMEM values.'))
     args = parser.parse_args()
 
     with args.data, args.exp, args.dexp:

--- a/sw/acc/crypto/tests/mlkem/gadgets/refreshios_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/refreshios_test.s
@@ -10,42 +10,43 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* Load stack pointer */
-    la x2, stack_end
+  /* Load stack pointer */
+  la x2, stack_end
 
-    /* dmem[rb] <= refreshios(dmem[xb], k, share stride). */
-    la  x10, xb
-    li  x11, BITSIZE
-    li  x12, SHARE_STR
-    la  x14, rb
-    jal x1, refreshios
+  /* dmem[rb] <= refreshios(dmem[xb], k, share stride). */
+  la  x10, xb
+  li  x11, BITSIZE
+  li  x12, SHARE_STR
+  la  x14, rb
+  jal x1, refreshios
 
-    /* Compute r */
-    la     x2, rb
-    la     x3, r
-    li     x4, 1
-    li     x5, NSHARES
-    addi   x5, x5, -1
-    loopi BITSIZE, 7
-        addi   x6, x2, SHARE_STR
-        bn.lid x0, 0(x2++)
-        loop x5, 3
-            bn.lid x4, 0(x6)
-            bn.xor w0, w0, w1
-            addi   x6, x6, SHARE_STR
-        endloop
-        bn.sid x0, 0(x3++)
+  /* Compute r */
+  la     x2, rb
+  la     x3, r
+  li     x4, 1
+  li     x5, NSHARES
+  addi   x5, x5, -1
+  loopi BITSIZE, 7
+    addi   x6, x2, SHARE_STR
+    bn.lid x0, 0(x2++)
+    loop x5, 3
+      bn.lid x4, 0(x6)
+      bn.xor w0, w0, w1
+      addi   x6, x6, SHARE_STR
     endloop
+    bn.sid x0, 0(x3++)
+  endloop
 
-    ecall
+  ecall
 
 .data
 .balign 32
 stack:
-    .zero STACK_SIZE
+  .zero STACK_SIZE
 stack_end:
+
 r:
-    .zero 32 * BITSIZE
+  .zero 32 * BITSIZE

--- a/sw/acc/crypto/tests/mlkem/gadgets/refreshios_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/refreshios_test.s
@@ -2,9 +2,6 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NSHARES 2
-#define BITSIZE 12
-#define SHARE_STR 384 /* 32 * BITSIZE */
 #define STACK_SIZE 8192
 
 .section .text.start
@@ -13,31 +10,24 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* Load stack pointer */
-  la x2, stack_end
-
-  /* dmem[rb] <= refreshios(dmem[xb], k, share stride). */
+  /* rb <- refreshios(xb). */
+  la  x2, stack_end
   la  x10, xb
-  li  x11, BITSIZE
-  li  x12, SHARE_STR
+  li  x11, 12
+  li  x12, 384
   la  x14, rb
   jal x1, refreshios
 
-  /* Compute r */
+  /* r <- unmask(rb). */
   la     x2, rb
-  la     x3, r
+  addi   x3, x2, 384
+  la     x5, r
   li     x4, 1
-  li     x5, NSHARES
-  addi   x5, x5, -1
-  loopi BITSIZE, 7
-    addi   x6, x2, SHARE_STR
+  loopi 12, 4
     bn.lid x0, 0(x2++)
-    loop x5, 3
-      bn.lid x4, 0(x6)
-      bn.xor w0, w0, w1
-      addi   x6, x6, SHARE_STR
-    endloop
-    bn.sid x0, 0(x3++)
+    bn.lid x4, 0(x3++)
+    bn.xor w0, w0, w1
+    bn.sid x0, 0(x5++)
   endloop
 
   ecall
@@ -49,4 +39,4 @@ stack:
 stack_end:
 
 r:
-  .zero 32 * BITSIZE
+  .zero 384

--- a/sw/acc/crypto/tests/mlkem/gadgets/refreshios_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/refreshios_testgen.py
@@ -11,6 +11,7 @@ from shared.testgen import write_test_data, write_test_exp, write_test_dexp
 
 N = 256
 NSHARES = 2
+K = 12
 
 
 def gen_refreshios_test(
@@ -20,31 +21,25 @@ def gen_refreshios_test(
     if seed is not None:
         random.seed(seed)
 
-    nshares = NSHARES
-    k = 12
-
-    operand_nbytes = 32 * nshares * k
-
-    x = [0] * nshares
+    # Generate input.
+    r = [0] * K
     x_bytes = bytes()
-    for i in range(nshares):
-        x[i] = [random.getrandbits(N) for _ in range(k)]
-        for j in range(k):
-            x_bytes += int.to_bytes(x[i][j], byteorder="little", length=32)
+    for _ in range(NSHARES):
+        for bit in range(K):
+            t = random.getrandbits(N)
+            r[bit] ^= t
+            x_bytes += int.to_bytes(t, byteorder="little", length=32)
 
     # Generate expected results.
-    r = x[0].copy()
-    for i in range(1, nshares):
-        for j in range(k):
-            r[j] ^= x[i][j]
     r_bytes = bytes()
-    for i in range(k):
-        r_bytes += int.to_bytes(r[i], byteorder="little", length=32)
-
-    rb_bytes = int.to_bytes(0, byteorder='little', length=operand_nbytes)
+    for bit in range(K):
+        r_bytes += int.to_bytes(r[bit], byteorder="little", length=32)
 
     # Write input values.
-    inputs = {'xb': x_bytes, 'rb': rb_bytes}
+    inputs = {
+        'xb': x_bytes,
+        'rb': int.to_bytes(0, byteorder='little', length=32 * NSHARES * K)
+    }
     write_test_data(inputs, data_file)
 
     # Write expected register values (none).

--- a/sw/acc/crypto/tests/mlkem/gadgets/refreshmodq_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/refreshmodq_test.s
@@ -10,12 +10,12 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* w16 = mod = qinv | q. */
+  /* w16 = mod = mqinv | q. */
   addi    x4, x0, 16
-  la      x5, modulus_bn
+  la      x5, const_q
   bn.lid  x4++, 0(x5)
   bn.rshi w16, w31, w16 >> 240
-  la      x5, modulus_inv
+  la      x5, const_mqinv
   bn.lid  x4, 0(x5)
   bn.or   w16, w16, w17 << 32
   bn.wsrw mod, w16

--- a/sw/acc/crypto/tests/mlkem/gadgets/refreshmodq_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/refreshmodq_test.s
@@ -10,10 +10,14 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* mod = q. */
+  /* mod = qinv | q. */
+  add     x4, x0, x0
   la      x5, modulus_bn
-  bn.lid  x0, 0(x5)
+  bn.lid  x4++, 0(x5)
   bn.rshi w0, w31, w0 >> 240
+  la      x5, modulus_inv
+  bn.lid  x4, 0(x5)
+  bn.or   w0, w0, w1 << 32
   bn.wsrw mod, w0
 
   /* ra <- refreshmodq(xa). */

--- a/sw/acc/crypto/tests/mlkem/gadgets/refreshmodq_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/refreshmodq_test.s
@@ -10,46 +10,47 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* MOD <= dmem[modulus] = KYBER_Q */
-    la      x6, modulus_bn
-    bn.lid  x0, 0(x6)
-    bn.rshi w0, w31, w0 >> 240
-    bn.wsrw mod, w0
+  /* MOD <= dmem[modulus] = KYBER_Q */
+  la      x6, modulus_bn
+  bn.lid  x0, 0(x6)
+  bn.rshi w0, w31, w0 >> 240
+  bn.wsrw mod, w0
 
-    /* Load stack pointer. */
-    la  x2, stack_end
+  /* Load stack pointer. */
+  la  x2, stack_end
 
-    /* dmem[ra] <= refreshmodq(dmem[xa]) */
-    bn.wsrr w16, mod
-    la      x10, xa
-    la      x12, ra
-    jal     x1, refreshmodq
+  /* dmem[ra] <= refreshmodq(dmem[xa]) */
+  bn.wsrr w16, mod
+  la      x10, xa
+  la      x12, ra
+  jal     x1, refreshmodq
 
-    /* Compute r */
-    la   x2, ra
-    la   x3, r
-    li   x4, 1
-    li   x5, NSHARES
-    addi x5, x5, -1
-    loopi N_WDR, 7
-        addi   x6, x2, NB_POLY
-        bn.lid x0, 0(x2++)
-        loop x5, 3
-            bn.lid       x4, 0(x6)
-            bn.addvm.16h w0, w0, w1
-            addi         x6, x6, NB_POLY
-        endloop
-        bn.sid x0, 0(x3++)
+  /* Compute r */
+  la   x2, ra
+  la   x3, r
+  li   x4, 1
+  li   x5, NSHARES
+  addi x5, x5, -1
+  loopi N_WDR, 7
+    addi   x6, x2, NB_POLY
+    bn.lid x0, 0(x2++)
+    loop x5, 3
+      bn.lid       x4, 0(x6)
+      bn.addvm.16h w0, w0, w1
+      addi         x6, x6, NB_POLY
     endloop
-    ecall
+    bn.sid x0, 0(x3++)
+  endloop
+  ecall
 
 .data
 .balign 32
 stack:
-    .zero STACK_SIZE
+  .zero STACK_SIZE
 stack_end:
+
 r:
-    .zero 32 * N_WDR
+  .zero 32 * N_WDR

--- a/sw/acc/crypto/tests/mlkem/gadgets/refreshmodq_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/refreshmodq_test.s
@@ -10,22 +10,21 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* mod = qinv | q. */
-  add     x4, x0, x0
+  /* w16 = mod = qinv | q. */
+  addi    x4, x0, 16
   la      x5, modulus_bn
   bn.lid  x4++, 0(x5)
-  bn.rshi w0, w31, w0 >> 240
+  bn.rshi w16, w31, w16 >> 240
   la      x5, modulus_inv
   bn.lid  x4, 0(x5)
-  bn.or   w0, w0, w1 << 32
-  bn.wsrw mod, w0
+  bn.or   w16, w16, w17 << 32
+  bn.wsrw mod, w16
 
   /* ra <- refreshmodq(xa). */
-  bn.wsrr w16, mod
-  la      x2, stack_end
-  la      x10, xa
-  la      x12, ra
-  jal     x1, refreshmodq
+  la  x2, stack_end
+  la  x10, xa
+  la  x12, ra
+  jal x1, refreshmodq
 
   /* r <- unmask(ra). */
   la   x2, ra

--- a/sw/acc/crypto/tests/mlkem/gadgets/refreshmodq_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/refreshmodq_test.s
@@ -2,9 +2,6 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NSHARES 2
-#define N_WDR 16
-#define NB_POLY 512
 #define STACK_SIZE 20000
 
 .section .text.start
@@ -13,37 +10,31 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* MOD <= dmem[modulus] = KYBER_Q */
-  la      x6, modulus_bn
-  bn.lid  x0, 0(x6)
+  /* mod = q. */
+  la      x5, modulus_bn
+  bn.lid  x0, 0(x5)
   bn.rshi w0, w31, w0 >> 240
   bn.wsrw mod, w0
 
-  /* Load stack pointer. */
-  la  x2, stack_end
-
-  /* dmem[ra] <= refreshmodq(dmem[xa]) */
+  /* ra <- refreshmodq(xa). */
   bn.wsrr w16, mod
+  la      x2, stack_end
   la      x10, xa
   la      x12, ra
   jal     x1, refreshmodq
 
-  /* Compute r */
+  /* r <- unmask(ra). */
   la   x2, ra
-  la   x3, r
+  addi x3, x2, 512
+  la   x5, r
   li   x4, 1
-  li   x5, NSHARES
-  addi x5, x5, -1
-  loopi N_WDR, 7
-    addi   x6, x2, NB_POLY
-    bn.lid x0, 0(x2++)
-    loop x5, 3
-      bn.lid       x4, 0(x6)
-      bn.addvm.16h w0, w0, w1
-      addi         x6, x6, NB_POLY
-    endloop
-    bn.sid x0, 0(x3++)
+  loopi 16, 4
+    bn.lid       x0, 0(x2++)
+    bn.lid       x4, 0(x3++)
+    bn.addvm.16h w0, w0, w1
+    bn.sid       x0, 0(x5++)
   endloop
+
   ecall
 
 .data
@@ -53,4 +44,4 @@ stack:
 stack_end:
 
 r:
-  .zero 32 * N_WDR
+  .zero 512

--- a/sw/acc/crypto/tests/mlkem/gadgets/refreshmodq_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/refreshmodq_testgen.py
@@ -11,7 +11,7 @@ from shared.testgen import write_test_data, write_test_exp, write_test_dexp
 
 N = 256
 NSHARES = 2
-N_WDR = 16
+Q = 3329
 
 
 def gen_refreshmodq_test(
@@ -21,31 +21,26 @@ def gen_refreshmodq_test(
     if seed is not None:
         random.seed(seed)
 
-    nshares = NSHARES
-    q = 3329
-    operand_nbytes = 32 * N_WDR * nshares
-
     # Generate input.
-    x = [random.randint(0, q - 1) for _ in range(N)]
-    rx = x.copy()
+    x = [0] * N
+    r = [0] * N
     x_bytes = bytes()
-    for i in range(nshares - 1):
-        t = [random.randint(0, q - 1) for _ in range(N)]
-        rx = [(rx[j] - t[j]) % q for j in range(N)]
-        t_int = sum(t[j] << (j * 16) for j in range(N))
-        x_bytes += int.to_bytes(t_int, byteorder="little", length=512)
-
-    t_int = sum(rx[i] << (i * 16) for i in range(N))
-    x_bytes += int.to_bytes(t_int, byteorder="little", length=512)
+    for _ in range(NSHARES):
+        for coeff in range(N):
+            x[coeff] = random.randint(0, Q - 1)
+            r[coeff] = (r[coeff] + x[coeff]) % Q
+        x_int = sum(x[coeff] << (coeff * 16) for coeff in range(N))
+        x_bytes += int.to_bytes(x_int, byteorder="little", length=512)
 
     # Generate expected result.
-    x_int = sum(x[i] << (i * 16) for i in range(N))
-    r_bytes = int.to_bytes(x_int, byteorder="little", length=512)
-
-    ra_bytes = int.to_bytes(0, byteorder="little", length=operand_nbytes)
+    r_int = sum(r[coeff] << (coeff * 16) for coeff in range(N))
+    r_bytes = int.to_bytes(r_int, byteorder="little", length=512)
 
     # Write input values.
-    inputs = {'xa': x_bytes, 'ra': ra_bytes}
+    inputs = {
+        'xa': x_bytes,
+        'ra': int.to_bytes(0, byteorder="little", length=512 * NSHARES)
+    }
     write_test_data(inputs, data_file)
 
     # Write expected register values (none).

--- a/sw/acc/crypto/tests/mlkem/gadgets/seca2b_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/seca2b_test.s
@@ -10,43 +10,44 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* Load stack pointer */
-    la x2, stack_end
+  /* Load stack pointer */
+  la x2, stack_end
 
-    /* dmem[rb] <= seca2b(dmem[xa], k, share bytes). */
-    la  x10, xa
-    li  x11, BITSIZE
-    li  x12, SHARE_STR
-    la  x14, rb
-    jal x1, seca2b
+  /* dmem[rb] <= seca2b(dmem[xa], k, share bytes). */
+  la  x10, xa
+  li  x11, BITSIZE
+  li  x12, SHARE_STR
+  la  x14, rb
+  jal x1, seca2b
 
-    /* Compute r */
-    la     x2, rb
-    la     x3, r
-    li     x4, 1
-    li     x5, NSHARES
-    addi   x5, x5, -1
-    li     x6, BITSIZE
-    loop x6, 7
-        addi   x7, x2, SHARE_STR
-        bn.lid x0, 0(x2++)
-        loop x5, 3
-            bn.lid x4, 0(x7)
-            bn.xor w0, w0, w1
-            addi   x7, x7, SHARE_STR
-        endloop
-        bn.sid x0, 0(x3++)
+  /* Compute r */
+  la     x2, rb
+  la     x3, r
+  li     x4, 1
+  li     x5, NSHARES
+  addi   x5, x5, -1
+  li     x6, BITSIZE
+  loop x6, 7
+    addi   x7, x2, SHARE_STR
+    bn.lid x0, 0(x2++)
+    loop x5, 3
+      bn.lid x4, 0(x7)
+      bn.xor w0, w0, w1
+      addi   x7, x7, SHARE_STR
     endloop
+    bn.sid x0, 0(x3++)
+  endloop
 
-    ecall
+  ecall
 
 .data
 .balign 32
 stack:
-    .zero STACK_SIZE
+  .zero STACK_SIZE
 stack_end:
+
 r:
-    .zero 32 * BITSIZE
+  .zero 32 * BITSIZE

--- a/sw/acc/crypto/tests/mlkem/gadgets/seca2b_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/seca2b_test.s
@@ -2,9 +2,6 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NSHARES 2
-#define BITSIZE 16
-#define SHARE_STR 512 /* 32 * BITSIZE */
 #define STACK_SIZE 20000
 
 .section .text.start
@@ -13,32 +10,24 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* Load stack pointer */
-  la x2, stack_end
-
-  /* dmem[rb] <= seca2b(dmem[xa], k, share bytes). */
+  /* rb <- seca2b(xa). */
+  la  x2, stack_end
   la  x10, xa
-  li  x11, BITSIZE
-  li  x12, SHARE_STR
+  li  x11, 16
+  li  x12, 512
   la  x14, rb
   jal x1, seca2b
 
-  /* Compute r */
+  /* r <- unmask(rb). */
   la     x2, rb
-  la     x3, r
+  addi   x3, x2, 512
+  la     x5, r
   li     x4, 1
-  li     x5, NSHARES
-  addi   x5, x5, -1
-  li     x6, BITSIZE
-  loop x6, 7
-    addi   x7, x2, SHARE_STR
+  loopi 16, 4
     bn.lid x0, 0(x2++)
-    loop x5, 3
-      bn.lid x4, 0(x7)
-      bn.xor w0, w0, w1
-      addi   x7, x7, SHARE_STR
-    endloop
-    bn.sid x0, 0(x3++)
+    bn.lid x4, 0(x3++)
+    bn.xor w0, w0, w1
+    bn.sid x0, 0(x5++)
   endloop
 
   ecall
@@ -50,4 +39,4 @@ stack:
 stack_end:
 
 r:
-  .zero 32 * BITSIZE
+  .zero 512

--- a/sw/acc/crypto/tests/mlkem/gadgets/seca2b_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/seca2b_testgen.py
@@ -5,12 +5,23 @@
 
 import argparse
 import random
-from typing import TextIO, Optional
+from typing import TextIO, Optional, List
 
 from shared.testgen import write_test_data, write_test_exp, write_test_dexp
 
 N = 256
 NSHARES = 2
+K = 16
+
+
+def bitslice(x: List[int], k: int) -> bytes:
+    r = bytes()
+    for bit in range(k):
+        t = 0
+        for coeff in range(N):
+            t |= (((x[coeff] >> bit) & 1) << coeff)
+        r += int.to_bytes(t, byteorder="little", length=32)
+    return r
 
 
 def gen_seca2b_test(
@@ -20,45 +31,25 @@ def gen_seca2b_test(
     if seed is not None:
         random.seed(seed)
 
-    nshares = NSHARES
-    k = 16
-
-    operand_nbytes = 32 * nshares * k
-
-    m = (1 << k) - 1
-    v = [0] * N
-    x = [0] * nshares
-    for i in range(nshares):
-        x[i] = [random.randint(0, m) for _ in range(N)]
-        for j in range(N):
-            v[j] = (v[j] + x[i][j]) & m
-
-    # Bitslicing v.
-    r = [0] * k
-    for i in range(N):
-        for j in range(k):
-            r[j] |= (((v[i] >> j) & 1) << i)
-
-    r_bytes = bytes()
-    for i in range(k):
-        t = int.to_bytes(r[i], byteorder="little", length=32)
-        r_bytes += t
-
-    # Bitslicing x.
+    # Generate input.
+    m = (1 << K) - 1
+    x = [0] * N
+    r = [0] * N
     x_bytes = bytes()
-    for s in range(nshares):
-        t = [0] * k
-        for i in range(N):
-            for j in range(k):
-                t[j] |= (((x[s][i] >> j) & 1) << i)
-        for i in range(k):
-            ti = int.to_bytes(t[i], byteorder="little", length=32)
-            x_bytes += ti
+    for _ in range(NSHARES):
+        for coeff in range(N):
+            x[coeff] = random.randint(0, m)
+            r[coeff] = (r[coeff] + x[coeff]) & m
+        x_bytes += bitslice(x, K)
 
-    rb_bytes = int.to_bytes(0, byteorder='little', length=operand_nbytes)
+    # Generate expected result.
+    r_bytes = bitslice(r, K)
 
     # Write input values.
-    inputs = {'xa': x_bytes, 'rb': rb_bytes}
+    inputs = {
+        'xa': x_bytes,
+        'rb': int.to_bytes(0, byteorder='little', length=512 * NSHARES)
+    }
     write_test_data(inputs, data_file)
 
     # Write expected register values (none).

--- a/sw/acc/crypto/tests/mlkem/gadgets/seca2bmodq_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/seca2bmodq_test.s
@@ -8,40 +8,41 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* Load stack pointer */
-    la x2, stack_end
+  /* Load stack pointer */
+  la x2, stack_end
 
-    /* dmem[rb] <= seca2bmodq(dmem[xa]). */
-    la  x10, xa
-    la  x12, rb
-    jal x1, seca2bmodq
+  /* dmem[rb] <= seca2bmodq(dmem[xa]). */
+  la  x10, xa
+  la  x12, rb
+  jal x1, seca2bmodq
 
-    /* Compute r */
-    la     x2, rb
-    la     x3, r
-    li     x4, 1
-    li     x5, NSHARES
-    addi   x5, x5, -1
-    loopi 12, 7
-        addi   x7, x2, 384
-        bn.lid x0, 0(x2++)
-        loop x5, 3
-            bn.lid x4, 0(x7)
-            bn.xor w0, w0, w1
-            addi   x7, x7, 384
-        endloop
-        bn.sid x0, 0(x3++)
+  /* Compute r */
+  la     x2, rb
+  la     x3, r
+  li     x4, 1
+  li     x5, NSHARES
+  addi   x5, x5, -1
+  loopi 12, 7
+    addi   x7, x2, 384
+    bn.lid x0, 0(x2++)
+    loop x5, 3
+      bn.lid x4, 0(x7)
+      bn.xor w0, w0, w1
+      addi   x7, x7, 384
     endloop
+    bn.sid x0, 0(x3++)
+  endloop
 
-    ecall
+  ecall
 
 .data
 .balign 32
 stack:
-    .zero STACK_SIZE
+  .zero STACK_SIZE
 stack_end:
+
 r:
-    .zero 32 * 12
+  .zero 32 * 12

--- a/sw/acc/crypto/tests/mlkem/gadgets/seca2bmodq_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/seca2bmodq_test.s
@@ -2,7 +2,6 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NSHARES 2
 #define STACK_SIZE 8192
 
 .section .text.start
@@ -11,29 +10,22 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* Load stack pointer */
-  la x2, stack_end
-
-  /* dmem[rb] <= seca2bmodq(dmem[xa]). */
+  /* rb <- seca2bmodq(xa). */
+  la  x2, stack_end
   la  x10, xa
   la  x12, rb
   jal x1, seca2bmodq
 
-  /* Compute r */
+  /* r <- unmask(rb). */
   la     x2, rb
-  la     x3, r
+  addi   x3, x2, 384
+  la     x5, r
   li     x4, 1
-  li     x5, NSHARES
-  addi   x5, x5, -1
-  loopi 12, 7
-    addi   x7, x2, 384
+  loopi 12, 4
     bn.lid x0, 0(x2++)
-    loop x5, 3
-      bn.lid x4, 0(x7)
-      bn.xor w0, w0, w1
-      addi   x7, x7, 384
-    endloop
-    bn.sid x0, 0(x3++)
+    bn.lid x4, 0(x3++)
+    bn.xor w0, w0, w1
+    bn.sid x0, 0(x5++)
   endloop
 
   ecall
@@ -45,4 +37,4 @@ stack:
 stack_end:
 
 r:
-  .zero 32 * 12
+  .zero 384

--- a/sw/acc/crypto/tests/mlkem/gadgets/seca2bmodq_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/seca2bmodq_testgen.py
@@ -11,14 +11,17 @@ from shared.testgen import write_test_data, write_test_exp, write_test_dexp
 
 N = 256
 NSHARES = 2
+Q = 3329
+K = 12
 
 
-def bitslice(x: List[int], k: int) -> List[int]:
-    r = [0] * k
-    for i in range(N):
-        for j in range(k):
-            bit = (x[i] >> j) & 1
-            r[j] |= (bit << i)
+def bitslice(x: List[int], k: int) -> bytes:
+    r = bytes()
+    for bit in range(k):
+        t = 0
+        for coeff in range(N):
+            t |= (((x[coeff] >> bit) & 1) << coeff)
+        r += int.to_bytes(t, byteorder="little", length=32)
     return r
 
 
@@ -29,35 +32,24 @@ def gen_seca2bmodq_test(
     if seed is not None:
         random.seed(seed)
 
-    nshares = NSHARES
-    q = 3329
-    k = 12
-    operand_nbytes = 32 * nshares * k
-
-    t = [0] * nshares
-    x = [random.randint(0, q - 1) for _ in range(N)]
-    rx = x.copy()
+    # Generate input.
+    x = [0] * N
+    r = [0] * N
     x_bytes = bytes()
-    for i in range(nshares - 1):
-        t[i] = [random.randint(0, q - 1) for _ in range(N)]
-        rx = [(rx[j] - t[i][j]) % q for j in range(N)]
-        tmp = bitslice(t[i], k)
-        for j in range(k):
-            x_bytes += int.to_bytes(tmp[j], byteorder="little", length=32)
-    tmp = bitslice(rx, k)
-    for j in range(k):
-        x_bytes += int.to_bytes(tmp[j], byteorder="little", length=32)
+    for _ in range(NSHARES):
+        for coeff in range(N):
+            x[coeff] = random.randint(0, Q - 1)
+            r[coeff] = (r[coeff] + x[coeff]) % Q
+        x_bytes += bitslice(x, K)
 
     # Generate expected result.
-    r = bitslice(x, k)
-    r_bytes = bytes()
-    for i in range(k):
-        r_bytes += int.to_bytes(r[i], byteorder="little", length=32)
-
-    rb_bytes = int.to_bytes(0, byteorder='little', length=operand_nbytes)
+    r_bytes = bitslice(r, K)
 
     # Write input values.
-    inputs = {'xa': x_bytes, 'rb': rb_bytes}
+    inputs = {
+        'xa': x_bytes,
+        'rb': int.to_bytes(0, byteorder='little', length=32 * K * NSHARES)
+    }
     write_test_data(inputs, data_file)
 
     # Write expected register values (none).

--- a/sw/acc/crypto/tests/mlkem/gadgets/secadd_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/secadd_test.s
@@ -10,46 +10,47 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* Load stack pointer. */
-    la  x2, stack_end
+  /* Load stack pointer. */
+  la  x2, stack_end
 
-    /* dmem[rb] <= secadd(dmem[xb], dmem[yb]) */
-    la  x10, xb
-    li  x11, SHARE_STR
-    la  x12, yb
-    li  x13, SHARE_STR
-    la  x15, rb
-    li  x16, SHARE_STR
-    li  x17, BITSIZE
-    jal x1, secadd
+  /* dmem[rb] <= secadd(dmem[xb], dmem[yb]) */
+  la  x10, xb
+  li  x11, SHARE_STR
+  la  x12, yb
+  li  x13, SHARE_STR
+  la  x15, rb
+  li  x16, SHARE_STR
+  li  x17, BITSIZE
+  jal x1, secadd
 
-    /* Compute r */
-    la     x2, rb
-    la     x3, r
-    li     x4, 1
-    li     x5, NSHARES
-    addi   x5, x5, -1
-    li     x6, BITSIZE
-    loop x6, 7
-        addi   x7, x2, SHARE_STR
-        bn.lid x0, 0(x2++)
-        loop x5, 3
-            bn.lid x4, 0(x7)
-            bn.xor w0, w0, w1
-            addi   x7, x7, SHARE_STR
-        endloop
-        bn.sid x0, 0(x3++)
+  /* Compute r */
+  la     x2, rb
+  la     x3, r
+  li     x4, 1
+  li     x5, NSHARES
+  addi   x5, x5, -1
+  li     x6, BITSIZE
+  loop x6, 7
+    addi   x7, x2, SHARE_STR
+    bn.lid x0, 0(x2++)
+    loop x5, 3
+      bn.lid x4, 0(x7)
+      bn.xor w0, w0, w1
+      addi   x7, x7, SHARE_STR
     endloop
+    bn.sid x0, 0(x3++)
+  endloop
 
-    ecall
+  ecall
 
 .data
 .balign 32
 stack:
-    .zero STACK_SIZE
+  .zero STACK_SIZE
 stack_end:
+
 r:
-    .zero 32 * BITSIZE
+  .zero 32 * BITSIZE

--- a/sw/acc/crypto/tests/mlkem/gadgets/secadd_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/secadd_test.s
@@ -2,9 +2,6 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NSHARES 2
-#define BITSIZE 16
-#define SHARE_STR 512
 #define STACK_SIZE 1024
 
 .section .text.start
@@ -13,35 +10,27 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* Load stack pointer. */
+  /* rb <- secadd(xb, yb). */
   la  x2, stack_end
-
-  /* dmem[rb] <= secadd(dmem[xb], dmem[yb]) */
   la  x10, xb
-  li  x11, SHARE_STR
+  li  x11, 512
   la  x12, yb
-  li  x13, SHARE_STR
+  li  x13, 512
   la  x15, rb
-  li  x16, SHARE_STR
-  li  x17, BITSIZE
+  li  x16, 512
+  li  x17, 16
   jal x1, secadd
 
-  /* Compute r */
+  /* r <- unmask(rb). */
   la     x2, rb
-  la     x3, r
+  addi   x3, x2, 512
+  la     x5, r
   li     x4, 1
-  li     x5, NSHARES
-  addi   x5, x5, -1
-  li     x6, BITSIZE
-  loop x6, 7
-    addi   x7, x2, SHARE_STR
+  loopi 16, 4
     bn.lid x0, 0(x2++)
-    loop x5, 3
-      bn.lid x4, 0(x7)
-      bn.xor w0, w0, w1
-      addi   x7, x7, SHARE_STR
-    endloop
-    bn.sid x0, 0(x3++)
+    bn.lid x4, 0(x3++)
+    bn.xor w0, w0, w1
+    bn.sid x0, 0(x5++)
   endloop
 
   ecall
@@ -53,4 +42,4 @@ stack:
 stack_end:
 
 r:
-  .zero 32 * BITSIZE
+  .zero 512

--- a/sw/acc/crypto/tests/mlkem/gadgets/secadd_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/secadd_testgen.py
@@ -11,6 +11,7 @@ from shared.testgen import write_test_data, write_test_exp, write_test_dexp
 
 N = 256
 NSHARES = 2
+K = 16
 
 
 def gen_secadd_test(
@@ -20,46 +21,42 @@ def gen_secadd_test(
     if seed is not None:
         random.seed(seed)
 
-    k = 16
-    nshares = NSHARES
+    x = [0] * K
+    y = [0] * K
+    x_bytes = bytes()
+    y_bytes = bytes()
+    for _ in range(NSHARES):
+        for bit in range(K):
+            t = random.getrandbits(N)
+            x[bit] ^= t
+            x_bytes += int.to_bytes(t, byteorder="little", length=32)
+            t = random.getrandbits(N)
+            y[bit] ^= t
+            y_bytes += int.to_bytes(t, byteorder="little", length=32)
 
-    operand_nbytes = 32 * nshares * k
-
-    x = [0] * k
-    y = [0] * k
-    xb = bytes()
-    yb = bytes()
-    for _ in range(nshares):
-        for i in range(k):
-            tx = random.getrandbits(N)
-            ty = random.getrandbits(N)
-            x[i] ^= tx
-            y[i] ^= ty
-            tx = int.to_bytes(tx, byteorder="little", length=32)
-            ty = int.to_bytes(ty, byteorder="little", length=32)
-            xb += tx
-            yb += ty
-
-    r = [0] * k
-    for i in range(N):
-        xi = 0
-        yi = 0
-        for j in range(k):
-            xi |= (((x[j] >> i) & 1) << j)
-            yi |= (((y[j] >> i) & 1) << j)
-        ri = (xi + yi) & ((1 << k) - 1)
-        for j in range(k):
-            r[j] |= (((ri >> j) & 1) << i)
+    # Generate expected result.
+    m = (1 << K) - 1
+    r = [0] * K
+    for coeff in range(N):
+        x_coeff = 0
+        y_coeff = 0
+        for bit in range(K):
+            x_coeff |= (((x[bit] >> coeff) & 1) << bit)
+            y_coeff |= (((y[bit] >> coeff) & 1) << bit)
+        r_coeff = (x_coeff + y_coeff) & m
+        for bit in range(K):
+            r[bit] |= (((r_coeff >> bit) & 1) << coeff)
 
     r_bytes = bytes()
-    for i in range(k):
-        t = int.to_bytes(r[i], byteorder="little", length=32)
-        r_bytes += t
-
-    rb_bytes = int.to_bytes(0, byteorder='little', length=operand_nbytes)
+    for bit in range(K):
+        r_bytes += int.to_bytes(r[bit], byteorder="little", length=32)
 
     # Write input values.
-    inputs = {'xb': xb, 'yb': yb, 'rb': rb_bytes}
+    inputs = {
+        'xb': x_bytes,
+        'yb': y_bytes,
+        'rb': int.to_bytes(0, byteorder='little', length=512 * NSHARES)
+    }
     write_test_data(inputs, data_file)
 
     # Write expected register values (none).

--- a/sw/acc/crypto/tests/mlkem/gadgets/secand_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/secand_test.s
@@ -8,40 +8,41 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* Load stack pointer. */
-    la  x2, stack_end
+  /* Load stack pointer. */
+  la  x2, stack_end
 
-    /* dmem[rb] <= secand(dmem[xb], dmem[yb]) */
-    la  x10, xb
-    li  x11, 32
-    la  x12, yb
-    li  x13, 32
-    la  x15, rb
-    li  x16, 32
-    jal x1, secand
+  /* dmem[rb] <= secand(dmem[xb], dmem[yb]) */
+  la  x10, xb
+  li  x11, 32
+  la  x12, yb
+  li  x13, 32
+  la  x15, rb
+  li  x16, 32
+  jal x1, secand
 
-    /* Compute r */
-    la     x2, rb
-    la     x3, r
-    li     x4, 1
-    li     x5, NSHARES
-    addi   x5, x5, -1
-    bn.lid x0, 0(x2++)
-    loop x5, 2
-        bn.lid x4, 0(x2++)
-        bn.xor w0, w0, w1
-    endloop
-    bn.sid x0, 0(x3)
+  /* Compute r */
+  la     x2, rb
+  la     x3, r
+  li     x4, 1
+  li     x5, NSHARES
+  addi   x5, x5, -1
+  bn.lid x0, 0(x2++)
+  loop x5, 2
+    bn.lid x4, 0(x2++)
+    bn.xor w0, w0, w1
+  endloop
+  bn.sid x0, 0(x3)
 
-    ecall
+  ecall
 
 .data
 .balign 32
 stack:
-    .zero STACK_SIZE
+  .zero STACK_SIZE
 stack_end:
+
 r:
-    .zero 32
+  .zero 32

--- a/sw/acc/crypto/tests/mlkem/gadgets/secand_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/secand_test.s
@@ -2,7 +2,6 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NSHARES 2
 #define STACK_SIZE 1024
 
 .section .text.start
@@ -11,10 +10,8 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* Load stack pointer. */
+  /* rb <- secand(xb, yb). */
   la  x2, stack_end
-
-  /* dmem[rb] <= secand(dmem[xb], dmem[yb]) */
   la  x10, xb
   li  x11, 32
   la  x12, yb
@@ -23,17 +20,13 @@ main:
   li  x16, 32
   jal x1, secand
 
-  /* Compute r */
+  /* r <- unmask(rb). */
   la     x2, rb
   la     x3, r
   li     x4, 1
-  li     x5, NSHARES
-  addi   x5, x5, -1
   bn.lid x0, 0(x2++)
-  loop x5, 2
-    bn.lid x4, 0(x2++)
-    bn.xor w0, w0, w1
-  endloop
+  bn.lid x4, 0(x2)
+  bn.xor w0, w0, w1
   bn.sid x0, 0(x3)
 
   ecall

--- a/sw/acc/crypto/tests/mlkem/gadgets/secand_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/secand_testgen.py
@@ -20,30 +20,29 @@ def gen_secand_test(
     if seed is not None:
         random.seed(seed)
 
-    nshares = NSHARES
-    operand_nbytes = 32 * nshares
-
+    # Generate inputs.
     x = 0
     y = 0
-    xb = 0
-    yb = 0
-    for i in range(nshares):
-        tx = random.getrandbits(N)
-        ty = random.getrandbits(N)
-        x ^= tx
-        y ^= ty
-        xb |= (tx << (i * N))
-        yb |= (ty << (i * N))
+    x_bytes = bytes()
+    y_bytes = bytes()
+    for _ in range(NSHARES):
+        t = random.getrandbits(N)
+        x ^= t
+        x_bytes += int.to_bytes(t, byteorder='little', length=32)
+        t = random.getrandbits(N)
+        y ^= t
+        y_bytes += int.to_bytes(t, byteorder='little', length=32)
 
+    # Generate expected result.
     r = x & y
-
-    xb_bytes = int.to_bytes(xb, byteorder='little', length=operand_nbytes)
-    yb_bytes = int.to_bytes(yb, byteorder='little', length=operand_nbytes)
     r_bytes = int.to_bytes(r, byteorder='little', length=32)
-    rb_bytes = int.to_bytes(0, byteorder='little', length=operand_nbytes)
 
     # Write input values.
-    inputs = {'xb': xb_bytes, 'yb': yb_bytes, 'rb': rb_bytes}
+    inputs = {
+        'xb': x_bytes,
+        'yb': y_bytes,
+        'rb': int.to_bytes(0, byteorder='little', length=32 * NSHARES)
+    }
     write_test_data(inputs, data_file)
 
     # Write expected register values (none).

--- a/sw/acc/crypto/tests/mlkem/gadgets/secb2amodq_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/secb2amodq_test.s
@@ -10,12 +10,12 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* w16 = mod = qinv | q. */
+  /* w16 = mod = mqinv | q. */
   addi    x4, x0, 16
-  la      x5, modulus_bn
+  la      x5, const_q
   bn.lid  x4++, 0(x5)
   bn.rshi w16, w31, w16 >> 240
-  la      x5, modulus_inv
+  la      x5, const_mqinv
   bn.lid  x4, 0(x5)
   bn.or   w16, w16, w17 << 32
   bn.wsrw mod, w16

--- a/sw/acc/crypto/tests/mlkem/gadgets/secb2amodq_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/secb2amodq_test.s
@@ -2,9 +2,6 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NSHARES 2
-#define N_WDR 16
-#define NB_POLY 512
 #define STACK_SIZE 20000
 
 .section .text.start
@@ -13,40 +10,34 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* MOD <= dmem[modulus] */
-  addi    x4, x0, 0
+  /* mod = qinv | q. */
+  add     x4, x0, x0
   la      x5, modulus_bn
   bn.lid  x4++, 0(x5)
   bn.rshi w0, w31, w0 >> 240
   la      x5, modulus_inv
   bn.lid  x4, 0(x5)
   bn.or   w0, w0, w1 << 32
-  bn.wsrw 0x0, w0
+  bn.wsrw mod, w0
 
-  /* Load stack pointer */
-  la x2, stack_end
-
-  /* dmem[ra] <= secb2amodq(dmem[xb]) */
+  /* ra <- secb2amodq(xb). */
+  la  x2, stack_end
   la  x10, xb
   la  x12, ra
   jal x1, secb2amodq
 
-  /* Compute r */
+  /* r <- unmask(ra). */
   la   x2, ra
-  la   x3, r
+  addi x3, x2, 512
+  la   x5, r
   li   x4, 1
-  li   x5, NSHARES
-  addi x5, x5, -1
-  loopi N_WDR, 7
-    addi   x6, x2, NB_POLY
-    bn.lid x0, 0(x2++)
-    loop x5, 3
-      bn.lid       x4, 0(x6)
-      bn.addvm.16h w0, w0, w1
-      addi         x6, x6, NB_POLY
-    endloop
-    bn.sid x0, 0(x3++)
+  loopi 16, 4
+    bn.lid       x0, 0(x2++)
+    bn.lid       x4, 0(x3++)
+    bn.addvm.16h w0, w0, w1
+    bn.sid       x0, 0(x5++)
   endloop
+
   ecall
 
 .data
@@ -56,4 +47,4 @@ stack:
 stack_end:
 
 r:
-  .zero 32 * N_WDR
+  .zero 512

--- a/sw/acc/crypto/tests/mlkem/gadgets/secb2amodq_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/secb2amodq_test.s
@@ -10,49 +10,50 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* MOD <= dmem[modulus] */
-    addi    x4, x0, 0
-    la      x5, modulus_bn
-    bn.lid  x4++, 0(x5)
-    bn.rshi w0, w31, w0 >> 240
-    la      x5, modulus_inv
-    bn.lid  x4, 0(x5)
-    bn.or   w0, w0, w1 << 32
-    bn.wsrw 0x0, w0
+  /* MOD <= dmem[modulus] */
+  addi    x4, x0, 0
+  la      x5, modulus_bn
+  bn.lid  x4++, 0(x5)
+  bn.rshi w0, w31, w0 >> 240
+  la      x5, modulus_inv
+  bn.lid  x4, 0(x5)
+  bn.or   w0, w0, w1 << 32
+  bn.wsrw 0x0, w0
 
-    /* Load stack pointer */
-    la x2, stack_end
+  /* Load stack pointer */
+  la x2, stack_end
 
-    /* dmem[ra] <= secb2amodq(dmem[xb]) */
-    la  x10, xb
-    la  x12, ra
-    jal x1, secb2amodq
+  /* dmem[ra] <= secb2amodq(dmem[xb]) */
+  la  x10, xb
+  la  x12, ra
+  jal x1, secb2amodq
 
-    /* Compute r */
-    la   x2, ra
-    la   x3, r
-    li   x4, 1
-    li   x5, NSHARES
-    addi x5, x5, -1
-    loopi N_WDR, 7
-        addi   x6, x2, NB_POLY
-        bn.lid x0, 0(x2++)
-        loop x5, 3
-            bn.lid       x4, 0(x6)
-            bn.addvm.16h w0, w0, w1
-            addi         x6, x6, NB_POLY
-        endloop
-        bn.sid x0, 0(x3++)
+  /* Compute r */
+  la   x2, ra
+  la   x3, r
+  li   x4, 1
+  li   x5, NSHARES
+  addi x5, x5, -1
+  loopi N_WDR, 7
+    addi   x6, x2, NB_POLY
+    bn.lid x0, 0(x2++)
+    loop x5, 3
+      bn.lid       x4, 0(x6)
+      bn.addvm.16h w0, w0, w1
+      addi         x6, x6, NB_POLY
     endloop
-    ecall
+    bn.sid x0, 0(x3++)
+  endloop
+  ecall
 
 .data
 .balign 32
 stack:
-    .zero STACK_SIZE
+  .zero STACK_SIZE
 stack_end:
+
 r:
-    .zero 32 * N_WDR
+  .zero 32 * N_WDR

--- a/sw/acc/crypto/tests/mlkem/gadgets/secb2amodq_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/secb2amodq_test.s
@@ -10,22 +10,21 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* mod = qinv | q. */
-  add     x4, x0, x0
+  /* w16 = mod = qinv | q. */
+  addi    x4, x0, 16
   la      x5, modulus_bn
   bn.lid  x4++, 0(x5)
-  bn.rshi w0, w31, w0 >> 240
+  bn.rshi w16, w31, w16 >> 240
   la      x5, modulus_inv
   bn.lid  x4, 0(x5)
-  bn.or   w0, w0, w1 << 32
-  bn.wsrw mod, w0
+  bn.or   w16, w16, w17 << 32
+  bn.wsrw mod, w16
 
   /* ra <- secb2amodq(xb). */
-  bn.wsrr w16, mod
-  la      x2, stack_end
-  la      x10, xb
-  la      x12, ra
-  jal     x1, secb2amodq
+  la  x2, stack_end
+  la  x10, xb
+  la  x12, ra
+  jal x1, secb2amodq
 
   /* r <- unmask(ra). */
   la   x2, ra

--- a/sw/acc/crypto/tests/mlkem/gadgets/secb2amodq_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/secb2amodq_test.s
@@ -21,10 +21,11 @@ main:
   bn.wsrw mod, w0
 
   /* ra <- secb2amodq(xb). */
-  la  x2, stack_end
-  la  x10, xb
-  la  x12, ra
-  jal x1, secb2amodq
+  bn.wsrr w16, mod
+  la      x2, stack_end
+  la      x10, xb
+  la      x12, ra
+  jal     x1, secb2amodq
 
   /* r <- unmask(ra). */
   la   x2, ra

--- a/sw/acc/crypto/tests/mlkem/gadgets/secb2amodq_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/secb2amodq_testgen.py
@@ -11,30 +11,29 @@ from shared.testgen import write_test_data, write_test_exp, write_test_dexp
 
 N = 256
 NSHARES = 2
+Q = 3329
+K = 12
 
 
-def bitslice(x: List[int], k: int) -> List[int]:
-    r = [0] * k
-    for i in range(N):
-        for j in range(k):
-            bit = (x[i] >> j) & 1
-            r[j] |= (bit << i)
-    return r
-
-
-def bitslice_vec(x: List[int], k: int) -> List[int]:
-    r = [0] * k
-    one = sum(1 << (i * 16) for i in range(16))
+def bitslice_vec(x: List[int], k: int) -> bytes:
     mask = (1 << N) - 1
-    x_int = sum(x[i] << (i * 16) for i in range(N))
-    for i in range(16):
+    # Generate 1 in 16 16-bit lanes.
+    vone = sum(1 << (lane * 16) for lane in range(16))
+
+    r = [0] * k
+    x_int = sum(x[coeff] << (coeff * 16) for coeff in range(N))
+    for _ in range(16):
         t = x_int & mask
         x_int >>= N
-        for j in range(k):
-            r[j] <<= 1
-            r[j] |= (t & one)
+        for bit in range(k):
+            r[bit] <<= 1
+            r[bit] |= (t & vone)
             t >>= 1
-    return r
+
+    r_bytes = bytes()
+    for bit in range(k):
+        r_bytes += int.to_bytes(r[bit], byteorder="little", length=32)
+    return r_bytes
 
 
 def gen_secb2amodq_test(
@@ -44,34 +43,27 @@ def gen_secb2amodq_test(
     if seed is not None:
         random.seed(seed)
 
-    nshares = NSHARES
-
-    q = 3329
-    k = 12
+    # Generate input.
+    r = [random.randint(0, Q - 1) for _ in range(N)]
+    last = r.copy()
+    x = [0] * N
+    x_bytes = bytes()
+    for _ in range(NSHARES - 1):
+        for coeff in range(N):
+            x[coeff] = random.randint(0, 2**K - 1)
+            last[coeff] ^= x[coeff]
+        x_bytes += bitslice_vec(x, K)
+    x_bytes += bitslice_vec(last, K)
 
     # Generate expected result.
-    x = [random.randint(0, q - 1) for _ in range(N)]
-    r = sum(x[i] << (i * 16) for i in range(N))
-    r_bytes = int.to_bytes(r, byteorder="little", length=32 * 16)
-
-    # Generate inputs.
-    t = [0] * nshares
-    rx = x.copy()
-    x_bytes = bytes()
-    for i in range(nshares - 1):
-        t[i] = [random.randint(0, 2**k - 1) for _ in range(N)]
-        rx = [(rx[j] ^ t[i][j]) for j in range(N)]
-        tmp = bitslice_vec(t[i], k)
-        for j in range(k):
-            x_bytes += int.to_bytes(tmp[j], byteorder="little", length=32)
-    tmp = bitslice_vec(rx, k)
-    for j in range(k):
-        x_bytes += int.to_bytes(tmp[j], byteorder="little", length=32)
-
-    ra_bytes = int.to_bytes(0, byteorder='little', length=32 * 16 * nshares)
+    r_int = sum(r[coeff] << (coeff * 16) for coeff in range(N))
+    r_bytes = int.to_bytes(r_int, byteorder="little", length=512)
 
     # Write input values.
-    inputs = {'xb': x_bytes, 'ra': ra_bytes}
+    inputs = {
+        'xb': x_bytes,
+        'ra': int.to_bytes(0, byteorder='little', length=512 * NSHARES)
+    }
     write_test_data(inputs, data_file)
 
     # Write expected register values (none).

--- a/sw/acc/crypto/tests/mlkem/gadgets/secfulladder_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/secfulladder_test.s
@@ -2,7 +2,6 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NSHARES 2
 #define STACK_SIZE 1024
 
 .section .text.start
@@ -11,10 +10,8 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* Load stack pointer */
-  la x2, stack_end
-
-  /* dmem[rb] <= secfulladder(dmem[xb], dmem[yb]) */
+  /* (rb, cout = cb) <- secfulladder(xb, yb, cin = cb). */
+  la  x2, stack_end
   la  x10, xb
   li  x11, 32
   la  x12, yb
@@ -27,27 +24,20 @@ main:
   li  x31, 32
   jal x1, secfulladder
 
-  /* Compute r */
-  la     x3, r
+  /* r <- unmask(rb). */
+  la     x2, r
+  la     x3, rb
   li     x4, 1
-  addi   x5, x0, NSHARES
-  addi   x5, x5, -1
-  /* Compute r[0]. */
-  la     x2, rb
-  bn.lid x0, 0(x2++)
-  loop x5, 2
-    bn.lid x4, 0(x2++)
-    bn.xor w0, w0, w1
-  endloop
-  bn.sid x0, 0(x3++)
-  /* Compute r[1]. */
-  la     x2, cb
-  bn.lid x0, 0(x2++)
-  loop x5, 2
-    bn.lid x4, 0(x2++)
-    bn.xor w0, w0, w1
-  endloop
-  bn.sid x0, 0(x3++)
+  bn.lid x0, 0(x3++)
+  bn.lid x4, 0(x3++)
+  bn.xor w0, w0, w1
+  bn.sid x0, 0(x2++)
+  /* cout <- unmask(cb). */
+  la     x3, cb
+  bn.lid x0, 0(x3++)
+  bn.lid x4, 0(x3++)
+  bn.xor w0, w0, w1
+  bn.sid x0, 0(x2++)
 
   ecall
 

--- a/sw/acc/crypto/tests/mlkem/gadgets/secfulladder_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/secfulladder_test.s
@@ -8,53 +8,54 @@
 .section .text.start
 
 main:
-    /* All-zero register. */
-    bn.xor w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-    /* Load stack pointer */
-    la x2, stack_end
+  /* Load stack pointer */
+  la x2, stack_end
 
-    /* dmem[rb] <= secfulladder(dmem[xb], dmem[yb]) */
-    la  x10, xb
-    li  x11, 32
-    la  x12, yb
-    li  x13, 32
-    la  x15, rb
-    li  x16, 32
-    la  x17, cb
-    li  x29, 32
-    la  x30, cb
-    li  x31, 32
-    jal x1, secfulladder
+  /* dmem[rb] <= secfulladder(dmem[xb], dmem[yb]) */
+  la  x10, xb
+  li  x11, 32
+  la  x12, yb
+  li  x13, 32
+  la  x15, rb
+  li  x16, 32
+  la  x17, cb
+  li  x29, 32
+  la  x30, cb
+  li  x31, 32
+  jal x1, secfulladder
 
-    /* Compute r */
-    la     x3, r
-    li     x4, 1
-    addi   x5, x0, NSHARES
-    addi   x5, x5, -1
-    /* Compute r[0]. */
-    la     x2, rb
-    bn.lid x0, 0(x2++)
-    loop x5, 2
-        bn.lid x4, 0(x2++)
-        bn.xor w0, w0, w1
-    endloop
-    bn.sid x0, 0(x3++)
-    /* Compute r[1]. */
-    la     x2, cb
-    bn.lid x0, 0(x2++)
-    loop x5, 2
-        bn.lid x4, 0(x2++)
-        bn.xor w0, w0, w1
-    endloop
-    bn.sid x0, 0(x3++)
+  /* Compute r */
+  la     x3, r
+  li     x4, 1
+  addi   x5, x0, NSHARES
+  addi   x5, x5, -1
+  /* Compute r[0]. */
+  la     x2, rb
+  bn.lid x0, 0(x2++)
+  loop x5, 2
+    bn.lid x4, 0(x2++)
+    bn.xor w0, w0, w1
+  endloop
+  bn.sid x0, 0(x3++)
+  /* Compute r[1]. */
+  la     x2, cb
+  bn.lid x0, 0(x2++)
+  loop x5, 2
+    bn.lid x4, 0(x2++)
+    bn.xor w0, w0, w1
+  endloop
+  bn.sid x0, 0(x3++)
 
-    ecall
+  ecall
 
 .data
 .balign 32
 stack:
-    .zero STACK_SIZE
+  .zero STACK_SIZE
 stack_end:
+
 r:
-    .zero 64
+  .zero 64

--- a/sw/acc/crypto/tests/mlkem/gadgets/secfulladder_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/secfulladder_testgen.py
@@ -20,50 +20,44 @@ def gen_secfulladder_test(
     if seed is not None:
         random.seed(seed)
 
-    nshares = NSHARES
-
-    operand_nbytes = 32 * nshares
-
+    # Generate inputs.
     x = 0
     y = 0
     c = 0
-    xb = 0
-    yb = 0
-    cb = 0
-    for i in range(nshares):
-        tx = random.getrandbits(N)
-        ty = random.getrandbits(N)
-        tc = random.getrandbits(N)
-        x ^= tx
-        y ^= ty
-        c ^= tc
-        xb |= (tx << (i * N))
-        yb |= (ty << (i * N))
-        cb |= (tc << (i * N))
+    x_bytes = bytes()
+    y_bytes = bytes()
+    c_bytes = bytes()
+    for _ in range(NSHARES):
+        t = random.getrandbits(N)
+        x ^= t
+        x_bytes += int.to_bytes(t, byteorder='little', length=32)
+        t = random.getrandbits(N)
+        y ^= t
+        y_bytes += int.to_bytes(t, byteorder='little', length=32)
+        t = random.getrandbits(N)
+        c ^= t
+        c_bytes += int.to_bytes(t, byteorder='little', length=32)
 
-    # Compute expected result x + y + c.
-    w0 = 0
-    w1 = 0
-    for i in range(N):
-        xi = (x >> i) & 1
-        yi = (y >> i) & 1
-        ci = (c >> i) & 1
-        t = xi + yi + ci
-        w0 |= ((t & 1) << i)
-        w1 |= (((t >> 1) & 1) << i)
-    w = w0 | (w1 << N)
-
-    xb_bytes = int.to_bytes(xb, byteorder='little', length=operand_nbytes)
-    yb_bytes = int.to_bytes(yb, byteorder='little', length=operand_nbytes)
-    cb_bytes = int.to_bytes(cb, byteorder='little', length=operand_nbytes)
-    r_bytes = int.to_bytes(w, byteorder='little', length=64)
-    rb_bytes = int.to_bytes(0, byteorder='little', length=operand_nbytes)
-    coutb_bytes = int.to_bytes(0, byteorder='little', length=operand_nbytes)
+    # Compute expected result.
+    sum = 0
+    cout = 0
+    for coeff in range(N):
+        x_coeff = (x >> coeff) & 1
+        y_coeff = (y >> coeff) & 1
+        c_coeff = (c >> coeff) & 1
+        r_coeff = x_coeff + y_coeff + c_coeff
+        sum |= ((r_coeff & 1) << coeff)
+        cout |= (((r_coeff >> 1) & 1) << coeff)
+    r_bytes = int.to_bytes(sum, byteorder='little', length=32)
+    r_bytes += int.to_bytes(cout, byteorder='little', length=32)
 
     # Write input values.
     inputs = {
-        'xb': xb_bytes, 'yb': yb_bytes, 'cb': cb_bytes,
-        'rb': rb_bytes, 'coutb': coutb_bytes
+        'xb': x_bytes,
+        'yb': y_bytes,
+        'cb': c_bytes,
+        'rb': int.to_bytes(0, byteorder='little', length=32 * NSHARES),
+        'coutb': int.to_bytes(0, byteorder='little', length=32 * NSHARES)
     }
     write_test_data(inputs, data_file)
 

--- a/sw/acc/crypto/tests/mlkem/gadgets/seconebitb2amodq_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/seconebitb2amodq_test.s
@@ -10,22 +10,21 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* mod = qinv | q. */
-  add     x4, x0, x0
+  /* w16 = mod = qinv | q. */
+  addi    x4, x0, 16
   la      x5, modulus_bn
   bn.lid  x4++, 0(x5)
-  bn.rshi w0, w31, w0 >> 240
+  bn.rshi w16, w31, w16 >> 240
   la      x5, modulus_inv
   bn.lid  x4, 0(x5)
-  bn.or   w0, w0, w1 << 32
-  bn.wsrw mod, w0
+  bn.or   w16, w16, w17 << 32
+  bn.wsrw mod, w16
 
   /* ra <- seconebitb2amodq(xb). */
-  la      x2, stack_end
-  bn.wsrr w16, mod
-  la      x10, xb
-  la      x12, ra
-  jal     x1, seconebitb2amodq
+  la  x2, stack_end
+  la  x10, xb
+  la  x12, ra
+  jal x1, seconebitb2amodq
 
   /* r <- unmask(ra). */
   la   x2, ra

--- a/sw/acc/crypto/tests/mlkem/gadgets/seconebitb2amodq_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/seconebitb2amodq_test.s
@@ -10,10 +10,14 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* mod = q. */
+  /* mod = qinv | q. */
+  add     x4, x0, x0
   la      x5, modulus_bn
-  bn.lid  x0, 0(x5)
+  bn.lid  x4++, 0(x5)
   bn.rshi w0, w31, w0 >> 240
+  la      x5, modulus_inv
+  bn.lid  x4, 0(x5)
+  bn.or   w0, w0, w1 << 32
   bn.wsrw mod, w0
 
   /* ra <- seconebitb2amodq(xb). */

--- a/sw/acc/crypto/tests/mlkem/gadgets/seconebitb2amodq_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/seconebitb2amodq_test.s
@@ -10,12 +10,12 @@ main:
   /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* w16 = mod = qinv | q. */
+  /* w16 = mod = mqinv | q. */
   addi    x4, x0, 16
-  la      x5, modulus_bn
+  la      x5, const_q
   bn.lid  x4++, 0(x5)
   bn.rshi w16, w31, w16 >> 240
-  la      x5, modulus_inv
+  la      x5, const_mqinv
   bn.lid  x4, 0(x5)
   bn.or   w16, w16, w17 << 32
   bn.wsrw mod, w16

--- a/sw/acc/crypto/tests/mlkem/gadgets/seconebitb2amodq_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/seconebitb2amodq_test.s
@@ -2,48 +2,39 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#define NSHARES 2
-#define N_WDR 16
-#define NB_POLY 512
 #define STACK_SIZE 20000
 
 .section .text.start
 
 main:
-  /* All-zero register */
+  /* All-zero register. */
   bn.xor w31, w31, w31
 
-  /* MOD <= dmem[modulus] = KYBER_Q */
-  la      x6, modulus_bn
-  bn.lid  x0, 0(x6)
+  /* mod = q. */
+  la      x5, modulus_bn
+  bn.lid  x0, 0(x5)
   bn.rshi w0, w31, w0 >> 240
   bn.wsrw mod, w0
 
-  /* Load stack pointer */
-  la x2, stack_end
-
-  /* dmem[ra] <= seconebitb2amodq(dmem[xb]) */
+  /* ra <- seconebitb2amodq(xb). */
+  la      x2, stack_end
   bn.wsrr w16, mod
   la      x10, xb
   la      x12, ra
   jal     x1, seconebitb2amodq
 
-  /* Compute r */
+  /* r <- unmask(ra). */
   la   x2, ra
-  la   x3, r
+  addi x3, x2, 512
+  la   x5, r
   li   x4, 1
-  li   x5, NSHARES
-  addi x5, x5, -1
-  loopi N_WDR, 7
-    addi   x6, x2, NB_POLY
-    bn.lid x0, 0(x2++)
-    loop x5, 3
-      bn.lid       x4, 0(x6)
-      bn.addvm.16h w0, w0, w1
-      addi         x6, x6, NB_POLY
-    endloop
-    bn.sid x0, 0(x3++)
+  loopi 16, 4
+    bn.lid       x0, 0(x2++)
+    bn.lid       x4, 0(x3++)
+    bn.addvm.16h w0, w0, w1
+    bn.sid       x0, 0(x5++)
   endloop
+
   ecall
 
 .data
@@ -53,4 +44,4 @@ stack:
 stack_end:
 
 r:
-  .zero 32 * N_WDR
+  .zero 512

--- a/sw/acc/crypto/tests/mlkem/gadgets/seconebitb2amodq_test.s
+++ b/sw/acc/crypto/tests/mlkem/gadgets/seconebitb2amodq_test.s
@@ -10,50 +10,47 @@
 .section .text.start
 
 main:
-    /* All-zero register */
-    bn.xor w31, w31, w31
+  /* All-zero register */
+  bn.xor w31, w31, w31
 
-    /* MOD <= dmem[modulus] = KYBER_Q */
-    la      x6, modulus_bn
-    bn.lid  x0, 0(x6)
-    bn.rshi w0, w31, w0 >> 240
-    bn.wsrw mod, w0
+  /* MOD <= dmem[modulus] = KYBER_Q */
+  la      x6, modulus_bn
+  bn.lid  x0, 0(x6)
+  bn.rshi w0, w31, w0 >> 240
+  bn.wsrw mod, w0
 
-    /* Load stack pointer */
-    la x2, stack_end
+  /* Load stack pointer */
+  la x2, stack_end
 
-    /* dmem[ra] <= seconebitb2amodq(dmem[xb]) */
-    bn.wsrr w16, mod
-    la      x10, xb
-    la      x12, ra
-    jal     x1, seconebitb2amodq
+  /* dmem[ra] <= seconebitb2amodq(dmem[xb]) */
+  bn.wsrr w16, mod
+  la      x10, xb
+  la      x12, ra
+  jal     x1, seconebitb2amodq
 
-    /* Compute r */
-    la   x2, ra
-    la   x3, r
-    li   x4, 1
-    li   x5, NSHARES
-    addi x5, x5, -1
-    loopi N_WDR, 7
-        addi   x6, x2, NB_POLY
-        bn.lid x0, 0(x2++)
-        loop x5, 3
-            bn.lid       x4, 0(x6)
-            bn.addvm.16h w0, w0, w1
-            addi         x6, x6, NB_POLY
-        endloop
-        bn.sid x0, 0(x3++)
+  /* Compute r */
+  la   x2, ra
+  la   x3, r
+  li   x4, 1
+  li   x5, NSHARES
+  addi x5, x5, -1
+  loopi N_WDR, 7
+    addi   x6, x2, NB_POLY
+    bn.lid x0, 0(x2++)
+    loop x5, 3
+      bn.lid       x4, 0(x6)
+      bn.addvm.16h w0, w0, w1
+      addi         x6, x6, NB_POLY
     endloop
-    ecall
+    bn.sid x0, 0(x3++)
+  endloop
+  ecall
 
 .data
 .balign 32
 stack:
-    .zero STACK_SIZE
+  .zero STACK_SIZE
 stack_end:
 
-
-
-
 r:
-    .zero 32 * N_WDR
+  .zero 32 * N_WDR

--- a/sw/acc/crypto/tests/mlkem/gadgets/seconebitb2amodq_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/gadgets/seconebitb2amodq_testgen.py
@@ -11,7 +11,6 @@ from shared.testgen import write_test_data, write_test_exp, write_test_dexp
 
 N = 256
 NSHARES = 2
-N_WDR = 16
 
 
 def gen_seconebitb2amodq_test(
@@ -21,25 +20,26 @@ def gen_seconebitb2amodq_test(
     if seed is not None:
         random.seed(seed)
 
-    nshares = NSHARES
-    operand_nbytes = 32 * N_WDR * nshares
-
-    # Generate input.
-    r = 0
+    # Generate inputs.
+    x = [0] * N
+    r = [0] * N
     x_bytes = bytes()
-    for _ in range(nshares):
-        t = [random.randint(0, 1) for _ in range(N)]
-        t_int = sum(t[j] << (j * 16) for j in range(N))
-        r ^= t_int
-        x_bytes += int.to_bytes(t_int, byteorder="little", length=512)
+    for _ in range(NSHARES):
+        for coeff in range(N):
+            x[coeff] = random.randint(0, 1)
+            r[coeff] ^= x[coeff]
+        x_int = sum(x[coeff] << (coeff * 16) for coeff in range(N))
+        x_bytes += int.to_bytes(x_int, byteorder="little", length=512)
 
     # Generate expected result.
-    r_bytes = int.to_bytes(r, byteorder='little', length=512)
-
-    ra_bytes = int.to_bytes(0, byteorder='little', length=operand_nbytes)
+    r_int = sum(r[coeff] << (coeff * 16) for coeff in range(N))
+    r_bytes = int.to_bytes(r_int, byteorder='little', length=512)
 
     # Write input values.
-    inputs = {'xb': x_bytes, 'ra': ra_bytes}
+    inputs = {
+        'xb': x_bytes,
+        'ra': int.to_bytes(0, byteorder='little', length=512 * NSHARES)
+    }
     write_test_data(inputs, data_file)
 
     # Write expected register values (none).

--- a/sw/acc/crypto/tests/mlkem/mlkem_decap_masked_test.s
+++ b/sw/acc/crypto/tests/mlkem/mlkem_decap_masked_test.s
@@ -17,9 +17,10 @@
 
 .globl main
 main:
-  bn.xor  w31, w31, w31
+  /* All-zero register. */
+  bn.xor w31, w31, w31
 
-  /* mod = mqinv | q. */
+  /* w16 = mod = mqinv | q. */
   li      x5, 16
   la      x6, const_q
   bn.lid  x5++, 0(x6)
@@ -29,6 +30,7 @@ main:
   bn.or   w16, w16, w17 << 32
   bn.wsrw mod, w16
 
+  /* ss <- crypto_kem_dec(ct, dk). */
   la   x2, stack_end
   la   x10, ct
   la   x11, dk
@@ -36,9 +38,9 @@ main:
   li   x13, KYBER_K
   jal  x1, crypto_kem_dec
 
-  /* Unmask the shared key: ss[0] ^= ss[1]. */
+  /* ss <- unmask(ss): ss_0 ^= ss_1. */
   la     x2, ss
-  addi   x4, x0, 1
+  li     x4, 1
   bn.lid x0, 0(x2)
   bn.lid x4, 32(x2)
   bn.xor w0, w0, w1

--- a/sw/acc/crypto/tests/mlkem/mlkem_decap_masked_test.s
+++ b/sw/acc/crypto/tests/mlkem/mlkem_decap_masked_test.s
@@ -19,12 +19,12 @@
 main:
   bn.xor  w31, w31, w31
 
-  /* mod = qinv | q. */
+  /* mod = mqinv | q. */
   li      x5, 16
-  la      x6, modulus_bn
+  la      x6, const_q
   bn.lid  x5++, 0(x6)
   bn.rshi w16, w31, w16 >> 240
-  la      x6, modulus_inv
+  la      x6, const_mqinv
   bn.lid  x5, 0(x6)
   bn.or   w16, w16, w17 << 32
   bn.wsrw mod, w16

--- a/sw/acc/crypto/tests/mlkem/mlkem_decap_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/mlkem_decap_testgen.py
@@ -19,6 +19,7 @@ INSTANCE_FOR_PARAMS = {
 
 Q = 3329
 N = 256
+NSHARES = 2
 
 
 def gen_decaps_test(mlkem, hardened: bool, mode_symbol: str, tc_file: TextIO,
@@ -40,7 +41,6 @@ def gen_decaps_test(mlkem, hardened: bool, mode_symbol: str, tc_file: TextIO,
     if not hardened:
         dk_input = dk
     else:
-        nshares = 2
         skpv = []
         dk_int = int.from_bytes(dk[0:384 * mlkem.k], byteorder="little")
         for k in range(mlkem.k):
@@ -51,29 +51,27 @@ def gen_decaps_test(mlkem, hardened: bool, mode_symbol: str, tc_file: TextIO,
                 tv.append(t)
             skpv.append(tv)
 
-        dk_bytes = 0
+        t = [0] * N
+        dk_bytes = bytes()
         for k in range(mlkem.k):
             sk = skpv[k].copy()
-            sk_bytes = 0
-            for i in range(nshares - 1):
-                t = [random.randint(0, Q - 1) for _ in range(N)]
-                sk = [(sk[j] - t[j]) % Q for j in range(N)]
-                t = sum(t[j] << (j * 12) for j in range(N))
-                sk_bytes |= (t << (i * N * 12))
-            sk_int = sum(sk[j] << (j * 12) for j in range(N))
-            sk_bytes |= (sk_int << ((nshares - 1) * N * 12))
-            dk_bytes |= (sk_bytes << (k * N * 12 * nshares))
-
-        dk_bytes = int.to_bytes(dk_bytes, byteorder='little', length=384 * nshares * mlkem.k)
+            for _ in range(NSHARES - 1):
+                for coeff in range(N):
+                    t[coeff] = random.randint(0, Q - 1)
+                    sk[coeff] = (sk[coeff] - t[coeff]) % Q
+                t_int = sum(t[coeff] << (coeff * 12) for coeff in range(N))
+                dk_bytes += int.to_bytes(t_int, byteorder="little", length=384)
+            sk_int = sum(sk[coeff] << (coeff * 12) for coeff in range(N))
+            dk_bytes += int.to_bytes(sk_int, byteorder="little", length=384)
 
         dk_bytes += dk[mlkem.k * 384:-32]
+
         # Mask z.
         z_int = int.from_bytes(dk[-32:], byteorder='little')
-        r1 = random.getrandbits(256)
-        r2 = r1 ^ z_int
-        tz = int.to_bytes(r1, byteorder='little', length=32)
-        tz += int.to_bytes(r2, byteorder='little', length=32)
-        dk_bytes += tz
+        z0 = random.getrandbits(N)
+        z1 = z0 ^ z_int
+        dk_bytes += int.to_bytes(z0, byteorder='little', length=32)
+        dk_bytes += int.to_bytes(z1, byteorder='little', length=32)
         dk_input = dk_bytes
 
     # Unprotected decap runs run_mlkem (dispatched by mode); the masked wrapper

--- a/sw/acc/crypto/tests/mlkem/mlkem_keypair_masked_test.s
+++ b/sw/acc/crypto/tests/mlkem/mlkem_keypair_masked_test.s
@@ -18,8 +18,6 @@
 
 .section .text.start
 
-#define NSHARES 2
-
 #ifndef KYBER_K
   #define KYBER_K 3
 #endif
@@ -34,9 +32,8 @@
 
 .globl main
 main:
+  /* All-zero register. */
   bn.xor w31, w31, w31
-
-  la x2, stack_end
 
   /* mod = mqinv | q. */
   li      x4, 16
@@ -48,56 +45,56 @@ main:
   bn.or   w16, w16, w17 << 32
   bn.wsrw mod, w16
 
-  la   x10, coins
-  la   x11, ek
-  la   x12, dk
-  li   x13, KYBER_K
-  jal  x1, crypto_kem_keypair
+  /* dk <- crypto_kem_keypair(coins, ek). */
+  la  x2, stack_end
+  la  x10, coins
+  la  x11, ek
+  la  x12, dk
+  li  x13, KYBER_K
+  jal x1, crypto_kem_keypair
 
   /* Unpack the masked dk secret polys into keygen-dead scratch. */
   la x10, dk
   la x11, mpolyvec_sk
-  loopi KYBER_K, 4
-    loopi NSHARES, 2
-      jal x1, poly_frombytes
-      nop
+  loopi KYBER_K, 3
+    jal x1, poly_frombytes
+    jal x1, poly_frombytes
     nop
-  addi x8, x10, 0 /* Start of ek in the masked dk. */
+  endloop
+  add x8, x10, x0 /* Start of ek in the masked dk. */
 
   /* Unmask dk: sum the arithmetic shares mod q. */
+  li   x4, 1
   la   x5, mpolyvec_sk
   la   x6, mpolyvec_sk
-  li   x4, 1
-  li   x7, NSHARES
-  slli x28, x7, 9 /* NSHARES * 512 */
-  addi x7, x7, -1
-  loopi KYBER_K, 10
-    addi x29, x5, 0
-    loopi 16, 7
-      addi   x30, x5, 512
-      bn.lid x0, 0(x5++)
-      loop x7, 3
-        bn.lid       x4, 0(x30)
-        bn.addvm.16h w0, w0, w1
-        addi         x30, x30, 512
-      bn.sid x0, 0(x6++)
-    add x5, x29, x28
+  loopi KYBER_K, 7
+    addi x7, x5, 512
+    loopi 16, 4
+      bn.lid       x0, 0(x5++)
+      bn.lid       x4, 0(x7++)
+      bn.addvm.16h w0, w0, w1
+      bn.sid       x0, 0(x6++)
+    endloop
+    addi x5, x5, 512
+  endloop
 
   /* Repack the plain dk in place (poly_frombytes read all shares first). */
-  la  x10, mpolyvec_sk
-  la  x11, dk
+  la x10, mpolyvec_sk
+  la x11, dk
   loopi KYBER_K, 2
     jal x1, poly_tobytes
     nop
-  addi x9, x11, 0
+  endloop
+  add x9, x11, x0 /* Start of ek in the plain dk. */
 
   /* Move ek (and H(ek) || z shares) down to the plain dk offset. src > dst,
    * copied forward, so there is no overwrite hazard. */
   li   x5, CRYPTO_PUBLICKEYBYTES
-  srli x5, x5, 5
-  addi x5, x5, 3
+  srli x5, x5, 5 /* Byte length of ek. */
+  addi x5, x5, 3 /* Byte length of H(ek) (unmasked) and z (masked). */
   loop x5, 2
     bn.lid x0, 0(x8++)
     bn.sid x0, 0(x9++)
+  endloop
 
   ecall

--- a/sw/acc/crypto/tests/mlkem/mlkem_keypair_masked_test.s
+++ b/sw/acc/crypto/tests/mlkem/mlkem_keypair_masked_test.s
@@ -38,12 +38,12 @@ main:
 
   la x2, stack_end
 
-  /* mod = qinv | q. */
+  /* mod = mqinv | q. */
   li      x4, 16
-  la      x5, modulus_bn
+  la      x5, const_q
   bn.lid  x4++, 0(x5)
   bn.rshi w16, w31, w16 >> 240
-  la      x5, modulus_inv
+  la      x5, const_mqinv
   bn.lid  x4, 0(x5)
   bn.or   w16, w16, w17 << 32
   bn.wsrw mod, w16

--- a/sw/acc/crypto/tests/mlkem/mlkem_keypair_testgen.py
+++ b/sw/acc/crypto/tests/mlkem/mlkem_keypair_testgen.py
@@ -11,6 +11,8 @@ from kyber_py.ml_kem import ML_KEM_512, ML_KEM_768, ML_KEM_1024
 
 from shared.testgen import write_testcase
 
+N = 256
+
 INSTANCE_FOR_PARAMS = {
     'mlkem512': ML_KEM_512,
     'mlkem768': ML_KEM_768,
@@ -24,20 +26,23 @@ def gen_keypair_test(mlkem, hardened: bool, mode_symbol: str, tc_file: TextIO):
     ek, dk = mlkem.key_derive(coins)
 
     if hardened:
-        # Generate shares for d.
+        # Mask d.
         d_int = int.from_bytes(coins[0:32], byteorder="little")
-        r1 = random.getrandbits(256)
-        r2 = r1 ^ d_int
-        td = int.to_bytes(r1, byteorder="little", length=32)
-        td += int.to_bytes(r2, byteorder="little", length=32)
-        # Generate shares for z.
+        d0 = random.getrandbits(N)
+        d1 = d0 ^ d_int
+        d_bytes = int.to_bytes(d0, byteorder="little", length=32)
+        d_bytes += int.to_bytes(d1, byteorder="little", length=32)
+
+        # Mask z.
         z_int = int.from_bytes(coins[32:], byteorder="little")
-        r1 = random.getrandbits(256)
-        r2 = r1 ^ z_int
-        tz = int.to_bytes(r1, byteorder="little", length=32)
-        tz += int.to_bytes(r2, byteorder="little", length=32)
-        coins = td + tz
-        dk = dk[:-32] + tz
+        z0 = random.getrandbits(N)
+        z1 = z0 ^ z_int
+        z_bytes = int.to_bytes(z0, byteorder="little", length=32)
+        z_bytes += int.to_bytes(z1, byteorder="little", length=32)
+
+        # Finalize masked input coins.
+        coins = d_bytes + z_bytes
+        dk = dk[:-32] + z_bytes
 
     # Unprotected keygen runs run_mlkem (dispatched by mode); the masked wrapper
     # calls the kernel directly, unmasks dk, and has no MODE_* symbol.


### PR DESCRIPTION
This PR (following #424) proposes the changes below to the whitening step
in ML-KEM and its gadgets to ensure share isolation:

- Whitening now uses `bn.xor w*, w31, w31` instead of `bn.xor w*, w*, w*`,
  so the ALU operand paths are driven to 0 as well as the destination.
- Whitening moved to *after* the registers are used, rather than before.
- Whitening between different bits/coefficients of the *same* share is
  removed. We can add a separate commit for this if it is strictly needed.
- Add missing whitening steps between two shares of a value.
- The `secand` and `secfulladder` rewrites address the same root cause by
  never loading or storing two shares back-to-back.
- Reallocate the registers used by `poly_hocompress_{du,dv}` and
  `masked_poly_tomsg` (constants in `w20`-`w22`, temporaries in
  `w17`-`w19`) so they share one whitening routine, reducing code size.
 
As discussed offline, I have also removed the whitening of the LSU paths from
this PR, since this can be done with evaluation later.