### PR TITLE
[rom] Fix fault behavior in dual-stage ROM

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -410,8 +410,8 @@ dual_cc_library(
         ["HAS_FLASH_CTRL"],
         [],
     ) + pavona_if_ip(
-        "keymgr",
-        ["HAS_KEYMGR"],
+        "keymgr_dpe",
+        ["HAS_KEYMGR_DPE"],
         [],
     ),
     deps = dual_inputs(
@@ -451,9 +451,9 @@ dual_cc_library(
             [dual_cc_device_library_of("//sw/device/silicon_creator/lib/drivers:flash_ctrl")],
             [],
         ) + pavona_if_ip(
-            "keymgr",
+            "keymgr_dpe",
+            ["//sw/device/silicon_creator/lib/drivers:keymgr_dpe"],
             ["//sw/device/silicon_creator/lib/drivers:keymgr"],
-            [],
         ),
     ),
 )

--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -33,7 +33,9 @@
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #endif
 
-#ifdef HAS_KEYMGR
+#ifdef HAS_KEYMGR_DPE
+#include "sw/device/silicon_creator/lib/drivers/keymgr_dpe.h"
+#else
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 #endif
 
@@ -455,11 +457,7 @@ SHUTDOWN_FUNC(NO_MODIFIERS, shutdown_flash_kill(void)) {
 #endif
 }
 
-SHUTDOWN_FUNC(NO_MODIFIERS, shutdown_keymgr_kill(void)) {
-#ifdef HAS_KEYMGR
-  sc_keymgr_disable();
-#endif
-}
+SHUTDOWN_FUNC(NO_MODIFIERS, shutdown_keymgr_kill(void)) { sc_keymgr_disable(); }
 
 SHUTDOWN_FUNC(noreturn, shutdown_hang(void)) {
   const uint32_t sram_ctrl_base =

--- a/sw/device/silicon_creator/rom/boot_second_rom.c
+++ b/sw/device/silicon_creator/rom/boot_second_rom.c
@@ -86,7 +86,7 @@ rom_error_t rom_boot_second_rom(void) {
   uint32_t rom_ctrl1_size =
       dt_rom_ctrl_memory_size(kDtRomCtrl1, kDtRomCtrlMemoryRom);
   const epmp_region_t second_rom_text = {
-      .start = _entry_point, .end = rom_ctrl1_base + rom_ctrl1_size};
+      .start = rom_ctrl1_base, .end = rom_ctrl1_base + rom_ctrl1_size};
   const epmp_region_t second_rom = {.start = rom_ctrl1_base,
                                     .end = rom_ctrl1_base + rom_ctrl1_size};
   epmp_prepare_boot_stage(second_rom_text, second_rom);


### PR DESCRIPTION
The ROM1 ePMP region did not include the interrupt vector, which caused exceptions that occurred during ROM1 execution to trigger a double-fault when attempting to run the exception handler. This PR fixes this and also fixes the shutdown handler to properly disable key manager on DPE platforms.