### PR TITLE
[test,otp] Fix otp_ctrl_mem_access_test

### DIFF
--- a/sw/device/tests/otp_ctrl_mem_access_test.c
+++ b/sw/device/tests/otp_ctrl_mem_access_test.c
@@ -94,6 +94,7 @@ static void otp_ctrl_dai_disable_test(uint32_t last_dai_value) {
     if (partition_info.zeroizable) {
       partition_len += sizeof(uint64_t);
     }
+    partition_len /= sizeof(uint32_t);
     LOG_INFO("Checking partition %d.", partition);
     uint32_t readout[partition_len];
     CHECK_STATUS_OK(otp_ctrl_testutils_dai_read32_array(

--- a/sw/device/tests/otp_ctrl_mem_access_test.c
+++ b/sw/device/tests/otp_ctrl_mem_access_test.c
@@ -87,6 +87,10 @@ static void otp_ctrl_dai_disable_test(uint32_t last_dai_value) {
     otp_partition_t partition = (otp_partition_t)i;
     dt_otp_partition_info_t partition_info =
         dt_otp_ctrl_partition(kDtOtpCtrl, partition);
+    // TODO: cover the secret partitions, which need 64-bit reads.
+    if (partition_info.align_mask != 0x3) {
+      continue;
+    }
     size_t partition_len = partition_info.size;
     if (partition_info.sw_digest || partition_info.hw_digest) {
       partition_len += sizeof(uint64_t);


### PR DESCRIPTION
I looked into the `//sw/device/tests:otp_ctrl_mem_access_test_fpga_cw340_sival` failure in the last [Nightly](https://github.com/pavona/pavona/actions/runs/34301922748/job/102338111383).
It looks like there are two problems in the `otp_ctrl_dai_disable_test`:
 - `partition_len` is a byte length, but is used as a word length
 - It tries to read secret partitions using dai_read32_array which fails on the second word due to `align_mask`

With these two fixed, the test works fine for me. 