### PR TITLE
[cryptotest] Remove non-PQC execution environments from hardened PQC KAT tests

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -103,7 +103,7 @@ cryptotest(
 # firmware, so the PQC CW340 job runs both variants without a second build.
 cryptotest(
     name = "mlkem_kat_hardened",
-    extra_exec_envs = {
+    exec_env = {
         "//hw/top_egret:fpga_cw340_pqc_test_rom": "fpga_cw340",
     },
     firmware_deps = [
@@ -147,7 +147,7 @@ cryptotest(
 # firmware, so the PQC CW340 job runs both variants without a second build.
 cryptotest(
     name = "mldsa_kat_hardened",
-    extra_exec_envs = {
+    exec_env = {
         "//hw/top_egret:fpga_cw340_pqc_test_rom": "fpga_cw340",
     },
     firmware_deps = [

--- a/sw/device/tests/crypto/cryptotest/cryptotest.bzl
+++ b/sw/device/tests/crypto/cryptotest/cryptotest.bzl
@@ -52,7 +52,7 @@ FIRMWARE_DEPS = [
     "//sw/device/tests/crypto/cryptotest/json:commands",
 ]
 
-def cryptotest(name, test_vectors, test_args, test_harness, slow_test = False, extra_exec_envs = {}, firmware_deps = FIRMWARE_DEPS):
+def cryptotest(name, test_vectors, test_args, test_harness, slow_test = False, exec_env = {}, extra_exec_envs = {}, firmware_deps = FIRMWARE_DEPS):
     """A macro for defining a CryptoTest test case.
 
     Args:
@@ -61,11 +61,13 @@ def cryptotest(name, test_vectors, test_args, test_harness, slow_test = False, e
         test_args: additional arguments to pass to the test.
         test_harness: the test harness to use.
         slow_test: indicate if the test should be run in the nightly CI.
+        exec_env: exec_env entries to override the defaults (empty dict if defaults should be kept).
         extra_exec_envs: additional exec_env entries merged into the defaults.
         firmware_deps: firmware dependencies (defaults to FIRMWARE_DEPS).
     """
     tags = ["slow_test"] if slow_test else []
-    exec_env = dict(CRYPTOTEST_EXEC_ENVS)
+    if not exec_env:
+        exec_env = dict(CRYPTOTEST_EXEC_ENVS)
     exec_env.update(extra_exec_envs)
     pavona_test(
         name = name,


### PR DESCRIPTION
This PR removes non-PQC execution environments from the hardened PQC KAT cryptotest tests, as non-PQC execution environments do not work with the `mlkem_kat_hardened` and `mldsa_kat_hardened` tests.

This should resolve the corresponding failures in the nightlies; see e.g. https://github.com/pavona/pavona/actions/runs/34178942384/job/101928764695. Running

```
ci/scripts/run-bazel-test-query.sh /dev/stdout "cw340_sival_rom_ext" "short,medium,long,eternal" //sw/device/tests/crypto/cryptotest:*
```

confirms as an example that the nightly CI job for CW340 SiVal ROM_EXT tests will not pick up the hardened KAT tests.