### PR TITLE
[bazel] Silence clang's GCC installation detection warning

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -277,6 +277,8 @@ register_toolchains("//third_party/foreign_cc:preinstalled_make_toolchain_macos"
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 llvm.toolchain(
     name = "llvm_toolchain",
+    # TODO: Drop once clang's GCC detection prefers complete installations.
+    extra_compile_flags = {"": ["-Wno-gcc-install-dir-libstdcxx"]},
     # macOS links the system libc++ dylib, so use its headers too.
     extra_cxx_flags = {"darwin-aarch64": [
         "-nostdinc++",


### PR DESCRIPTION
On hosts that have a newer GCC without libstdc++ headers next to a complete older one, clang 22 warns that a future release will pick the older installation instead.  openocd is built with -Werror, so there the warning is an error and `bazel build //third_party/openocd:openocd_bin` fails.

The choice does not matter for us: nothing resolves out of the GCC installation anyway.

Fixes #397