### PR TITLE
[cryptotest] Move SPHINCS+ command buffers into the scratch area

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -50,6 +50,7 @@ static union {
   hash_test_scratch_t hash;
   mlkem_test_scratch_t mlkem;
   mldsa_test_scratch_t mldsa;
+  sphincsplus_test_scratch_t sphincsplus;
 } cryptotest_scratch;
 
 OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
@@ -98,7 +99,7 @@ status_t process_cmd(ujson_t *uj) {
         RESP_ERR(uj, handle_rsa(uj));
         break;
       case kCryptotestCommandSphincsPlus:
-        RESP_ERR(uj, handle_sphincsplus(uj));
+        RESP_ERR(uj, handle_sphincsplus(uj, &cryptotest_scratch.sphincsplus));
         break;
       case kCryptotestCommandEd25519:
         RESP_ERR(uj, handle_ed25519(uj));

--- a/sw/device/tests/crypto/cryptotest/firmware/sphincsplus.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/sphincsplus.c
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sphincsplus.h"
+
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/impl/integrity.h"
@@ -13,28 +15,28 @@
 #include "sw/device/silicon_creator/lib/sigverify/sphincsplus/verify.h"
 #include "sw/device/tests/crypto/cryptotest/json/sphincsplus_commands.h"
 
-status_t handle_sphincsplus_verify(ujson_t *uj) {
+status_t handle_sphincsplus_verify(ujson_t *uj, sphincsplus_test_scratch_t *s) {
   // Declare SPHINCS+ parameter ujson deserializer types
   cryptotest_sphincsplus_hash_alg_t uj_hash_alg;
   cryptotest_sphincsplus_public_key_t uj_public_key;
-  cryptotest_sphincsplus_message_t uj_message;
-  cryptotest_sphincsplus_signature_t uj_signature;
+  cryptotest_sphincsplus_message_t *uj_message = &s->message;
+  cryptotest_sphincsplus_signature_t *uj_signature = &s->signature;
 
   // Deserialize ujson byte stream into SPHINCS+ parameters
   TRY(ujson_deserialize_cryptotest_sphincsplus_hash_alg_t(uj, &uj_hash_alg));
   TRY(ujson_deserialize_cryptotest_sphincsplus_public_key_t(uj,
                                                             &uj_public_key));
-  TRY(ujson_deserialize_cryptotest_sphincsplus_message_t(uj, &uj_message));
-  TRY(ujson_deserialize_cryptotest_sphincsplus_signature_t(uj, &uj_signature));
+  TRY(ujson_deserialize_cryptotest_sphincsplus_message_t(uj, uj_message));
+  TRY(ujson_deserialize_cryptotest_sphincsplus_signature_t(uj, uj_signature));
 
   if (uj_public_key.public_len != kSpxVerifyPkBytes) {
     LOG_ERROR("Incorrect public key length: (expected = %d, got = %d)",
               kSpxVerifyPkBytes, uj_public_key.public_len);
     return INVALID_ARGUMENT();
   }
-  if (uj_signature.signature_len != kSpxVerifySigBytes) {
+  if (uj_signature->signature_len != kSpxVerifySigBytes) {
     LOG_ERROR("Incorrect signature length: (expected = %d, got = %d)",
-              kSpxVerifySigBytes, uj_signature.signature_len);
+              kSpxVerifySigBytes, uj_signature->signature_len);
     return INVALID_ARGUMENT();
   }
 
@@ -52,8 +54,8 @@ status_t handle_sphincsplus_verify(ujson_t *uj) {
   spx_public_key_root((uint32_t *)uj_public_key.public, exp_root);
   uint32_t act_root[kSpxVerifyRootNumWords];
   rom_error_t error =
-      spx_verify((uint32_t *)uj_signature.signature, NULL, 0, NULL, 0, NULL, 0,
-                 (uint8_t *)uj_message.message, uj_message.message_len,
+      spx_verify((uint32_t *)uj_signature->signature, NULL, 0, NULL, 0, NULL, 0,
+                 (uint8_t *)uj_message->message, uj_message->message_len,
                  (uint32_t *)uj_public_key.public, act_root);
   cryptotest_sphincsplus_verify_output_t uj_output;
   switch (error) {
@@ -86,12 +88,12 @@ status_t handle_sphincsplus_verify(ujson_t *uj) {
   return OK_STATUS(0);
 }
 
-status_t handle_sphincsplus(ujson_t *uj) {
+status_t handle_sphincsplus(ujson_t *uj, sphincsplus_test_scratch_t *s) {
   cryptotest_sphincsplus_operation_t uj_op;
   TRY(ujson_deserialize_cryptotest_sphincsplus_operation_t(uj, &uj_op));
   switch (uj_op) {
     case kCryptotestSphincsPlusOperationVerify:
-      return handle_sphincsplus_verify(uj);
+      return handle_sphincsplus_verify(uj, s);
     default:
       LOG_ERROR("Unsupported SPHINCS+ operation: %d", uj_op);
       return INVALID_ARGUMENT();

--- a/sw/device/tests/crypto/cryptotest/firmware/sphincsplus.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/sphincsplus.h
@@ -7,7 +7,14 @@
 
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/tests/crypto/cryptotest/json/sphincsplus_commands.h"
 
-status_t handle_sphincsplus(ujson_t *uj);
+// Scratch memory for SPHINCS+ tests.
+typedef struct sphincsplus_test_scratch {
+  cryptotest_sphincsplus_message_t message;
+  cryptotest_sphincsplus_signature_t signature;
+} sphincsplus_test_scratch_t;
+
+status_t handle_sphincsplus(ujson_t *uj, sphincsplus_test_scratch_t *s);
 
 #endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_SPHINCSPLUS_H_


### PR DESCRIPTION
handle_sphincsplus is inlined into process_cmd, so its 7860-byte signature and 3304-byte message buffers sat on the stack for the whole life of the dispatch loop. This caused stack overflow in the RSA KAT and ML-KEM KAT.

Move the 11 KiB off the stack into a static buffer shared with large ML-KEM and ML-DSA buffers.